### PR TITLE
Release ChunkMap locks on acquisition thread

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -130,9 +130,6 @@ trait ExecPlan extends QueryCommand {
           qLogger.debug(s"queryId: ${id} Successful execution of ${getClass.getSimpleName} with transformers")
           QueryResult(id, finalRes._2, r)
         }
-        // When the query is done, clean up lingering shared locks caused by iterator limit.
-        .doOnFinish(_ => Task.now(OffheapLFSortedIDMap.releaseAllSharedLocks()))
-        .doOnCancel(Task.now(OffheapLFSortedIDMap.releaseAllSharedLocks()))
         .onErrorHandle { case ex: Throwable =>
           qLogger.error(s"queryId: ${id} Exception during execution of query: ${printTree()}", ex)
           QueryError(id, ex)

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -12,7 +12,6 @@ import filodb.core.DatasetRef
 import filodb.core.metadata.Dataset
 import filodb.core.query.{RangeVector, ResultSchema, SerializableRangeVector}
 import filodb.core.store.ChunkSource
-import filodb.memory.data.OffheapLFSortedIDMap
 import filodb.query._
 import filodb.query.Query.qLogger
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Locks may be released on a different thread than the one it is acquired in.

**New behavior :**

Locks are released on same thread as the are acquired. Acquisition happens when iterator consumption begins. Release is done immediately after that on the same thread.
