### PR TITLE
fix(memory): Eliminate ConcurrentModificationException, caused by rem…

### DIFF
--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -177,13 +177,13 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
   protected def tryReclaim(num: Int): Unit = {
     var reclaimed = 0
     var currList = 0
-    val timeOrderedListIt = usedBlocksTimeOrdered.entrySet.iterator.asScala
+    val timeOrderedListIt = usedBlocksTimeOrdered.entrySet.iterator
     while ( reclaimed < num &&
             timeOrderedListIt.hasNext ) {
       val entry = timeOrderedListIt.next
       reclaimFrom(entry.getValue, stats.timeOrderedBlocksReclaimedMetric)
       // If the block list is now empty, remove it from tree map
-      if (entry.getValue.isEmpty) usedBlocksTimeOrdered.remove(entry.getKey)
+      if (entry.getValue.isEmpty) timeOrderedListIt.remove()
     }
     if (reclaimed < num) reclaimFrom(usedBlocks, stats.blocksReclaimedMetric)
 


### PR DESCRIPTION
…oving from TreeMap without using the iterator.remove method.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Bug found when running test suite:

[info] - should flush MemStore data to C*, and be able to read back data from C* directly *** FAILED ***
[info]   java.util.ConcurrentModificationException:
[info]   at java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1211)
[info]   at java.util.TreeMap$EntryIterator.next(TreeMap.java:1247)
[info]   at java.util.TreeMap$EntryIterator.next(TreeMap.java:1242)
[info]   at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:43)
[info]   at filodb.memory.PageAlignedBlockManager.tryReclaim(BlockManager.scala:183)
[info]   at filodb.memory.PageAlignedBlockManager.reclaimAll(BlockManager.scala:225)
[info]   at filodb.core.memstore.TimeSeriesShard.reclaimAllBlocksTestOnly(TimeSeriesShard.scala:929)

**New behavior :**

Remove from the iterator instead of the TreeMap.