### PR TITLE
feat(coordinator): Add start/stop shard support

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -266,6 +266,7 @@ private[filodb] final class IngestionActor(dataset: Dataset,
   /** Guards that only this dataset's commands are acted upon. */
   private def stop(ds: DatasetRef, shard: Int, origin: ActorRef): Unit =
     if (invalid(ds)) handleInvalid(StopShardIngestion(ds, shard), Some(origin)) else {
+      // TODO: Wait for all the queries to stop
       logger.warn(s"Stopping ingestion on shard $shard")
       streamSubscriptions.remove(shard).foreach(_.cancel)
       streams.remove(shard).foreach(_.teardown())

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -36,7 +36,9 @@ object NodeClusterActor {
 
   case class GetDatasetFromRef(datasetRef: DatasetRef)
 
-  final case class ReassignShards(reassignmentConfig: ReassignShardConfig, datasetRef: DatasetRef)
+  final case class StopShards(reassignmentConfig: ReassignShardConfig, datasetRef: DatasetRef)
+
+  final case class StartShards(reassignmentConfig: ReassignShardConfig, datasetRef: DatasetRef)
 
   /**
    * Sets up a dataset for streaming ingestion and querying, with specs for sharding.
@@ -336,7 +338,8 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
     case e: AddCoordinator        => addCoordinator(e)
     case RemoveStaleCoordinators  => shardManager.removeStaleCoordinators()
     case e: SetupDataset          => setupDataset(e, sender())
-    case e: ReassignShards        => shardManager.reassignShards(e, sender())
+    case e: StartShards           => shardManager.startShards(e, sender())
+    case e: StopShards            => shardManager.stopShards(e, sender())
   }
 
   def subscriptionHandler: Receive = LoggingReceive {

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 
 import filodb.core._
 import filodb.core.metadata.Dataset
-import filodb.core.store.{IngestionConfig, MetaStore, ReassignShardConfig, StoreConfig}
+import filodb.core.store.{AssignShardConfig, IngestionConfig, MetaStore, StoreConfig, UnassignShardConfig}
 
 object NodeClusterActor {
 
@@ -36,9 +36,9 @@ object NodeClusterActor {
 
   case class GetDatasetFromRef(datasetRef: DatasetRef)
 
-  final case class StopShards(reassignmentConfig: ReassignShardConfig, datasetRef: DatasetRef)
+  final case class StopShards(unassignmentConfig: UnassignShardConfig, datasetRef: DatasetRef)
 
-  final case class StartShards(reassignmentConfig: ReassignShardConfig, datasetRef: DatasetRef)
+  final case class StartShards(assignmentConfig: AssignShardConfig, datasetRef: DatasetRef)
 
   /**
    * Sets up a dataset for streaming ingestion and querying, with specs for sharding.

--- a/coordinator/src/test/scala/filodb.coordinator/ReassignShardsSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ReassignShardsSpec.scala
@@ -5,8 +5,9 @@ import akka.testkit.TestProbe
 
 import filodb.coordinator.NodeClusterActor._
 import filodb.coordinator.client.IngestionCommands.DatasetSetup
-import filodb.core.{store, DatasetRef, Success, TestData}
+import filodb.core.{DatasetRef, Success, TestData}
 import filodb.core.metadata.Dataset
+import filodb.core.store.{AssignShardConfig, UnassignShardConfig}
 
 class ReassignShardsSpec extends AkkaSpec {
   import NodeClusterActor.{DatasetResourceSpec, IngestionSource, SetupDataset}
@@ -61,11 +62,11 @@ class ReassignShardsSpec extends AkkaSpec {
       shardManager.datasetInfo.size shouldBe 0
       coord4.expectNoMessage() // since there are no more shards left to assign
 
-      val shardAssign1 = store.ReassignShardConfig(coord1Address.toString, Seq(0,1))
+      val shardAssign1 = AssignShardConfig(coord1Address.toString, Seq(0,1))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsg(DatasetUnknown(dataset1)) // since there are no datasets
 
-      val shardAssign2 = store.ReassignShardConfig(coordInvalidAddress.toString, Seq(0,1))
+      val shardAssign2 = AssignShardConfig(coordInvalidAddress.toString, Seq(0,1))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign2, dataset2), self)
       expectMsg(DatasetUnknown(dataset2))
 
@@ -110,21 +111,21 @@ class ReassignShardsSpec extends AkkaSpec {
       }
       subscriber.expectNoMessage()
 
-      val shardAssign1 = store.ReassignShardConfig(coord4Address.toString, Seq(5))
+      val shardAssign1 = AssignShardConfig(coord4Address.toString, Seq(5))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsgPF() { case s: BadSchema =>
         s.message should startWith(s"Can not start")
       }
       subscriber.expectNoMessage()
 
-      val shardAssign2 = store.ReassignShardConfig(coord2Address.toString, Seq(0))
+      val shardAssign2 = AssignShardConfig(coord2Address.toString, Seq(0))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign2, dataset1), self)
       expectMsg(BadData(s"${coord2Address.toString} not found"))
       subscriber.expectNoMessage()
     }
 
     "fail with invalid node" in {
-      val shardAssign1 = store.ReassignShardConfig(coordInvalidAddress.toString, Seq(0))
+      val shardAssign1 = AssignShardConfig(coordInvalidAddress.toString, Seq(0))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsg(BadData(s"${coordInvalidAddress.toString} not found"))
     }
@@ -148,8 +149,8 @@ class ReassignShardsSpec extends AkkaSpec {
         (coord4.ref, ShardStatusAssigned), (coord3.ref, ShardStatusAssigned), (coord3.ref, ShardStatusAssigned),
         (coord3.ref, ShardStatusAssigned), (coord2.ref, ShardStatusAssigned), (coord2.ref, ShardStatusAssigned))
 
-      val shardAssign1 = store.ReassignShardConfig(coord2Address.toString, Seq(5))
-      shardManager.stopShards(NodeClusterActor.StopShards(shardAssign1, dataset1), self)
+      val shardAssign1 = AssignShardConfig(coord2Address.toString, Seq(5))
+      shardManager.stopShards(NodeClusterActor.StopShards(UnassignShardConfig(shardAssign1.shardList), dataset1), self)
       expectMsg(Success)
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsg(Success)
@@ -176,7 +177,7 @@ class ReassignShardsSpec extends AkkaSpec {
     }
 
     "fail with invalid datasets" in {
-      val shardAssign = store.ReassignShardConfig(coord1Address.toString, Seq(0,1))
+      val shardAssign = AssignShardConfig(coord1Address.toString, Seq(0,1))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign, dataset2), self)
       expectMsg(DatasetUnknown(dataset2))
 
@@ -189,7 +190,7 @@ class ReassignShardsSpec extends AkkaSpec {
 
     "fail with invalid shardNum" in {
 
-      val shardAssign1 = store.ReassignShardConfig(coord1Address.toString, Seq(8))
+      val shardAssign1 = AssignShardConfig(coord1Address.toString, Seq(8))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsg(BadSchema(s"Invalid shards found List(8). Valid shards are List()"))
 
@@ -202,7 +203,7 @@ class ReassignShardsSpec extends AkkaSpec {
     }
 
     "fail when assigned to same node" in {
-      val shardAssign1 = store.ReassignShardConfig(coord4Address.toString, Seq(0))
+      val shardAssign1 = AssignShardConfig(coord4Address.toString, Seq(0))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsgPF() { case s: BadSchema =>
         s.message should startWith (s"Can not reassign shards to same node")
@@ -210,7 +211,7 @@ class ReassignShardsSpec extends AkkaSpec {
     }
 
     "fail when coord has no capacity" in {
-      val shardAssign1 = store.ReassignShardConfig(coord4Address.toString, Seq(4))
+      val shardAssign1 = AssignShardConfig(coord4Address.toString, Seq(4))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsgPF() { case s: BadSchema =>
         s.message should startWith (s"Can not start List")
@@ -219,8 +220,8 @@ class ReassignShardsSpec extends AkkaSpec {
 
     "succeed with single node" in {
 
-      val shardAssign1 = store.ReassignShardConfig(coord1Address.toString, Seq(2))
-      shardManager.stopShards(NodeClusterActor.StopShards(shardAssign1, dataset1), self)
+      val shardAssign1 = AssignShardConfig(coord1Address.toString, Seq(2))
+      shardManager.stopShards(NodeClusterActor.StopShards(UnassignShardConfig(shardAssign1.shardList), dataset1), self)
       expectMsg(Success)
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsg(Success)
@@ -232,8 +233,8 @@ class ReassignShardsSpec extends AkkaSpec {
         s.map.shardsForCoord(coord1.ref) shouldEqual Seq(2)
       }
 
-      val shardAssign2 = store.ReassignShardConfig(coord3Address.toString, Seq(1))
-      shardManager.stopShards(NodeClusterActor.StopShards(shardAssign2, dataset1), self)
+      val shardAssign2 = AssignShardConfig(coord3Address.toString, Seq(1))
+      shardManager.stopShards(NodeClusterActor.StopShards(UnassignShardConfig(shardAssign2.shardList), dataset1), self)
       expectMsg(Success)
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign2, dataset1), self)
       expectMsg(Success)
@@ -248,8 +249,8 @@ class ReassignShardsSpec extends AkkaSpec {
 
     "succeed with multiple shards" in {
 
-      val shardAssign2 = store.ReassignShardConfig(coord1Address.toString, Seq(0, 7))
-      shardManager.stopShards(NodeClusterActor.StopShards(shardAssign2, dataset1), self)
+      val shardAssign2 = AssignShardConfig(coord1Address.toString, Seq(0, 7))
+      shardManager.stopShards(NodeClusterActor.StopShards(UnassignShardConfig(shardAssign2.shardList), dataset1), self)
       expectMsg(Success)
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign2, dataset1), self)
       expectMsg(Success)
@@ -274,12 +275,12 @@ class ReassignShardsSpec extends AkkaSpec {
         s.map.shardsForCoord(coord1.ref) shouldEqual Seq(0, 2, 7)
       }
 
-      val shardAssign1 = store.ReassignShardConfig(coord3Address.toString, Seq(0))
+      val shardAssign1 = AssignShardConfig(coord3Address.toString, Seq(0))
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsg(BadData(s"${coord3Address.toString} not found"))
 
-      val shardAssign2 = store.ReassignShardConfig(coord4Address.toString, Seq(2))
-      shardManager.stopShards(NodeClusterActor.StopShards(shardAssign2, dataset1), self)
+      val shardAssign2 = AssignShardConfig(coord4Address.toString, Seq(2))
+      shardManager.stopShards(NodeClusterActor.StopShards(UnassignShardConfig(shardAssign2.shardList), dataset1), self)
       expectMsg(Success)
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign2, dataset1), self)
       expectMsg(Success)
@@ -296,8 +297,8 @@ class ReassignShardsSpec extends AkkaSpec {
       shardManager.removeDataset(dataset1)
       shardManager.datasetInfo.size shouldBe 0
 
-      val shardAssign1 = store.ReassignShardConfig(coord1Address.toString, Seq(0,1))
-      shardManager.stopShards(NodeClusterActor.StopShards(shardAssign1, dataset1), self)
+      val shardAssign1 = AssignShardConfig(coord1Address.toString, Seq(0,1))
+      shardManager.stopShards(NodeClusterActor.StopShards(UnassignShardConfig(shardAssign1.shardList), dataset1), self)
       expectMsg(DatasetUnknown(dataset1)) // since there are no datasets
 
     }
@@ -310,8 +311,8 @@ class ReassignShardsSpec extends AkkaSpec {
       assignments shouldEqual Map(coord1.ref -> Seq(0, 1, 2), coord2.ref -> Seq(3, 4, 5), coord4.ref -> Seq(6, 7))
       expectMsg(DatasetVerified)
 
-      val shardAssign1 = store.ReassignShardConfig(coord4Address.toString, Seq(5))
-      shardManager.stopShards(NodeClusterActor.StopShards(shardAssign1, dataset1), self)
+      val shardAssign1 = AssignShardConfig(coord4Address.toString, Seq(5))
+      shardManager.stopShards(NodeClusterActor.StopShards(UnassignShardConfig(shardAssign1.shardList), dataset1), self)
       expectMsg(Success)
       shardManager.startShards(NodeClusterActor.StartShards(shardAssign1, dataset1), self)
       expectMsg(Success)

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -50,7 +50,9 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "demand-paging-enabled" -> demandPagingEnabled).asJava)
 }
 
-final case class ReassignShardConfig(address: String, shardList: Seq[Int])
+final case class AssignShardConfig(address: String, shardList: Seq[Int])
+
+final case class UnassignShardConfig(shardList: Seq[Int])
 
 object StoreConfig {
   // NOTE: there are no defaults for flush interval and shard memory, those should be explicitly calculated

--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -128,7 +128,7 @@ The POST body describes the ingestion source and parameters, such as Kafka confi
 Stop all the given shards.
 The POST body describes the stop shard config that should have the list of shards to be stopped.
 
-* POST body should be a ReassignShardConfig in JSON format as follows:
+* POST body should be a UnassignShardConfig in JSON format as follows:
 ```json
 {
     "shardList": [
@@ -148,7 +148,7 @@ The POST body describes the stop shard config that should have the list of shard
 Start the shards on the given node.
 The POST body describes the start shard config that should have both destination node address and the list of shards to be started.
 
-* POST body should be a ReassignShardConfig in JSON format as follows:
+* POST body should be a AssignShardConfig in JSON format as follows:
 ```json
 {
     "address": "akka.tcp://filo-standalone@127.0.0.1:2552",

--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -11,7 +11,8 @@
     - [GET /api/v1/cluster/{dataset}/status](#get-apiv1clusterdatasetstatus)
     - [GET /api/v1/cluster/{dataset}/statusByAddress](#get-apiv1clusterdatasetstatusbyaddress)
     - [POST /api/v1/cluster/{dataset}](#post-apiv1clusterdataset)
-    - [POST /api/v1/cluster/{dataset}/reassignshards](#post-apiv1clusterdatasetreassignshards)
+    - [POST /api/v1/cluster/{dataset}/stopshards](#post-apiv1clusterdatasetstopshards)
+    - [POST /api/v1/cluster/{dataset}/startshards](#post-apiv1clusterdatasetstartshards)
   - [Prometheus-compatible APIs](#prometheus-compatible-apis)
     - [GET /promql/{dataset}/api/v1/query_range?query={promQLString}&start={startTime}&step={step}&end={endTime}](#get-promqldatasetapiv1query_rangequerypromqlstringstartstarttimestepstependendtime)
     - [GET /promql/{dataset}/api/v1/query?=query={promQLString}&time={timestamp}](#get-promqldatasetapiv1queryquerypromqlstringtimetimestamp)
@@ -122,10 +123,30 @@ The POST body describes the ingestion source and parameters, such as Kafka confi
 }
 ```
 
-#### POST /api/v1/cluster/{dataset}/reassignshards
+#### POST /api/v1/cluster/{dataset}/stopshards
 
-Reassigns the shards to the given node. 
-The POST body describes the reassign shard config that should have both destination node address and the list of shards to be assigned.
+Stop all the given shards.
+The POST body describes the stop shard config that should have the list of shards to be stopped.
+
+* POST body should be a ReassignShardConfig in JSON format as follows:
+```json
+{
+    "shardList": [
+       2, 3
+    ]
+}
+```
+* A successful POST results in something like `{"status": "success", "data": []}`
+* 400 is returned if the POST body cannot be parsed or any of the following validation fails:
+     1. If the given dataset does not exist
+     3. Check if all the given shards are valid
+        1. Shard number should be >= 0 and < maxAllowedShard
+        2. Shard should be assigned to a node
+
+#### POST /api/v1/cluster/{dataset}/startshards
+
+Start the shards on the given node.
+The POST body describes the start shard config that should have both destination node address and the list of shards to be started.
 
 * POST body should be a ReassignShardConfig in JSON format as follows:
 ```json
@@ -142,7 +163,7 @@ The POST body describes the reassign shard config that should have both destinat
      2. If the given node doesn not exist
      3. Check if all the given shards are valid
         1. Shard number should be >= 0 and < maxAllowedShard
-        2. Shard should not be already assigned to given node in ReassignShards request
+        2. Shard should not be assigned to any node
      4. Verify whether there are enough capacity to add new shards on the node
 
 ### Prometheus-compatible APIs

--- a/http/src/main/scala/filodb/http/ClusterApiRoute.scala
+++ b/http/src/main/scala/filodb/http/ClusterApiRoute.scala
@@ -10,7 +10,7 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 
 import filodb.coordinator.{CurrentShardSnapshot, NodeClusterActor}
 import filodb.core.{DatasetRef, ErrorResponse, Success => SuccessResponse}
-import filodb.core.store.{IngestionConfig, ReassignShardConfig}
+import filodb.core.store.{AssignShardConfig, IngestionConfig, UnassignShardConfig}
 import filodb.http.apiv1.{HttpSchema, HttpShardDetails, HttpShardState, HttpShardStateByAddress}
 
 class ClusterApiRoute(clusterProxy: ActorRef) extends FiloRoute with StrictLogging {
@@ -95,26 +95,25 @@ class ClusterApiRoute(clusterProxy: ActorRef) extends FiloRoute with StrictLoggi
         }
       }
     } ~
-      // POST /api/v1/cluster/<dataset>/stopshards - shard reassignment request
-      // Sample input as follows:
-      // {{{
-      //  {
-      //    "shardList": [23, 24]
-      //  }
-      // }}}
-      path(Segment / "stopshards") { dataset =>
-        post {
-          entity(as[ReassignShardConfig]) { shardConfig =>
-            try onSuccess(asyncAsk(clusterProxy, StopShards(shardConfig, DatasetRef.fromDotString(dataset)))) {
-              case SuccessResponse  => complete(httpList(Seq.empty[String]))
-              case e: ErrorResponse => complete(Codes.BadRequest -> httpErr(e.toString, e.toString))
-            }
-            catch {
-              case e: Exception => complete(Codes.InternalServerError -> httpErr(e))
-            }
+    // POST /api/v1/cluster/<dataset>/stopshards - shard reassignment request
+    // Sample input as follows:
+    // {{{
+    //  {
+    //    "shardList": [23, 24]
+    //  }
+    // }}}
+    path(Segment / "stopshards") { dataset =>
+      post {
+        entity(as[UnassignShardConfig]) { shardConfig =>
+          try onSuccess(asyncAsk(clusterProxy, StopShards(shardConfig, DatasetRef.fromDotString(dataset)))) {
+            case SuccessResponse  => complete(httpList(Seq.empty[String]))
+            case e: ErrorResponse => complete(Codes.BadRequest -> httpErr(e.toString, e.toString))
+          } catch {
+            case e: Exception => complete(Codes.InternalServerError -> httpErr(e))
           }
         }
-      } ~
+      }
+    } ~
     // POST /api/v1/cluster/<dataset>/startshards - shard reassignment request
     // Sample input as follows:
     // {{{
@@ -125,12 +124,11 @@ class ClusterApiRoute(clusterProxy: ActorRef) extends FiloRoute with StrictLoggi
     // }}}
     path(Segment / "startshards") { dataset =>
       post {
-        entity(as[ReassignShardConfig]) { shardConfig =>
+        entity(as[AssignShardConfig]) { shardConfig =>
           try onSuccess(asyncAsk(clusterProxy, StartShards(shardConfig, DatasetRef.fromDotString(dataset)))) {
             case SuccessResponse  => complete(httpList(Seq.empty[String]))
             case e: ErrorResponse => complete(Codes.BadRequest -> httpErr(e.toString, e.toString))
-          }
-          catch {
+          } catch {
             case e: Exception => complete(Codes.InternalServerError -> httpErr(e))
           }
         }

--- a/http/src/test/scala/filodb/http/ClusterApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/ClusterApiRouteSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.FunSpec
 
 import filodb.coordinator._
 import filodb.core.{AsyncTest, GdeltTestData, TestData, Success}
-import filodb.core.store.ReassignShardConfig
+import filodb.core.store.{AssignShardConfig, UnassignShardConfig}
 
 object ClusterApiRouteSpec extends ActorSpecConfig
 
@@ -122,7 +122,7 @@ class ClusterApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncTest
 
   describe("/api/v1/cluster/<dataset>/startshards") {
     it("should return 200 with valid config") {
-      val conf = ReassignShardConfig("akka.tcp://filo-standalone@127.0.0.1:25523", Seq(2, 5))
+      val conf = AssignShardConfig("akka.tcp://filo-standalone@127.0.0.1:25523", Seq(2, 5))
       Post("/api/v1/cluster/gdelt/startshards", conf).
         withHeaders(RawHeader("Content-Type", "application/json")) ~> clusterRoute ~> check {
         handled shouldBe true
@@ -135,7 +135,7 @@ class ClusterApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncTest
 
   describe("/api/v1/cluster/<dataset>/stopshards") {
     it("should return 200 with valid config") {
-      val conf = ReassignShardConfig("", Seq(2, 5))
+      val conf = UnassignShardConfig(Seq(2, 5))
       Post("/api/v1/cluster/gdelt/stopshards", conf).
         withHeaders(RawHeader("Content-Type", "application/json")) ~> clusterRoute ~> check {
         handled shouldBe true

--- a/http/src/test/scala/filodb/http/ClusterApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/ClusterApiRouteSpec.scala
@@ -120,10 +120,24 @@ class ClusterApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncTest
     }
   }
 
-  describe("/api/v1/cluster/<dataset>/reassignshards") {
+  describe("/api/v1/cluster/<dataset>/startshards") {
     it("should return 200 with valid config") {
       val conf = ReassignShardConfig("akka.tcp://filo-standalone@127.0.0.1:25523", Seq(2, 5))
-      Post("/api/v1/cluster/gdelt/reassignshards", conf).withHeaders(RawHeader("Content-Type", "application/json")) ~> clusterRoute ~> check {
+      Post("/api/v1/cluster/gdelt/startshards", conf).
+        withHeaders(RawHeader("Content-Type", "application/json")) ~> clusterRoute ~> check {
+        handled shouldBe true
+        status shouldEqual StatusCodes.BadRequest
+        responseAs[HttpError].status shouldEqual "error"
+        responseAs[HttpError].error shouldEqual "DatasetUnknown(gdelt)"
+      }
+    }
+  }
+
+  describe("/api/v1/cluster/<dataset>/stopshards") {
+    it("should return 200 with valid config") {
+      val conf = ReassignShardConfig("", Seq(2, 5))
+      Post("/api/v1/cluster/gdelt/stopshards", conf).
+        withHeaders(RawHeader("Content-Type", "application/json")) ~> clusterRoute ~> check {
         handled shouldBe true
         status shouldEqual StatusCodes.BadRequest
         responseAs[HttpError].status shouldEqual "error"

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -123,7 +123,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
   <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+   <parameter name="maxMethods"><![CDATA[50]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

We currently have a single /reassignshards request endpoint that unassigns and assigns the shards.
https://github.com/filodb/FiloDB/commit/0a8dc865e41da491d618902de7d37dc249560ff0

**New behavior :**

Removing the /reassignshards endpoint and creating following two new endpoint:

1. POST /api/v1/cluster/datasethere/stopshards - shard stop request that accepts the following payload:
```
 {
   "shardList": [23, 24]
 }
```

2. POST /api/v1/cluster/datasethere/startshards - shard start request that accepts the following payload:
Sample input as follows:
```
 {
   "address": "akka.tcp://filo-standalone@23.13.16.45:91007",
   "shardList": [23, 24]
 }
```