### PR TITLE
feat(query,coordinator): Special __col PromQL filter for target column name

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,11 +364,11 @@ FiloDB can be queried using the [Prometheus Query Language](https://prometheus.i
 
 ### FiloDB PromQL Extensions
 
-Since FiloDB supports multiple schemas, there needs to be a way to specify the target column to query.  This is done using the special `__col` tag filter, like this request which pulls out the "min" column:
+Since FiloDB supports multiple schemas, there needs to be a way to specify the target column to query.  This is done using the special `__col__` tag filter, like this request which pulls out the "min" column:
 
-    http_req_timer{app="foo",__col="min"}
+    http_req_timer{app="foo",__col__="min"}
 
-By default if `__col` is not specified then the `valueColumn` option of the Dataset is used.
+By default if `__col__` is not specified then the `valueColumn` option of the Dataset is used.
 
 Some special functions exist to aid debugging and for other purposes:
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ FiloDB can be queried using the [Prometheus Query Language](https://prometheus.i
 
 ### FiloDB PromQL Extensions
 
+Since FiloDB supports multiple schemas, there needs to be a way to specify the target column to query.  This is done using the special `__col` tag filter, like this request which pulls out the "min" column:
+
+    http_req_timer{app="foo",__col="min"}
+
+By default if `__col` is not specified then the `valueColumn` option of the Dataset is used.
+
 Some special functions exist to aid debugging and for other purposes:
 
 | function | description    |

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -99,6 +99,13 @@ class QueryEngineSpec extends FunSpec with Matchers {
     }
   }
 
+  it("should throw BadQuery if illegal column name in LogicalPlan") {
+    val raw3 = raw2.copy(columns = Seq("foo"))
+    intercept[BadQueryException] {
+      engine.materialize(raw3, QueryOptions())
+    }
+  }
+
   it("should use spread function to change/override spread and generate ExecPlan with appropriate shards") {
     val spreadFunc = QueryOptions.simpleMapSpreadFunc("job", Map("myService" -> 2), 1)
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -106,6 +106,23 @@ class QueryEngineSpec extends FunSpec with Matchers {
     }
   }
 
+  it("should rename Prom __name__ filters if dataset has different metric column") {
+    // Custom QueryEngine with different dataset with different metric name
+    val dataset2 = dataset.copy(options = dataset.options.copy(
+                     metricColumn = "kpi", shardKeyColumns = Seq("kpi", "job")))
+    val engine2 = new QueryEngine(dataset2, mapperRef)
+
+    // materialized exec plan
+    val execPlan = engine2.materialize(raw2, QueryOptions())
+    // println(execPlan.printTree())
+    execPlan.isInstanceOf[DistConcatExec] shouldEqual true
+    execPlan.children.foreach { l1 =>
+      l1.isInstanceOf[SelectRawPartitionsExec] shouldEqual true
+      val rpExec = l1.asInstanceOf[SelectRawPartitionsExec]
+      rpExec.filters.map(_.column).toSet shouldEqual Set("kpi", "job")
+    }
+  }
+
   it("should use spread function to change/override spread and generate ExecPlan with appropriate shards") {
     val spreadFunc = QueryOptions.simpleMapSpreadFunc("job", Map("myService" -> 2), 1)
 

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -6,7 +6,7 @@ import filodb.query._
 
 object Vectors {
   // The "tag" or key used to indicate the column to query to FiloDB.  A non-standard Prom extension.
-  val ColumnSelectorLabel = "__col"
+  val ColumnSelectorLabel = "__col__"
 
   val PromMetricLabel = "__name__"
 }
@@ -93,10 +93,13 @@ trait Vectors extends Scalars with TimeUnits with Base {
           case NotEqual(false) => ColumnFilter(labelMatch.label, query.Filter.NotEquals(labelMatch.value))
           case other: Any      => throw new IllegalArgumentException(s"Unknown match operator $other")
         }
+      // Remove the column selector as that is not a real time series filter
       }.filterNot(_.column == ColumnSelectorLabel)
 
     protected def labelMatchesToColumnName(labels: Seq[LabelMatch]): Seq[String] =
       labels.collect {
+        // TODO: We may support multiple columns with the regex filter or some other
+        //       custom "in" operator that we can specify in PromQL
         case LabelMatch(ColumnSelectorLabel, EqualMatch, col) => col
       }
   }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -236,6 +236,8 @@ class ParserSpec extends FunSpec with Matchers {
         "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\",group=\"canary\"}" ->
         "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(group,Equals(canary)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000)",
+      "http_requests_total{job=\"prometheus\",__col=\"min\"}" ->
+        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(min)),1524855988000,1000,1524855988000)",
       "sum(http_requests_total) by (application, group)" ->
         "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000),List(),List(application, group),List())",
       "sum(http_requests_total) without (instance)" ->

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -236,7 +236,7 @@ class ParserSpec extends FunSpec with Matchers {
         "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\",group=\"canary\"}" ->
         "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(group,Equals(canary)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000)",
-      "http_requests_total{job=\"prometheus\",__col=\"min\"}" ->
+      "http_requests_total{job=\"prometheus\",__col__=\"min\"}" ->
         "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(min)),1524855988000,1000,1524855988000)",
       "sum(http_requests_total) by (application, group)" ->
         "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000,1524855988000),List(),List(application, group),List())",

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -27,6 +27,9 @@ case class IntervalSelector(from: Seq[Any], to: Seq[Any]) extends RangeSelector
 
 /**
   * Concrete logical plan to query for raw data in a given range
+  * @param columns the columns to read from raw chunks.  Note that it is not necessary to include
+  *        the timestamp column, that will be automatically added.
+  *        If no columns are included, the default value column will be used.
   */
 case class RawSeries(rangeSelector: RangeSelector,
                      filters: Seq[ColumnFilter],

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -25,6 +25,7 @@ final case class SelectRawPartitionsExec(id: String,
                                          filters: Seq[ColumnFilter],
                                          rowKeyRange: RowKeyRange,
                                          colIds: Seq[Types.ColumnId]) extends LeafExecPlan {
+  require(colIds.nonEmpty)
 
   protected def schemaOfDoExecute(dataset: Dataset): ResultSchema =
     ResultSchema(dataset.infosFromIDs(colIds),

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -9,7 +9,7 @@ import filodb.core.{DatasetRef, Types}
 import filodb.core.metadata.Dataset
 import filodb.core.query.{ColumnFilter, RangeVector, ResultSchema}
 import filodb.core.store.{AllChunkScan, ChunkSource, FilteredPartitionScan, RowKeyChunkScan, ShardSplit}
-import filodb.query.{BadQueryException, QueryConfig}
+import filodb.query.QueryConfig
 
 
 /**
@@ -24,24 +24,17 @@ final case class SelectRawPartitionsExec(id: String,
                                          shard: Int,
                                          filters: Seq[ColumnFilter],
                                          rowKeyRange: RowKeyRange,
-                                         columns: Seq[String]) extends LeafExecPlan {
+                                         colIds: Seq[Types.ColumnId]) extends LeafExecPlan {
 
-  protected def schemaOfDoExecute(dataset: Dataset): ResultSchema = {
-    val colIds = if (columns.nonEmpty) getColumnIDs(dataset, columns)
-    else dataset.dataColumns.map(_.id) // includes row-key
+  protected def schemaOfDoExecute(dataset: Dataset): ResultSchema =
     ResultSchema(dataset.infosFromIDs(colIds),
       colIds.zip(dataset.rowKeyIDs).takeWhile { case (a, b) => a == b }.length)
-  }
 
   protected def doExecute(source: ChunkSource,
                           dataset: Dataset,
                           queryConfig: QueryConfig)
                          (implicit sched: Scheduler,
                           timeout: FiniteDuration): Observable[RangeVector] = {
-
-    // if no columns are chosen, auto-select data and row key columns
-    val colIds = if (columns.nonEmpty) getColumnIDs(dataset, columns)
-    else dataset.dataColumns.map(_.id) // includes row-key
     require(colIds.indexOfSlice(dataset.rowKeyIDs) == 0)
 
     val chunkMethod = rowKeyRange match {
@@ -53,20 +46,6 @@ final case class SelectRawPartitionsExec(id: String,
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     source.rangeVectors(dataset, colIds, partMethod, chunkMethod)
           .filter(_.rows.nonEmpty)
-  }
-
-  /**
-    * Convert column name strings into columnIDs.  NOTE: column names should not include row key columns
-    * as those are automatically prepended.
-    * TODO: move this step to logical -> physical plan conversion validation
-    */
-  private def getColumnIDs(dataset: Dataset, cols: Seq[String]): Seq[Types.ColumnId] = {
-    val ids = dataset.colIDs(cols: _*)
-      .recover(missing => throw new BadQueryException(s"Undefined columns $missing"))
-      .get
-    // avoid duplication if first ids are already row keys
-    if (ids.take(dataset.rowKeyIDs.length) == dataset.rowKeyIDs) { ids }
-    else { dataset.rowKeyIDs ++ ids }
   }
 
   protected def args: String = s"shard=$shard, rowKeyRange=$rowKeyRange, filters=$filters"

--- a/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
@@ -62,7 +62,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
                        ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher,
-      timeseriesDataset.ref, 0, filters, AllChunks, Seq("timestamp", "value"))
+      timeseriesDataset.ref, 0, filters, AllChunks, Seq(0, 1))
 
     val resp = execPlan.execute(memStore, timeseriesDataset, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
@@ -82,7 +82,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val end: BinaryRecord = BinaryRecord(timeseriesDataset, Seq(now - (numRawSamples-10) * reportingInterval))
 
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, timeseriesDataset.ref, 0,
-      filters, RowKeyInterval(start, end), Seq("timestamp", "value"))
+      filters, RowKeyInterval(start, end), Seq(0, 1))
 
     val resp = execPlan.execute(memStore, timeseriesDataset, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
@@ -98,7 +98,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, timeseriesDataset.ref, 0,
-      filters, AllChunks, Seq("timestamp", "value"))
+      filters, AllChunks, Seq(0, 1))
     val start = now - numRawSamples * reportingInterval - 100 // reduce by 100 to not coincide with reporting intervals
     val step = 20000
     val end = now - (numRawSamples-100) * reportingInterval
@@ -130,7 +130,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, timeseriesDataset.ref, 0,
-      filters, AllChunks, Seq("timestamp", "value"))
+      filters, AllChunks, Seq(0, 1))
     val resultSchema = execPlan.schema(timeseriesDataset)
     resultSchema.isTimeSeries shouldEqual true
     resultSchema.numRowKeyColumns shouldEqual 1


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

There is no way to specify the target column name for PromQL queries.  Instead, it is assumed the schema is timestamp/value, and the second column is always used as the value column.

**New behavior :**

1. A special PromQL tag, `__col`, is exposed and can be used to target a specific column for querying
2. `SelectRawPartitionsExec` now takes numeric ColumnIDs, and column name to ID validation is done during LP to EP materialize call.
3. `__name__` filter is transformed into the right filter if the dataset metricColumn is not __name__

