### PR TITLE
feat(core,query,prom): LP, ExecPlan, and _filodb_chunkmeta_all function to debug chunk metadata info

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Now run the time series generator. This will ingest 20 time series (the default)
 java -cp gateway/target/scala-2.11/gateway-*-SNAPSHOT filodb.timeseries.TestTimeseriesProducer -c conf/timeseries-dev-source.conf
 ```
 
+NOTE: The `TestTimeseriesProducer` logs to logs/gateway-server.log.
+
 At this point, you should be able to confirm such a message in the server logs: `KAMON counter name=memstore-rows-ingested count=4999`
 
 Now you are ready to query FiloDB for the ingested data. The following command should return matching subset of the data that was ingested by the producer.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ See [architecture](doc/architecture.md) and [datasets and reading](doc/datasets_
   - [Predicate Pushdowns](#predicate-pushdowns)
   - [Sharding](#sharding)
 - [Using the FiloDB HTTP API](#using-the-filodb-http-api)
+- [PromQL Compatibility](#promql-compatibility)
+  - [FiloDB Extensions](#filodb-extensions)
 - [Using FiloDB Data Source with Spark](#using-filodb-data-source-with-spark)
   - [Configuring FiloDB](#configuring-filodb)
     - [Passing Cassandra Authentication Settings](#passing-cassandra-authentication-settings)
@@ -179,7 +181,7 @@ At this point, you should be able to confirm such a message in the server logs: 
 Now you are ready to query FiloDB for the ingested data. The following command should return matching subset of the data that was ingested by the producer.
 
 ```
-./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries --promql 'heap_usage{job="A2"}'
+./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries --promql 'heap_usage{job="App-2"}'
 ```
 
 You can also look at Cassandra to check for persisted data. Look at the tables in `filodb` and `filodb-admin` keyspaces.
@@ -380,6 +382,18 @@ TODO: add details about FiloDB sharding, the shard-key vs partition key mechanis
 ## Using the FiloDB HTTP API
 
 Please see the [HTTP API](doc/http_api.md) doc.
+
+## PromQL Compatibility
+
+Current status:
+
+### FiloDB Extensions
+
+Some special functions exist to aid debugging and for other purposes:
+
+| function | description    |
+|----------|----------------|
+| `_filodb_chunkmeta_all` | (CLI Only) Returns chunk metadata fields for all chunks matching the time range and filter criteria - ID, # rows, start and end time, as well as the number of bytes and type of encoding used for a particular column.  |
 
 ## Using FiloDB Data Source with Spark
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ Some special functions exist to aid debugging and for other purposes:
 |----------|----------------|
 | `_filodb_chunkmeta_all` | (CLI Only) Returns chunk metadata fields for all chunks matching the time range and filter criteria - ID, # rows, start and end time, as well as the number of bytes and type of encoding used for a particular column.  |
 
+Example of debugging chunk metadata using the CLI:
+
+    ./filo-cli --host 127.0.0.1 --dataset prometheus --promql '_filodb_chunkmeta_all(heap_usage{app="App-0"})' --start XX --end YY
+
 ## Using FiloDB Data Source with Spark
 
 FiloDB has a Spark data-source module - `filodb.spark`. So, you can use the Spark Dataframes `read` and `write` APIs with FiloDB. To use it, follow the steps below

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ At this point, you should be able to confirm such a message in the server logs: 
 Now you are ready to query FiloDB for the ingested data. The following command should return matching subset of the data that was ingested by the producer.
 
 ```
-./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries --promql 'heap_usage{job="App-2"}'
+./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries --promql 'heap_usage{app="App-2"}'
 ```
 
 You can also look at Cassandra to check for persisted data. Look at the tables in `filodb` and `filodb-admin` keyspaces.

--- a/conf/timeseries-standalonetest-source.conf
+++ b/conf/timeseries-standalonetest-source.conf
@@ -1,4 +1,4 @@
-    dataset = "timeseries"
+    dataset = "prometheus"
     num-shards = 4
     min-num-nodes = 2
     sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -273,8 +273,10 @@ private[filodb] final class IngestionActor(dataset: Dataset,
       statusActor ! IngestionStopped(dataset.ref, shard)
 
       // Release memory for shard in MemStore
-      val shardInstance = memStore.asInstanceOf[TimeSeriesMemStore].getShardE(ds, shard)
-      shardInstance.shutdown()
+      memStore.asInstanceOf[TimeSeriesMemStore].getShard(ds, shard)
+              .foreach { shard =>
+                shard.shutdown()
+              }
       logger.info(s"Stopped streaming ingestion for shard $shard and released resources")
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -189,7 +189,8 @@ class QueryEngine(dataset: Dataset,
                                       options: QueryOptions,
                                       lp: RawChunkMeta): Seq[ExecPlan] = {
     // Translate column name to ID and validate here
-    val colID = dataset.colIDs(lp.column).get.head
+    val colName = if (lp.column.isEmpty) dataset.options.valueColumn else lp.column
+    val colID = dataset.colIDs(colName).get.head
     shardsFromFilters(lp.filters, options).map { shard =>
       val dispatcher = dispatcherForShard(shard)
       SelectChunkInfosExec(queryId, submitTime, options.itemLimit, dispatcher, dataset.ref, shard,

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -347,7 +347,7 @@ final class BinaryRecordRowReader(schema: RecordSchema,
   def getLong(columnNo: Int): Long = schema.getLong(recordBase, recordOffset, columnNo)
   def getDouble(columnNo: Int): Double = schema.getDouble(recordBase, recordOffset, columnNo)
   def getFloat(columnNo: Int): Float = ???
-  def getString(columnNo: Int): String = ???
+  def getString(columnNo: Int): String = filoUTF8String(columnNo).toString
   def getAny(columnNo: Int): Any = schema.columnTypes(columnNo).keyType.extractor.getField(this, columnNo)
   override def filoUTF8String(i: Int): ZeroCopyUTF8String = schema.asZCUTF8Str(recordBase, recordOffset, i)
 

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -165,9 +165,14 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
         // Compare desired time range with start key and see if in memory data covers desired range
         // Also assume we have in memory all data since first key.  Just return the missing range of keys.
         case r: RowKeyChunkScan         =>
+          logger.debug(s"  XXX: part ${partition.stringPartition}  numChunks=${partition.numChunks}")
           if (partition.numChunks > 0) {
             val memStartTime = partition.earliestTime
             val endQuery = memStartTime - 1   // do not include earliestTime, otherwise will pull in first chunk
+            logger.debug(s"   - memStartTime=$memStartTime  query $r (${r.startTime}, ${r.endTime})")
+            partition.infos(AllChunkScan).toBuffer.foreach { c: ChunkSetInfo =>
+              logger.debug(s"  --> info startTime = ${c.startTime}  endTime = ${c.endTime}")
+            }
             if (r.startTime < memStartTime) { Some(RowKeyChunkScan(r.startkey, BinaryRecord.timestamp(endQuery))) }
             else                            { None }
           } else {

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -165,14 +165,9 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
         // Compare desired time range with start key and see if in memory data covers desired range
         // Also assume we have in memory all data since first key.  Just return the missing range of keys.
         case r: RowKeyChunkScan         =>
-          logger.debug(s"  XXX: part ${partition.stringPartition}  numChunks=${partition.numChunks}")
           if (partition.numChunks > 0) {
             val memStartTime = partition.earliestTime
             val endQuery = memStartTime - 1   // do not include earliestTime, otherwise will pull in first chunk
-            logger.debug(s"   - memStartTime=$memStartTime  query $r (${r.startTime}, ${r.endTime})")
-            partition.infos(AllChunkScan).toBuffer.foreach { c: ChunkSetInfo =>
-              logger.debug(s"  --> info startTime = ${c.startTime}  endTime = ${c.endTime}")
-            }
             if (r.startTime < memStartTime) { Some(RowKeyChunkScan(r.startkey, BinaryRecord.timestamp(endQuery))) }
             else                            { None }
           } else {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -52,7 +52,7 @@ extends MemStore with StrictLogging {
   /**
     * Retrieve shard for given dataset and shard number as an Option
     */
-  private[core] def getShard(dataset: DatasetRef, shard: Int): Option[TimeSeriesShard] =
+  private[filodb] def getShard(dataset: DatasetRef, shard: Int): Option[TimeSeriesShard] =
     datasets.get(dataset).flatMap { shards => Option(shards.get(shard)) }
 
   /**

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -16,6 +16,8 @@ object TimeSeriesPartition extends StrictLogging {
   val nullChunks    = UnsafeUtils.ZeroPointer.asInstanceOf[AppenderArray]
   val nullInfo      = ChunkSetInfo(UnsafeUtils.ZeroPointer.asInstanceOf[BinaryRegion.NativePointer])
 
+  val _log = logger
+
   def partKeyString(dataset: Dataset, partKeyBase: Any, partKeyOffset: Long): String = {
     dataset.partKeySchema.stringify(partKeyBase, partKeyOffset)
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -742,7 +742,8 @@ class TimeSeriesShard(val dataset: Dataset,
       val newPart = createNewPartition(partKeyArray, partKeyOffset, group)
       if (newPart != OutOfMemPartition) {
         val partId = newPart.partID
-        val startTime = binRecordReader.getLong(timestampColId)
+        // NOTE: Don't use binRecordReader here.  recordOffset might not be set correctly
+        val startTime = dataset.ingestionSchema.getLong(recordBase, recordOff, timestampColId)
         partKeyIndex.addPartKey(newPart.partKeyBytes, partId, startTime)()
         timeBucketBitmaps.get(currentIndexTimeBucket).set(partId)
         activelyIngesting.set(partId)

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -275,3 +275,50 @@ class FilteredChunkInfoIterator(base: ChunkInfoIterator, filter: ChunkSetInfo =>
     nextnext
   }
 }
+
+/**
+ * A RowReader that returns info about each ChunkSetInfo set via setInfo with a schema like this:
+ * 0:  ID (Long)
+ * 1:  NumRows (Int)
+ * 2:  startTime (Long)
+ * 3:  endTime (Long)
+ * 4:  numBytes(Int) of chunk
+ * 5:  readerclass of chunk
+ */
+class ChunkInfoRowReader(column: Column) extends RowReader {
+  import Column.ColumnType._
+  var info: ChunkSetInfo = _
+
+  def setInfo(newInfo: ChunkSetInfo): Unit = { info = newInfo }
+
+  def notNull(columnNo: Int): Boolean = columnNo < 6
+  def getBoolean(columnNo: Int): Boolean = ???
+  def getInt(columnNo: Int): Int = columnNo match {
+    case 1 => info.numRows
+    case 4 => BinaryVector.totalBytes(info.vectorPtr(column.id))
+  }
+  def getLong(columnNo: Int): Long = columnNo match {
+    case 0 => info.id
+    case 2 => info.startTime
+    case 3 => info.endTime
+  }
+
+  def getDouble(columnNo: Int): Double = ???
+  def getFloat(columnNo: Int): Float = ???
+  def getString(columnNo: Int): String = column.columnType match {
+    case IntColumn    => vectors.IntBinaryVector(info.vectorPtr(column.id)).getClass.getName
+    case LongColumn   => vectors.LongBinaryVector(info.vectorPtr(column.id)).getClass.getName
+    case TimestampColumn => vectors.LongBinaryVector(info.vectorPtr(column.id)).getClass.getName
+    case DoubleColumn => vectors.DoubleVector(info.vectorPtr(column.id)).getClass.getName
+    case StringColumn => vectors.UTF8Vector(info.vectorPtr(column.id)).getClass.getName
+    case o: Any       => "nananana, heyheyhey, goodbye"
+  }
+
+  override def filoUTF8String(columnNo: Int): ZeroCopyUTF8String = ZeroCopyUTF8String(getString(columnNo))
+
+  def getAny(columnNo: Int): Any = ???
+
+  def getBlobBase(columnNo: Int): Any = ???
+  def getBlobOffset(columnNo: Int): Long = ???
+  def getBlobNumBytes(columnNo: Int): Int = ???
+}

--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -45,8 +45,6 @@ object GatewayServer extends StrictLogging {
   // Get global configuration using universal FiloDB/Akka-based config
   val config = GlobalConfig.systemConfig
 
-  Kamon.loadReportersFromConfig()
-
   // ==== Metrics ====
   val numInfluxMessages = Kamon.counter("num-influx-messages")
   val numInfluxParseErrors = Kamon.counter("num-influx-parse-errors")
@@ -55,6 +53,8 @@ object GatewayServer extends StrictLogging {
   val containersSize = Kamon.histogram("containers-size-bytes")
 
   def main(args: Array[String]): Unit = {
+    Kamon.loadReportersFromConfig()
+
     if (args.length < 1) {
       //scalastyle:off
       println("Arguments: [path/to/source-config.conf]")

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -34,9 +34,7 @@ case object FlushCommand extends DataOrCommand
   *
   */
 object TestTimeseriesProducer extends StrictLogging {
-  val dataset = FormatConversion.dataset.copy(
-                  options = FormatConversion.dataset.options.copy(
-                    shardKeyColumns = Seq("__name__", "job")))
+  val dataset = FormatConversion.dataset
 
   class ProducerOptions(args: Seq[String]) extends ScallopConf(args) {
     val samplesPerSeries = opt[Int](short = 'n', default = Some(100),
@@ -99,9 +97,9 @@ object TestTimeseriesProducer extends StrictLogging {
       val endQuery = startQuery + 300
       val query =
         s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries """ +
-        s"""--promql 'heap_usage{dc="DC0",job="App-0"}' --start $startQuery --end $endQuery --limit 15"""
+        s"""--promql 'heap_usage{dc="DC0",app="App-0"}' --start $startQuery --end $endQuery --limit 15"""
       logger.info(s"Sample Query you can use: \n$query")
-      val q = URLEncoder.encode("heap_usage{dc=\"DC0\",job=\"App-0\"}", StandardCharsets.UTF_8.toString)
+      val q = URLEncoder.encode("heap_usage{dc=\"DC0\",app=\"App-0\"}", StandardCharsets.UTF_8.toString)
       val url = s"http://localhost:8080/promql/timeseries/api/v1/query_range?" +
         s"query=$q&start=$startQuery&end=$endQuery&step=15"
       logger.info(s"Sample URL you can use to query: \n$url")
@@ -150,7 +148,7 @@ object TestTimeseriesProducer extends StrictLogging {
       val value = 15 + Math.sin(n + 1) + rand.nextGaussian()
 
       val tags = Map("dc"       -> s"DC$dc",
-                     "job"      -> s"App-$app",
+                     "app"      -> s"App-$app",
                      "partition" -> s"partition-$partition",
                      "host"     -> s"H$host",
                      "instance" -> s"Instance-$instance")

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -6,20 +6,14 @@ import java.nio.charset.StandardCharsets
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.util.Random
-import scala.util.control.NonFatal
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
-import monix.execution.Scheduler
-import monix.kafka._
-import monix.reactive.Observable
 import org.rogach.scallop._
 
-import filodb.coordinator.ShardMapper
-import filodb.core.binaryrecord2.RecordBuilder
-import filodb.core.metadata.Dataset
-import filodb.gateway.KafkaContainerSink
-import filodb.memory.MemFactory
+import filodb.coordinator.{GlobalConfig, ShardMapper}
+import filodb.gateway.GatewayServer
+import filodb.gateway.conversion.PrometheusInputRecord
 import filodb.prometheus.FormatConversion
 
 sealed trait DataOrCommand
@@ -35,7 +29,6 @@ case object FlushCommand extends DataOrCommand
   *
   */
 object TestTimeseriesProducer extends StrictLogging {
-  import collection.JavaConverters._
 
   class ProducerOptions(args: Seq[String]) extends ScallopConf(args) {
     val samplesPerSeries = opt[Int](short = 'n', default = Some(100),
@@ -62,6 +55,7 @@ object TestTimeseriesProducer extends StrictLogging {
       .getOrElse((numSamples.toDouble / numTimeSeries / 6).ceil.toInt )  // at 6 samples per minute
 
     Await.result(produceMetrics(sourceConfig, numSamples, numTimeSeries, startMinutesAgo), 1.hour)
+    sys.exit(0)
   }
 
   /**
@@ -72,47 +66,49 @@ object TestTimeseriesProducer extends StrictLogging {
     * @param startMinutesAgo the samples will carry a timestamp starting from these many minutes ago
     * @return
     */
-  def produceMetrics(conf: Config, numSamples: Int, numTimeSeries: Int, startMinutesAgo: Long): Future[Unit] = {
+  def produceMetrics(sourceConfig: Config, numSamples: Int, numTimeSeries: Int, startMinutesAgo: Long): Future[Unit] = {
     val startTime = System.currentTimeMillis() - startMinutesAgo.minutes.toMillis
-    val numShards = conf.getInt("num-shards")
+    val numShards = sourceConfig.getInt("num-shards")
+    val shardMapper = new ShardMapper(numShards)
+    val spread = if (numShards >= 2) { (Math.log10(numShards / 2) / Math.log10(2.0)).toInt } else { 0 }
+    val dataset = FormatConversion.dataset.copy(
+                    options = FormatConversion.dataset.options.copy(
+                      shardKeyColumns = Seq("__name__", "job")))
+    val topicName = sourceConfig.getString("sourceconfig.filo-topic-name")
 
-    // TODO: use the official KafkaIngestionStream stuff to parse the file.  This is just faster for now.
-    val producerCfg = KafkaProducerConfig.default.copy(
-      bootstrapServers = conf.getString("sourceconfig.bootstrap.servers").split(',').toList
-    )
-    val topicName = conf.getString("sourceconfig.filo-topic-name")
+    val (shardQueues, containerStream) = GatewayServer.shardingPipeline(GlobalConfig.systemConfig, numShards, dataset)
+    GatewayServer.setupKafkaProducer(sourceConfig, containerStream)
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val producingFut = Future {
+      timeSeriesData(startTime, numShards, numTimeSeries)
+        .take(numSamples)
+        .foreach { sample =>
+          val rec = PrometheusInputRecord(sample.tags, dataset, sample.timestamp, sample.value)
+          val shard = shardMapper.ingestionShard(rec.shardKeyHash, rec.partitionKeyHash, spread)
+          while (!shardQueues(shard).offer(rec)) { Thread sleep 50 }
+        }
+    }
 
     logger.info(s"Started producing $numSamples messages into topic $topicName with timestamps " +
       s"from about ${(System.currentTimeMillis() - startTime) / 1000 / 60} minutes ago")
 
-    implicit val io = Scheduler.io("kafka-producer")
-
-    val shardKeys = Set("__name__", "job")  // the tag keys used to compute the shard key hash
-    val batchedData = timeSeriesData(startTime, numShards, numTimeSeries)
-                        .take(numSamples)
-                        .grouped(128)
-    val containerStream = batchSingleThreaded(Observable.fromIterator(batchedData),
-                                              FormatConversion.dataset, numShards, shardKeys)
-    val sink = new KafkaContainerSink(producerCfg, topicName)
-    sink.writeTask(containerStream)
-        .runAsync
-        .map { _ =>
-          logger.info(s"Finished producing $numSamples messages into topic $topicName with timestamps " +
-            s"from about ${(System.currentTimeMillis() - startTime) / 1000 / 60} minutes ago at $startTime")
-          val startQuery = startTime / 1000
-          val endQuery = startQuery + 300
-          val query =
-            s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries """ +
-            s"""--promql 'heap_usage{dc="DC0",job="App-0"}' --start $startQuery --end $endQuery --limit 15"""
-          logger.info(s"Sample Query you can use: \n$query")
-          val q = URLEncoder.encode("heap_usage{dc=\"DC0\",job=\"App-0\"}", StandardCharsets.UTF_8.toString)
-          val url = s"http://localhost:8080/promql/timeseries/api/v1/query_range?" +
-            s"query=$q&start=$startQuery&end=$endQuery&step=15"
-          logger.info(s"Sample URL you can use to query: \n$url")
-        }
-        .recover { case NonFatal(e) =>
-          logger.error("Error occurred while producing messages to Kafka", e)
-        }
+    producingFut.map { _ =>
+      // Give enough time for the last containers to be sent off successfully to Kafka
+      Thread sleep 2000
+      logger.info(s"Finished producing $numSamples messages into topic $topicName with timestamps " +
+        s"from about ${(System.currentTimeMillis() - startTime) / 1000 / 60} minutes ago at $startTime")
+      val startQuery = startTime / 1000
+      val endQuery = startQuery + 300
+      val query =
+        s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries """ +
+        s"""--promql 'heap_usage{dc="DC0",job="App-0"}' --start $startQuery --end $endQuery --limit 15"""
+      logger.info(s"Sample Query you can use: \n$query")
+      val q = URLEncoder.encode("heap_usage{dc=\"DC0\",job=\"App-0\"}", StandardCharsets.UTF_8.toString)
+      val url = s"http://localhost:8080/promql/timeseries/api/v1/query_range?" +
+        s"query=$q&start=$startQuery&end=$endQuery&step=15"
+      logger.info(s"Sample URL you can use to query: \n$url")
+    }
   }
 
   /**
@@ -142,84 +138,6 @@ object TestTimeseriesProducer extends StrictLogging {
                      "host"     -> s"H$host",
                      "instance" -> s"Instance-$instance")
       DataSample(tags, timestamp, value)
-    }
-  }
-
-  // scalastyle:off method.length
-  /**
-   * Batches the source data stream into separate RecordContainers per shard, single threaded,
-   * using proper logic to calculate hashes correctly for shard and partition hashes.
-   * @param {[Dataset]} dataset: Dataset the Dataset schema to use for encoding
-   * @param {[Int]} numShards: Int the total number of shards or Kafka partitions
-   * @param shardKeys The hash keys to use for shard number calculation
-   */
-  def batchSingleThreaded(items: Observable[Seq[DataSample]],
-                          dataset: Dataset,
-                          numShards: Int,
-                          shardKeys: Set[String],
-                          flushInterval: FiniteDuration = 1.second)
-                         (implicit io: Scheduler): Observable[(Int, Seq[Array[Byte]])] = {
-    val builders = (0 until numShards).map(s => new RecordBuilder(MemFactory.onHeapFactory, dataset.ingestionSchema))
-                                      .toArray
-    val shardMapper = new ShardMapper(numShards)
-    val spread = if (numShards >= 2) { (Math.log10(numShards / 2) / Math.log10(2.0)).toInt } else { 0 }
-
-    var streamIsDone: Boolean = false
-    // Flush at 1 second intervals until original item stream is complete.  Also send one last flush at the end.
-    val itemStream = items.doOnComplete(() => streamIsDone = true)
-    val flushStream = Observable.intervalAtFixedRate(flushInterval).map(n => FlushCommand)
-                                .takeWhile(n => !streamIsDone)
-    (Observable.merge(itemStream, flushStream) ++ Observable.now(FlushCommand))
-      .flatMap {
-        case s: Seq[DataSample] @unchecked =>
-          logger.debug(s"Adding batch of ${s.length} samples")
-          s.foreach { case DataSample(tags, timestamp, value) =>
-            // Compute keys/values for shard calculation vs original
-            // Specifically we need to drop _bucket _sum _count etc from __name__ to put histograms in same shard
-            val scalaKVs = tags.toSeq
-            val originalKVs = new java.util.ArrayList(scalaKVs.asJava)
-            val forShardKVs = scalaKVs.map { case (k, v) =>
-                                val trimmedVal = RecordBuilder.trimShardColumn(dataset, k, v)
-                                (k, trimmedVal)
-                              }
-            val kvsForShardCalc = new java.util.ArrayList(forShardKVs.asJava)
-
-            // Get hashes and sort tags of the keys/values for shard calculation
-            val hashes = RecordBuilder.sortAndComputeHashes(kvsForShardCalc)
-
-            // Compute partition, shard key hashes and compute shard number
-            // TODO: what to do if not all shard keys included?  Just return a 0 hash?  Or maybe random?
-            val shardKeyHash = 0 // TODO: this code is being replaced w/ the PrometheusInputRecord
-            val partKeyHash = RecordBuilder.combineHashExcluding(kvsForShardCalc, hashes, shardKeys)
-            val shard = shardMapper.ingestionShard(shardKeyHash, partKeyHash, spread)
-
-            // Add stuff to RecordContainer for correct partition/shard
-            originalKVs.sort(RecordBuilder.stringPairComparator)
-            val builder = builders(shard)
-            builder.startNewRecord()
-            builder.addLong(timestamp)
-            builder.addDouble(value)
-            builder.addSortedPairsAsMap(originalKVs, hashes)
-            builder.endRecord()
-          }
-          Observable.empty
-
-        case FlushCommand =>  // now produce records, turn into observable
-          Observable.fromIterable(flushBuilders(builders))
-      }
-  }
-  // scalastyle:on method.length
-
-  private def flushBuilders(builders: Array[RecordBuilder]): Seq[(Int, Seq[Array[Byte]])] = {
-    builders.zipWithIndex.map { case (builder, shard) =>
-      logger.debug(s"Flushing shard $shard with ${builder.allContainers.length} containers")
-
-      // get optimal byte arrays out of containers and reset builder so it can keep going
-      if (builder.allContainers.nonEmpty) {
-        (shard, builder.optimalContainerBytes(true))
-      } else {
-        (0, Nil)
-      }
     }
   }
 }

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -102,10 +102,10 @@ class QueryInMemoryBenchmark extends StrictLogging {
    * ## ========  Queries ===========
    * They are designed to match all the time series (common case) under a particular metric and job
    */
-  val queries = Seq("heap_usage{job=\"App-2\"}",  // raw time series
-                    """sum(rate(heap_usage{job="App-2"}[5m]))""",
-                    """quantile(0.75, heap_usage{job="App-2"})""",
-                    """sum_over_time(heap_usage{job="App-2"}[5m])""")
+  val queries = Seq("heap_usage{app=\"App-2\"}",  // raw time series
+                    """sum(rate(heap_usage{app="App-2"}[5m]))""",
+                    """quantile(0.75, heap_usage{app="App-2"})""",
+                    """sum_over_time(heap_usage{app="App-2"}[5m])""")
   val queryTime = startTime + (5 * 60 * 1000)  // 5 minutes from start until 60 minutes from start
   val qParams = QueryParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -13,10 +13,10 @@ import monix.eval.Task
 import monix.reactive.Observable
 import org.openjdk.jmh.annotations._
 
+import filodb.coordinator.ShardMapper
 import filodb.core.binaryrecord2.RecordContainer
 import filodb.core.memstore.{SomeData, TimeSeriesMemStore}
 import filodb.core.store.StoreConfig
-import filodb.prometheus.FormatConversion
 import filodb.prometheus.ast.QueryParams
 import filodb.prometheus.parse.Parser
 import filodb.query.{QueryError => QError, QueryResult => QueryResult2}
@@ -45,6 +45,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   val numQueries = 500
   val queryIntervalMin = 55  // # minutes between start and stop
   val queryStep = 60         // # of seconds between each query sample "step"
+  val spread = 1
 
   // TODO: move setup and ingestion to another trait
   val system = ActorSystem("test", ConfigFactory.load("filodb-defaults.conf"))
@@ -55,7 +56,9 @@ class QueryInMemoryBenchmark extends StrictLogging {
   private val clusterActor = cluster.clusterSingleton(ClusterRole.Server, None)
 
   // Set up Prometheus dataset in cluster, initialize in metastore
-  private val dataset = FormatConversion.dataset
+  private val dataset = TestTimeseriesProducer.dataset
+  private val shardMapper = new ShardMapper(numShards)
+
   Await.result(cluster.metaStore.initialize(), 3.seconds)
   Await.result(cluster.metaStore.newDataset(dataset), 5.seconds)
 
@@ -74,12 +77,9 @@ class QueryInMemoryBenchmark extends StrictLogging {
   // Manually pump in data ourselves so we know when it's done.
   // TODO: ingest into multiple shards
   Thread sleep 2000    // Give setup command some time to set up dataset shards etc.
-  val batchedData = TestTimeseriesProducer.timeSeriesData(startTime, numShards, numSeries)
-                                          .take(numSamples * numSeries)
-                                          .grouped(128)
-  val ingestTask = TestTimeseriesProducer.batchSingleThreaded(
-                    Observable.fromIterator(batchedData), dataset, numShards, Set("__name__", "job"))
-                    .groupBy(_._1)
+  val (producingFut, containerStream) = TestTimeseriesProducer.metricsToContainerStream(startTime, numShards, numSeries,
+                                          numSamples * numSeries, dataset, shardMapper, spread)
+  val ingestTask = containerStream.groupBy(_._1)
                     // Asynchronously subcribe and ingest each shard
                     .mapAsync(numShards) { groupedStream =>
                       val shard = groupedStream.key
@@ -93,7 +93,8 @@ class QueryInMemoryBenchmark extends StrictLogging {
                         cluster.memStore.ingestStream(dataset.ref, shard, shardStream, global) {
                           case e: Exception => throw e })
                     }.countL.runAsync
-  Await.result(ingestTask, 30.seconds)
+  Await.result(producingFut, 30.seconds)
+  Thread sleep 2000
   cluster.memStore.asInstanceOf[TimeSeriesMemStore].commitIndexForTesting(dataset.ref) // commit lucene index
   println(s"Ingestion ended")
 

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -129,10 +129,10 @@ class QueryOnDemandBenchmark extends StrictLogging {
    * ## ========  Queries ===========
    * They are designed to match all the time series (common case) under a particular metric and job
    */
-  val queries = Seq("heap_usage{job=\"App-2\"}",  // raw time series
-                    """quantile(0.75, heap_usage{job="App-2"})""",
-                    """sum(rate(heap_usage{job="App-1"}[5m]))""",
-                    """sum_over_time(heap_usage{job="App-0"}[5m])""")
+  val queries = Seq("heap_usage{app=\"App-2\"}",  // raw time series
+                    """quantile(0.75, heap_usage{app="App-2"})""",
+                    """sum(rate(heap_usage{app="App-1"}[5m]))""",
+                    """sum_over_time(heap_usage{app="App-0"}[5m])""")
   val queryTime = startTime + (5 * 60 * 1000)  // 5 minutes from start until 60 minutes from start
   val qParams = QueryParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -13,10 +13,10 @@ import monix.eval.Task
 import monix.reactive.Observable
 import org.openjdk.jmh.annotations.{Level => JmhLevel, _}
 
+import filodb.coordinator.ShardMapper
 import filodb.core.binaryrecord2.RecordContainer
 import filodb.core.memstore.{DataOrCommand, FlushStream, SomeData, TimeSeriesMemStore}
 import filodb.core.store.StoreConfig
-import filodb.prometheus.FormatConversion
 import filodb.prometheus.ast.QueryParams
 import filodb.prometheus.parse.Parser
 import filodb.query.{QueryError => QError, QueryResult => QueryResult2}
@@ -45,6 +45,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
   val numQueries = 10    // Should be low, so most queries actually hit C*/disk
   val queryIntervalMin = 55  // # minutes between start and stop
   val queryStep = 60         // # of seconds between each query sample "step"
+  val spread = 1
 
   // TODO: move setup and ingestion to another trait
   val config = ConfigFactory.parseString("""
@@ -61,7 +62,9 @@ class QueryOnDemandBenchmark extends StrictLogging {
   private val cluster = FilodbCluster(system)
 
   // Set up Prometheus dataset in cluster, initialize in metastore
-  private val dataset = FormatConversion.dataset
+  private val dataset = TestTimeseriesProducer.dataset
+  private val shardMapper = new ShardMapper(numShards)
+
   Await.result(cluster.metaStore.initialize(), 3.seconds)
   Await.result(cluster.metaStore.clearAllData(), 5.seconds)  // to clear IngestionConfig
   Await.result(cluster.metaStore.newDataset(dataset), 5.seconds)
@@ -91,12 +94,9 @@ class QueryOnDemandBenchmark extends StrictLogging {
   // Manually pump in data ourselves so we know when it's done.
   // TODO: ingest into multiple shards
   Thread sleep 2000    // Give setup command some time to set up dataset shards etc.
-  val batchedData = TestTimeseriesProducer.timeSeriesData(startTime, numShards, numSeries)
-                                          .take(numSamples * numSeries)
-                                          .grouped(128)
-  val ingestTask = TestTimeseriesProducer.batchSingleThreaded(
-                    Observable.fromIterator(batchedData), dataset, numShards, Set("__name__", "job"))
-                    .groupBy(_._1)
+  val (producingFut, containerStream) = TestTimeseriesProducer.metricsToContainerStream(startTime, numShards, numSeries,
+                                          numSamples * numSeries, dataset, shardMapper, spread)
+  val ingestTask = containerStream.groupBy(_._1)
                     // Asynchronously subcribe and ingest each shard
                     .mapAsync(numShards) { groupedStream =>
                       val shard = groupedStream.key
@@ -112,7 +112,8 @@ class QueryOnDemandBenchmark extends StrictLogging {
                         memStore.ingestStream(dataset.ref, shard, combinedStream, global, 3 * 86400) {
                           case e: Exception => throw e })
                     }.countL.runAsync
-  Await.result(ingestTask, 30.seconds)
+  Await.result(producingFut, 30.seconds)
+  Thread sleep 2000
   memStore.commitIndexForTesting(dataset.ref) // commit lucene index
   println(s"Ingestion ended.")
 

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -135,6 +135,7 @@ object FiloSettings extends Build {
       internalDependencyClasspath in IntegrationTest, exportedProducts in Test)).value)
 
   lazy val multiJvmSettings = SbtMultiJvm.multiJvmSettings ++ Seq(
+    javaOptions in MultiJvm := Seq("-Xmx2G", "-Dakka.test.timefactor=3"),
     compile in MultiJvm := ((compile in MultiJvm) triggeredBy (compile in Test)).value)
 
   lazy val testMultiJvmToo = Seq(

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -9,7 +9,8 @@ trait Functions extends Base with Operators with Vectors {
 
     if (!ignoreChecks &&
       InstantFunctionId.withNameLowercaseOnlyOption(name.toLowerCase).isEmpty &&
-      RangeFunctionId.withNameLowercaseOnlyOption(name.toLowerCase).isEmpty) {
+      RangeFunctionId.withNameLowercaseOnlyOption(name.toLowerCase).isEmpty &&
+      FiloFunctionId.withNameLowercaseOnlyOption(name.toLowerCase).isEmpty) {
       throw new IllegalArgumentException(s"Invalid function name [$name]")
     }
 
@@ -17,12 +18,26 @@ trait Functions extends Base with Operators with Vectors {
       val seriesParam = allParams.filter(_.isInstanceOf[Series]).head.asInstanceOf[Series]
       val otherParams = allParams.filter(!_.isInstanceOf[Series]).map(_.asInstanceOf[Scalar].toScalar)
       val instantFunctionIdOpt = InstantFunctionId.withNameInsensitiveOption(name)
+      val filoFunctionIdOpt = FiloFunctionId.withNameInsensitiveOption(name)
 
       if (instantFunctionIdOpt.isDefined) {
         val instantFunctionId = instantFunctionIdOpt.get
         val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(queryParams)
 
         ApplyInstantFunction(periodicSeriesPlan, instantFunctionId, otherParams)
+      // Special FiloDB functions to extract things like chunk metadata
+      } else if (filoFunctionIdOpt.isDefined) {
+        // No lookback needed as we are looking at chunk metadata only, not raw samples
+        val rangeSelector = IntervalSelector(Seq(queryParams.start * 1000),
+                                             Seq(queryParams.end * 1000))
+        val filters = seriesParam match {
+          case i: InstantExpression => i.columnFilters :+ i.nameFilter
+          case r: RangeExpression   => r.columnFilters :+ r.nameFilter
+        }
+        filoFunctionIdOpt.get match {
+          case FiloFunctionId.ChunkMetaAll =>   // Just get the raw chunk metadata
+            RawChunkMeta(rangeSelector, filters, "")
+        }
       } else {
         val rangeFunctionId = RangeFunctionId.withNameInsensitiveOption(name).get
         val rangeExpression = seriesParam.asInstanceOf[RangeExpression]

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -111,9 +111,9 @@ trait Vectors extends Scalars with TimeUnits with Base {
       throw new IllegalArgumentException("Metric name should not be set twice")
     }
 
-    private val columnFilters = labelMatchesToFilters(labelSelection)
+    private[prometheus] val columnFilters = labelMatchesToFilters(labelSelection)
 
-    private val nameFilter = ColumnFilter("__name__", query.Filter.Equals(metricName))
+    private[prometheus] val nameFilter = ColumnFilter("__name__", query.Filter.Equals(metricName))
 
     def toPeriodicSeriesPlan(queryParams: QueryParams): PeriodicSeriesPlan = {
 
@@ -144,9 +144,9 @@ trait Vectors extends Scalars with TimeUnits with Base {
       throw new IllegalArgumentException("Metric name should not be set twice")
     }
 
-    private val columnFilters = labelMatchesToFilters(labelSelection)
+    private[prometheus] val columnFilters = labelMatchesToFilters(labelSelection)
 
-    private val nameFilter = ColumnFilter("__name__", query.Filter.Equals(metricName))
+    private[prometheus] val nameFilter = ColumnFilter("__name__", query.Filter.Equals(metricName))
 
     val allFilters: Seq[ColumnFilter] = columnFilters :+ nameFilter
 

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -212,8 +212,6 @@ trait Selector extends Operator with Unit with BaseParser {
     }
 
   lazy val vector: PackratParser[Vector] = rangeVectorSelector | instantVectorSelector
-
-
 }
 
 ////////////////////// END SELECTORS ///////////////////////////////////////////

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -38,7 +38,7 @@ case class RawSeries(rangeSelector: RangeSelector,
  */
 case class RawChunkMeta(rangeSelector: RangeSelector,
                         filters: Seq[ColumnFilter],
-                        column: String) extends RawSeriesPlan
+                        column: String) extends PeriodicSeriesPlan
 
 /**
   * Concrete logical plan to query for data in a given range

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -33,6 +33,14 @@ case class RawSeries(rangeSelector: RangeSelector,
                      columns: Seq[String]) extends RawSeriesPlan
 
 /**
+ * Concrete logical plan to query for chunk metadata from raw time series in a given range
+ * @param column the column name from which to extract chunk information like chunk size and encoding type
+ */
+case class RawChunkMeta(rangeSelector: RangeSelector,
+                        filters: Seq[ColumnFilter],
+                        column: String) extends RawSeriesPlan
+
+/**
   * Concrete logical plan to query for data in a given range
   * with results in a regular time interval.
   *

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -104,6 +104,14 @@ object RangeFunctionId extends Enum[RangeFunctionId] {
 
 }
 
+sealed abstract class FiloFunctionId(override val entryName: String) extends EnumEntry
+
+object FiloFunctionId extends Enum[FiloFunctionId] {
+  val values = findValues
+
+  case object ChunkMetaAll extends FiloFunctionId("_filodb_chunkmeta_all")
+}
+
 sealed abstract class AggregationOperator(override val entryName: String) extends EnumEntry
 
 object AggregationOperator extends Enum[AggregationOperator] {

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -1,0 +1,72 @@
+package filodb.query.exec
+
+import scala.concurrent.duration.FiniteDuration
+
+import monix.execution.Scheduler
+import monix.reactive.Observable
+
+import filodb.core.{DatasetRef, Types}
+import filodb.core.metadata.{Column, Dataset}
+import filodb.core.query._
+import filodb.core.store.{AllChunkScan, ChunkSource, FilteredPartitionScan, RowKeyChunkScan, ShardSplit}
+import filodb.query.QueryConfig
+
+object SelectChunkInfosExec {
+  import Column.ColumnType._
+
+  val ChunkInfosSchema = ResultSchema(
+    Seq(
+      ColumnInfo("id", LongColumn),
+      ColumnInfo("numRows", IntColumn),
+      ColumnInfo("startTime", LongColumn),
+      ColumnInfo("endTime", LongColumn),
+      ColumnInfo("numBytes", IntColumn),
+      ColumnInfo("readerKlazz", StringColumn)
+    ), 0
+  )
+}
+
+/**
+  * ExecPlan to select raw ChunkInfos and chunk stats from partitions that the given filter resolves to,
+  * in the given shard, for the given row key range, for one particular column
+  * ID (Long), NumRows (Int), startTime (Long), endTime (Long), numBytes(I) of chunk, readerclass of chunk
+  */
+final case class SelectChunkInfosExec(id: String,
+                                      submitTime: Long,
+                                      limit: Int,
+                                      dispatcher: PlanDispatcher,
+                                      dataset: DatasetRef,
+                                      shard: Int,
+                                      filters: Seq[ColumnFilter],
+                                      rowKeyRange: RowKeyRange,
+                                      column: Types.ColumnId) extends LeafExecPlan {
+  import SelectChunkInfosExec._
+
+  protected def schemaOfDoExecute(dataset: Dataset): ResultSchema = ChunkInfosSchema
+
+  protected def doExecute(source: ChunkSource,
+                          dataset: Dataset,
+                          queryConfig: QueryConfig)
+                         (implicit sched: Scheduler,
+                          timeout: FiniteDuration): Observable[RangeVector] = {
+    val dataColumn = dataset.dataColumns(column)
+    val chunkMethod = rowKeyRange match {
+      case RowKeyInterval(from, to) => RowKeyChunkScan(from, to)
+      case AllChunks => AllChunkScan
+      case WriteBuffers => ???
+      case EncodedChunks => ???
+    }
+    val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
+    val partCols = dataset.infosFromIDs(dataset.partitionColumns.map(_.id))
+    source.scanPartitions(dataset, Seq(column), partMethod, chunkMethod)
+          .map { partition =>
+            source.stats.incrReadPartitions(1)
+            val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,
+                                                  dataset.partKeySchema, partCols, shard)
+            ChunkInfoRangeVector(key, partition, chunkMethod, dataColumn)
+          }
+  }
+
+  protected def args: String = s"shard=$shard, rowKeyRange=$rowKeyRange, filters=$filters"
+}
+

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -64,7 +64,7 @@ final case class SelectChunkInfosExec(id: String,
             val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,
                                                   dataset.partKeySchema, partCols, shard)
             ChunkInfoRangeVector(key, partition, chunkMethod, dataColumn)
-          }
+          }.filter(_.rows.nonEmpty)
   }
 
   protected def args: String = s"shard=$shard, rowKeyRange=$rowKeyRange, filters=$filters"

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -58,6 +58,7 @@ final case class SelectRawPartitionsExec(id: String,
   /**
     * Convert column name strings into columnIDs.  NOTE: column names should not include row key columns
     * as those are automatically prepended.
+    * TODO: move this step to logical -> physical plan conversion validation
     */
   private def getColumnIDs(dataset: Dataset, cols: Seq[String]): Seq[Types.ColumnId] = {
     val ids = dataset.colIDs(cols: _*)

--- a/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
@@ -92,7 +92,7 @@ abstract class ClusterSingletonFailoverSpec extends StandaloneMultiJvmSpec(Clust
       colStore.initialize(dataset).futureValue shouldBe Success
       colStore.truncate(dataset).futureValue shouldBe Success
 
-      val datasetObj = TestTimeseriesProducer.dataset.copy(name = "timeseries")
+      val datasetObj = TestTimeseriesProducer.dataset
       metaStore.newDataset(datasetObj).futureValue shouldBe Success
       colStore.initialize(dataset).futureValue shouldBe Success
       logger.info("Dataset created")

--- a/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 
 import filodb.coordinator._
 import filodb.coordinator.client.LocalClient
-import filodb.core.{MetricsTestData, Success}
+import filodb.core.Success
 import filodb.timeseries.TestTimeseriesProducer
 
 object ClusterSingletonFailoverMultiNodeConfig extends MultiNodeConfig {
@@ -23,7 +23,7 @@ object ClusterSingletonFailoverMultiNodeConfig extends MultiNodeConfig {
   val myConfig = overrides.withFallback(GlobalConfig.systemConfig)
   commonConfig(myConfig)
 
-  val ingestDuration = 15.seconds
+  val ingestDuration = 70.seconds   // Needs to be long enough to allow Lucene to flush index
 
   def overrides: Config = ConfigFactory.parseString(
     """
@@ -92,7 +92,7 @@ abstract class ClusterSingletonFailoverSpec extends StandaloneMultiJvmSpec(Clust
       colStore.initialize(dataset).futureValue shouldBe Success
       colStore.truncate(dataset).futureValue shouldBe Success
 
-      val datasetObj = MetricsTestData.timeseriesDataset
+      val datasetObj = TestTimeseriesProducer.dataset.copy(name = "timeseries")
       metaStore.newDataset(datasetObj).futureValue shouldBe Success
       colStore.initialize(dataset).futureValue shouldBe Success
       logger.info("Dataset created")
@@ -165,18 +165,20 @@ abstract class ClusterSingletonFailoverSpec extends StandaloneMultiJvmSpec(Clust
     enterBarrier("cluster-status-normal-on-cli")
   }
 
+        // NOTE: 10000 samples / 100 time series = 100 samples per series
+        // 100 * 10s = 1000seconds =~ 16 minutes
+  val queryTimestamp = System.currentTimeMillis() - 195.minutes.toMillis
+
   it should "be able to ingest data into FiloDB via Kafka" in {
-    within(ingestDuration + 5.seconds) {
+    within(chunkDurationTimeout) {
       runOn(third) {
-        val task = TestTimeseriesProducer.produceMetrics(source, 1000, 100, 400)
+        TestTimeseriesProducer.produceMetrics(source, 10000, 100, 200)
         info(s"Waiting for ingest-duration ($ingestDuration) to pass")
-        awaitCond(task.isCompleted, ingestDuration)
+        Thread.sleep(chunkDuration.toMillis + 7000)
       }
       enterBarrier("data1-ingested")
     }
   }
-
-  val queryTimestamp = System.currentTimeMillis() - 395.minutes.toMillis
 
   it should "answer query successfully" in {
     runOn(first, third) { // TODO check second=UnknownDataset

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -159,7 +159,7 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
   it should "be able to ingest larger amounts of data into FiloDB via Kafka again" in {
     within(chunkDurationTimeout) {
       runOn(first) {
-        queryTimestamp = System.currentTimeMillis() - 195.minutes.toMillis
+        queryTimestamp = System.currentTimeMillis() - 100.minutes.toMillis
         TestTimeseriesProducer.produceMetrics(source, 10000, 100, 200).futureValue(producePatience)
         info("Waiting for part of the chunk-duration so that there are unpersisted chunks")
         Thread.sleep(chunkDuration.toMillis / 3)
@@ -170,6 +170,10 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
 
   it should "answer query successfully" in {
     runOn(first) {
+      // Print the top values in each shard just for debugging
+      topValuesInShards(client1, "job", 0 to 3)
+      topValuesInShards(client1, "dc", 0 to 3)
+
       query1Response = runCliQuery(client1, queryTimestamp)
       val httpQueryResponse = runHttpQuery(queryTimestamp)
       query1Response shouldEqual httpQueryResponse

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -87,7 +87,7 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
 
   it should "be able to create dataset on node 1" in {
     runOn(first) {
-      val datasetObj = TestTimeseriesProducer.dataset.copy(name = "timeseries")
+      val datasetObj = TestTimeseriesProducer.dataset
       metaStore.newDataset(datasetObj).futureValue shouldBe Success
       colStore.initialize(dataset).futureValue shouldBe Success
       info("Dataset created")

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import filodb.coordinator._
 import filodb.coordinator.NodeClusterActor.SubscribeShardUpdates
 import filodb.coordinator.client.Client
-import filodb.core.{MetricsTestData, Success}
+import filodb.core.Success
 import filodb.timeseries.TestTimeseriesProducer
 
 object IngestionAndRecoveryMultiNodeConfig extends MultiNodeConfig {
@@ -87,7 +87,7 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
 
   it should "be able to create dataset on node 1" in {
     runOn(first) {
-      val datasetObj = MetricsTestData.timeseriesDataset
+      val datasetObj = TestTimeseriesProducer.dataset.copy(name = "timeseries")
       metaStore.newDataset(datasetObj).futureValue shouldBe Success
       colStore.initialize(dataset).futureValue shouldBe Success
       info("Dataset created")
@@ -173,7 +173,7 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
   it should "answer query successfully" in {
     runOn(first) {
       // Print the top values in each shard just for debugging
-      topValuesInShards(client1, "job", 0 to 3)
+      topValuesInShards(client1, "app", 0 to 3)
       topValuesInShards(client1, "dc", 0 to 3)
 
       query1Response = runCliQuery(client1, queryTimestamp)

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -159,7 +159,9 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
   it should "be able to ingest larger amounts of data into FiloDB via Kafka again" in {
     within(chunkDurationTimeout) {
       runOn(first) {
-        queryTimestamp = System.currentTimeMillis() - 100.minutes.toMillis
+        // NOTE: 10000 samples / 100 time series = 100 samples per series
+        // 100 * 10s = 1000seconds =~ 16 minutes
+        queryTimestamp = System.currentTimeMillis() - 195.minutes.toMillis
         TestTimeseriesProducer.produceMetrics(source, 10000, 100, 200).futureValue(producePatience)
         info("Waiting for part of the chunk-duration so that there are unpersisted chunks")
         Thread.sleep(chunkDuration.toMillis / 3)

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -169,7 +169,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     import PromCirceSupport._
 
     implicit val sttpBackend = AkkaHttpBackend()
-    val url = uri"http://localhost:8080/promql/timeseries/api/v1/query?query=$query&time=${queryTimestamp/1000}"
+    val url = uri"http://localhost:8080/promql/prometheus/api/v1/query?query=$query&time=${queryTimestamp/1000}"
     info(s"Querying: $url")
     val result1 = sttp.get(url).response(asJson[SuccessResponse]).send().futureValue.unsafeBody.right.get.data.result
     val result = result1.flatMap(_.values.map { d => (d.timestamp, d.value) })
@@ -194,7 +194,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
                                   .setStartTimestampMs(start)
                                   .setEndTimestampMs(queryTimestamp / 1000 * 1000)
     val rr = Snappy.compress(ReadRequest.newBuilder().addQueries(query).build().toByteArray())
-    val url = uri"http://localhost:8080/promql/timeseries/api/v1/read"
+    val url = uri"http://localhost:8080/promql/prometheus/api/v1/read"
     info(s"Querying: $url")
     val result1 = sttp.post(url).body(rr).response(asByteArray).send().futureValue.unsafeBody
     val result = ReadResponse.parseFrom(Snappy.uncompress(result1))

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -145,7 +145,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     }
   }
 
-  val query = "heap_usage{dc=\"DC0\",job=\"App-2\"}[1m]"
+  val query = "heap_usage{dc=\"DC0\",app=\"App-2\"}[1m]"
   // queryTimestamp is in millis
   def runCliQuery(client: LocalClient, queryTimestamp: Long): Double = {
     val logicalPlan = Parser.queryToLogicalPlan(query, queryTimestamp/1000)
@@ -187,7 +187,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val end = queryTimestamp / 1000 * 1000
     val nameMatcher = LabelMatcher.newBuilder().setName("__name__").setValue("heap_usage")
     val dcMatcher = LabelMatcher.newBuilder().setName("dc").setValue("DC0")
-    val jobMatcher = LabelMatcher.newBuilder().setName("job").setValue("App-2")
+    val jobMatcher = LabelMatcher.newBuilder().setName("app").setValue("App-2")
     val query = Query.newBuilder().addMatchers(nameMatcher)
                                   .addMatchers(dcMatcher)
                                   .addMatchers(jobMatcher)

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -138,16 +138,25 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     }
   }
 
-  val query = "heap_usage{dc=\"DC0\",job=\"App-2\"}[1m]"
+  def topValuesInShards(client: LocalClient, tagKey: String, shards: Seq[Int]): Unit = {
+    shards.foreach { shard =>
+      val values = client.getIndexValues(dataset, tagKey, shard)
+      info(s"Top values for shard=$shard tag=$tagKey is: $values")
+    }
+  }
+
+  val query = "heap_usage{dc=\"DC0\",job=\"App-2\"}[1h]"
   // queryTimestamp is in millis
   def runCliQuery(client: LocalClient, queryTimestamp: Long): Double = {
     val logicalPlan = Parser.queryToLogicalPlan(query, queryTimestamp/1000)
 
+    val curTime = System.currentTimeMillis
     val result = client.logicalPlan2Query(dataset, logicalPlan) match {
       case r: QueryResult2 =>
-        val vals = r.result.flatMap(_.rows.map(_.getDouble(1)))
+        val vals = r.result.flatMap(_.rows.map { r => (r.getLong(0) - curTime, r.getDouble(1)) })
         info(s"result values were $vals")
-        vals.sum
+        vals.length should be > 0
+        vals.map(_._2).sum
       case e: QueryError => fail(e.t)
     }
     info(s"CLI Query Result for $query at $queryTimestamp was $result")
@@ -163,10 +172,12 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val url = uri"http://localhost:8080/promql/timeseries/api/v1/query?query=$query&time=${queryTimestamp/1000}"
     info(s"Querying: $url")
     val result1 = sttp.get(url).response(asJson[SuccessResponse]).send().futureValue.unsafeBody.right.get.data.result
-    val result = result1.flatMap(_.values.map(_.value))
+    val result = result1.flatMap(_.values.map { d => (d.timestamp, d.value) })
     info(s"result values were $result")
-    info(s"HTTP Query Result for $query at $queryTimestamp was ${result.sum}")
-    result.sum
+    result.length should be > 0
+    val sum = result.map(_._2).sum
+    info(s"HTTP Query Result for $query at $queryTimestamp was $sum")
+    sum
   }
 
   def runRemoteReadQuery(queryTimestamp: Long): Double = {

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -145,7 +145,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     }
   }
 
-  val query = "heap_usage{dc=\"DC0\",job=\"App-2\"}[1h]"
+  val query = "heap_usage{dc=\"DC0\",job=\"App-2\"}[1m]"
   // queryTimestamp is in millis
   def runCliQuery(client: LocalClient, queryTimestamp: Long): Double = {
     val logicalPlan = Parser.queryToLogicalPlan(query, queryTimestamp/1000)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

This PR creates a new special function, parseable through PromQL, `_filodb_chunkmeta_all` which returns `ChunkSetInfo` records for matching time series.  It returns all the fields from the ChunkSetInfo plus additional data (# bytes and the Reader class) for chunks in one particular column.  This data can be used to debug many issues including potential missing chunks or missing data, as well as to debug encoding and compression issues.

other related changes:
- One line minor fix for index startTime
- Fixed the standalone IngestionAndRecoverySpec; switched TestTimeseriesProducer to use the new Gateway pipeline

