### PR TITLE
feat(coord): Automatically Reassign error shard

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ sbt standalone/assembly cli/assembly gateway/assembly
 First set up the dataset. This should create the keyspaces and tables in Cassandra. 
 ```
 ./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command init
-./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset timeseries --dataColumns timestamp:ts,value:double --partitionColumns tags:map --shardKeyColumns __name__,app
+./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus --dataColumns timestamp:ts,value:double --partitionColumns tags:map --shardKeyColumns __name__,app
 ```
 Verify that tables were created in `filodb` and `filodb-admin` keyspaces.
 

--- a/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
@@ -40,7 +40,7 @@ class MemstoreCassandraSinkSpec extends AllTablesTest {
     val start = System.currentTimeMillis
     val stream = Observable.fromIterable(groupedRecords(dataset1, linearMultiSeries(startTs=start)))
     val flushStream = FlushStream.everyN(4, 50, stream.share)
-    memStore.ingestStream(dataset1.ref, 0, stream, scheduler, flushStream)(ex => throw ex).futureValue
+    memStore.ingestStream(dataset1.ref, 0, stream, scheduler, flushStream).futureValue
 
     // Two flushes and 3 chunksets have been flushed
     memStore.store.sinkStats.chunksetsWritten should be >= 3

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -173,9 +173,10 @@ private[filodb] final class IngestionActor(dataset: Dataset,
         case Failure(x) =>
           handleError(dataset.ref, shard, x)
         case Success(_) =>
-          // TODO following line breaks a few tests since it does some validation once
-          // ingestion has stopped, whereas this addition cleans up that state.
-          removeAndReleaseResources(dataset.ref, shard)
+          // We dont release resources when fitite ingestion ends normally.
+          // Kafka ingestion is usually infinite and does not end unless canceled.
+          // Cancel operation is already releasing after cancel is done.
+          // We also have some tests that validate after finite ingestion is complete
           if (source != NodeClusterActor.noOpSource) statusActor ! IngestionStopped(dataset.ref, shard)
       }
     } recover { case t: Throwable =>

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -191,7 +191,7 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
   val roleToCoords = new MutableHashMap[String, Set[ActorRef]]().withDefaultValue(Set.empty[ActorRef])
   val datasets = new MutableHashMap[DatasetRef, Dataset]
   val sources = new MutableHashMap[DatasetRef, IngestionSource]
-  val shardManager = new ShardManager(assignmentStrategy)
+  val shardManager = new ShardManager(settings, assignmentStrategy)
   val localRemoteAddr = RemoteAddressExtension(context.system).address
   var everybodyLeftSender: Option[ActorRef] = None
   val shardUpdates = new MutableHashSet[DatasetRef]

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -355,7 +355,7 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
   private def handleShardEvent(e: ShardEvent) = {
     logger.debug(s"Received ShardEvent $e from $sender")
     shardUpdates += e.ref
-    shardManager.updateFromExternalShardEvent(e)
+    shardManager.updateFromExternalShardEvent(sender(), e)
   }
 
   // TODO: Save acks for when snapshots are published?

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -355,7 +355,7 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
   private def handleShardEvent(e: ShardEvent) = {
     logger.debug(s"Received ShardEvent $e from $sender")
     shardUpdates += e.ref
-    shardManager.updateFromShardEvent(e)
+    shardManager.updateFromExternalShardEvent(e)
   }
 
   // TODO: Save acks for when snapshots are published?

--- a/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
@@ -26,6 +26,8 @@ class ShardHealthStats(ref: DatasetRef,
   val numError = Kamon.gauge(s"num-error-shards-$ref")
   val numStopped = Kamon.gauge(s"num-stopped-shards-$ref")
   val numDown = Kamon.gauge(s"num-down-shards-$ref")
+  val numErrorReassignmentsDone = Kamon.counter(s"num-error-reassignments-done-$ref")
+  val numErrorReassignmentsSkipped = Kamon.counter(s"num-error-reassignments-skipped-$ref")
 
   def update(mapper: ShardMapper): Unit = {
     numActive.set(shardMapFunc.statuses.count(_ == ShardStatusActive))

--- a/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
@@ -435,38 +435,47 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
     * Applies an event (usually) from IngestionActor to
     * the ShardMapper for dataset.
     */
-  def updateFromExternalShardEvent(event: ShardEvent): Unit = {
-    updateFromShardEvent(event)
+  def updateFromExternalShardEvent(sender: ActorRef, event: ShardEvent): Unit = {
     _shardMappers.get(event.ref) foreach { mapper =>
-      val currentCoord = mapper.coordForShard(event.shard)
-      // reassign shard if IngestionError. Exclude previous node since it had error shards.
-      event match {
-        case _: IngestionError =>
-          require(mapper.unassignedShards.contains(event.shard))
-          val lastReassignment = getShardReassignmentTime(event.ref, event.shard)
-          val now = System.currentTimeMillis()
-          val info = _datasetInfo(event.ref)
-          if (now - lastReassignment > shardReassignmentMinInterval.toMillis) {
-            logger.warn(s"Attempting to reassign shard ${event.shard} from dataset ${event.ref}. " +
-              s"It was last reassigned at ${lastReassignment}")
-            val assignments = assignShardsToNodes(event.ref, mapper, info.resources, Seq(currentCoord))
-            if (assignments.valuesIterator.flatten.contains(event.shard)) {
-              setShardReassignmentTime(event.ref, event.shard, now)
-              info.metrics.numErrorReassignmentsDone.increment()
-            } else {
-              info.metrics.numErrorReassignmentsSkipped.increment()
-              logger.warn(s"Shard ${event.shard} from dataset ${event.ref} was NOT reassigned possibly " +
-                s"because no other node was available")
-            }
-          } else {
-            info.metrics.numErrorReassignmentsSkipped.increment()
-            logger.warn(s"Skipping reassignment of shard ${event.shard} from dataset ${event.ref} since " +
-              s"it was already reassigned within ${shardReassignmentMinInterval} at ${lastReassignment}")
+      // ensure that we only respond to the events from the node shard is assigned to.
+      // Needed to avoid race conditions where IngestionStopped for an old assignment comes after shard is reassigned.
+      if (mapper.coordForShard(event.shard).path.address == sender.path.address) {
+        updateFromShardEvent(event)
+        _shardMappers.get(event.ref) foreach { mapper =>
+          val currentCoord = mapper.coordForShard(event.shard)
+          // reassign shard if IngestionError. Exclude previous node since it had error shards.
+          event match {
+            case _: IngestionError =>
+              require(mapper.unassignedShards.contains(event.shard))
+              val lastReassignment = getShardReassignmentTime(event.ref, event.shard)
+              val now = System.currentTimeMillis()
+              val info = _datasetInfo(event.ref)
+              if (now - lastReassignment > shardReassignmentMinInterval.toMillis) {
+                logger.warn(s"Attempting to reassign shard ${event.shard} from dataset ${event.ref}. " +
+                  s"It was last reassigned at ${lastReassignment}")
+                val assignments = assignShardsToNodes(event.ref, mapper, info.resources, Seq(currentCoord))
+                if (assignments.valuesIterator.flatten.contains(event.shard)) {
+                  setShardReassignmentTime(event.ref, event.shard, now)
+                  info.metrics.numErrorReassignmentsDone.increment()
+                } else {
+                  info.metrics.numErrorReassignmentsSkipped.increment()
+                  logger.warn(s"Shard ${event.shard} from dataset ${event.ref} was NOT reassigned possibly " +
+                    s"because no other node was available")
+                }
+              } else {
+                info.metrics.numErrorReassignmentsSkipped.increment()
+                logger.warn(s"Skipping reassignment of shard ${event.shard} from dataset ${event.ref} since " +
+                  s"it was already reassigned within ${shardReassignmentMinInterval} at ${lastReassignment}")
+              }
+            case _ =>
           }
-        case _ =>
+        }
+        updateShardMetrics()
+      } else {
+        logger.warn(s"Ignoring event $event from $sender since it does not match current " +
+          s"owner of shard ${event.shard} which is ${mapper.coordForShard(event.shard)}")
       }
     }
-    updateShardMetrics()
   }
 
   private def getShardReassignmentTime(dataset: DatasetRef, shard: Int): Long = {

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -195,7 +195,7 @@ class ShardMapper(val numShards: Int) extends Serializable {
       registerNode(Seq(shard), node)
     case IngestionError(_, shard, _) =>
       statusMap(shard) = ShardStatusError
-      Success(())
+      unassignShard(shard)
     case IngestionStopped(_, shard) =>
       statusMap(shard) = ShardStatusStopped
       Success(())

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -190,6 +190,9 @@ class ShardMapper(val numShards: Int) extends Serializable {
     case IngestionStarted(_, shard, node) =>
       statusMap(shard) = ShardStatusActive
       registerNode(Seq(shard), node)
+    case RecoveryStarted(_, shard, node, progress) =>
+      statusMap(shard) = ShardStatusRecovery(progress)
+      registerNode(Seq(shard), node)
     case RecoveryInProgress(_, shard, node, progress) =>
       statusMap(shard) = ShardStatusRecovery(progress)
       registerNode(Seq(shard), node)

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -32,14 +32,13 @@ object ClusterRecoverySpecConfig extends MultiNodeConfig {
 abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig) {
   import akka.testkit._
 
-  import client.QueryCommands._
   import ClusterRecoverySpecConfig._
   import filodb.query._
   import GdeltTestData._
   import NodeClusterActor._
   import sources.CsvStreamFactory
 
-  override def initialParticipants = roles.size
+  override def initialParticipants: Int = roles.size
 
   override def beforeAll(): Unit = multiNodeSpecBeforeAll()
 

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
-import org.scalatest.BeforeAndAfterEach
+import org.scalatest.{BeforeAndAfterEach, Ignore}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 
@@ -17,6 +17,7 @@ object IngestionStreamSpec extends ActorSpecConfig
 // This is really an end to end ingestion test, it's what a client talking to a FiloDB node would do.
 // Most of the tests use the automated DatasetSetup where the coordinators set up the IngestionStream, but
 // some set them up manually by invoking the factories directly.
+@Ignore // since this spec contains validations that can no longer be done after shard has stopped
 class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) with StrictLogging
   with ScalaFutures with BeforeAndAfterEach {
 

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -2,10 +2,9 @@ package filodb.coordinator
 
 import scala.concurrent.duration._
 
-import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
-import org.scalatest.{BeforeAndAfterEach, Ignore}
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 
@@ -17,7 +16,6 @@ object IngestionStreamSpec extends ActorSpecConfig
 // This is really an end to end ingestion test, it's what a client talking to a FiloDB node would do.
 // Most of the tests use the automated DatasetSetup where the coordinators set up the IngestionStream, but
 // some set them up manually by invoking the factories directly.
-@Ignore // since this spec contains validations that can no longer be done after shard has stopped
 class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) with StrictLogging
   with ScalaFutures with BeforeAndAfterEach {
 
@@ -104,20 +102,15 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
 
     var latestStatus: ShardStatus = ShardStatusAssigned
     // sometimes we receive multiple status snapshots
-    while (latestStatus != ShardStatusStopped) {
+    while (latestStatus != ShardStatusError) {
       expectMsgPF(within) {
         case CurrentShardSnapshot(dataset33.ref, mapper) =>
-          mapper.shardsForCoord(coordinatorActor) shouldEqual Seq(0)
           latestStatus = mapper.statuses.head
+          if (latestStatus != ShardStatusError)
+            mapper.shardsForCoord(coordinatorActor) shouldEqual Seq(0)
       }
       info(s"Latest status = $latestStatus")
     }
-
-    // expectMsg(IngestionStopped(dataset33.ref, 0))
-
-    // NOTE: right now ingestion errors do not cause IngestionActor to disappear.  Should it?
-    coordinatorActor ! GetIngestionStats(dataset33.ref)
-    expectMsg(IngestionActor.IngestionStatus(45))   // the error happens earlier now, used to be 50
   }
 
   // TODO: Simulate more failures.  Maybe simulate I/O failure or use a custom source
@@ -136,27 +129,6 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
         mapper.statuses.head shouldEqual ShardStatusStopped
     }
 
-  }
-
-  // TODO: consider getting rid of this test, it's *almost* the same as the next one
-  it("should start and stop cleanly") {
-    import IngestionActor.IngestionStatus
-
-    val batchSize = 100
-    setup(dataset6.ref, "/GDELT-sample-test.csv", rowsToRead = batchSize, None)
-
-    import akka.pattern.ask
-    implicit val timeout: Timeout = cluster.settings.InitializationTimeout
-
-    // Wait for all messages to be ingested
-    expectMsgPF(within) {
-      case CurrentShardSnapshot(dataset6.ref, mapper) =>
-        mapper.shardsForCoord(coordinatorActor) shouldEqual Seq(0)
-        mapper.statuses.head shouldEqual ShardStatusStopped
-    }
-
-    val func = (coordinatorActor ? GetIngestionStats(dataset6.ref)).mapTo[IngestionStatus]
-    awaitCond(func.futureValue.rowsIngested == batchSize - 1, max=within)
   }
 
   it("should ingest all rows directly into MemStore") {

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -54,7 +54,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
   implicit val ec = cluster.ec
 
   val strategy = DefaultShardAssignmentStrategy
-  protected val shardManager = new ShardManager(DefaultShardAssignmentStrategy)
+  protected val shardManager = new ShardManager(cluster.settings, DefaultShardAssignmentStrategy)
 
 
   val clusterActor = system.actorOf(Props(new Actor {

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -61,8 +61,8 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     import StatusActor._
     def receive: Receive = {
       case SubscribeShardUpdates(ref) => shardManager.subscribe(sender(), ref)
-      case e: ShardEvent              => shardManager.updateFromShardEvent(e)
-      case EventEnvelope(seq, events) => events.foreach(shardManager.updateFromShardEvent)
+      case e: ShardEvent              => shardManager.updateFromExternalShardEvent(e)
+      case EventEnvelope(seq, events) => events.foreach(shardManager.updateFromExternalShardEvent)
                                          sender() ! StatusAck(seq)
     }
   }))

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -61,8 +61,8 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     import StatusActor._
     def receive: Receive = {
       case SubscribeShardUpdates(ref) => shardManager.subscribe(sender(), ref)
-      case e: ShardEvent              => shardManager.updateFromExternalShardEvent(e)
-      case EventEnvelope(seq, events) => events.foreach(shardManager.updateFromExternalShardEvent)
+      case e: ShardEvent              => shardManager.updateFromExternalShardEvent(sender(), e)
+      case EventEnvelope(seq, events) => events.foreach(e => shardManager.updateFromExternalShardEvent(sender(), e))
                                          sender() ! StatusAck(seq)
     }
   }))
@@ -353,7 +353,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     val split = memStore.getScanSplits(ref, 1).head
     val q2 = LogicalPlan2Query(ref,
                Aggregate(AggregationOperator.Sum,
-                 PeriodicSeries(    // No filters, operate on all rows.  Yes this is not a possible PromQL query. So what
+                 PeriodicSeries(  // No filters, operate on all rows.  Yes this is not a possible PromQL query. So what
                    RawSeries(AllChunksSelector, Nil, Seq("AvgTone")), 0, 10, 99)), qOpt)
     probe.send(coordinatorActor, q2)
     probe.expectMsgPF() {

--- a/coordinator/src/test/scala/filodb.coordinator/ReassignShardsSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ReassignShardsSpec.scala
@@ -2,6 +2,7 @@ package filodb.coordinator
 
 import akka.actor.{ActorRef, Address}
 import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
 
 import filodb.coordinator.NodeClusterActor._
 import filodb.coordinator.client.IngestionCommands.DatasetSetup
@@ -19,7 +20,8 @@ class ReassignShardsSpec extends AkkaSpec {
 
   protected val resources1 = DatasetResourceSpec(8, 3)
 
-  protected val shardManager = new ShardManager(DefaultShardAssignmentStrategy)
+  val settings = new FilodbSettings(ConfigFactory.load("application_test.conf"))
+  protected val shardManager = new ShardManager(settings, DefaultShardAssignmentStrategy)
 
   val coord1 = TestProbe("coordinator1")
   val coord1Address = uniqueAddress(coord1.ref)

--- a/coordinator/src/test/scala/filodb.coordinator/ShardManagerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardManagerSpec.scala
@@ -253,7 +253,8 @@ class ShardManagerSpec extends AkkaSpec {
 
     "ingestion error on a shard should reassign shard to another node" in {
       shardManager.coordinators shouldEqual Seq(coord3.ref, coord2.ref, coord4.ref)
-      shardManager.updateFromExternalShardEvent(IngestionError(dataset1, 0, new IllegalStateException("simulated")))
+      shardManager.updateFromExternalShardEvent(subscriber.ref,
+                                                IngestionError(dataset1, 0, new IllegalStateException("simulated")))
 
       coord4.expectMsgPF() { case ds: DatasetSetup =>
         ds.compactDatasetStr shouldEqual datasetObj1.asCompactString
@@ -269,12 +270,12 @@ class ShardManagerSpec extends AkkaSpec {
         s.map.unassignedShards shouldEqual Nil
       }
       subscriber.expectNoMessage()
-
     }
 
     "continual ingestion error on a shard should not reassign shard to another node" in {
       shardManager.coordinators shouldEqual Seq(coord3.ref, coord2.ref, coord4.ref)
-      shardManager.updateFromExternalShardEvent(IngestionError(dataset1, 0, new IllegalStateException("simulated")))
+      shardManager.updateFromExternalShardEvent(subscriber.ref,
+                                                IngestionError(dataset1, 0, new IllegalStateException("simulated")))
       coord3.expectNoMessage()
       coord2.expectNoMessage()
       coord4.expectNoMessage()

--- a/coordinator/src/test/scala/filodb.coordinator/ShardManagerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardManagerSpec.scala
@@ -276,6 +276,8 @@ class ShardManagerSpec extends AkkaSpec {
       shardManager.coordinators shouldEqual Seq(coord3.ref, coord2.ref, coord4.ref)
       shardManager.updateFromExternalShardEvent(IngestionError(dataset1, 0, new IllegalStateException("simulated")))
       coord3.expectNoMessage()
+      coord2.expectNoMessage()
+      coord4.expectNoMessage()
       subscriber.expectNoMessage()
     }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -33,6 +33,7 @@ filodb {
   }
 
   shard-manager {
+    # Minimum time required between successive automatic shard reassignments done by ShardManager
     reassignment-min-interval = 2 hours
   }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -32,6 +32,10 @@ filodb {
     sample-limit = 200
   }
 
+  shard-manager {
+    reassignment-min-interval = 2 hours
+  }
+
   cassandra {
     hosts = ["localhost"]
     port = 9042

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -85,7 +85,6 @@ trait MemStore extends ChunkSource {
    * @param flushSched the Scheduler to use to schedule flush tasks
    * @param flushStream the stream of FlushCommands for regular flushing of chunks to ChunkSink
    * @param diskTimeToLiveSeconds the time for chunks in this stream to live on disk (Cassandra)
-   * @param errHandler this is called when an ingestion error occurs
    * @return a CancelableFuture for cancelling the stream subscription, which should be done on teardown
    *        the Future completes when both stream and flushStream ends.  It is up to the caller to ensure this.
    */
@@ -94,8 +93,7 @@ trait MemStore extends ChunkSource {
                    stream: Observable[SomeData],
                    flushSched: Scheduler,
                    flushStream: Observable[FlushCommand] = FlushStream.empty,
-                   diskTimeToLiveSeconds: Int = 259200)
-                  (errHandler: Throwable => Unit): CancelableFuture[Unit]
+                   diskTimeToLiveSeconds: Int = 259200): CancelableFuture[Unit]
 
 
   def recoverIndex(dataset: DatasetRef, shard: Int): Future[Unit]

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -74,10 +74,9 @@ extends MemStore with StrictLogging {
                    stream: Observable[SomeData],
                    flushSched: Scheduler,
                    flushStream: Observable[FlushCommand] = FlushStream.empty,
-                   diskTimeToLiveSeconds: Int = 259200)
-                  (errHandler: Throwable => Unit): CancelableFuture[Unit] = {
+                   diskTimeToLiveSeconds: Int = 259200): CancelableFuture[Unit] = {
     val ingestCommands = Observable.merge(stream, flushStream)
-    ingestStream(dataset, shard, ingestCommands, flushSched, diskTimeToLiveSeconds)(errHandler)
+    ingestStream(dataset, shard, ingestCommands, flushSched, diskTimeToLiveSeconds)
   }
 
   def recoverIndex(dataset: DatasetRef, shard: Int): Future[Unit] =
@@ -90,8 +89,7 @@ extends MemStore with StrictLogging {
                    shardNum: Int,
                    combinedStream: Observable[DataOrCommand],
                    flushSched: Scheduler,
-                   diskTimeToLiveSeconds: Int)
-                  (errHandler: Throwable => Unit): CancelableFuture[Unit] = {
+                   diskTimeToLiveSeconds: Int): CancelableFuture[Unit] = {
     val shard = getShardE(dataset, shardNum)
     combinedStream.map {
                     case d: SomeData =>       shard.ingest(d)
@@ -107,7 +105,6 @@ extends MemStore with StrictLogging {
                   }.collect { case Some(flushGroup) => flushGroup }
                   .mapAsync(numParallelFlushes) { f => shard.createFlushTask(f).executeOn(flushSched) }
                   .foreach({ x => })(shard.ingestSched)
-                  .recover { case ex: Throwable => errHandler(ex) }
   }
 
   // a more optimized ingest stream handler specifically for recovery

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -15,6 +15,10 @@ filodb {
     ingestion-consistency-level = "ONE"
   }
 
+  shard-manager {
+    reassignment-min-interval = 2 hours
+  }
+
   store = "timeseries-null"
 
   tasks {

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -159,8 +159,8 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
 
     // val stream = Observable.fromIterable(linearMultiSeries().take(100).grouped(5).toSeq.map(records(dataset1, _)))
     val stream = Observable.fromIterable(groupedRecords(dataset1, linearMultiSeries()))
-    val fut1 = memStore.ingestStream(dataset1.ref, 0, stream, s, FlushStream.empty)(ex => throw ex)
-    val fut2 = memStore.ingestStream(dataset1.ref, 1, stream, s, FlushStream.empty)(ex => throw ex)
+    val fut1 = memStore.ingestStream(dataset1.ref, 0, stream, s, FlushStream.empty)
+    val fut2 = memStore.ingestStream(dataset1.ref, 1, stream, s, FlushStream.empty)
     // Allow both futures to run first before waiting for completion
     fut1.futureValue
     fut2.futureValue
@@ -180,14 +180,12 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
 
   it("should handle errors from ingestStream") {
     memStore.setup(dataset1, 0, TestData.storeConf)
-    var err: Throwable = null
-
     val errStream = Observable.fromIterable(groupedRecords(dataset1, linearMultiSeries()))
                               .endWithError(new NumberFormatException)
-    val fut = memStore.ingestStream(dataset1.ref, 0, errStream, s) { ex => err = ex }
-    fut.futureValue
-
-    err shouldBe a[NumberFormatException]
+    val fut = memStore.ingestStream(dataset1.ref, 0, errStream, s)
+    ScalaFutures.whenReady(fut.failed) { e =>
+      e shouldBe a[NumberFormatException]
+    }
   }
 
   it("should ingestStream and flush on interval") {
@@ -200,7 +198,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val stream = Observable.fromIterable(groupedRecords(dataset1, linearMultiSeries()))
                            .executeWithModel(BatchedExecution(5))
     val flushStream = FlushStream.everyN(4, 50, stream)
-    memStore.ingestStream(dataset1.ref, 0, stream, s, flushStream)(ex => throw ex).futureValue
+    memStore.ingestStream(dataset1.ref, 0, stream, s, flushStream).futureValue
 
     // Two flushes and 3 chunksets have been flushed
     chunksetsWritten shouldEqual initChunksWritten + 4
@@ -223,7 +221,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val stream = Observable.fromIterable(groupedRecords(dataset1, linearMultiSeries(), n = 500, groupSize = 10))
       .executeWithModel(BatchedExecution(5)) // results in 200 records
     val flushStream = FlushStream.everyN(2, 10, stream)
-    memStore.ingestStream(dataset1.ref, 0, stream, s, flushStream)(ex => throw ex).futureValue
+    memStore.ingestStream(dataset1.ref, 0, stream, s, flushStream).futureValue
 
     // 500 records / 2 flushGroups per flush interval / 10 records per flush = 25 time buckets
     timebucketsWritten shouldEqual initTimeBuckets + 25

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -183,7 +183,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val errStream = Observable.fromIterable(groupedRecords(dataset1, linearMultiSeries()))
                               .endWithError(new NumberFormatException)
     val fut = memStore.ingestStream(dataset1.ref, 0, errStream, s)
-    ScalaFutures.whenReady(fut.failed) { e =>
+    whenReady(fut.failed) { e =>
       e shouldBe a[NumberFormatException]
     }
   }

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -142,7 +142,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400)(ex => throw ex).futureValue
+    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)
@@ -204,7 +204,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset3, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset3))
     // Force flush of all groups at end
-    memStore.ingestStream(dataset3.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400)(ex => throw ex).futureValue
+    memStore.ingestStream(dataset3.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)
@@ -233,7 +233,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400)(ex => throw ex).futureValue
+    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)

--- a/doc/sharding.md
+++ b/doc/sharding.md
@@ -145,8 +145,8 @@ def receive: Actor.Receive = {
 The Cluster Singleton assumes that the IngestionActor and the Ingest stream handles all recoverable errors.
 If an exception is thrown, the error is not recoverable.
 
-When an unrecoverable exception occurs in the ingestion stream, the IngestionActor sends releases resources
-for the shard, and an IngestionError event to the singleton.
+When an unrecoverable exception occurs in the ingestion stream, the IngestionActor releases resources
+for the shard, and an IngestionError event is sent to the singleton.
 
 The ShardManager then attempts to reassign the shard to another node. This reassignment is done only if
 the shard was not previously reassigned within 2 hours (configurable). This is to prevent errors arising from

--- a/doc/sharding.md
+++ b/doc/sharding.md
@@ -141,6 +141,16 @@ def receive: Actor.Receive = {
     // via the `ShardMapper` API
 }
 ```
+##### Automatic Reassignment of Shards
+The Cluster Singleton assumes that the IngestionActor and the Ingest stream handles all recoverable errors.
+If an exception is thrown, the error is not recoverable.
+
+When an unrecoverable exception occurs in the ingestion stream, the IngestionActor sends releases resources
+for the shard, and an IngestionError event to the singleton.
+
+The ShardManager then attempts to reassign the shard to another node. This reassignment is done only if
+the shard was not previously reassigned within 2 hours (configurable). This is to prevent errors arising from
+data or load causing shard to be continuously reassigned.
 
 #### Unsubscribe to Shard Status Events
 A subscriber can unsubscribe at any time by sending the `NodeClusterActor` a `Unsubscribe(self)` command,

--- a/filodb-dev-start.sh
+++ b/filodb-dev-start.sh
@@ -47,5 +47,5 @@ if [ "$SETUP_DATASET" = "YES" ]; then
     sleep 20
 
     echo "Configuring the timeseries dataset..."
-    ./filo-cli -Dakka.remote.netty.tcp.hostname=127.0.0.1 --host 127.0.0.1 --dataset timeseries --command setup --filename conf/timeseries-dev-source.conf
+    ./filo-cli -Dakka.remote.netty.tcp.hostname=127.0.0.1 --host 127.0.0.1 --dataset prometheus --command setup --filename conf/timeseries-dev-source.conf
 fi

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -96,11 +96,11 @@ object TestTimeseriesProducer extends StrictLogging {
       val startQuery = startTime / 1000
       val endQuery = startQuery + 300
       val query =
-        s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset timeseries """ +
+        s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus """ +
         s"""--promql 'heap_usage{dc="DC0",app="App-0"}' --start $startQuery --end $endQuery --limit 15"""
       logger.info(s"Sample Query you can use: \n$query")
       val q = URLEncoder.encode("heap_usage{dc=\"DC0\",app=\"App-0\"}", StandardCharsets.UTF_8.toString)
-      val url = s"http://localhost:8080/promql/timeseries/api/v1/query_range?" +
+      val url = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
         s"query=$q&start=$startQuery&end=$endQuery&step=15"
       logger.info(s"Sample URL you can use to query: \n$url")
     }

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -94,8 +94,7 @@ class QueryAndIngestBenchmark extends StrictLogging {
                         Observable.fromIterable(data)
                       }
                       Task.fromFuture(
-                        cluster.memStore.ingestStream(dataset.ref, shard, shardStream, global) {
-                          case e: Exception => throw e })
+                        cluster.memStore.ingestStream(dataset.ref, shard, shardStream, global))
                     }.countL.runAsync
 
   val memstore = cluster.memStore.asInstanceOf[TimeSeriesMemStore]

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -89,9 +89,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
                         val data = bytes.map { array => SomeData(RecordContainer(array), idx) }
                         Observable.fromIterable(data)
                       }
-                      Task.fromFuture(
-                        cluster.memStore.ingestStream(dataset.ref, shard, shardStream, global) {
-                          case e: Exception => throw e })
+                      Task.fromFuture(cluster.memStore.ingestStream(dataset.ref, shard, shardStream, global))
                     }.countL.runAsync
   Await.result(producingFut, 30.seconds)
   Thread sleep 2000

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -108,9 +108,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
                       }
                       // Just do a single flush at the end for all groups
                       val combinedStream: Observable[DataOrCommand] = shardStream ++ FlushStream.allGroups(4)
-                      Task.fromFuture(
-                        memStore.ingestStream(dataset.ref, shard, combinedStream, global, 3 * 86400) {
-                          case e: Exception => throw e })
+                      Task.fromFuture(memStore.ingestStream(dataset.ref, shard, combinedStream, global, 3 * 86400))
                     }.countL.runAsync
   Await.result(producingFut, 30.seconds)
   Thread sleep 2000


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

When shard errors out, it stays in error state. We do not automatically restart the shards.

**New behavior :**

When shard results in in IngestionError event, ShardManager attempts to reassign it another node. Reassignment is attempted only if last reassignment is more than 2 hours earlier. This is so that we do not keep bouncing the shard for errors which are more related to data, than the node itself.

Fixed a possible bug that existed in code on race condition between IngestionStopped vs. MemberDown event that would be exacerbated with the automatic reassignment feature. When member goes down, all shards on node are stopped and IngestionStopped events are generated. Now, there is a race condition between MemberDown event and IngestionStopped events. If IngestionStopped event is consumed by cluster singleton after MemberDown is processed, then the moved shards may again be reassigned. We prevent this by validating that the singleton consumes shard events only if they are generated from the address of the node the shard is assigned to.
