### PR TITLE
misc: Correct typo/misspell in scaladocs, test suites

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/client/NodeCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/NodeCommands.scala
@@ -77,7 +77,7 @@ object IngestionCommands {
   /**
    * Initiates a flush of the remaining MemTable rows of the given dataset and version.
    * Usually used when at the end of ingesting some large blob of data.
-   * @return Flushed when the flush cycle has finished successfully, commiting data to columnstore.
+   * @return Flushed when the flush cycle has finished successfully, committing data to columnstore.
    */
   final case class Flush(dataset: DatasetRef) extends NodeCommand
   case object Flushed extends NodeResponse

--- a/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
@@ -186,7 +186,7 @@ class ShardMapperSpec extends ActorTest(ShardMapperSpec.getNewSystem) {
     map.statusForShard(3) == ShardStatusUnassigned
   }
 
-  it("should be idempotent for shard already assigned to the given coordinator for transitionable status") {
+  it("should be idempotent for shard already assigned to the given coordinator for transitional status") {
     val numShards = 32
     val map = new ShardMapper(numShards)
     val shards = Seq(1, 2)

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -162,7 +162,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     result.resultSchema shouldEqual roundTripResult.resultSchema
     result.id shouldEqual roundTripResult.id
     for { i <- 0 until roundTripResult.result.size } {
-      // BinaryVector deserializes to different impl, so cannot compare top levle object
+      // BinaryVector deserializes to different impl, so cannot compare top level object
       roundTripResult.result(i).schema shouldEqual result.result(i).schema
       roundTripResult.result(i).rows.map(_.getDouble(1)).toSeq shouldEqual
         result.result(i).rows.map(_.getDouble(1)).toSeq

--- a/core/src/main/scala/filodb.core/memstore/BitmapIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/BitmapIndex.scala
@@ -73,7 +73,7 @@ class BitmapIndex[K](indexName: UTF8Str) {
   def get(value: K): Option[EWAHCompressedBitmap] = Option(bitmaps.get(value))
 
   /**
-   * Obtains the combined bitmap from ORing the bitmaps occuring between start and end.
+   * Obtains the combined bitmap from ORing the bitmaps occurring between start and end.
    * Returns the empty bitmap if no values occur between start and end.
    * @param endInclusive true if the end of the range is inclusive. start is always inclusive.
    */

--- a/core/src/main/scala/filodb.core/memstore/PartitionSet.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionSet.scala
@@ -403,7 +403,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
   }
 
   /**
-   * Grow the underlying array to best accomodate the set's size.
+   * Grow the underlying array to best accommodate the set's size.
    *
    * To preserve hashing access speed, the set's size should never be
    * more than 66% of the underlying array's size. When this size is
@@ -592,7 +592,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
     fold(0)((n, a) => if (p(a)) n + 1 else n)
 
   /**
-   * Determine if every member of the set satisifes the predicate p.
+   * Determine if every member of the set satisfies the predicate p.
    *
    * This is an O(n) operation, where n is the size of the
    * set. However, it will return as soon as a false result is
@@ -606,7 +606,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
   }
 
   /**
-   * Determine if any member of the set satisifes the predicate p.
+   * Determine if any member of the set satisfies the predicate p.
    *
    * This is an O(n) operation, where n is the size of the
    * set. However, it will return as soon as a true result is

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -32,7 +32,7 @@ class SeqMapConsumer extends MapItemConsumer {
 }
 
 /**
-  * Range Vector Key backed by a BinaryRecord v2 partition key, whic is basically a pointer to memory on or offheap.
+  * Range Vector Key backed by a BinaryRecord v2 partition key, which is basically a pointer to memory on or offheap.
   */
 final case class PartitionRangeVectorKey(partBase: Array[Byte],
                                          partOffset: Long,

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -335,7 +335,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
     memStore.indexValues(dataset1.ref, 0, "series").toSeq should have length (10)
 
-    // Purposely mark two partitions endTime as occuring a while ago to mark them eligible for eviction
+    // Purposely mark two partitions endTime as occurring a while ago to mark them eligible for eviction
     // We also need to switch buffers so that internally ingestionEndTime() is accurate
     val endTime = markPartitionsForEviction(0 to 1)
 
@@ -369,7 +369,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
     memStore.indexValues(dataset1.ref, 0, "series").toSeq should have length (10)
 
-    // Purposely mark two partitions endTime as occuring a while ago to mark them eligible for eviction
+    // Purposely mark two partitions endTime as occurring a while ago to mark them eligible for eviction
     // We also need to switch buffers so that internally ingestionEndTime() is accurate
     val endTime = markPartitionsForEviction(0 to 1)
 

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -107,7 +107,7 @@ trait ReusableMemory extends StrictLogging {
 }
 
 /**
-  * A block is a resuable piece of memory beginning at the address and has a capacity.
+  * A block is a reusable piece of memory beginning at the address and has a capacity.
   * It is capable of holding metadata also for reclaims.
   * Normally usage of a block starts at position 0 and grows upward.  Metadata usage starts at the top and grows
   * downward.  Each piece of metadata must be < 64KB as two bytes are used to denote size at the start of each piece of
@@ -168,7 +168,7 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
 
   /**
     * @param forSize the size for which to check the capacity for
-    * @return Whether this block has capacity remaining to accomodate passed size of bytes.
+    * @return Whether this block has capacity remaining to accommodate passed size of bytes.
     */
   def hasCapacity(forSize: Long): Boolean = {
     forSize <= remaining()

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Expressions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Expressions.scala
@@ -19,7 +19,7 @@ trait Expressions extends Aggregates with Functions {
         if (lhs.isInstanceOf[ScalarExpression] || rhs.isInstanceOf[ScalarExpression])
           throw new IllegalArgumentException("set operators not allowed in binary scalar expression")
 
-      case comparision: Comparision if !comparision.isBool =>
+      case comparison: Comparision if !comparison.isBool =>
         if (lhs.isInstanceOf[ScalarExpression] && rhs.isInstanceOf[ScalarExpression])
           throw new IllegalArgumentException("comparisons between scalars must use BOOL modifier")
       case _ =>

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -19,7 +19,7 @@ trait Window {
   * All Range Vector Functions are implementation of this trait.
   * There are two choices for function implementation:
   * 1. Use the `addToWindow` and `removeFromWindow` events to evaluate the next value to emit.
-  *    This may result in O(n) complexity for emiting the entire range vector.
+  *    This may result in O(n) complexity for emitting the entire range vector.
   * 2. Use the entire window content in `apply` to emit the next value. Depending on whether the
   *    entire window is examined, this may result in O(n) or O(n-squared) for the entire range vector.
   */


### PR DESCRIPTION
This pull request fixes the minor typos/misspells detected by https://github.com/client9/misspell

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [-] Tests for the changes have been added (for bug fixes / features) ?
- [ -] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

```
$ find . -name *.scala | xargs misspell
./coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala:165:76: "levle" is a misspelling of "level"
./coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala:189:83: "transitionable" is a misspelling of "transitional"
./coordinator/src/main/scala/filodb.coordinator/client/NodeCommands.scala:80:69: "commiting" is a misspelling of "committing"
./core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala:338:48: "occuring" is a misspelling of "occurring"
./core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala:372:48: "occuring" is a misspelling of "occurring"
./core/src/main/scala/filodb.core/memstore/BitmapIndex.scala:76:56: "occuring" is a misspelling of "occurring"
./core/src/main/scala/filodb.core/memstore/PartitionSet.scala:406:39: "accomodate" is a misspelling of "accommodate"
./core/src/main/scala/filodb.core/memstore/PartitionSet.scala:595:42: "satisifes" is a misspelling of "satisfies"
./core/src/main/scala/filodb.core/memstore/PartitionSet.scala:609:40: "satisifes" is a misspelling of "satisfies"
./core/src/main/scala/filodb.core/query/RangeVector.scala:35:64: "whic" is a misspelling of "which"
./memory/src/main/scala/filodb.memory/Block.scala:110:17: "resuable" is a misspelling of "reusable"
./memory/src/main/scala/filodb.memory/Block.scala:171:59: "accomodate" is a misspelling of "accommodate"
./prometheus/src/main/scala/filodb/prometheus/ast/Expressions.scala:22:11: "comparision" is a misspelling of "comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Expressions.scala:22:24: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:43:15: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:47:47: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:51:41: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:55:41: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:59:42: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:63:41: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:67:42: "Comparision" is a misspelling of "Comparison"
```

**New behavior :**

```
$ find . -name *.scala | xargs misspell
./prometheus/src/main/scala/filodb/prometheus/ast/Expressions.scala:22:23: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:43:15: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:47:47: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:51:41: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:55:41: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:59:42: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:63:41: "Comparision" is a misspelling of "Comparison"
./prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala:67:42: "Comparision" is a misspelling of "Comparison"
```

**BREAKING CHANGES**

No breaking change included. 

The tool dectected misspells in `prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala`, but I didn't modify the source because changing it would bring breaking changes. If you're welcome to have deprecation on existing ones and introduce correctly spelled ones, I am willing to work on it.

**Other information**: