### PR TITLE
bug(core): Remove more eager iteration by ChunkIterators

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -254,8 +254,8 @@ extends ReadablePartition with MapHolder {
     val chunkIter = infos(method)
     try {
       chunkIter.hasNext
-    } catch {
-      case e: Throwable => chunkIter.close(); throw e;
+    } finally {
+      chunkIter.close()
     }
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -250,6 +250,15 @@ extends ReadablePartition with MapHolder {
                                 }
   }
 
+  def hasChunks(method: ChunkScanMethod): Boolean = {
+    val chunkIter = infos(method)
+    try {
+      chunkIter.hasNext
+    } catch {
+      case e: Throwable => chunkIter.close(); throw e;
+    }
+  }
+
   // Caller must acquire shared lock, which is released when finished.
   private class OneChunkInfo(info: ChunkSetInfo) extends ChunkInfoIterator {
     var closed = false

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -166,12 +166,7 @@ object SerializableRangeVector extends StrictLogging {
     // Important TODO / TechDebt: We need to replace Iterators with cursors to better control
     // the chunk iteration, lock acquisition and release. This is much needed for safe memory access.
     try {
-      // validate no locks are held by the thread. If there are, quite possible a lock acquire or release bug exists
-      val numLocksReleased = OffheapLFSortedIDMap.releaseAllSharedLocks()
-      if (numLocksReleased > 0) {
-        logger.warn(s"Number of locks before query iterator consumption was non-zero: $numLocksReleased. " +
-          s"This is indicative of a possible lock acquisition/release bug.")
-      }
+      OffheapLFSortedIDMap.validateNoSharedLocks()
       rv.rows.take(limit).foreach { row =>
         numRows += 1
         builder.addFromReader(row)

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -98,6 +98,7 @@ trait ChunkSource extends RawChunkSource {
     val ids = columnIDs.toArray
     val partCols = dataset.infosFromIDs(dataset.partitionColumns.map(_.id))
     scanPartitions(dataset, columnIDs, partMethod, chunkMethod)
+      .filter(_.hasChunks(chunkMethod))
       .map { partition =>
         stats.incrReadPartitions(1)
         val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,

--- a/core/src/main/scala/filodb.core/store/ReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/store/ReadablePartition.scala
@@ -92,6 +92,11 @@ trait ReadablePartition extends FiloPartition {
   def infos(method: ChunkScanMethod): ChunkInfoIterator
 
   /**
+    * Use to check if a ChunkScanMethod for this partition results in any chunks
+    */
+  def hasChunks(method: ChunkScanMethod): Boolean
+
+  /**
    * Returns true if the partition has the chunk with the given id
    */
   def hasChunksAt(id: ChunkID): Boolean

--- a/memory/src/main/scala/filodb.memory/data/ElementIterator.scala
+++ b/memory/src/main/scala/filodb.memory/data/ElementIterator.scala
@@ -35,7 +35,7 @@ trait ElementIterator {
  * Lazily instantiates a wrapped iterator until hasNext or next is called.
  */
 //scalastyle:off
-class LazyElementIterator(source: => ElementIterator) extends ElementIterator {
+class LazyElementIterator(source: () => ElementIterator) extends ElementIterator {
   private var it: ElementIterator = _
 
   // Note: If close is called before the iterator is assigned, then there's seemingly no
@@ -49,7 +49,7 @@ class LazyElementIterator(source: => ElementIterator) extends ElementIterator {
   override def next: NativePointer = sourceIt().next
 
   private def sourceIt(): ElementIterator = {
-    if (it == null) it = source
+    if (it == null) it = source()
     it
   }
 }

--- a/memory/src/main/scala/filodb.memory/data/OffheapLFSortedIDMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/OffheapLFSortedIDMap.scala
@@ -151,6 +151,19 @@ object OffheapLFSortedIDMap extends StrictLogging {
   }
   //scalastyle:on
 
+  /**
+    * Validate no locks are held by the thread. Typically invoked prior to
+    * consumption from a query iterator. If there are lingering locks,
+    * it is quite possible a lock acquire or release bug exists
+    */
+  def validateNoSharedLocks(): Unit = {
+    val numLocksReleased = OffheapLFSortedIDMap.releaseAllSharedLocks()
+    if (numLocksReleased > 0) {
+      logger.warn(s"Number of locks was non-zero: $numLocksReleased. " +
+        s"This is indicative of a possible lock acquisition/release bug.")
+    }
+  }
+
   def bytesNeeded(maxElements: Int): Int = {
     require(maxElements <= MaxMaxElements)
     OffsetElementPtrs + 8 * maxElements

--- a/memory/src/main/scala/filodb.memory/data/OffheapLFSortedIDMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/OffheapLFSortedIDMap.scala
@@ -289,7 +289,7 @@ class OffheapLFSortedIDMapReader(memFactory: MemFactory, holderKlass: Class[_ <:
    * @param inst the instance (eg TSPartition) with the mapPtr field containing the map address
    */
   final def iterate(inst: MapHolder): ElementIterator = {
-    new LazyElementIterator({
+    new LazyElementIterator(() => {
       acquireShared(inst)
       try {
         makeElemIterator(inst, 0)(alwaysContinue)
@@ -306,7 +306,7 @@ class OffheapLFSortedIDMapReader(memFactory: MemFactory, holderKlass: Class[_ <:
    * @param endKey end iteration when element is greater than endKey.  endKey is inclusive.
    */
   final def slice(inst: MapHolder, startKey: Long, endKey: Long): ElementIterator = {
-    new LazyElementIterator({
+    new LazyElementIterator(() => {
       acquireShared(inst)
       try {
         val _mapPtr = mapPtr(inst)
@@ -325,7 +325,7 @@ class OffheapLFSortedIDMapReader(memFactory: MemFactory, holderKlass: Class[_ <:
    * @param startKey start at element whose key is equal or immediately greater than startKey
    */
   final def sliceToEnd(inst: MapHolder, startKey: Long): ElementIterator = {
-    new LazyElementIterator({
+    new LazyElementIterator(() => {
       acquireShared(inst)
       try {
         val _mapPtr = mapPtr(inst)

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -5,12 +5,14 @@ import java.nio.ByteBuffer
 import scala.collection.mutable
 
 import com.tdunning.math.stats.{ArrayDigest, TDigest}
+import com.typesafe.scalalogging.StrictLogging
 import monix.reactive.Observable
 
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
 import filodb.core.query._
+import filodb.memory.data.OffheapLFSortedIDMap
 import filodb.memory.format.{RowReader, UnsafeUtils, ZeroCopyUTF8String}
 import filodb.query._
 import filodb.query.AggregationOperator._
@@ -452,7 +454,7 @@ object AvgRowAggregator extends RowAggregator {
   * Present: The top/bottom-k samples for each timestamp are placed into distinct RangeVectors for each RangeVectorKey
   *         Materialization is needed here, because it cannot be done lazily.
   */
-class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
+class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator with StrictLogging {
 
   private val numRowReaderColumns = 1 + k*2 // one for timestamp, two columns for each top-k
   private val rvkStringCache = mutable.HashMap[RangeVectorKey, ZeroCopyUTF8String]()
@@ -513,18 +515,30 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
     val colSchema = Seq(ColumnInfo("timestamp", ColumnType.LongColumn), ColumnInfo("value", ColumnType.DoubleColumn))
     val recSchema = SerializableRangeVector.toSchema(colSchema)
     val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
-    // We limit the results wherever it is materialized first. So it is done here.
-    aggRangeVector.rows.take(limit).foreach { row =>
-      var i = 1
-      while(row.notNull(i)) {
-        val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
-        val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.toBuilder(recSchema))
-        builder.startNewRecord()
-        builder.addLong(row.getLong(0))
-        builder.addDouble(row.getDouble(i + 1))
-        builder.endRecord()
-        i += 2
+    // Important TODO / TechDebt: We need to replace Iterators with cursors to better control
+    // the chunk iteration, lock acquisition and release. This is much needed for safe memory access.
+    try {
+      // validate no locks are held by the thread. If there are, quite possible a lock acquire or release bug exists
+      val numLocksReleased = OffheapLFSortedIDMap.releaseAllSharedLocks()
+      if (numLocksReleased > 0) {
+        logger.warn(s"Number of locks before query iterator consumption was non-zero: $numLocksReleased. " +
+          s"This is indicative of a possible lock acquisition/release bug.")
       }
+      // We limit the results wherever it is materialized first. So it is done here.
+      aggRangeVector.rows.take(limit).foreach { row =>
+        var i = 1
+        while(row.notNull(i)) {
+          val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
+          val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.toBuilder(recSchema))
+          builder.startNewRecord()
+          builder.addLong(row.getLong(0))
+          builder.addDouble(row.getDouble(i + 1))
+          builder.endRecord()
+          i += 2
+        }
+      }
+    } finally {
+      OffheapLFSortedIDMap.releaseAllSharedLocks()
     }
     resRvs.map { case (key, builder) =>
       val numRows = builder.allContainers.map(_.countRecords).sum

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -518,12 +518,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
     // Important TODO / TechDebt: We need to replace Iterators with cursors to better control
     // the chunk iteration, lock acquisition and release. This is much needed for safe memory access.
     try {
-      // validate no locks are held by the thread. If there are, quite possible a lock acquire or release bug exists
-      val numLocksReleased = OffheapLFSortedIDMap.releaseAllSharedLocks()
-      if (numLocksReleased > 0) {
-        logger.warn(s"Number of locks before query iterator consumption was non-zero: $numLocksReleased. " +
-          s"This is indicative of a possible lock acquisition/release bug.")
-      }
+      OffheapLFSortedIDMap.validateNoSharedLocks()
       // We limit the results wherever it is materialized first. So it is done here.
       aggRangeVector.rows.take(limit).foreach { row =>
         var i = 1

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -59,12 +59,13 @@ final case class SelectChunkInfosExec(id: String,
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     val partCols = dataset.infosFromIDs(dataset.partitionColumns.map(_.id))
     source.scanPartitions(dataset, Seq(column), partMethod, chunkMethod)
+          .filter(_.hasChunks(chunkMethod))
           .map { partition =>
             source.stats.incrReadPartitions(1)
             val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,
                                                   dataset.partKeySchema, partCols, shard)
             ChunkInfoRangeVector(key, partition, chunkMethod, dataColumn)
-          }.filter(_.rows.nonEmpty)
+          }
   }
 
   protected def args: String = s"shard=$shard, rowKeyRange=$rowKeyRange, filters=$filters"

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -46,7 +46,6 @@ final case class SelectRawPartitionsExec(id: String,
     }
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     source.rangeVectors(dataset, colIds, partMethod, chunkMethod)
-          .filter(_.rows.nonEmpty)
   }
 
   protected def args: String = s"shard=$shard, rowKeyRange=$rowKeyRange, filters=$filters"


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We filter out Range Vectors that are returned by the index, but do not have any data in memory. In order to do that we do a hasNext in the query data pipeline setup phase itself. This can cause unreleased locks in some cases. 

There is one other place where we materialize a SerializableRangeVector, and needs to be protected with the lock release logic.

**New behavior :**

Fix is to check if nonEmpty using a different chunk iterator than the one used to iterate through the data. We release lock for that check immediately. 
