### PR TITLE
feat(core, query): Full support for BinaryRecordColumn

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -371,7 +371,7 @@ object CliMain extends ArgMain[Arguments] with CsvImportExport with FilodbCluste
       case Some(intervalSecs) =>
         val fut = Observable.intervalAtFixedRate(intervalSecs.seconds).foreach { n =>
           client.logicalPlan2Query(ref, plan, qOpts) match {
-            case QueryResult(_, schema, result) => result.foreach(rv => println(rv.prettyPrint(schema)))
+            case QueryResult(_, schema, result) => result.foreach(rv => println(rv.prettyPrint()))
             case err: QueryError                => throw new ClientException(err)
           }
         }.recover {
@@ -383,7 +383,7 @@ object CliMain extends ArgMain[Arguments] with CsvImportExport with FilodbCluste
         try {
           client.logicalPlan2Query(ref, plan, qOpts) match {
             case QueryResult(_, schema, result) => println(s"Number of Range Vectors: ${result.size}")
-                                                   result.foreach(rv => println(rv.prettyPrint(schema)))
+                                                   result.foreach(rv => println(rv.prettyPrint()))
             case QueryError(_,ex)               => println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")
           }
         } catch {

--- a/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
@@ -124,7 +124,8 @@ class RecordSchemaSerializer extends KryoSerializer[RecordSchema] {
 class RecordSchema2Serializer extends KryoSerializer[RecordSchema2] {
   override def read(kryo: Kryo, input: Input, typ: Class[RecordSchema2]): RecordSchema2 = {
     val tuple = kryo.readClassAndObject(input)
-    RecordSchema2.fromSerializableTuple(tuple.asInstanceOf[(Seq[Column.ColumnType], Option[Int], Seq[String])])
+    RecordSchema2.fromSerializableTuple(tuple.asInstanceOf[(Seq[String], Seq[Column.ColumnType],
+                                                            Option[Int], Seq[String], Map[Int, RecordSchema2])])
   }
 
   override def write(kryo: Kryo, output: Output, schema: RecordSchema2): Unit = {

--- a/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
@@ -9,6 +9,7 @@ import filodb.core._
 import filodb.core.binaryrecord.{ArrayBinaryRecord, BinaryRecord, RecordSchema}
 import filodb.core.binaryrecord2.{RecordSchema => RecordSchema2}
 import filodb.core.metadata.Column
+import filodb.core.query.ColumnInfo
 import filodb.memory.format.ZeroCopyUTF8String
 
 /**
@@ -124,8 +125,8 @@ class RecordSchemaSerializer extends KryoSerializer[RecordSchema] {
 class RecordSchema2Serializer extends KryoSerializer[RecordSchema2] {
   override def read(kryo: Kryo, input: Input, typ: Class[RecordSchema2]): RecordSchema2 = {
     val tuple = kryo.readClassAndObject(input)
-    RecordSchema2.fromSerializableTuple(tuple.asInstanceOf[(Seq[String], Seq[Column.ColumnType],
-                                                            Option[Int], Seq[String], Map[Int, RecordSchema2])])
+    RecordSchema2.fromSerializableTuple(tuple.asInstanceOf[(Seq[ColumnInfo], Option[Int],
+                                                            Seq[String], Map[Int, RecordSchema2])])
   }
 
   override def write(kryo: Kryo, output: Output, schema: RecordSchema2): Unit = {

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
@@ -21,7 +21,8 @@ final class RecordComparator(ingestSchema: RecordSchema) {
   require(ingestSchema.partitionFieldStart.isDefined)
   require(ingestSchema.columnTypes.length > ingestSchema.partitionFieldStart.get, "no partition fields")
 
-  val partitionKeySchema = new RecordSchema(ingestSchema.columnTypes.drop(ingestSchema.partitionFieldStart.get),
+  val partitionKeySchema = new RecordSchema(ingestSchema.colNames.drop(ingestSchema.partitionFieldStart.get),
+                                            ingestSchema.columnTypes.drop(ingestSchema.partitionFieldStart.get),
                                             Some(0),
                                             ingestSchema.predefinedKeys)
   // NOTE: remember that private final val results in a Java field, much much faster

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
@@ -21,8 +21,7 @@ final class RecordComparator(ingestSchema: RecordSchema) {
   require(ingestSchema.partitionFieldStart.isDefined)
   require(ingestSchema.columnTypes.length > ingestSchema.partitionFieldStart.get, "no partition fields")
 
-  val partitionKeySchema = new RecordSchema(ingestSchema.colNames.drop(ingestSchema.partitionFieldStart.get),
-                                            ingestSchema.columnTypes.drop(ingestSchema.partitionFieldStart.get),
+  val partitionKeySchema = new RecordSchema(ingestSchema.columns.drop(ingestSchema.partitionFieldStart.get),
                                             Some(0),
                                             ingestSchema.predefinedKeys)
   // NOTE: remember that private final val results in a Java field, much much faster

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -77,6 +77,7 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
       (row: RowReader, builder: RecordBuilder) => builder.addSlowly(row.getAny(colNo))
   }.toArray
 
+  def numColumns: Int = columns.length
 
   def isTimeSeries: Boolean = columnTypes.length >= 1 &&
     (columnTypes.head == LongColumn || columnTypes.head == TimestampColumn)
@@ -274,9 +275,8 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
   }
 
   // For serialization purposes
-  private[filodb] def toSerializableTuple: (Seq[String], Seq[Column.ColumnType],
-                                            Option[Int], Seq[String], Map[Int, RecordSchema]) =
-    (colNames, columnTypes, partitionFieldStart, predefinedKeys, brSchema)
+  private[filodb] def toSerializableTuple: (Seq[ColumnInfo], Option[Int], Seq[String], Map[Int, RecordSchema]) =
+    (columns, partitionFieldStart, predefinedKeys, brSchema)
 }
 
 trait MapItemConsumer {

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -1,6 +1,7 @@
 package filodb.core.binaryrecord2
 
 import filodb.core.metadata.{Column, Dataset}
+import filodb.core.metadata.Column.ColumnType.{LongColumn, TimestampColumn}
 import filodb.memory.{BinaryRegion, BinaryRegionLarge, UTF8StringMedium}
 import filodb.memory.format.{RowReader, UnsafeUtils, ZeroCopyUTF8String}
 import filodb.memory.format.{vectors => bv}
@@ -24,12 +25,15 @@ import filodb.memory.format.{vectors => bv}
  *   the fact that all variable length fields after the partitionFieldStart are contiguous and can be binary compared
  *
  * @param columnTypes In order, the field or column type of each field in this schema
+ * @param brSchema schema of any binary record type column
  * @param partitionFieldStart Some(n) from n to the last field are considered the partition key.  A field number.
  * @param predefinedKeys A list of predefined keys to save space for the tags/MapColumn field(s)
  */
-final class RecordSchema(val columnTypes: Seq[Column.ColumnType],
+final class RecordSchema(val colNames: Seq[String],
+                         val columnTypes: Seq[Column.ColumnType],
                          val partitionFieldStart: Option[Int] = None,
-                         val predefinedKeys: Seq[String] = Nil) {
+                         val predefinedKeys: Seq[String] = Nil,
+                         val brSchema: Map[Int, RecordSchema] = Map.empty) {
   import RecordSchema._
   import BinaryRegion.NativePointer
 
@@ -63,13 +67,17 @@ final class RecordSchema(val columnTypes: Seq[Column.ColumnType],
     case (Column.ColumnType.StringColumn, colNo) =>
       // TODO: we REALLY need a better API than ZeroCopyUTF8String as it creates so much garbage
       (row: RowReader, builder: RecordBuilder) => builder.addBlob(row.filoUTF8String(colNo))
-    case (Column.ColumnType.PartitionKeyColumn, colNo) =>
+    case (Column.ColumnType.BinaryRecordColumn, colNo) =>
       (row: RowReader, builder: RecordBuilder) =>
         builder.addBlob(row.getBlobBase(colNo), row.getBlobOffset(colNo), row.getBlobNumBytes(colNo))
     case (t: Column.ColumnType, colNo) =>
       // TODO: add more efficient methods
       (row: RowReader, builder: RecordBuilder) => builder.addSlowly(row.getAny(colNo))
   }.toArray
+
+
+  def isTimeSeries: Boolean = columnTypes.length >= 1 &&
+    (columnTypes.head == LongColumn || columnTypes.head == TimestampColumn)
 
   def fieldOffset(index: Int): Int = offsets(index)
 
@@ -144,32 +152,34 @@ final class RecordSchema(val columnTypes: Seq[Column.ColumnType],
     asZCUTF8Str(UnsafeUtils.ZeroPointer, address, index)
 
   /**
-   * EXPENSIVE. Creates a easy-to-read Java String representation of the contents of this BinaryRecord.
+   * EXPENSIVE to do at server side. Creates a easy-to-read string
+   * representation of the contents of this BinaryRecord.
    */
-  def stringify(base: Any, offset: Long): String = {
-    import Column.ColumnType._
-    val parts: Seq[Any] = columnTypes.zipWithIndex.map {
-      case (IntColumn, i)    => getInt(base, offset, i)
-      case (LongColumn, i)   => getLong(base, offset, i)
-      case (DoubleColumn, i) => getDouble(base, offset, i)
-      case (StringColumn, i) => asJavaString(base, offset, i)
-      case (TimestampColumn, i) => getLong(base, offset, i)
-      case (BitmapColumn, i) => getInt(base, offset, i) != 0
-      case (MapColumn, i)    =>
-        val consumer = new StringifyMapItemConsumer
-        consumeMapItems(base, offset, i, consumer)
-        consumer.prettyPrint
-      case (PartitionKeyColumn, i)    =>
-        // FIXME: Looks like we are assuming that partition key is always a map. This is not necessarily true
-        val consumer = new StringifyMapItemConsumer
-        consumeMapItems(base, offset, i, consumer)
-        consumer.prettyPrint
-    }
-    s"b2[${parts.mkString(",")}]"
-  }
+  def stringify(base: Any, offset: Long): String =
+    s"b2[${mapify(base, offset).map(_.productIterator.mkString("=")).mkString(",")}]"
 
   def stringify(address: NativePointer): String = stringify(UnsafeUtils.ZeroPointer, address)
   def stringify(bytes: Array[Byte]): String = stringify(bytes, UnsafeUtils.arayOffset)
+
+  /**
+    * EXPENSIVE to do at server side. Creates a stringified map with contents of this BinaryRecord.
+    */
+  def mapify(base: Any, offset: Long): Map[String, String] = {
+    import Column.ColumnType._
+    val resultMap = collection.mutable.Map[String, String]()
+    columnTypes.zipWithIndex.map {
+      case (IntColumn, i)    => resultMap.put(colNames(i), getInt(base, offset, i).toString)
+      case (LongColumn, i)   => resultMap.put(colNames(i), getLong(base, offset, i).toString)
+      case (DoubleColumn, i) => resultMap.put(colNames(i), getDouble(base, offset, i).toString)
+      case (StringColumn, i) => resultMap.put(colNames(i), asJavaString(base, offset, i).toString)
+      case (TimestampColumn, i) => resultMap.put(colNames(i), getLong(base, offset, i).toString)
+      case (BitmapColumn, i) => resultMap.put(colNames(i), (getInt(base, offset, i) != 0).toString)
+      case (MapColumn, i)    => consumeMapItems(base, offset, i, new MapifyMapItemConsumer(resultMap))
+      case (BinaryRecordColumn, i)  => brSchema(i).mapify(base, offset)
+                                                  .foreach { case (k,v) => resultMap.put(k,v)}
+    }
+    resultMap.toMap
+  }
 
   /**
    * Iterates through each key/value pair of a MapColumn field without any object allocations.
@@ -261,8 +271,9 @@ final class RecordSchema(val columnTypes: Seq[Column.ColumnType],
   }
 
   // For serialization purposes
-  private[filodb] def toSerializableTuple: (Seq[Column.ColumnType], Option[Int], Seq[String]) =
-    (columnTypes, partitionFieldStart, predefinedKeys)
+  private[filodb] def toSerializableTuple: (Seq[String], Seq[Column.ColumnType],
+                                            Option[Int], Seq[String], Map[Int, RecordSchema]) =
+    (colNames, columnTypes, partitionFieldStart, predefinedKeys, brSchema)
 }
 
 trait MapItemConsumer {
@@ -288,6 +299,12 @@ class StringifyMapItemConsumer extends MapItemConsumer {
   }
 }
 
+class MapifyMapItemConsumer(toAdd: collection.mutable.Map[String, String]) extends MapItemConsumer {
+  def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
+    toAdd.put(UTF8StringMedium.toString(keyBase, keyOffset), UTF8StringMedium.toString(valueBase, valueOffset))
+  }
+}
+
 object RecordSchema {
   import Column.ColumnType._
 
@@ -296,7 +313,7 @@ object RecordSchema {
                                                        DoubleColumn -> 8,
                                                        TimestampColumn -> 8,  // Just a long ms timestamp
                                                        StringColumn -> 4,
-                                                       PartitionKeyColumn -> 4,
+                                                       BinaryRecordColumn -> 4,
                                                        MapColumn -> 4)
 
   /**
@@ -321,12 +338,14 @@ object RecordSchema {
    * Create an "ingestion" RecordSchema with the data columns followed by the partition columns.
    */
   def ingestion(dataset: Dataset, predefinedKeys: Seq[String] = Nil): RecordSchema = {
+    val colNames = dataset.dataColumns.map(_.name) ++ dataset.partitionColumns.map(_.name)
     val colTypes = dataset.dataColumns.map(_.columnType) ++ dataset.partitionColumns.map(_.columnType)
-    new RecordSchema(colTypes, Some(dataset.dataColumns.length), predefinedKeys)
+    new RecordSchema(colNames, colTypes, Some(dataset.dataColumns.length), predefinedKeys)
   }
 
-  def fromSerializableTuple(tuple: (Seq[Column.ColumnType], Option[Int], Seq[String])): RecordSchema =
-    new RecordSchema(tuple._1, tuple._2, tuple._3)
+  def fromSerializableTuple(tuple: (Seq[String], Seq[Column.ColumnType],
+                                    Option[Int], Seq[String], Map[Int, RecordSchema])): RecordSchema =
+    new RecordSchema(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5)
 }
 
 // Used with PartitionTimeRangeReader, when a user queries for a partition column

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -276,10 +276,10 @@ class PartKeyLuceneIndex(dataset: Dataset,
                            partKeyNumBytes: Int,
                            partId: Int, startTime: Long, endTime: Long): Document = {
     val document = new Document()
-    // TODO We can use RecordSchema.mapify to get the name/value pairs from partKey.
+    // TODO We can use RecordSchema.toStringPairs to get the name/value pairs from partKey.
     // That is far more simpler with much of the logic abstracted out.
     // Currently there is a bit of leak in abstraction of Binary Record processing in this class.
-    
+
     luceneDocument.set(document) // threadlocal since we are not able to pass the document into mapconsumer
     for { i <- 0 until numPartColumns optimized } {
       indexers(i).fromPartKey(partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset), partId)

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -276,6 +276,10 @@ class PartKeyLuceneIndex(dataset: Dataset,
                            partKeyNumBytes: Int,
                            partId: Int, startTime: Long, endTime: Long): Document = {
     val document = new Document()
+    // TODO We can use RecordSchema.mapify to get the name/value pairs from partKey.
+    // That is far more simpler with much of the logic abstracted out.
+    // Currently there is a bit of leak in abstraction of Binary Record processing in this class.
+    
     luceneDocument.set(document) // threadlocal since we are not able to pass the document into mapconsumer
     for { i <- 0 until numPartColumns optimized } {
       indexers(i).fromPartKey(partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset), partId)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -361,7 +361,7 @@ extends ReadablePartition with MapHolder {
   }
 }
 
-final case class TSPartitionRowReader(records: Iterator[TimeSeriesPartition]) extends Iterator[RowReader] {
+final case class PartKeyRowReader(records: Iterator[TimeSeriesPartition]) extends Iterator[RowReader] {
   var currVal: TimeSeriesPartition = _
 
   private val rowReader = new RowReader {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -22,7 +22,7 @@ import filodb.core.{ErrorResponse, _}
 import filodb.core.binaryrecord2._
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
-import filodb.core.query.{ColumnFilter, SeqIndexValueConsumer}
+import filodb.core.query.{ColumnFilter, ColumnInfo, SeqIndexValueConsumer}
 import filodb.core.store._
 import filodb.memory._
 import filodb.memory.data.{OffheapLFSortedIDMap, OffheapLFSortedIDMapMutator}
@@ -103,8 +103,9 @@ object TimeSeriesShard {
     }
   }
 
-  val indexTimeBucketSchema = new RecordSchema(Seq("startTime", "endTime", "partKey"),
-                                       Seq(ColumnType.LongColumn, ColumnType.LongColumn, ColumnType.StringColumn))
+  val indexTimeBucketSchema = new RecordSchema(Seq(ColumnInfo("startTime", ColumnType.LongColumn),
+                                                   ColumnInfo("endTime", ColumnType.LongColumn),
+                                                   ColumnInfo("partKey", ColumnType.StringColumn)))
 
   // TODO make configurable if necessary
   val indexTimeBucketTtlPaddingSeconds = 24.hours.toSeconds.toInt

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -103,9 +103,8 @@ object TimeSeriesShard {
     }
   }
 
-  val indexTimeBucketSchema = new RecordSchema(Seq(ColumnType.LongColumn,  // startTime
-                                               ColumnType.LongColumn,       // endTime
-                                               ColumnType.StringColumn))    // partKey bytes
+  val indexTimeBucketSchema = new RecordSchema(Seq("startTime", "endTime", "partKey"),
+                                       Seq(ColumnType.LongColumn, ColumnType.LongColumn, ColumnType.StringColumn))
 
   // TODO make configurable if necessary
   val indexTimeBucketTtlPaddingSeconds = 24.hours.toSeconds.toInt

--- a/core/src/main/scala/filodb.core/metadata/Column.scala
+++ b/core/src/main/scala/filodb.core/metadata/Column.scala
@@ -76,7 +76,7 @@ object Column extends StrictLogging {
     case object BitmapColumn extends RichColumnType[Boolean]("bitmap")
     case object TimestampColumn extends RichColumnType[Long]("ts")
     case object MapColumn extends RichColumnType[UTF8Map]("map")
-    case object PartitionKeyColumn extends RichColumnType[ZeroCopyUTF8String]("partKey")
+    case object BinaryRecordColumn extends RichColumnType[ZeroCopyUTF8String]("br")
   }
 
   val typeNameToColType = ColumnType.values.map { colType => colType.typeName -> colType }.toMap

--- a/core/src/main/scala/filodb.core/metadata/SimpleComputations.scala
+++ b/core/src/main/scala/filodb.core/metadata/SimpleComputations.scala
@@ -135,7 +135,7 @@ object SimpleComputations {
           case BitmapColumn => wrap((b: Boolean) => (if (b) 1 else 0) % numBuckets)
           case TimestampColumn => wrap((l: Long) => Math.abs(l % numBuckets).toInt)
           case MapColumn => wrap((m: UTF8Map) => Math.abs(m.hashCode % numBuckets))
-          case PartitionKeyColumn => wrap((s: UTF8Str) => Math.abs(s.hashCode % numBuckets))
+          case BinaryRecordColumn => wrap((s: UTF8Str) => Math.abs(s.hashCode % numBuckets))
         }
         computedColumn(expr, dataset, info, IntColumn, extractor)
       }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -153,12 +153,11 @@ final class SerializableRangeVector(val key: RangeVectorKey,
             s"${new DateTime(timeStamp).toString()} (${(curTime - timeStamp)/1000}s ago) $timeStamp"
           } else {
             schema.columnTypes(0) match {
-              // FIXME: underlying stringify method assumes that partition key is a map. Not necessarily true
               case BinaryRecordColumn => schema.stringify(reader.getBlobBase(0), reader.getBlobOffset(0))
               case _ => reader.getAny(0).toString
             }
           }
-          (firstCol +: (1 until schema.columnTypes.length).map(reader.getAny(_).toString)).mkString("\t")
+          (firstCol +: (1 until schema.numColumns).map(reader.getAny(_).toString)).mkString("\t")
       }.mkString("\n\t") + "\n"
   }
 }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -222,10 +222,7 @@ object SerializableRangeVector extends StrictLogging {
 
   def toSchema(colSchema: Seq[ColumnInfo], brColInfos: Map[Int, Seq[ColumnInfo]] = Map.empty): RecordSchema = {
     val brSchemas = brColInfos.mapValues(toSchema(_))
-    schemaCache.getOrElseUpdate(colSchema, { cols => new RecordSchema(colNames = cols.map(_.name),
-                                                                      columnTypes = cols.map(_.colType),
-                                                                      brSchema = brSchemas)
-                                           })
+    schemaCache.getOrElseUpdate(colSchema, { cols => new RecordSchema(columns = cols, brSchema = brSchemas) })
   }
 
   def toBuilder(schema: RecordSchema): RecordBuilder =

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -36,8 +36,10 @@ final case class ColumnInfo(name: String, colType: Column.ColumnType)
 /**
  * Describes the full schema of Vectors and Tuples, including how many initial columns are for row keys.
  * The first ColumnInfo in the schema describes the first vector in Vectors and first field in Tuples, etc.
+ * @param brSchemas if any of the columns is a binary record, thsi
  */
-final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int) {
+final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
+                              brSchemas: Map[Int, Seq[ColumnInfo]] = Map.empty) {
   import Column.ColumnType._
 
   def length: Int = columns.length

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -15,7 +15,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
   val schema1 = RecordSchema.ingestion(dataset1)
   val schema2 = RecordSchema.ingestion(dataset2)
-  val longStrSchema = new RecordSchema(Seq(ColumnType.LongColumn, ColumnType.StringColumn))
+  val longStrSchema = new RecordSchema(Seq("lc", "sc"), Seq(ColumnType.LongColumn, ColumnType.StringColumn))
 
   val records = new collection.mutable.ArrayBuffer[(Any, Long)]
 
@@ -284,7 +284,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
     it("should hash correctly with different ways of adding UTF8 fields") {
       // schema for part key with only a string
-      val stringSchema = new RecordSchema(Seq(ColumnType.StringColumn), Some(0))
+      val stringSchema = new RecordSchema(Seq("sc"), Seq(ColumnType.StringColumn), Some(0))
       val builder = new RecordBuilder(nativeMem, stringSchema)
 
       val str = "Serie zero"

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, Matchers}
 import filodb.core.{MachineMetricsData, Types}
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.{Dataset, DatasetOptions}
+import filodb.core.query.ColumnInfo
 import filodb.memory.{BinaryRegion, BinaryRegionConsumer, MemFactory, NativeMemoryManager, UTF8StringMedium}
 import filodb.memory.format.{SeqRowReader, UnsafeUtils}
 
@@ -15,7 +16,8 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
   val schema1 = RecordSchema.ingestion(dataset1)
   val schema2 = RecordSchema.ingestion(dataset2)
-  val longStrSchema = new RecordSchema(Seq("lc", "sc"), Seq(ColumnType.LongColumn, ColumnType.StringColumn))
+  val longStrSchema = new RecordSchema(Seq(ColumnInfo("lc", ColumnType.LongColumn),
+                                           ColumnInfo("sc", ColumnType.StringColumn)))
 
   val records = new collection.mutable.ArrayBuffer[(Any, Long)]
 
@@ -284,7 +286,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
     it("should hash correctly with different ways of adding UTF8 fields") {
       // schema for part key with only a string
-      val stringSchema = new RecordSchema(Seq("sc"), Seq(ColumnType.StringColumn), Some(0))
+      val stringSchema = new RecordSchema(Seq(ColumnInfo("sc", ColumnType.StringColumn)), Some(0))
       val builder = new RecordBuilder(nativeMem, stringSchema)
 
       val str = "Serie zero"

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -12,7 +12,7 @@ import filodb.core.MetricsTestData.{builder, timeseriesDataset}
 import filodb.core.TestData
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.metadata.Column.ColumnType.{PartitionKeyColumn, StringColumn}
+import filodb.core.metadata.Column.ColumnType.{BinaryRecordColumn, StringColumn}
 import filodb.core.query.{ColumnFilter, Filter, SeqMapConsumer}
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
@@ -56,12 +56,12 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, now, now - 5000, 10)
-    val schema = new RecordSchema(Seq(ColumnType.PartitionKeyColumn))
+    val schema = new RecordSchema(Seq("brc"), Seq(ColumnType.BinaryRecordColumn))
     val seqMapConsumer = new SeqMapConsumer()
     val record = metadata.next()
     val result = (schema.columnTypes.map(columnType => columnType match {
       case StringColumn => record.toString
-      case PartitionKeyColumn => schema.consumeMapItems(record.partKeyBase, record.partKeyOffset, 0, seqMapConsumer)
+      case BinaryRecordColumn => schema.consumeMapItems(record.partKeyBase, record.partKeyOffset, 0, seqMapConsumer)
         seqMapConsumer.pairs
       case _ => ???
     }))

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -13,7 +13,7 @@ import filodb.core.TestData
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Column.ColumnType.{BinaryRecordColumn, StringColumn}
-import filodb.core.query.{ColumnFilter, Filter, SeqMapConsumer}
+import filodb.core.query.{ColumnFilter, ColumnInfo, Filter, SeqMapConsumer}
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 
@@ -56,7 +56,7 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, now, now - 5000, 10)
-    val schema = new RecordSchema(Seq("brc"), Seq(ColumnType.BinaryRecordColumn))
+    val schema = new RecordSchema(Seq(ColumnInfo("brc", ColumnType.BinaryRecordColumn)))
     val seqMapConsumer = new SeqMapConsumer()
     val record = metadata.next()
     val result = (schema.columnTypes.map(columnType => columnType match {

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -104,7 +104,7 @@ trait ExecPlan extends QueryCommand {
         qLogger.debug(s"queryId: ${id} Started Transformer ${transf.getClass.getSimpleName} with ${transf.args}")
         (transf.apply(acc._1, queryConfig, limit, acc._2), transf.schema(dataset, acc._2))
       }
-      val recSchema = SerializableRangeVector.toSchema(finalRes._2.columns)
+      val recSchema = SerializableRangeVector.toSchema(finalRes._2.columns, finalRes._2.brSchemas)
       val builder = SerializableRangeVector.toBuilder(recSchema)
       finalRes._1
         .map {

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -28,7 +28,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
 
-  val partKeyLabelValues = Map("__name__"->"http_req_total", "job"->"myCoolService", "instance"->"someHost:8787")
+  val partKeyLabelValues = Map("__name__"->"http_req_total", "instance"->"someHost:8787", "job"->"myCoolService")
   val jobQueryResult1 = "myCoolService"
 
   val partTagsUTF8 = partKeyLabelValues.map { case (k, v) => (k.utf8, v.utf8) }
@@ -107,10 +107,10 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
         response.size shouldEqual 1
         val record = response(0).rows.next()
         val schema = response(0).schema
-        schema.mapify(record.getBlobBase(0), record.getBlobOffset(0))
+        schema.toStringPairs(record.getBlobBase(0), record.getBlobOffset(0))
       }
     }
-    result shouldEqual partKeyLabelValues
+    result shouldEqual partKeyLabelValues.toSeq
   }
 
 }

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -197,7 +197,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",app=\"App-2\"})"
     val logicalPlan = Parser.queryRangeToLogicalPlan(chunkMetaQuery, TimeStepParams(0, 60, Int.MaxValue))
     client.logicalPlan2Query(dataset, logicalPlan) match {
-      case QueryResult2(_, schema, result) => result.foreach(rv => println(rv.prettyPrint(schema)))
+      case QueryResult2(_, schema, result) => result.foreach(rv => println(rv.prettyPrint()))
       case e: QueryError => fail(e.t)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

In metadata query results, we were assuming that partKeys returned was
always a map. This is not necessarily true.

**New behavior :**

* Partition Keys can now be sent across as a binary record column.
* The schema of the binary record column is sent in separately
  as part of the ResultSchema object itself.
* RecordSchema now also includes column names so that client can
  string/mapify the binary record that is returned in results
* Fixed isses in metadata API which returns partition keys.
  We dont assume that it is a map now.


**BREAKING CHANGES**

Has changes in RecordSchema object. May not be able to do rolling upgrades. Clients need to be upgraded to new version.