### PR TITLE
bug(query): Fix eager getNext in iteration chain

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -215,16 +215,27 @@ class DropOutOfOrderSamplesIterator(iter: Iterator[RowReader]) extends Iterator[
   private val cur = new TransientRow(-1, -1)
   private val nextVal = new TransientRow(-1, -1)
   private var hasNextVal = false
-  setNext()
+  private var hasNextDefined = false
 
-  override def hasNext: Boolean = hasNextVal
+  override def hasNext: Boolean = {
+    if (!hasNextDefined) {
+      setNext()
+      hasNextDefined = true
+    }
+    hasNextVal
+  }
+
   override def next(): TransientRow = {
+    if (!hasNextDefined) {
+      setNext()
+      hasNextDefined = true
+    }
     cur.copyFrom(nextVal)
     setNext()
     cur
   }
 
-  def setNext(): Unit = {
+  private def setNext(): Unit = {
     hasNextVal = false
     while (!hasNextVal && iter.hasNext) {
       val nxt = iter.next()


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

DropOutOfOrderSamples iterator does an eager invocation of getNext

**New behavior :**

The getNext invocation has been changed to be lazy. We do not want iteration to start during the setup  phase of the query pipeline.
