### PR TITLE
Fix thread safety of freeing memory, and also prevent double free.

### DIFF
--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -228,7 +228,10 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
   def releaseBlocks(): Unit = {
     lock.lock()
     try {
-      MemoryIO.getCheckedInstance.freeMemory(firstPageAddress)
+      if (firstPageAddress != 0) {
+        MemoryIO.getCheckedInstance.freeMemory(firstPageAddress)
+        firstPageAddress = 0
+      }
     } catch {
       case e: Throwable => logger.warn(s"Could not release blocks at $firstPageAddress", e)
     } finally {

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -113,7 +113,7 @@ class NativeMemoryManager(val upperBoundSizeInBytes: Long) extends MemFactory {
     }
   }
 
-  protected[memory] def freeAll(): Unit = {
+  protected[memory] def freeAll(): Unit = synchronized {
     sizeMapping.foreach { case (addr, size) =>
       MemoryIO.getCheckedInstance().freeMemory(addr)
     }


### PR DESCRIPTION
Fixes random test failures in which the JVM would crash when native memory was freed.