### PR TITLE
feat(query): implement query support for Resets, Deriv, IDelta and Irate Functions

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -13,7 +13,7 @@ trait BaseParser extends Expressions with JavaTokenParsers with RegexParsers wit
   }
 
   lazy val labelIdentifier: PackratParser[Identifier] = {
-    "[a-zA-Z_][a-zA-Z0-9_:]*".r ^^ { str => Identifier(str) }
+    "[a-zA-Z_][a-zA-Z0-9_:\\-\\.]*".r ^^ { str => Identifier(str) }
   }
 
   lazy val string: PackratParser[Identifier] = {

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -40,6 +40,8 @@ class ParserSpec extends FunSpec with Matchers {
     parseSuccessfully("(1 + heap_size{a=\"b\"}) + 5")
     parseSuccessfully("(1 + heap_size{a=\"b\"}) + 5 * (3 - cpu_load{c=\"d\"})")
     parseSuccessfully("((1 + heap_size{a=\"b\"}) + 5) * (3 - cpu_load{c=\"d\"})")
+    parseSuccessfully("foo:ba-r:a.b{a=\"bc\"}")
+    parseSuccessfully("foo:ba-001:a.b{a=\"b-c\"}")
 
     parseError("")
     parseError("# just a comment\n\n")
@@ -226,6 +228,8 @@ class ParserSpec extends FunSpec with Matchers {
 
   it("Should be able to make logical plans for Series Expressions") {
     val queryToLpString = Map(
+      "primary:instance-001:no.ofrequests{job=\"my-job\"}" ->
+        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(my-job)), ColumnFilter(__name__,Equals(primary:instance-001:no.ofrequests))),List()),1524855988000,1000,1524855988000)",
       "absent(nonexistent{job=\"myjob\"})" ->
         "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000,1524855988000),Absent,List())",
       "rate(http_requests_total[5m] offset 1w)" ->
@@ -270,6 +274,12 @@ class ParserSpec extends FunSpec with Matchers {
         "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000),List(5.0),List(),List())",
       "irate(http_requests_total{job=\"api-server\"}[5m])" ->
         "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000,300000,Irate,List())",
+      "idelta(http_requests_total{job=\"api-server\"}[5m])" ->
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000,300000,Idelta,List())",
+      "resets(http_requests_total{job=\"api-server\"}[5m])" ->
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000,300000,Resets,List())",
+      "deriv(http_requests_total{job=\"api-server\"}[5m])" ->
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000,300000,Deriv,List())",
       "rate(http_requests_total{job=\"api-server\"}[5m])" ->
         "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\"}[5m]" ->

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -67,7 +67,7 @@ trait RangeFunction {
             sampleToEmit: TransientRow,
             queryConfig: QueryConfig): Unit
 }
-
+// scalastyle:off
 object RangeFunction {
   def apply(func: Option[RangeFunctionId],
             funcParams: Seq[Any] = Nil): RangeFunction = {
@@ -76,6 +76,10 @@ object RangeFunction {
       case Some(Rate)             => RateFunction
       case Some(Increase)         => IncreaseFunction
       case Some(Delta)            => DeltaFunction
+      case Some(Resets)           => ResetsFunction
+      case Some(Irate)            => IRateFunction
+      case Some(Idelta)           => IDeltaFunction
+      case Some(Deriv)            => DerivFunction
       case Some(MaxOverTime)      => new MinMaxOverTimeFunction(Ordering[Double])
       case Some(MinOverTime)      => new MinMaxOverTimeFunction(Ordering[Double].reverse)
       case Some(CountOverTime)    => new CountOverTimeFunction()
@@ -87,6 +91,7 @@ object RangeFunction {
     }
   }
 }
+// scalastyle:on
 
 object LastSampleFunction extends RangeFunction {
 

--- a/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
@@ -236,5 +236,3 @@ object ResetsFunction extends RangeFunction {
     sampleToEmit.setValues(endTimestamp, resets)
   }
 }
-
-


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

resets, deriv, idelta and irate functions are not supported in the query

**New behavior :**

- logical plan creation for resets, deriv, idelta and irate functions
- execution logic for resets, deriv, idelta and irate functions
- bug fix in the query parser for labels having special characters - "." and "-"
