### PR TITLE
feat(jmh): 100-record container ingestion benchmark; query+ingest benchmark

### DIFF
--- a/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
@@ -70,6 +70,10 @@ class IngestionBenchmark {
   /**
    * Ingest a single RecordContainer with 100 records in it.  Note that the throughput reported is x100 so
    * it is not the containers throughput but the actual records throughput.
+   *
+   * NOTE: based on -prof stack profiling, this benchmark does invoke the flushing logic plus
+   * WriteBufferPool buffer recycling logic.  The time is thus heavily influenced by the chunking/encoding
+   * logic, OffheapSortedIDMap stuff, and native memory allocation cost.
    */
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))

--- a/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
@@ -3,10 +3,13 @@ package filodb.jmh
 import java.util.concurrent.TimeUnit
 
 import ch.qos.logback.classic.{Level, Logger}
+import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
 import filodb.core.{MachineMetricsData, TestData}
 import filodb.core.binaryrecord2.{RecordBuilder, RecordComparator, RecordSchema}
+import filodb.core.memstore._
+import filodb.core.store._
 import filodb.memory.{BinaryRegionConsumer, MemFactory}
 
 /**
@@ -26,7 +29,8 @@ class IngestionBenchmark {
 
   org.slf4j.LoggerFactory.getLogger("filodb").asInstanceOf[Logger].setLevel(Level.ERROR)
 
-  val dataStream = withMap(linearMultiSeries(), extraTags=extraTags) take 50
+  // # of records in a container to test ingestion speed
+  val dataStream = withMap(linearMultiSeries(), extraTags=extraTags) take 100
 
   val schemaWithPredefKeys = RecordSchema.ingestion(dataset2,
                                                     Seq("job", "instance"))
@@ -43,7 +47,14 @@ class IngestionBenchmark {
   val (ingBr2Base, ingBr2Off) = (ingestBuilder.allContainers.head.base, ingestBuilder.allContainers.head.offset + 4)
   val (partBr2Base, partBr2Off) = (partKeyBuilder.allContainers.head.base, partKeyBuilder.allContainers.head.offset + 4)
 
-  // TODO: measure deserialization from ProtoBuf
+  import monix.execution.Scheduler.Implicits.global
+
+  val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
+  val policy = new FixedMaxPartitionsEvictionPolicy(100)
+  val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
+  memStore.setup(dataset1, 0, TestData.storeConf)
+
+  val shard = memStore.getShardE(dataset1.ref, 0)
 
   /**
    * Equality of incoming ingest BinaryRecord2 partition fields vs a BinaryRecord2 partition key
@@ -56,14 +67,16 @@ class IngestionBenchmark {
     comparator.partitionMatch(ingBr2Base, ingBr2Off, partBr2Base, partBr2Off)
   }
 
-  // Creating 50 PartKey BRv2 from 50 ingestion BRv2's
+  /**
+   * Ingest a single RecordContainer with 100 records in it.  Note that the throughput reported is x100 so
+   * it is not the containers throughput but the actual records throughput.
+   */
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
-  def makePartKeyBRv2(): Int = {
-    partKeyBuilder.resetCurrent()
-    ingestBuilder.allContainers.head.consumeRecords(consumer)
-    0
+  @OperationsPerInvocation(100)
+  def ingest100records(): Unit = {
+    shard.ingest(ingestBuilder.allContainers.head, 0)
   }
 
   @Benchmark

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -17,6 +17,8 @@ import filodb.coordinator.ShardMapper
 import filodb.core.binaryrecord2.RecordContainer
 import filodb.core.memstore.{SomeData, TimeSeriesMemStore}
 import filodb.core.store.StoreConfig
+import filodb.gateway.GatewayServer
+import filodb.gateway.conversion.PrometheusInputRecord
 import filodb.prometheus.ast.QueryParams
 import filodb.prometheus.parse.Parser
 import filodb.query.{QueryError => QError, QueryResult => QueryResult2}
@@ -25,12 +27,13 @@ import filodb.timeseries.TestTimeseriesProducer
 //scalastyle:off regex
 /**
  * A macrobenchmark (IT-test level) for QueryEngine2 aggregations, in-memory only (no on-demand paging)
- * No ingestion occurs while query test is running -- this is intentional to allow for query-focused CPU
- * and memory allocation analysis.
+ * Ingestion runs while query is running too to measure impact of ingestion on querying.
+ * Note that some CPU is needed for generating the pseudorandom input data, so use this benchmark not as
+ * an absolute but as a relative benchmark to test impact of changes.
  * Ingests a fixed amount of tsgenerator data in Prometheus schema (time, value, tags) and runs various queries.
  */
 @State(Scope.Thread)
-class QueryInMemoryBenchmark extends StrictLogging {
+class QueryAndIngestBenchmark extends StrictLogging {
   org.slf4j.LoggerFactory.getLogger("filodb").asInstanceOf[Logger].setLevel(Level.WARN)
 
   import filodb.coordinator._
@@ -77,8 +80,9 @@ class QueryInMemoryBenchmark extends StrictLogging {
   // Manually pump in data ourselves so we know when it's done.
   // TODO: ingest into multiple shards
   Thread sleep 2000    // Give setup command some time to set up dataset shards etc.
-  val (producingFut, containerStream) = TestTimeseriesProducer.metricsToContainerStream(startTime, numShards, numSeries,
-                                          numSamples * numSeries, dataset, shardMapper, spread)
+
+  val (shardQueues, containerStream) = GatewayServer.shardingPipeline(GlobalConfig.systemConfig, numShards, dataset)
+
   val ingestTask = containerStream.groupBy(_._1)
                     // Asynchronously subcribe and ingest each shard
                     .mapAsync(numShards) { groupedStream =>
@@ -93,10 +97,22 @@ class QueryInMemoryBenchmark extends StrictLogging {
                         cluster.memStore.ingestStream(dataset.ref, shard, shardStream, global) {
                           case e: Exception => throw e })
                     }.countL.runAsync
-  Await.result(producingFut, 30.seconds)
+
+  private def ingestSamples(noSamples: Int): Future[Unit] = Future {
+    TestTimeseriesProducer.timeSeriesData(startTime, numShards, numSeries)
+      .take(noSamples * numSeries)
+      .foreach { sample =>
+        val rec = PrometheusInputRecord(sample.tags, sample.metric, dataset, sample.timestamp, sample.value)
+        val shard = shardMapper.ingestionShard(rec.shardKeyHash, rec.partitionKeyHash, spread)
+        while (!shardQueues(shard).offer(rec)) { Thread sleep 50 }
+      }
+  }
+
+  // Initial ingest just to populate index
+  Await.result(ingestSamples(30), 30.seconds)
   Thread sleep 2000
   cluster.memStore.asInstanceOf[TimeSeriesMemStore].commitIndexForTesting(dataset.ref) // commit lucene index
-  println(s"Ingestion ended")
+  println(s"Initial ingestion ended, indexes set up")
 
   /**
    * ## ========  Queries ===========
@@ -113,8 +129,12 @@ class QueryInMemoryBenchmark extends StrictLogging {
     LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 100))
   }
 
+  private var testProducingFut: Future[Unit] = _
+
   @TearDown
   def shutdownFiloActors(): Unit = {
+    // Wait for producing future to end
+    Await.result(testProducingFut, 30.seconds)
     cluster.shutdown()
   }
 
@@ -123,6 +143,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   @OutputTimeUnit(TimeUnit.SECONDS)
   @OperationsPerInvocation(500)
   def parallelQueries(): Unit = {
+    testProducingFut = ingestSamples(numSamples)
     val futures = (0 until numQueries).map { n =>
       val f = asyncAsk(coordinator, queryCommands(n % queryCommands.length))
       f.onSuccess {

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -148,6 +148,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(10)
   def parallelQueries(): Unit = {
     val futures = (0 until numQueries).map { n =>
       val f = asyncAsk(coordinator, queryCommands(n % queryCommands.length))

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -2,6 +2,7 @@
 sbt "jmh/jmh:run -rf json -i 15 -wi 10 -f3 -jvmArgsAppend -XX:MaxInlineLevel=20 \
  -jvmArgsAppend -Xmx4g -jvmArgsAppend -XX:MaxInlineSize=99 \
  filodb.jmh.QueryInMemoryBenchmark \
+ filodb.jmh.QueryAndIngestBenchmark \
  filodb.jmh.IngestionBenchmark \
  filodb.jmh.QueryOnDemandBenchmark \
  filodb.jmh.GatewayBenchmark \


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

Two benchmarks are added - a much more realistic 100-record container ingestion benchmark, and a combined ingestion+querying benchmark.  Before, the IngestionBenchmark only benchmarked very small portions of ingestion, such as comparing a BinaryRecord to existing partitions.  This is the first benchmark that comprehensively covers ingesting multiple records, dealing with write buffer flushing, memory allocations, etc.

Current numbers on my 2017 MBP:

```
[info]  26.8%  26.8% filodb.core.binaryrecord2.RecordContainer.consumeRecords
[info]  16.3%  16.3% filodb.memory.format.BinaryAppendableVector$mcJ$sp$class.addVector$mcJ$sp
[info]  14.7%  14.7% com.kenai.jffi.Foreign.allocateMemory
[info]  14.6%  14.6% filodb.memory.data.OffheapLFSortedIDMapReader.innerBinSearch$1
[info]  10.5%  10.5% filodb.core.memstore.PartitionSet.loop$2
[info]   4.9%   4.9% filodb.memory.format.vectors.DeltaDeltaVector$$anonfun$fromLongVector$1.apply
[info]   4.7%   4.7% filodb.core.memstore.PartitionSet.getWithIngestBR
[info]   2.5%   2.5% com.kenai.jffi.Foreign.freeMemory
[info]   1.0%   1.0% filodb.memory.format.PrimitiveAppendableVector.freeze
[info]   0.9%   0.9% filodb.memory.data.OffheapLFSortedIDMapReader.binarySearch
[info]   3.1%   3.1% <other>
[info]
[info]
[info]
[info] # Run complete. Total time: 00:01:20
[info]
[info] Benchmark                                    Mode  Cnt        Score       Error  Units
[info] IngestionBenchmark.ingest100records         thrpt   45  1980615.751 ± 81468.990  ops/s
[info] IngestionBenchmark.ingest100records:·stack  thrpt               NaN                ---
```