### PR TITLE
bug(query): fix metadata query result creation

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -159,11 +159,7 @@ final class RecordSchema(val columnTypes: Seq[Column.ColumnType],
         val consumer = new StringifyMapItemConsumer
         consumeMapItems(base, offset, i, consumer)
         consumer.prettyPrint
-      case (PartitionKeyColumn, i)    =>
-        // FIXME: Looks like we are assuming that partition key is always a map. This is not necessarily true
-        val consumer = new StringifyMapItemConsumer
-        consumeMapItems(base, offset, i, consumer)
-        consumer.prettyPrint
+      case (PartitionKeyColumn, i)    => ???
     }
     s"b2[${parts.mkString(",")}]"
   }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -12,7 +12,7 @@ import filodb.core.MetricsTestData.{builder, timeseriesDataset}
 import filodb.core.TestData
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.metadata.Column.ColumnType.{PartitionKeyColumn, StringColumn}
+import filodb.core.metadata.Column.ColumnType.MapColumn
 import filodb.core.query.{ColumnFilter, Filter, SeqMapConsumer}
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
@@ -56,15 +56,14 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, now, now - 5000, 10)
-    val schema = new RecordSchema(Seq(ColumnType.PartitionKeyColumn))
+    val schema = new RecordSchema(Seq(ColumnType.MapColumn))
     val seqMapConsumer = new SeqMapConsumer()
     val record = metadata.next()
-    val result = (schema.columnTypes.map(columnType => columnType match {
-      case StringColumn => record.toString
-      case PartitionKeyColumn => schema.consumeMapItems(record.partKeyBase, record.partKeyOffset, 0, seqMapConsumer)
+    val result = (schema.columnTypes.zipWithIndex.map{case (c,i) => c match {
+      case MapColumn => schema.consumeMapItems(record.partKeyBase, record.partKeyOffset, 0, seqMapConsumer)
         seqMapConsumer.pairs
       case _ => ???
-    }))
+    }})
     result.head shouldEqual jobQueryResult2
   }
 

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -80,7 +80,7 @@ trait ExecPlan extends QueryCommand {
   }
 
   /**
-    * callback to set per-row schema - e.g for decoding TSPartition back
+    * callback to set per-row schema - e.g for decoding PartitionKey back
     */
   def rowSchema(dataset: Dataset, recordSchema: RecordSchema): RecordSchema = {
     recordSchema

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -80,7 +80,8 @@ trait ExecPlan extends QueryCommand {
   }
 
   /**
-    * callback to set per-row schema - e.g for decoding PartitionKey back
+    * callback to set per-row schema - e.g for decoding PartitionKey back.
+    * No-Op in most cases.
     */
   def rowSchema(dataset: Dataset, recordSchema: RecordSchema): RecordSchema = {
     recordSchema

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -37,7 +37,7 @@ final case class PartKeysDistConcatExec(id: String,
     * Compose the sub-query/leaf results here.
     */
   override protected def compose(childResponses: Observable[QueryResponse], queryConfig: QueryConfig):
-  Observable[RangeVector] = {
+      Observable[RangeVector] = {
 
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     val taskOfResults = childResponses.map {

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -6,6 +6,7 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.DatasetRef
+import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore.{MemStore, TSPartitionRowReader}
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
@@ -16,8 +17,8 @@ import filodb.query._
 import filodb.query.Query.qLogger
 
 final case class PartKeysDistConcatExec(id: String,
-                                      dispatcher: PlanDispatcher,
-                                      children: Seq[ExecPlan]) extends NonLeafExecPlan {
+                                        dispatcher: PlanDispatcher,
+                                        children: Seq[ExecPlan]) extends NonLeafExecPlan {
 
   require(!children.isEmpty)
 
@@ -36,7 +37,7 @@ final case class PartKeysDistConcatExec(id: String,
     * Compose the sub-query/leaf results here.
     */
   override protected def compose(childResponses: Observable[QueryResponse], queryConfig: QueryConfig):
-      Observable[RangeVector] = {
+  Observable[RangeVector] = {
 
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     val taskOfResults = childResponses.map {
@@ -48,11 +49,14 @@ final case class PartKeysDistConcatExec(id: String,
     Observable.fromTask(taskOfResults)
   }
 
+  override def rowSchema(dataset: Dataset, recordSchema: RecordSchema): RecordSchema =
+    dataset.partKeySchema
+
 }
 
 final case class LabelValuesDistConcatExec(id: String,
-                                    dispatcher: PlanDispatcher,
-                                    children: Seq[ExecPlan]) extends NonLeafExecPlan {
+                                           dispatcher: PlanDispatcher,
+                                           children: Seq[ExecPlan]) extends NonLeafExecPlan {
 
   require(!children.isEmpty)
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -49,8 +49,7 @@ final case class PartKeysDistConcatExec(id: String,
     Observable.fromTask(taskOfResults)
   }
 
-  override def rowSchema(dataset: Dataset, recordSchema: RecordSchema): RecordSchema =
-    dataset.partKeySchema
+  override def rowSchema(dataset: Dataset, recordSchema: RecordSchema): RecordSchema = dataset.partKeySchema
 
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Current implementation assumes that PartitionKey always has only one MapColumn

**New behavior :**

- PartitionKeySchema is added in the SerializableRangeVectors of the QueryResponse so that clients can read the column values back
