### PR TITLE
bug(query): Some query optimizations to remove top allocation

### DIFF
--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -209,6 +209,8 @@ object SerializableRangeVector extends StrictLogging {
       rv.rows.take(limit).foreach { row =>
         numRows += 1
         builder.addFromReader(row)
+        // Do not remove Unit below. Scala compiler tries to box the long for addFromReader return value otherwise (!!)
+        Unit
       }
     } finally {
       // When the query is done, clean up lingering shared locks caused by iterator limit.

--- a/query/src/main/scala/filodb/query/util/IndexedArrayQueue.scala
+++ b/query/src/main/scala/filodb/query/util/IndexedArrayQueue.scala
@@ -38,10 +38,10 @@ class IndexedArrayQueue[T](initialSize: Int = 8) {
 
   private def doubleCapacity(): Unit = {
     require(hd == tl)
-    val initialSize = items.size
+    val initialSize = items.length
     val numLeftOfHead = hd
-    val numRightOfHead = items.size - numLeftOfHead
-    val newCapacity = items.size << 1
+    val numRightOfHead = items.length - numLeftOfHead
+    val newCapacity = items.length << 1
     if (newCapacity < 0) throw new IllegalStateException("Overflow. Cannot allocate.")
     val newItems = new Array[Any](newCapacity)
     Array.copy(items, numLeftOfHead, newItems, 0, numRightOfHead)
@@ -53,11 +53,11 @@ class IndexedArrayQueue[T](initialSize: Int = 8) {
 
   def add(e: T): Unit = {
     items(tl) = e
-    tl = (tl + 1) & (items.size - 1) // can do & instead of % since power of 2
+    tl = (tl + 1) & (items.length - 1) // can do & instead of % since power of 2
     if (tl == hd) doubleCapacity()
   }
 
-  def size: Int = (tl - hd) & (items.size - 1)
+  def size: Int = (tl - hd) & (items.length - 1)
 
   def isEmpty: Boolean = size == 0
 
@@ -67,7 +67,7 @@ class IndexedArrayQueue[T](initialSize: Int = 8) {
     // scalastyle:off
     items(hd) = null  // remove reference
     // scalastyle:on
-    hd = (hd + 1) & (items.size - 1)
+    hd = (hd + 1) & (items.length - 1)
     result.asInstanceOf[T]
   }
 
@@ -75,13 +75,13 @@ class IndexedArrayQueue[T](initialSize: Int = 8) {
 
   def last: T = {
     if (size == 0) throw new NoSuchElementException()
-    val idx = if (tl == 0) items.size - 1 else tl -1
+    val idx = if (tl == 0) items.length - 1 else tl -1
     items(idx).asInstanceOf[T]
   }
 
   def apply(i: Int): T = {
     if (i < 0 || i >= size) throw new ArrayIndexOutOfBoundsException(i)
-    val idx = (hd + i) & (items.size - 1)
+    val idx = (hd + i) & (items.length - 1)
     items(idx).asInstanceOf[T]
   }
 

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 sbt "jmh/jmh:run -rf json -i 15 -wi 10 -f3 -jvmArgsAppend -XX:MaxInlineLevel=20 \
  -jvmArgsAppend -Xmx4g -jvmArgsAppend -XX:MaxInlineSize=99 \
+ -prof jmh.extras.JFR:dir=/tmp/filo-jmh
  filodb.jmh.QueryInMemoryBenchmark \
  filodb.jmh.QueryAndIngestBenchmark \
  filodb.jmh.IngestionBenchmark \


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Fixed following bugs/optimizations:

* fixed QueryAndIngestionBenchmark to not ingest same timestamps
  repeatedly and cause out of order samples and contention in
  out-of-order samples counter
* Array.size replaced with Array.length. There is a hot code path
  method due to ArrayOps$ofRef object allocation for each size() call.
* BinaryJoinExec used function references with primitive args which
  causes boxing for each sample.
* Seq.foreach with the closure's last function returning long strangely
  causes boxing of the Long
* run_benchmarks automatically creates JFR file
