### PR TITLE
refactor(coordinator): replace filter.size with more concise count

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
@@ -28,13 +28,13 @@ class ShardHealthStats(ref: DatasetRef,
   val numDown = Kamon.gauge(s"num-down-shards-$ref")
 
   def update(mapper: ShardMapper): Unit = {
-    numActive.set(shardMapFunc.statuses.filter(_ == ShardStatusActive).size)
-    numRecovering.set(shardMapFunc.statuses.filter(_.isInstanceOf[ShardStatusRecovery]).size)
-    numUnassigned.set(shardMapFunc.statuses.filter(_ == ShardStatusUnassigned).size)
-    numAssigned.set(shardMapFunc.statuses.filter(_ == ShardStatusAssigned).size)
-    numError.set(shardMapFunc.statuses.filter(_ == ShardStatusError).size)
-    numStopped.set(shardMapFunc.statuses.filter(_ == ShardStatusStopped).size)
-    numDown.set(shardMapFunc.statuses.filter(_ == ShardStatusDown).size)
+    numActive.set(shardMapFunc.statuses.count(_ == ShardStatusActive))
+    numRecovering.set(shardMapFunc.statuses.count(_.isInstanceOf[ShardStatusRecovery]))
+    numUnassigned.set(shardMapFunc.statuses.count(_ == ShardStatusUnassigned))
+    numAssigned.set(shardMapFunc.statuses.count(_ == ShardStatusAssigned))
+    numError.set(shardMapFunc.statuses.count(_ == ShardStatusError))
+    numStopped.set(shardMapFunc.statuses.count(_ == ShardStatusStopped))
+    numDown.set(shardMapFunc.statuses.count(_ == ShardStatusDown))
   }
 
    /**


### PR DESCRIPTION
A simple refactor where `count` can replace `filter(...).size` (based on 

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- ~[ ] Tests for the changes have been added (for bug fixes / features) ?~
- ~[ ] Docs have been added / updated (for bug fixes / features) ?~