### PR TITLE
Modified to handle errors during read path

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/Util.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/Util.scala
@@ -30,6 +30,7 @@ object Util {
       // from invalid Enum strings, which should never happen, or some other parsing error
       case e: NoSuchElementException   => throw MetadataException(e)
       case e: IllegalArgumentException => throw MetadataException(e)
+      case e: Exception                => throw e
     }
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/Util.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/Util.scala
@@ -20,7 +20,7 @@ object Util {
         if (resultSet.wasApplied) Success else notAppliedResponse
       }.recover {
         case e: DriverException => throw StorageEngineException(e)
-        case e: Exception       => throw e
+        case e: Exception       => throw StorageEngineException(e)
       }
     }
   }
@@ -31,7 +31,7 @@ object Util {
       // from invalid Enum strings, which should never happen, or some other parsing error
       case e: NoSuchElementException   => throw MetadataException(e)
       case e: IllegalArgumentException => throw MetadataException(e)
-      case e: Exception                => throw e
+      case e: Exception                => throw StorageEngineException(e)
     }
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/Util.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/Util.scala
@@ -20,6 +20,7 @@ object Util {
         if (resultSet.wasApplied) Success else notAppliedResponse
       }.recover {
         case e: DriverException => throw StorageEngineException(e)
+        case e: Exception       => throw e
       }
     }
   }

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkRowMapTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkRowMapTable.scala
@@ -70,7 +70,7 @@ sealed class ChunkRowMapTable(dataset: DatasetRef, connector: FiloCassandraConne
                    version: Int): Future[Iterator[ChunkRowMapRecord]] =
     session.executeAsync(allPartReadCql.bind(toBuffer(binPartition),
                                              version: java.lang.Integer))
-           .toIterator.map(_.map(fromRow))
+           .toIterator.map(_.map(fromRow)).handleErrors
 
   /**
    * Retrieves a whole series of chunk maps, in the range [startSegmentId, untilSegmentId)
@@ -83,7 +83,7 @@ sealed class ChunkRowMapTable(dataset: DatasetRef, connector: FiloCassandraConne
     session.executeAsync(cql.bind(toBuffer(keyRange.partition),
                                   version: java.lang.Integer,
                                   toBuffer(keyRange.start), toBuffer(keyRange.end)))
-           .toIterator.map(_.map(fromRow))
+           .toIterator.map(_.map(fromRow)).handleErrors
   }
 
   val tokenQ = "TOKEN(partition, version)"
@@ -99,7 +99,7 @@ sealed class ChunkRowMapTable(dataset: DatasetRef, connector: FiloCassandraConne
                .filter(_.getInt("version") == version)
                .map { row => fromRow(row) }
       }
-    }
+    }.handleErrors
   }
 
   /**


### PR DESCRIPTION
Related to issue: No error is displayed when cassandra nodes are down for read path #120