### PR TITLE
fix(core): Don't schedule an empty ODP task on the ingestion thread

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -102,7 +102,8 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
   // 3. Deal with partitions no longer in memory but still indexed in Lucene.
   //    Basically we need to create TSPartitions for them in the ingest thread -- if there's enough memory
   private def odpPartTask(indexIt: PartitionIterator, partKeyBytesToPage: ArrayBuffer[Array[Byte]],
-                          methods: ArrayBuffer[ChunkScanMethod], chunkMethod: ChunkScanMethod) = {
+                          methods: ArrayBuffer[ChunkScanMethod], chunkMethod: ChunkScanMethod) =
+  if (indexIt.skippedPartIDs.nonEmpty) {
     createODPPartitionsTask(indexIt.skippedPartIDs, { case (bytes, offset) =>
       val partKeyBytes = if (offset == UnsafeUtils.arayOffset) bytes
                          else BinaryRegionLarge.asNewByteArray(bytes, offset)
@@ -110,7 +111,8 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
       methods += chunkMethod
       shardStats.partitionsRestored.increment
     }).executeOn(ingestSched)
-  }
+  // No need to execute the task on ingestion thread if it's empty / no ODP partitions
+  } else Task.now(Nil)
 
   /**
    * Creates a Task which is meant ONLY TO RUN ON INGESTION THREAD
@@ -118,28 +120,27 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
    * It runs in ingestion thread so it can correctly verify which ones to actually create or not
    */
   private def createODPPartitionsTask(partIDs: Buffer[Int], callback: (Array[Byte], Int) => Unit):
-  Task[Seq[TimeSeriesPartition]] =
-    if (partIDs.nonEmpty) Task {
-      partIDs.map { id =>
-        // for each partID: look up in partitions
-        partitions.get(id) match {
-          case TimeSeriesShard.OutOfMemPartition =>
-            logger.debug(s"Creating TSPartition for ODP from part ID $id")
-            // If not there, then look up in Lucene and get the details
-            for { partKeyBytesRef <- partKeyIndex.partKeyFromPartId(id)
-                  unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(partKeyBytesRef.offset)
-                  group = partKeyGroup(partKeyBytesRef.bytes, unsafeKeyOffset)
-                  part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, 4)) } yield {
-              partSet.add(part)
-              callback(partKeyBytesRef.bytes, unsafeKeyOffset)
-              part
-            }
-            // create the partition and update data structures (but no need to add to Lucene!)
-            // NOTE: if no memory, then no partition!
-          case p: TimeSeriesPartition => Some(p)
-        }
-      }.toVector.flatten
-    } else Task.now(Nil)
+  Task[Seq[TimeSeriesPartition]] = Task {
+    partIDs.map { id =>
+      // for each partID: look up in partitions
+      partitions.get(id) match {
+        case TimeSeriesShard.OutOfMemPartition =>
+          logger.debug(s"Creating TSPartition for ODP from part ID $id")
+          // If not there, then look up in Lucene and get the details
+          for { partKeyBytesRef <- partKeyIndex.partKeyFromPartId(id)
+                unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(partKeyBytesRef.offset)
+                group = partKeyGroup(partKeyBytesRef.bytes, unsafeKeyOffset)
+                part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, 4)) } yield {
+            partSet.add(part)
+            callback(partKeyBytesRef.bytes, unsafeKeyOffset)
+            part
+          }
+          // create the partition and update data structures (but no need to add to Lucene!)
+          // NOTE: if no memory, then no partition!
+        case p: TimeSeriesPartition => Some(p)
+      }
+    }.toVector.flatten
+  }
 
   def computeBoundingMethod(methods: Seq[ChunkScanMethod]): ChunkScanMethod = if (methods.isEmpty) {
     AllChunkScan

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -121,6 +121,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
    */
   private def createODPPartitionsTask(partIDs: Buffer[Int], callback: (Array[Byte], Int) => Unit):
   Task[Seq[TimeSeriesPartition]] = Task {
+    require(partIDs.nonEmpty)
     partIDs.map { id =>
       // for each partID: look up in partitions
       partitions.get(id) match {

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -111,7 +111,7 @@ object FiloSettings extends Build {
     // Uncomment below to debug Typesafe Config file loading
     // javaOptions ++= List("-Xmx2G", "-Dconfig.trace=loads"),
     // Make Akka tests more resilient esp for CI/CD/Travis/etc.
-    javaOptions ++= List("-Xmx3G", "-Dakka.test.timefactor=3"),
+    javaOptions ++= List("-Xmx2G", "-XX:+CMSClassUnloadingEnabled", "-Dakka.test.timefactor=3"),
     // Needed to avoid cryptic EOFException crashes in forked tests
     // in Travis with `sudo: false`.
     // See https://github.com/sbt/sbt/issues/653

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -111,7 +111,7 @@ object FiloSettings extends Build {
     // Uncomment below to debug Typesafe Config file loading
     // javaOptions ++= List("-Xmx2G", "-Dconfig.trace=loads"),
     // Make Akka tests more resilient esp for CI/CD/Travis/etc.
-    javaOptions ++= List("-Xmx2G", "-Dakka.test.timefactor=3"),
+    javaOptions ++= List("-Xmx3G", "-Dakka.test.timefactor=3"),
     // Needed to avoid cryptic EOFException crashes in forked tests
     // in Travis with `sudo: false`.
     // See https://github.com/sbt/sbt/issues/653


### PR DESCRIPTION
… Speeds up in-memory queries

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

An ODP task is always created on the ingestion thread for every query, whether there are on-demand paging partitions or not.   This leads to higher query latencies and potential timeouts if the ingestion thread gets stuck.

**New behavior :**

If there are no new partitions to on-demand page (i.e. all partitions asked are already in memory, which is vast majority of times), an empty task with Nil is returned immediately rather than being scheduled on the ingestion thread.  Thus in most cases the ingestion thread will not block queries.
