### PR TITLE
Fix double segment key rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FiloDB
 
 [![Join the chat at https://gitter.im/velvia/FiloDB](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/velvia/FiloDB?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/tuplejump/FiloDB.svg?branch=master)](https://travis-ci.org/tuplejump/FiloDB)
+[![Build Status](https://travis-ci.org/filodb/FiloDB.svg?branch=master)](https://travis-ci.org/filodb/FiloDB)
 
 High-performance distributed analytical database + Spark SQL queries + built for streaming.
 

--- a/core/src/main/scala/filodb.core/KeyType.scala
+++ b/core/src/main/scala/filodb.core/KeyType.scala
@@ -181,6 +181,7 @@ object SingleKeyTypes {
     def fromString(str: String): Double = str.toDouble
 
     override def size(key: Double): Int = 8
+    override def isSegmentType: Boolean = true
   }
 
   implicit case object DoubleKeyType extends DoubleKeyTypeLike

--- a/core/src/test/scala/filodb.core/metadata/ComputedColumnSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/ComputedColumnSpec.scala
@@ -82,12 +82,12 @@ class ComputedColumnSpec extends FunSpec with Matchers {
     }
 
     it("should round double value") {
-      val dblDataset = Dataset("a", ":round dbl 2.0", ":string /0")
+      val dblDataset = Dataset("a", ":round dbl 2.5", ":string /0")
       val dblColumn = DataColumn(0, "dbl", "a", 0, Column.ColumnType.DoubleColumn)
       val proj = RichProjection(dblDataset, Seq(dblColumn))
-      proj.rowKeyFunc(TupleRowReader((Some(1.999), None))) should equal (0.0)
-      proj.rowKeyFunc(TupleRowReader((Some(3.999), None))) should equal (2.0)
-      proj.rowKeyFunc(TupleRowReader((Some(2.00001), None))) should equal (2.0)
+      proj.rowKeyFunc(TupleRowReader((Some(2.499), None))) should equal (0.0)
+      proj.rowKeyFunc(TupleRowReader((Some(4.999), None))) should equal (2.5)
+      proj.rowKeyFunc(TupleRowReader((Some(2.501), None))) should equal (2.5)
     }
   }
 


### PR DESCRIPTION
This fixes the bug where using a DoubleColumn as the segment key was not possible. Also added a test for using `:round` to round to non-integer values and fixed the URL to Travis. Tests pass on my end.