### PR TITLE
bug(query): Avg aggr over RVs did not handle 0 counts properly

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -421,13 +421,13 @@ object AvgRowAggregator extends RowAggregator {
   def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = {
     mapInto.setLong(0, item.getLong(0))
     mapInto.setDouble(1, item.getDouble(1))
-    mapInto.setLong(2, 1L)
+    mapInto.setLong(2, if (item.getDouble(1).isNaN) 0L else 1L)
     mapInto
   }
   def reduceAggregate(acc: AvgHolder, aggRes: RowReader): AvgHolder = {
-    val newMean = (acc.mean * acc.count + aggRes.getDouble(1) * aggRes.getLong(2))/ (acc.count + aggRes.getLong(2))
-    acc.timestamp = aggRes.getLong(0)
-    if (!aggRes.getDouble(1).isNaN) {
+    if (aggRes.getLong(2) > 0) {
+      val newMean = (acc.mean * acc.count + aggRes.getDouble(1) * aggRes.getLong(2)) / (acc.count + aggRes.getLong(2))
+      acc.timestamp = aggRes.getLong(0)
       acc.mean = newMean
       acc.count += aggRes.getLong(2)
     }

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -425,9 +425,9 @@ object AvgRowAggregator extends RowAggregator {
     mapInto
   }
   def reduceAggregate(acc: AvgHolder, aggRes: RowReader): AvgHolder = {
+    acc.timestamp = aggRes.getLong(0)
     if (aggRes.getLong(2) > 0) {
       val newMean = (acc.mean * acc.count + aggRes.getDouble(1) * aggRes.getLong(2)) / (acc.count + aggRes.getLong(2))
-      acc.timestamp = aggRes.getLong(0)
       acc.mean = newMean
       acc.count += aggRes.getLong(2)
     }

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -128,29 +128,18 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
     tdig.quantile(q)
   }
 
-  it ("should ignore NaN while aggregating") {
-    val ignoreKey = CustomRangeVectorKey(
-      Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
+  val ignoreKey = CustomRangeVectorKey(
+    Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
 
-    val noKey = CustomRangeVectorKey(Map.empty)
-    def noGrouping(rv: RangeVector): RangeVectorKey = noKey
+  val noKey = CustomRangeVectorKey(Map.empty)
+  def noGrouping(rv: RangeVector): RangeVectorKey = noKey
+
+  it ("should ignore NaN while aggregating") {
 
     val samples: Array[RangeVector] = Array(
-      new RangeVector {
-        override def key: RangeVectorKey = ignoreKey
-        override def rows: Iterator[RowReader] = Seq(new TransientRow(1L, Double.NaN),
-                                                     new TransientRow(2L, 5.6d)).iterator
-      },
-      new RangeVector {
-        override def key: RangeVectorKey = ignoreKey
-        override def rows: Iterator[RowReader] = Seq(new TransientRow(1L, 4.6d),
-                                                     new TransientRow(2L, 4.4d)).iterator
-      },
-      new RangeVector {
-        override def key: RangeVectorKey = ignoreKey
-        override def rows: Iterator[RowReader] = Seq(new TransientRow(1L, 2.1d),
-                                                     new TransientRow(2L, 5.4d)).iterator
-      }
+      toRv(Seq((1L, Double.NaN), (2L, 5.6d))),
+      toRv(Seq((1L, 4.6d), (2L, 4.4d))),
+      toRv(Seq((1L, 2.1d), (2L, 5.4d)))
     )
 
     // Sum
@@ -224,27 +213,10 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
   }
 
   it ("should be able to serialize to and deserialize t-digest from SerializableRangeVector") {
-    val noKey = CustomRangeVectorKey(Map.empty)
-    def noGrouping(rv: RangeVector): RangeVectorKey = noKey
-
-    val ignoreKey = CustomRangeVectorKey(
-      Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
     val samples: Array[RangeVector] = Array(
-      new RangeVector {
-        override def key: RangeVectorKey = ignoreKey
-        override def rows: Iterator[RowReader] = Seq(new TransientRow(1L, Double.NaN),
-          new TransientRow(2L, 5.6d)).iterator
-      },
-      new RangeVector {
-        override def key: RangeVectorKey = ignoreKey
-        override def rows: Iterator[RowReader] = Seq(new TransientRow(1L, 4.6d),
-          new TransientRow(2L, 4.4d)).iterator
-      },
-      new RangeVector {
-        override def key: RangeVectorKey = ignoreKey
-        override def rows: Iterator[RowReader] = Seq(new TransientRow(1L, 2.1d),
-          new TransientRow(2L, 5.4d)).iterator
-      }
+      toRv(Seq((1L, Double.NaN), (2L, 5.6d))),
+      toRv(Seq((1L, 4.6d), (2L, 4.4d))),
+      toRv(Seq((1L, 2.1d), (2L, 5.4d)))
     )
 
     // Quantile
@@ -264,6 +236,34 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
     val finalResult = resultObs7b.toListL.runAsync.futureValue
     compareIter(finalResult(0).rows.map(_.getDouble(1)), Seq(3.35d, 5.4d).iterator)
 
+  }
+
+  private def toRv(samples: Seq[(Long, Double)]): RangeVector = {
+    new RangeVector {
+      override def key: RangeVectorKey = ignoreKey
+      override def rows: Iterator[RowReader] = samples.map(r => new TransientRow(r._1, r._2)).iterator
+    }
+  }
+
+  it ("average should work with NaN Test case 2 ") {
+    val s1 = Seq( (1541190600L, Double.NaN), (1541190660L, Double.NaN), (1541190720L, Double.NaN),
+         (1541190780L, Double.NaN), (1541190840L, Double.NaN), (1541190900L, 1.0), (1541190960L, 1.0))
+    val s2 = Seq( (1541190600L, 1.0d), (1541190660L,1.0d), (1541190720L,1.0d),
+         (1541190780L,1.0d), (1541190840L,1.0d), (1541190900L,1.0d), (1541190960L,1.0d))
+
+    val mapped1 = RangeVectorAggregator.mapReduce(AggregationOperator.Avg,
+      Nil, false, Observable.fromIterable(Seq(toRv(s1))), noGrouping)
+
+    val mapped2 = RangeVectorAggregator.mapReduce(AggregationOperator.Avg,
+      Nil, false, Observable.fromIterable(Seq(toRv(s2))), noGrouping)
+
+    val resultObs4 = RangeVectorAggregator.mapReduce(AggregationOperator.Avg,
+      Nil, true, mapped1 ++ mapped2, rv=>rv.key)
+    val result4 = resultObs4.toListL.runAsync.futureValue
+    result4.size shouldEqual 1
+    result4(0).key shouldEqual noKey
+    // prior to this fix, test was returning List(NaN, NaN, NaN, NaN, NaN, 1.0, 1.0)
+    result4(0).rows.map(_.getDouble(1)).toList shouldEqual Seq(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
   }
 
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Reduction of aggregates to calculate average had a bug where zero count and NaN was not being handled correctly. 

