### PR TITLE
bug(query): Sliding window bug fixes

### DIFF
--- a/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
+++ b/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
@@ -75,8 +75,7 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
             // but Akka doesnt support snappy out of the box. Elegant solution is a TODO for later.
             val readReq = ReadRequest.parseFrom(Snappy.uncompress(bytes.toArray))
             val asks = toFiloDBLogicalPlans(readReq).map { logicalPlan =>
-              asyncAsk(nodeCoord, LogicalPlan2Query(DatasetRef.fromDotString(dataset), logicalPlan,
-                QueryOptions(itemLimit = settings.querySampleLimit)))
+              asyncAsk(nodeCoord, LogicalPlan2Query(DatasetRef.fromDotString(dataset), logicalPlan, queryOptions))
             }
             Future.sequence(asks)
           }
@@ -101,7 +100,7 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
   }
 
   private def askQueryAndRespond(dataset: String, logicalPlan: LogicalPlan) = {
-    val command = LogicalPlan2Query(DatasetRef.fromDotString(dataset), logicalPlan)
+    val command = LogicalPlan2Query(DatasetRef.fromDotString(dataset), logicalPlan, queryOptions)
     onSuccess(asyncAsk(nodeCoord, command)) {
       case qr: QueryResult => complete(toPromSuccessResponse(qr))
       case qr: QueryError => complete(toPromErrorResponse(qr))

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -67,7 +67,9 @@ object PrometheusModel {
       b.addLabels(LabelPair.newBuilder().setName(lv._1.toString).setValue(lv._2.toString))
     }
     srv.rows.foreach { row =>
-      b.addSamples(Sample.newBuilder().setTimestampMs(row.getLong(0)).setValue(row.getDouble(1)))
+      if (!row.getDouble(1).isNaN) {
+        b.addSamples(Sample.newBuilder().setTimestampMs(row.getLong(0)).setValue(row.getDouble(1)))
+      }
     }
     b.build()
   }

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -61,15 +61,17 @@ object PrometheusModel {
     b.build()
   }
 
+  /**
+    * Used to send out raw data
+    */
   def toPromTimeSeries(srv: SerializableRangeVector): TimeSeries = {
     val b = TimeSeries.newBuilder()
     srv.key.labelValues.foreach {lv =>
       b.addLabels(LabelPair.newBuilder().setName(lv._1.toString).setValue(lv._2.toString))
     }
     srv.rows.foreach { row =>
-      if (!row.getDouble(1).isNaN) {
-        b.addSamples(Sample.newBuilder().setTimestampMs(row.getLong(0)).setValue(row.getDouble(1)))
-      }
+      // no need to remove NaN here.
+      b.addSamples(Sample.newBuilder().setTimestampMs(row.getLong(0)).setValue(row.getDouble(1)))
     }
     b.build()
   }
@@ -86,9 +88,18 @@ object PrometheusModel {
     }
   }
 
+  /**
+    * Used to send out HTTP response
+    */
   def toPromResult(srv: SerializableRangeVector): Result = {
     Result(srv.key.labelValues.map { case (k, v) => (k.toString, v.toString)},
-      srv.rows.map(r => Sampl(r.getLong(0) / 1000, r.getDouble(1))).toSeq)
+      // remove NaN in HTTP results
+      // Known Issue: Until we support NA in our vectors, we may not be able to return NaN as an end-of-time-series
+      // in HTTP raw query results.
+      srv.rows.filter(!_.getDouble(1).isNaN).map { r =>
+          Sampl(r.getLong(0) / 1000, r.getDouble(1))
+      }.toSeq
+    )
   }
 
   def toPromErrorResponse(qe: filodb.query.QueryError): ErrorResponse = {

--- a/query/src/main/scala/filodb/query/util/IndexedArrayQueue.scala
+++ b/query/src/main/scala/filodb/query/util/IndexedArrayQueue.scala
@@ -59,6 +59,8 @@ class IndexedArrayQueue[T](initialSize: Int = 8) {
 
   def size: Int = (tl - hd) & (items.size - 1)
 
+  def isEmpty: Boolean = size == 0
+
   def remove(): T = {
     if (size == 0) throw new NoSuchElementException
     val result = items(hd)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

Bug Fixes for:
1. Sliding window keeps a last sample even after time series stops ingesting,
   so functions like SumOverTime return incorrect value after stop.
2. Sliding window should not include values at window start time.
   Otherwise, values are double counted for the case where step==window

