### PR TITLE
feat(core,gateway): Unify shardKeyHash algorithm and add copyTags feature to PromInputRecord

### DIFF
--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -160,9 +160,10 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
     config.root.render(ConfigRenderOptions.concise)
   }
 
-  val nonMetricShardColumns = shardKeyColumns.filterNot(_ == metricColumn)
+  val nonMetricShardColumns = shardKeyColumns.filterNot(_ == metricColumn).sorted
   val nonMetricShardKeyBytes = nonMetricShardColumns.map(_.getBytes).toArray
   val nonMetricShardKeyHash = nonMetricShardKeyBytes.map(BinaryRegion.hash32)
+  val ignorePartKeyHashTags = ignoreTagsOnPartitionKeyHash.toSet
 
   val metricBytes = metricColumn.getBytes
   val metricHash = BinaryRegion.hash32(metricBytes)

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -147,7 +147,9 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
                           // TODO: deprecate these options once we move all input to Telegraf/Influx
                           // They are needed only to differentiate raw Prometheus-sourced data
                           ignoreShardKeyColumnSuffixes: Map[String, Seq[String]] = Map.empty,
-                          ignoreTagsOnPartitionKeyHash: Seq[String] = Nil) {
+                          ignoreTagsOnPartitionKeyHash: Seq[String] = Nil,
+                          // For each key, copy the tag to the value if the value is absent
+                          copyTags: Map[String, String] = Map.empty) {
   override def toString: String = {
     val map: Map[String, Any] = Map(
                    "shardKeyColumns" -> shardKeyColumns.asJava,
@@ -155,7 +157,8 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
                    "valueColumn" -> valueColumn,
                    "ignoreShardKeyColumnSuffixes" ->
                      ignoreShardKeyColumnSuffixes.mapValues(_.asJava).asJava,
-                   "ignoreTagsOnPartitionKeyHash" -> ignoreTagsOnPartitionKeyHash.asJava)
+                   "ignoreTagsOnPartitionKeyHash" -> ignoreTagsOnPartitionKeyHash.asJava,
+                   "copyTags" -> copyTags.asJava)
     val config = ConfigFactory.parseMap(map.asJava)
     config.root.render(ConfigRenderOptions.concise)
   }
@@ -173,6 +176,7 @@ object DatasetOptions {
   val DefaultOptions = DatasetOptions(shardKeyColumns = Nil,
                                       metricColumn = "__name__",
                                       valueColumn = "value",
+                                      // defaults that work well for Prometheus
                                       ignoreShardKeyColumnSuffixes =
                                         Map("__name__" -> Seq("_bucket", "_count", "_sum")),
                                       ignoreTagsOnPartitionKeyHash = Seq("le"))
@@ -187,7 +191,8 @@ object DatasetOptions {
                    valueColumn = config.getString("valueColumn"),
                    ignoreShardKeyColumnSuffixes =
                      config.as[Map[String, Seq[String]]]("ignoreShardKeyColumnSuffixes"),
-                   ignoreTagsOnPartitionKeyHash = config.as[Seq[String]]("ignoreTagsOnPartitionKeyHash"))
+                   ignoreTagsOnPartitionKeyHash = config.as[Seq[String]]("ignoreTagsOnPartitionKeyHash"),
+                   copyTags = config.as[Map[String, String]]("copyTags"))
 }
 
 /**

--- a/core/src/test/scala/filodb.core/binaryrecord2/HashRandomnessSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/HashRandomnessSpec.scala
@@ -1,31 +1,25 @@
 package filodb.core.binaryrecord2
 
-import java.util.ArrayList
-
 import org.scalatest.{FunSpec, Matchers}
 
 /**
  * A test to ensure that the hashing algorithm used in RecordBuilder for maps is random enough
  */
 class HashRandomnessSpec extends FunSpec with Matchers {
-  import collection.JavaConverters._
 
   val NumPairs = 10000
 
   // val apps = Seq("prometheus", "cassandra", "kafka", "filodb")
-  def genPairs(i: Int): ArrayList[(String, String)] = {
+  def genPairs(i: Int): Map[String, String] = {
     // val app = apps(i % apps.length)
-    new ArrayList(Map("__name__" -> s"Counter${i % 100}", "job" -> s"App-$i").toList.asJava)
+    Map("__name__" -> s"Counter${i % 100}", "job" -> s"App-$i")
   }
 
   it("RecordBuilder.sortAndComputeHashes/combineHashes should be random enough") {
     val allPairs = (0 until NumPairs).map(genPairs)
-    val hashes = allPairs.map { pairs => RecordBuilder.sortAndComputeHashes(pairs) }
 
-    // println(s"allPairs=${allPairs.take(100)}\nhashes=${hashes.take(100).map(_.toList)}")
-
-    val shardHashes = allPairs.zip(hashes).map { case (pairs, hashes) =>
-      RecordBuilder.combineHashIncluding(pairs, hashes, Set("__name__", "job")).get
+    val shardHashes = allPairs.map { case pairs =>
+      RecordBuilder.shardKeyHash(Seq(pairs("job")), pairs("__name__"))
     }
 
     // println(s"shardHashes=${shardHashes.take(100)}")

--- a/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
@@ -148,6 +148,8 @@ class DatasetSpec extends FunSpec with Matchers {
   describe("Dataset serialization") {
     it("should serialize and deserialize") {
       val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, "age")
+                 .copy(options = DatasetOptions.DefaultOptions.copy(
+                   copyTags = Map("exporter" -> "app")))
       Dataset.fromCompactString(ds.asCompactString) shouldEqual ds
 
       val ds2 = ds.copy(options = DatasetOptions.DefaultOptions.copy(shardKeyColumns = Seq("metric")))

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
@@ -37,7 +37,6 @@ trait InfluxRecord extends InputRecord {
             nonMetricShardValues += new String(bytes, valueIndex, valueLen)
 
             // calculate hash too
-            tagsShardHash = RecordBuilder.combineHash(tagsShardHash, dsOptions.nonMetricShardKeyHash(nonMetricIndex))
             nonMetricIndex += 1
             val valueHash = BinaryRegion.hasher32.hash(bytes, valueIndex, valueLen, BinaryRegion.Seed)
             tagsShardHash = RecordBuilder.combineHash(tagsShardHash, valueHash)

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -108,7 +108,15 @@ object PrometheusInputRecord {
   }
 
   def transformTags(tags: Seq[(String, String)], dataset: Dataset): Seq[(String, String)] = {
-    // TODO: look for "app" or non-metric shardKey. If not present, use alternatives
-    tags
+    val keys = tags.map(_._1).toSet
+    val extraTags = new collection.mutable.ArrayBuffer[(String, String)]()
+    tags.foreach { case (k, v) =>
+      if (dataset.options.copyTags contains k) {
+        val renamedKey = dataset.options.copyTags(k)
+        if (!(keys contains renamedKey))
+          extraTags += renamedKey -> v
+      }
+    }
+    tags ++ extraTags
   }
 }

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -189,7 +189,7 @@ object TestTimeseriesProducer extends StrictLogging {
 
             // Compute partition, shard key hashes and compute shard number
             // TODO: what to do if not all shard keys included?  Just return a 0 hash?  Or maybe random?
-            val shardKeyHash = RecordBuilder.combineHashIncluding(kvsForShardCalc, hashes, shardKeys).get
+            val shardKeyHash = 0 // TODO: this code is being replaced w/ the PrometheusInputRecord
             val partKeyHash = RecordBuilder.combineHashExcluding(kvsForShardCalc, hashes, shardKeys)
             val shard = shardMapper.ingestionShard(shardKeyHash, partKeyHash, spread)
 

--- a/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
@@ -59,6 +59,9 @@ class InfluxRecordSpec extends FunSpec with Matchers {
       recordOpts(3).get.shardKeyHash shouldEqual thirdShardHash
       println(thirdShardHash)
 
+      // Should match what is computable with shardKeyHash method
+      thirdShardHash shouldEqual RecordBuilder.shardKeyHash(Seq("filodb"), "num_partitions")
+
       val thirdPartHash = recordOpts(2).get.partitionKeyHash
       thirdPartHash should not equal (7)
       recordOpts(3).get.partitionKeyHash should not equal (thirdPartHash)

--- a/gateway/src/test/scala/filodb/gateway/conversion/PrometheusInputRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/PrometheusInputRecordSpec.scala
@@ -1,0 +1,59 @@
+package filodb.gateway.conversion
+
+import org.scalatest.{FunSpec, Matchers}
+
+import remote.RemoteStorage.{LabelPair, Sample, TimeSeries}
+
+import filodb.core.binaryrecord2.{RecordBuilder, StringifyMapItemConsumer}
+import filodb.memory.MemFactory
+import filodb.prometheus.FormatConversion
+
+object TimeSeriesFixture {
+  //  "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,app=filodb counter=0 1536790212000000000",
+  def timeseries(no: Int, tags: Map[String, String]): TimeSeries = {
+    val builder = TimeSeries.newBuilder
+                    .addSamples(Sample.newBuilder.setTimestampMs(1000000L + no).setValue(1.1 + no).build)
+    tags.foldLeft(builder) { case (b, (k, v)) =>
+      b.addLabels(LabelPair.newBuilder.setName(k).setValue(v).build)
+    }.build
+  }
+}
+
+class PrometheusInputRecordSpec extends FunSpec with Matchers {
+  val dataset = FormatConversion.dataset
+  val baseTags = Map("dataset" -> "timeseries",
+                     "host" -> "MacBook-Pro-229.local",
+                     "shard" -> "0")
+  val tagsWithMetric = baseTags + ("__name__" -> "num_partitions")
+
+  it("should parse from TimeSeries proto and write to RecordBuilder") {
+    val proto1 = TimeSeriesFixture.timeseries(0, tagsWithMetric + ("app" -> "filodb"))
+    val builder = new RecordBuilder(MemFactory.onHeapFactory, dataset.ingestionSchema)
+
+    val records = PrometheusInputRecord(proto1, dataset)
+    records should have length (1)
+    val record1 = records.head
+    record1.tags shouldEqual (baseTags + ("app" -> "filodb"))
+    record1.getMetric shouldEqual "num_partitions"
+    record1.nonMetricShardValues shouldEqual Seq("filodb")
+
+    record1.shardKeyHash shouldEqual RecordBuilder.shardKeyHash(Seq("filodb"), "num_partitions")
+
+    record1.addToBuilder(builder)
+    builder.allContainers.head.foreach { case (base, offset) =>
+      dataset.ingestionSchema.partitionHash(base, offset) should not equal (7)
+      dataset.ingestionSchema.getLong(base, offset, 0) shouldEqual 1000000L
+      dataset.ingestionSchema.getDouble(base, offset, 1) shouldEqual 1.1
+
+      val consumer = new StringifyMapItemConsumer()
+      dataset.ingestionSchema.consumeMapItems(base, offset, 2, consumer)
+      consumer.stringPairs.toMap shouldEqual (tagsWithMetric + ("app" -> "filodb"))
+    }
+  }
+
+  it("should not return any records if metric missing") {
+    val proto1 = TimeSeriesFixture.timeseries(0, baseTags)
+    val records = PrometheusInputRecord(proto1, dataset)
+    records should have length (0)
+  }
+}

--- a/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
@@ -75,7 +75,7 @@ class GatewayBenchmark extends StrictLogging {
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   def promCounterProtoConversion(): Int = {
-    val record = PrometheusInputRecord(TimeSeries.parseFrom(singlePromTSBytes), dataset)
+    val record = PrometheusInputRecord(TimeSeries.parseFrom(singlePromTSBytes), dataset).head
     val partHash = record.partitionKeyHash
     val shardHash = record.shardKeyHash
     record.getMetric
@@ -105,7 +105,7 @@ class GatewayBenchmark extends StrictLogging {
   def promHistogramProtoConversion(): Int = {
     var overallHash = 7
     histPromBytes.foreach { tsBytes =>
-      val record = PrometheusInputRecord(TimeSeries.parseFrom(tsBytes), dataset)
+      val record = PrometheusInputRecord(TimeSeries.parseFrom(tsBytes), dataset).head
       val partHash = record.partitionKeyHash
       val shardHash = record.shardKeyHash
       record.getMetric

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -147,7 +147,7 @@ object FiloBuild extends Build {
   lazy val gateway = project
     .in(file("gateway"))
     .settings(commonSettings: _*)
-    .settings(name := "gateway")
+    .settings(name := "filodb-gateway")
     .settings(libraryDependencies ++= gatewayDeps)
     .settings(gatewayAssemblySettings: _*)
     .dependsOn(coordinator % "compile->compile; test->test",

--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -2,7 +2,6 @@ package filodb.prometheus
 
 import remote.RemoteStorage.TimeSeries
 
-import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.{Dataset, DatasetOptions}
 
 /**
@@ -24,27 +23,5 @@ object FormatConversion {
       list.add((labelPair.getName, labelPair.getValue))
     }
     list
-  }
-
-  /**
-   * Adds BinaryRecord v2 to the builder/containers, one per Sample per TimeSeries proto instance.
-   * Prior to calling this, one should have called builder.sortAndComputeHashes().
-   * @param builder a filodb.core.binaryrecord2.RecordBuilder with schema from the dataset method above
-   * @param ts the Protobuf TimeSeries proto instance
-   * @param sortedLabels labels from getLabels after calling sortAndComputeHashes(), which sorts them
-   * @param hashes hashes from the output of sortAndComputeHashes() method
-   */
-  def addRecord(builder: RecordBuilder,
-                ts: TimeSeries,
-                sortedLabels: java.util.ArrayList[(String, String)],
-                hashes: Array[Int]): Unit = {
-    for { i <- 0 until ts.getSamplesCount } {
-      val sample = ts.getSamples(i)
-      builder.startNewRecord()
-      builder.addLong(sample.getTimestampMs)
-      builder.addDouble(sample.getValue)
-      builder.addSortedPairsAsMap(sortedLabels, hashes)
-      builder.endRecord()
-    }
   }
 }

--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -11,7 +11,8 @@ object FormatConversion {
   // An official Prometheus-format Dataset object with a single timestamp and value
   val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
                   .copy(options = DatasetOptions(Seq("__name__", "app"),
-                    "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le")))
+                    "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
+                    Map("exporter" -> "app", "job" -> "app")))
 
   /**
    * Extracts a java ArrayList of labels from the TimeSeries


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

- InfluxRecord and PrometheusInputRecord have different shard key hash algorithms
- PrometheusInputRecord is missing some features

**New behavior :**

- InfluxRecord, PrometheusInputRecord and the QueryActor now all use the same hash algorithm and the number of methods is reduced down to one.   Namely the keys (which never changes) is not part of the calculation any longer
- PrometheusInputRecord now rejects "le" or whatever is defined in ignoreTagsForPartitionKeyHash
- `PrometheusInputRecord` can rename/copy tags that are missing based on new `copyTags` `DatasetOptions` config
- `PrometheusInputRecord` parsing is about 15% faster than before, due to just trimming the metric and not having to sort and process a second set of key-value pairs
