### PR TITLE
feat(coordinator): Custom downing provider and CoordinatedShutdown for split brains

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/metastore/IngestionConfigTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/IngestionConfigTable.scala
@@ -2,7 +2,7 @@ package filodb.cassandra.metastore
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import com.datastax.driver.core.Row
+import com.datastax.driver.core.{ConsistencyLevel, Row}
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
 
 import filodb.cassandra.{FiloCassandraConnector, FiloSessionProvider}
@@ -56,8 +56,15 @@ sealed class IngestionConfigTable(val config: Config, val sessionProvider: FiloS
                             state.streamFactoryClass,
                             state.streamStoreConfig.root.render(ConfigRenderOptions.concise)), AlreadyExists)
 
+  // SELECT * with consistency ONE to let it succeed more often.  This is a temporary workaround to rearranging
+  // the schema so we don't need to do a full table scan.  It is justified because the ingestion config table
+  // almost never changes, this read is done only on new cluster startup, and the table is only written to with
+  // the setup command (which always runs well after cluster startup).
+  val readAllCql = session.prepare(s"SELECT * FROM $tableString")
+                          .setConsistencyLevel(ConsistencyLevel.ONE)
+
   def readAllConfigs(): Future[Seq[IngestionConfig]] =
-    session.executeAsync(s"SELECT * FROM $tableString")
+    session.executeAsync(readAllCql.bind())
            .toIterator.map(_.map(fromRow).toSeq)
 
   def deleteIngestionConfig(dataset: DatasetRef): Future[Response] =

--- a/cassandra/src/main/scala/filodb.cassandra/metastore/IngestionConfigTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/IngestionConfigTable.scala
@@ -60,7 +60,7 @@ sealed class IngestionConfigTable(val config: Config, val sessionProvider: FiloS
   // the schema so we don't need to do a full table scan.  It is justified because the ingestion config table
   // almost never changes, this read is done only on new cluster startup, and the table is only written to with
   // the setup command (which always runs well after cluster startup).
-  val readAllCql = session.prepare(s"SELECT * FROM $tableString")
+  lazy val readAllCql = session.prepare(s"SELECT * FROM $tableString")
                           .setConsistencyLevel(ConsistencyLevel.ONE)
 
   def readAllConfigs(): Future[Seq[IngestionConfig]] =

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -203,7 +203,8 @@ object CliMain extends ArgMain[Arguments] with CsvImportExport with FilodbCluste
         e.printStackTrace()
         exitCode = 2
     } finally {
-      shutdown()
+      // No need to shutdown, just exit.  This ensures things like C* client are not started by accident and
+      // ensures a much quicker exit, which is important for CLI.
       sys.exit(exitCode)
     }
   }

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -3,12 +3,14 @@ package filodb.coordinator
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import scala.collection.immutable
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
 
 import akka.actor._
 import akka.cluster._
 import akka.cluster.ClusterEvent._
 import akka.util.Timeout
+import akka.Done
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
@@ -172,50 +174,45 @@ final class FilodbCluster(val system: ExtendedActorSystem) extends Extension wit
       actor
     }
 
-  /** Begins node graceful shutdown:
-    *   A. Sets `isTerminating` to true and `isJoined` and `isInitialized` to false,
-    *   B. Calls `akka.cluster.Cluster.leave(selfAddress)`
-    *   C. Awaits the async graceful shutdown of the `filodb.coordinator.NodeGuardian`
-    *      supervised child actors via `filodb.coordinator.GracefulStopStrategy`
-    *   D. Shuts down `monix.execution.Scheduler.io` and `filodb.core.store.StoreFactory`'s MetaStore and MemStore
-    *   E. Calls the async terminate on `akka.actor.ActorSystem`
-    *
-    * Idempotent.
-    */
-  protected[filodb] def shutdown(): Unit =
-    if (!isTerminated) {
-      import akka.pattern.gracefulStop
+  /**
+   * Hook into Akka's CoordinatedShutdown sequence
+   * Please see https://doc.akka.io/docs/akka/current/actors.html#coordinated-shutdown for details
+   */
+  CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceUnbind, "queryShutdown") { () =>
+    implicit val timeout = Timeout(15.seconds)
+    // Reset shuts down all ingestion and query actors on this node
+    // TODO: be sure that status gets updated across cluster?
+    (coordinatorActor ? NodeProtocol.ResetState).map(_ ⇒ Done)
+  }
 
-      import NodeProtocol.GracefulShutdown
+  // TODO: hook into service-stop "forcefully kill connections?"  Maybe send each outstanding query "TooBad" etc.
 
-      logger.info("Leaving the cluster.")
-      _cluster.get foreach (_.leave(selfAddress))
+  CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "storeShutdown") { () =>
+    _isInitialized.set(false)
+    logger.info("Terminating: starting shutdown")
 
-      _isInitialized.set(false)
-      logger.info("Terminating: starting shutdown")
-
-      try {
-        if (clusterActor.isDefined) {
-          Await.result(gracefulStop(guardian, GracefulStopTimeout, GracefulShutdown), GracefulStopTimeout)
-        }
-
-        system.terminate foreach { _ =>
-          logger.info("Actor system was shut down")
-        }
-        metaStore.shutdown()
-        memStore.shutdown()
+    try {
+      metaStore.shutdown()
+      memStore.shutdown()
+      ioPool.shutdown()
+    } catch {
+      case NonFatal(e) =>
+        system.terminate()
         ioPool.shutdown()
-      } catch {
-        case NonFatal(e) =>
-          system.terminate()
-          ioPool.shutdown()
-      }
-      finally _isTerminated.set(true)
     }
+    finally _isTerminated.set(true)
 
-  Runtime.getRuntime.addShutdownHook(new Thread() {
-    override def run(): Unit = shutdown()
-  })
+    Future.successful(Done)
+  }
+
+  /**
+   * Invokes CoordinatedShutdown to shut down the ActorSystem, leave the Cluster, and our hooks above
+   * which shuts down the stores and threadpools.
+   * NOTE: Depending on the setting of coordinated-shutdown.exit-jvm, this might cause the JVM to exit.
+   */
+  protected[filodb] def shutdown(): Unit = {
+    CoordinatedShutdown(system).run(CoordinatedShutdown.UnknownReason)
+  }
 
   /** For usage when the `akka.cluster.Member` is needed in a non-actor.
     * Creates a temporary actor which subscribes to `akka.cluster.MemberRemoved`.
@@ -285,7 +282,5 @@ private[filodb] trait FilodbClusterNode extends NodeConfiguration with StrictLog
   def clusterSingleton(role: ClusterRole, watcher: Option[ActorRef]): ActorRef =
     cluster.clusterSingleton(role, watcher)
 
-  /** Only calls `akka.cluster.leave` akka.cluster.Cluster was called by user. */
   def shutdown(): Unit = cluster.shutdown()
-
 }

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -89,10 +89,10 @@ final class FilodbCluster(val system: ExtendedActorSystem) extends Extension wit
   }
 
   def cluster: Cluster = _cluster.get.getOrElse {
-    logger.info(s"Filodb cluster node starting on $selfAddress")
     val c = Cluster(system)
     _cluster.set(Some(c))
     c.registerOnMemberUp(startListener())
+    logger.info(s"Filodb cluster node starting on ${c.selfAddress}")
     c
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -216,6 +216,8 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
              }.recover {
                case e: Exception =>
                  logger.error(s"Unable to restore ingestion state: $e\nTry manually setting up ingestion again", e)
+                 // Continue the protocol, so that the singleton can come up
+                 initiateShardStateRecovery()
              }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -230,6 +230,7 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
     ingesters.clear()
     queryActors.clear()
     memStore.reset()
+    origin ! NodeProtocol.StateReset
   }
 
   private def clearState(ref: DatasetRef): Unit = {

--- a/coordinator/src/main/scala/filodb.coordinator/NodeGuardian.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeGuardian.scala
@@ -14,7 +14,7 @@ final class NodeGuardian(val settings: FilodbSettings,
                          metaStore: MetaStore,
                          memStore: MemStore,
                          assignmentStrategy: ShardAssignmentStrategy
-                        ) extends GracefulStopAwareSupervisor {
+                        ) extends BaseActor {
 
   import ActorName._
   import NodeProtocol._
@@ -45,7 +45,7 @@ final class NodeGuardian(val settings: FilodbSettings,
     case e: ListenerRef            => failureAware ! e
   }
 
-  override def receive: Actor.Receive = guardianReceive orElse super.receive
+  override def receive: Actor.Receive = guardianReceive
 
   /** Sends the current state of local `ShardMapper`
     * and `ShardSubscription` collections to the `requestor`.
@@ -164,7 +164,6 @@ object NodeProtocol {
                                                               ) extends LifecycleCommand
 
   private[coordinator] case object CreateCoordinator extends LifecycleCommand
-  private[coordinator] case object GracefulShutdown extends LifecycleCommand
 
   private[coordinator] final case class ShutdownComplete(ref: ActorRef) extends LifecycleAck
 

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/NodeClusterSpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/NodeClusterSpec.scala
@@ -4,18 +4,28 @@ import scala.concurrent.duration._
 
 import akka.actor.ActorRef
 import akka.remote.testkit.MultiNodeConfig
+// import akka.remote.transport.ThrottlerTransportAdapter.Direction.Both
 import com.typesafe.config.ConfigFactory
 
 import filodb.core._
 
 object NodeClusterSpecConfig extends MultiNodeConfig {
+  // It seems testTransport does not work, maybe because soemthing in the commonConfig is overriding it.
+  // testTransport(on = true)
+
   // register the named roles (nodes) of the test
   val first = role("first")
   val second = role("second")
+  val third = role("third")
 
   // this configuration will be used for all nodes
   // Uses our common Akka test config from application_test.conf
-  val globalConfig = ConfigFactory.parseString("""filodb.memstore.groups-per-shard = 4""".stripMargin)
+  val globalConfig = ConfigFactory.parseString("""filodb.memstore.groups-per-shard = 4
+                                                 |akka.remote.netty.tcp.applied-adapters = [trttl, gremlin]
+                                                 |akka.remote.artery.advanced.test-mode = on
+                                                 |akka.coordinated-shutdown.exit-jvm = on
+                                                 |akka.cluster.run-coordinated-shutdown-when-down = on
+                                               """.stripMargin)
                        .withFallback(ConfigFactory.parseResources("application_test.conf"))
                        .withFallback(ConfigFactory.load("filodb-defaults.conf"))
   commonConfig(globalConfig)
@@ -23,7 +33,7 @@ object NodeClusterSpecConfig extends MultiNodeConfig {
 
 /**
  * Tests the NodeClusterActor cluster singleton, dataset setup error responses,
- * and shard assignment changes when nodes join and leave
+ * and shard assignment changes when nodes join and leave, and in case of split brains.
  */
 abstract class NodeClusterSpec extends ClusterSpec(NodeClusterSpecConfig) {
 
@@ -163,20 +173,78 @@ abstract class NodeClusterSpec extends ClusterSpec(NodeClusterSpecConfig) {
       }
     }
 
-    clusterActor ! ListRegisteredDatasets
-    expectMsg(Seq(ref))
-    clusterActor ! GetShardMap(ref)
-    expectMsgPF(3.seconds.dilated) {
-      case CurrentShardSnapshot(ds, map) =>
-        map.numAssignedShards shouldEqual 4
-        map.allNodes.size shouldEqual 2
+    runOn(first, second) {
+      clusterActor ! ListRegisteredDatasets
+      expectMsg(Seq(ref))
+      clusterActor ! GetShardMap(ref)
+      expectMsgPF(5.seconds.dilated) {
+        case CurrentShardSnapshot(ds, map) =>
+          map.numAssignedShards shouldEqual 4
+          map.allNodes.size shouldEqual 2
+      }
     }
 
     enterBarrier("second-node-update-received")
   }
 
-  it("should update PartitionMap if node goes down") (pending)
+  it("should get the same ShardMapper snapshot when third node joins") {
+    // because there are only 4 shards, 2 shards per node, so map is full
+    runOn(third) {
+      cluster join address1
+      awaitCond(cluster.isJoined)
+      clusterActor = cluster.clusterSingleton(ClusterRole.Server, None)
+    }
+    enterBarrier("third-node-joined")
+
+    runOn(first) {
+      expectMsgPF(10.seconds.dilated) {
+        case CurrentShardSnapshot(ds, map) =>
+          map.numAssignedShards shouldEqual 4
+          map.allNodes.size shouldEqual 2
+      }
+    }
+    enterBarrier("third-node-update-received")
+  }
+
+  // There are a couple problems with this test.
+  // 1. The second node which is isolated will exit the JVM which causes the barrier to fail and the test to fail.
+  //    (note: if the split brain resolver is working, it should exit and kill itself)
+  // 2. The AutoDown actor for the resolver doesn't seem to be running so not sure how #1 is happening.
+  // 3. The test takes a long time.
+  // The code is being left here to be continued as getting the testConductor blackhole to even run was nontrivial.
+  ignore("should update PartitionMap and shut down node 2 on network partition") {
+    // Create network partition between node1-node2 and node3-node2
+    // node2 will be in minority and should shut itself down
+    within(2.minutes) {
+      runOn(first) {
+        println("Starting split brain network partition.... please be patient....")
+        // It seems the testConductor only runs on the first node?
+        // testConductor.blackhole(first, second, Both).futureValue
+        // testConductor.blackhole(third, second, Both).futureValue
+        testConductor.disconnect(first, second)
+        testConductor.disconnect(third, second)
+        // Need to wait for a while for the partition to take effect and split brain resolver to act
+        Thread sleep (70.seconds.toMillis)
+
+        // The 2nd node should be dead by now.  Remove it from the testConductor so other nodes can pass barrier
+        testConductor.removeNode(second).futureValue
+      }
+      enterBarrier("network-partition-created")
+    }
+
+    runOn(first) {
+      val currentRoles = testConductor.getNodes.futureValue
+      currentRoles shouldEqual Seq(first, third)
+
+      expectMsgPF(3.seconds.dilated) {
+        case CurrentShardSnapshot(ds, map) =>
+          map.numAssignedShards shouldEqual 4
+          map.allNodes.size shouldEqual 2
+      }
+    }
+  }
 }
 
 class NodeClusterSpecMultiJvmNode1 extends NodeClusterSpec
 class NodeClusterSpecMultiJvmNode2 extends NodeClusterSpec
+class NodeClusterSpecMultiJvmNode3 extends NodeClusterSpec

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/NodeClusterSpecMultiJvmNode3.opts
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/NodeClusterSpecMultiJvmNode3.opts
@@ -1,0 +1,1 @@
+-Dmultijvm.node=node3 -Dlogback.configurationFile=logback-multijvm-test.xml

--- a/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
@@ -40,22 +40,6 @@ trait FilodbClusterNodeSpec extends AbstractSpec with FilodbClusterNode with Sca
   }
 }
 
-class ClusterNodeCliSpec extends FilodbClusterNodeSpec {
-
-  override val role = ClusterRole.Cli
-
-  "Cli" must {
-    "have the expected config for ClusterRole.Cli" in {
-      val roles = akka.japi.Util.immutableSeq(cluster.settings.allConfig.getStringList("akka.cluster.roles"))
-      roles.size shouldEqual 1
-      roles.forall(_ == ClusterRole.Cli.roleName) shouldEqual true
-    }
-    "become initialized after the coordinator is created" in {
-      assertInitialized()
-    }
-  }
-}
-
 class ClusterNodeDriverSpec extends FilodbClusterNodeSpec {
 
   override val role = ClusterRole.Driver

--- a/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
@@ -35,7 +35,8 @@ trait FilodbClusterNodeSpec extends AbstractSpec with FilodbClusterNode with Sca
 
   def assertShutdown(): Unit = {
     shutdown()
-    eventually(cluster.isTerminated) shouldEqual true
+    val probe = TestProbe()(system)
+    probe.awaitCond(cluster.isTerminated, cluster.settings.GracefulStopTimeout)
   }
 }
 

--- a/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
@@ -1,7 +1,7 @@
 package filodb.coordinator
 
 import akka.testkit.TestProbe
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 
@@ -9,6 +9,11 @@ import filodb.coordinator.client.MiscCommands
 import filodb.core.{AbstractSpec, Success}
 
 trait FilodbClusterNodeSpec extends AbstractSpec with FilodbClusterNode with ScalaFutures {
+  // Ensure that CoordinatedShutdown does not shutdown the whole test JVM, otherwise Travis CI/CD fails
+  override protected lazy val roleConfig = ConfigFactory.parseString(
+        """akka.coordinated-shutdown.run-by-jvm-shutdown-hook=off
+          |akka.coordinated-shutdown.exit-jvm = off
+        """.stripMargin)
 
   implicit abstract override val patienceConfig: PatienceConfig =
     PatienceConfig(

--- a/coordinator/src/test/scala/filodb.coordinator/FilodbClusterSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/FilodbClusterSpec.scala
@@ -29,9 +29,9 @@ class FilodbClusterSpec extends AkkaSpec {
       cluster.clusterActor.isDefined shouldEqual true
       pathElementsExist(clusterActor) should be (true)
     }
+    // Maybe we should just take out this test as we now use Akka's CoordinatedShutdown, not our own shutdown
     "shutdown cleanly" in {
       cluster.shutdown()
-      cluster.isInitialized shouldEqual false
       awaitCond(cluster.isTerminated, cluster.settings.GracefulStopTimeout)
     }
   }

--- a/coordinator/src/test/scala/filodb.coordinator/FilodbClusterSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/FilodbClusterSpec.scala
@@ -29,10 +29,5 @@ class FilodbClusterSpec extends AkkaSpec {
       cluster.clusterActor.isDefined shouldEqual true
       pathElementsExist(clusterActor) should be (true)
     }
-    // Maybe we should just take out this test as we now use Akka's CoordinatedShutdown, not our own shutdown
-    "shutdown cleanly" in {
-      cluster.shutdown()
-      awaitCond(cluster.isTerminated, cluster.settings.GracefulStopTimeout)
-    }
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -64,10 +64,6 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
     Thread sleep 2000
   }
 
-  override def afterAll(): Unit = {
-    super.afterAll()
-  }
-
   def setup(ref: DatasetRef, resource: String, rowsToRead: Int = 5, source: Option[IngestionSource]): Unit = {
     val config = ConfigFactory.parseString(s"""header = true
                                            batch-size = $rowsToRead

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -58,6 +58,7 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
     metaStore.newDataset(dataset6).futureValue shouldEqual Success
     metaStore.newDataset(dataset33).futureValue shouldEqual Success
     coordinatorActor ! NodeProtocol.ResetState
+    expectMsg(NodeProtocol.StateReset)
     clusterActor ! NodeProtocol.ResetState
     expectMsg(NodeProtocol.StateReset)
     Thread sleep 2000
@@ -65,7 +66,6 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
 
   override def afterAll(): Unit = {
     super.afterAll()
-    cluster.shutdown()
   }
 
   def setup(ref: DatasetRef, resource: String, rowsToRead: Int = 5, source: Option[IngestionSource]): Unit = {

--- a/coordinator/src/test/scala/filodb.coordinator/SupervisorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/SupervisorSpec.scala
@@ -48,20 +48,5 @@ class SupervisorSpec extends AkkaSpec {
       }
       system stop guardian
     }
-    "stop gracefully" in {
-      val guardian = system.actorOf(guardianProps)
-      guardian ! CreateCoordinator
-      expectMsgClass(classOf[CoordinatorIdentity])
-      guardian ! CreateClusterSingleton("worker", None)
-      expectMsgClass(classOf[ClusterSingletonIdentity])
-
-      guardian ! GracefulShutdown
-      expectMsgPF() {
-        case ShutdownComplete(ref) =>
-          ref should equal (guardian)
-      }
-      // TODO handle deadletter CurrentClusterState on start
-      // while shutting test down during startup
-    }
   }
 }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -280,7 +280,11 @@ akka {
 
     # Auto downing is turned off by default.  See
     # http://doc.akka.io/docs/akka/2.3.16/scala/cluster-usage.html#Automatic_vs__Manual_Downing
-    # auto-down-unreachable-after = 120s
+    # Instead, we use this repo to provide smarter downing solutions:
+    # https://github.com/TanUkkii007/akka-cluster-custom-downing
+    # Note that this strategy should work well but for fixed size clusters QuorumLeader might be better
+    downing-provider-class = "tanukki.akka.cluster.autodown.MajorityLeaderAutoDowning"
+
     metrics.enabled = off
     failure-detector {
       heartbeat-interval = 5s
@@ -317,5 +321,15 @@ akka {
   coordinated-shutdown.terminate-actor-system = off
   coordinated-shutdown.run-by-jvm-shutdown-hook = off
   cluster.run-coordinated-shutdown-when-down = off
+}
 
+
+custom-downing {
+  stable-after = 20s
+
+  majority-leader-auto-downing {
+    majority-member-role = "worker"    # Must match akka.cluster.roles
+    down-if-in-minority = true
+    shutdown-actor-system-on-resolution = true
+  }
 }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -315,12 +315,10 @@ akka {
     throughput = 100
   }
 
-  # Don't terminate ActorSystem via CoordinatedShutdown in tests
-  # https://doc.akka.io/docs/akka/2.5/project/migration-guide-2.4.x-2.5.x.html#coordinated-shutdown
-  # Remove after 2.4 akka cleanup code
-  coordinated-shutdown.terminate-actor-system = off
-  coordinated-shutdown.run-by-jvm-shutdown-hook = off
-  cluster.run-coordinated-shutdown-when-down = off
+  # Be sure to terminate/exit JVM process after Akka shuts down.  This is important for the
+  # custom downing provider's split brain resolution to work properly.  Basically, the minority
+  # group will shut down itself and exit the process, helping to bring newer nodes online.
+  coordinated-shutdown.exit-jvm = on
 }
 
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -96,4 +96,10 @@ akka {
     # don't use sigar for tests, native lib not in path
     metrics.collector-class = akka.cluster.JmxMetricsCollector
   }
+
+  # Don't terminate ActorSystem via CoordinatedShutdown in tests
+  # Otherwise, the SBT forked process for tests will die prematurely
+  #coordinated-shutdown.terminate-actor-system = off
+  cluster.run-coordinated-shutdown-when-down = off
+  coordinated-shutdown.exit-jvm = off
 }

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -34,6 +34,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
   // First create the tables in C*
   override def beforeAll(): Unit = {
     super.beforeAll()
+    metaStore.initialize().futureValue
     colStore.initialize(dataset.ref).futureValue
     colStore.initialize(GdeltTestData.dataset2.ref).futureValue
     colStore.initialize(datasetDb2.ref).futureValue

--- a/http/src/test/scala/filodb/http/ClusterApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/ClusterApiRouteSpec.scala
@@ -42,6 +42,7 @@ class ClusterApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncTest
 
   before {
     probe.send(cluster.coordinatorActor, NodeProtocol.ResetState)
+    probe.expectMsg(NodeProtocol.StateReset)
     cluster.metaStore.clearAllData().futureValue
     cluster.metaStore.newDataset(dataset6).futureValue shouldEqual Success
     probe.send(clusterProxy, NodeProtocol.ResetState)

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -243,6 +243,7 @@ object FiloBuild extends Build {
     // Redirect minlog logs to SLF4J
      "com.dorkbox"         % "MinLog-SLF4J"       % "1.12",
     "com.opencsv"          % "opencsv"            % "3.3",
+    "com.github.TanUkkii007" %% "akka-cluster-custom-downing" % "0.0.12",
     "com.typesafe.akka"    %% "akka-testkit"      % akkaVersion % Test,
     "com.typesafe.akka"    %% "akka-multi-node-testkit" % akkaVersion % Test
   )

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -275,6 +275,7 @@ object FiloSettings extends Build {
       "Velvia Bintray" at "https://dl.bintray.com/velvia/maven",
       "spray repo" at "http://repo.spray.io"
     ),
+    resolvers += Resolver.bintrayRepo("tanukkii007", "maven"),
 
     cancelable in Global := true,
 

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -173,9 +173,8 @@ object FiloSettings extends Build {
   }
 
   // NOTE: The -Xms1g and using RemoteActorRefProvider (no Cluster startup) both help CLI startup times
+  // Also note: CLI-specific config overrides are set in FilodbCluster.scala
   lazy val shellScript = """#!/bin/bash
-  # ClusterActorRefProvider by default. Enable this line if needed for some of the commands
-  # allprops="-Dakka.actor.provider=akka.remote.RemoteActorRefProvider"
   while [ "${1:0:2}" = "-D" ]
   do
     allprops="$allprops $1"


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently we are using Akka Cluster's auto-downing in several places, which is really not recommended for production and also leads to split brains with each side not coming down.

**New behavior :**

1. Switch to use akka-cluster-custom-downing provider, with a default strategy of majority-quorum.  The default settings cause the minority side to shut itself down automatically, thus preventing a lingering split brain situation, and leading to smooth resolution of split brains.
2. Switch to Akka's CoordinatedShutdown sequence instead of our custom one.  Add hooks for shutdown of the memstore, etc.  One advantage of this scheme is that the shutdown will first remove the QueryActors so that new queries will stop immediately before the rest of the shutdown commences.  Another advantage, besides coordination with the split brain resolver, is that the JVM will exit after shutdown, thus guaranteeing the minority side does not survive and new nodes can come up.
3. Minor bug fix for NodeClusterActor so that if ingestionconfig recovery errors out, it will continue to come up.  Otherwise there is no singleton in the system.

Have verified that the custom downing provider works:

```
[2018-12-03 17:03:51,136] INFO  t.a.c.a.MajorityLeaderAutoDown [filo-standalone-akka.actor.default-dispatcher-19] - Majority is auto-downing unreachable node [akka.tcp://filo-standalone@127.0.0.1:56723]
[2018-12-03 17:03:51,137] INFO  a.c.Cluster(akka://filo-standalone) [filo-standalone-akka.actor.default-dispatcher-19] - Cluster Node [akka.tcp://filo-standalone@127.0.0.1:2552] - Marking unreachable node [akka.tcp://filo-standalone@127.0.0.1:56723] as [Down]
[2018-12-03 17:03:53,095] INFO  a.c.Cluster(akka://filo-standalone) [filo-standalone-akka.actor.default-dispatcher-47] - Cluster Node [akka.tcp://filo-standalone@127.0.0.1:2552] - Leader can perform its duties again
[2018-12-03 17:03:53,103] INFO  a.c.Cluster(akka://filo-standalone) [filo-standalone-akka.actor.default-dispatcher-47] - Cluster Node [akka.tcp://filo-standalone@127.0.0.1:2552] - Leader is removing unreachable node [akka.tcp://filo-standalone@127.0.0.1:56723]
[2018-12-03 17:03:53,103] INFO  f.a.ClusterMembershipTracker [filo-standalone-akka.actor.default-dispatcher-18] - Member is Removed: akka.tcp://filo-standalone@127.0.0.1:56723 after Down. New member list Set(akka.tcp://filo-standalone@127.0.0.1:2552, akka.tcp://filo-standalone@127.0.0.1:56732)
```

### TODO

- Add an explicit split brain test (@helena are there examples of using the Akka multi-jVM test kit's facilities to inject a network partition?)

**BREAKING CHANGES**
None

**Other information**: