### PR TITLE
 feat(core, query): Drop out of order samples at ingestion time, not query time

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,8 @@ You can get the huge variety of JMH options by running `jmh:run -help`.  For goo
 
 This should last a good 15 minutes at least.  While it is running, fire up JMC (java Mission Control) and flight record the "jmh.ForkMain" process for 15 minutes.  This gives you excellent CPU as well as memory allocation analysis.
 
+You can also run a stack profiler with an option like ` -prof stack:lines=4;detailLine=true`, but the analysis is not as good as JMC/JVisualVM/YourKit etc., or even the flamegraph options.
+
 There is also a script, `run_benchmarks.sh`
 
 ## You can help!

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -62,6 +62,7 @@ class TimeSeriesPartition(val partID: Int,
                           offheapInfoMap: OffheapLFSortedIDMapMutator,
                           // Lock state used by OffheapLFSortedIDMap.
                           var lockState: Int = 0,
+                          // NOTE: this is a var because much faster to access this than lastInfo.endTime
                           var lastTime: Long = -1L)
 extends ReadablePartition with MapHolder {
   import TimeSeriesPartition._
@@ -109,6 +110,7 @@ extends ReadablePartition with MapHolder {
    * @param blockHolder the BlockMemFactory to use for encoding chunks in case of WriteBuffer overflow
    */
   final def ingest(row: RowReader, blockHolder: BlockMemFactory): Unit = {
+    // NOTE: lastTime is not persisted for recovery.  Thus the first sample after recovery might still be out of order.
     val ts = dataset.timestamp(row)
     if (ts < lastTime) {
       shardStats.outOfOrderDropped.increment

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1005,6 +1005,13 @@ class TimeSeriesShard(val dataset: Dataset,
   private[filodb] def reclaimAllBlocksTestOnly() = blockStore.reclaimAll()
 
   /**
+   * For testing only. Resets the lastTime of each partition so that the same data can be ingested again and again.
+   */
+  private[filodb] def resetLastTimes(): Unit = {
+    partSet.foreach { tsPart => tsPart.asInstanceOf[TimeSeriesPartition].lastTime = -1L }
+  }
+
+  /**
     * Reset all state in this shard.  Memory is not released as once released, then this class
     * cannot be used anymore.
     */

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1005,13 +1005,6 @@ class TimeSeriesShard(val dataset: Dataset,
   private[filodb] def reclaimAllBlocksTestOnly() = blockStore.reclaimAll()
 
   /**
-   * For testing only. Resets the lastTime of each partition so that the same data can be ingested again and again.
-   */
-  private[filodb] def resetLastTimes(): Unit = {
-    partitions.values.asScala.foreach { tsPart => tsPart.asInstanceOf[TimeSeriesPartition].lastTime = -1L }
-  }
-
-  /**
     * Reset all state in this shard.  Memory is not released as once released, then this class
     * cannot be used anymore (except partition key/chunkmap state is removed.)
     */

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -35,6 +35,7 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val rowsIngested = Kamon.counter("memstore-rows-ingested").refine(tags)
   val partitionsCreated = Kamon.counter("memstore-partitions-created").refine(tags)
   val dataDropped = Kamon.counter("memstore-data-dropped").refine(tags)
+  val outOfOrderDropped = Kamon.counter("memstore-out-of-order-samples").refine(tags)
   val rowsSkipped  = Kamon.counter("recovery-row-skipped").refine(tags)
   val rowsPerContainer = Kamon.histogram("num-samples-per-container")
   val numSamplesEncoded = Kamon.counter("memstore-samples-encoded").refine(tags)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1008,17 +1008,16 @@ class TimeSeriesShard(val dataset: Dataset,
    * For testing only. Resets the lastTime of each partition so that the same data can be ingested again and again.
    */
   private[filodb] def resetLastTimes(): Unit = {
-    partSet.foreach { tsPart => tsPart.asInstanceOf[TimeSeriesPartition].lastTime = -1L }
+    partitions.values.asScala.foreach { tsPart => tsPart.asInstanceOf[TimeSeriesPartition].lastTime = -1L }
   }
 
   /**
     * Reset all state in this shard.  Memory is not released as once released, then this class
-    * cannot be used anymore.
+    * cannot be used anymore (except partition key/chunkmap state is removed.)
     */
   def reset(): Unit = {
     logger.info(s"Clearing all MemStore state for shard $shardNum")
-    partitions.clear()
-    partSet.clear()
+    partitions.values.asScala.foreach(removePartition)
     partKeyIndex.reset()
     ingested = 0L
     for { group <- 0 until numGroups } {

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -256,7 +256,7 @@ object MachineMetricsData {
     }
   }
 
-  def addToBuilder(builder: RecordBuilder, data: Stream[Seq[Any]]): Unit = {
+  def addToBuilder(builder: RecordBuilder, data: Seq[Seq[Any]]): Unit = {
     data.foreach { values =>
       builder.startNewRecord()
       builder.addLong(values(0).asInstanceOf[Long])     // timestamp

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -349,8 +349,6 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
   it("should drop out of time order ingested samples") {
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(12)
-    val initTS = data(0).getLong(0)
-    val lastTS = data.last.getLong(0)
     val minData = data.map(_.getDouble(1))
 
     // Ingest first 5, then: 8th, 6th, 7th, 9th, 10th
@@ -382,6 +380,9 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part.appendingChunkLen shouldEqual 2
     val readData1 = part.timeRangeRows(AllChunkScan, Array(1)).map(_.getDouble(0))
     readData1.toBuffer shouldEqual (minData take 5) ++ (minData drop 7)
+    val timestamps = data.map(_.getLong(0))
+    val readData2 = part.timeRangeRows(AllChunkScan, Array(0)).map(_.getLong(0))
+    readData2.toBuffer shouldEqual (timestamps take 5) ++ (timestamps drop 7)
   }
 
 }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -141,7 +141,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val initTS = data(0).getLong(0)
     val appendingTS = data.last.getLong(0)
     val minData = data.map(_.getDouble(1))
-    data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.take(10).foreach { r => part.ingest(r, ingestBlockHolder) }
 
     // First 10 rows ingested. Now flush in a separate Future while ingesting the remaining row
     part.switchBuffers(ingestBlockHolder)
@@ -295,7 +295,9 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     // Do this 4 more times so that we get old recycled metadata back
     (0 until 4).foreach { n =>
       (0 to 9).foreach { i =>
-      data.foreach { case d => partitions(i).ingest(d, ingestBlockHolder) }
+        // Cheat here. Manually reset the lastTime of a partition so it will ingest old data.
+        partitions(i).lastTime = -1L
+        data.foreach { case d => partitions(i).ingest(d, ingestBlockHolder) }
         partitions(i).appendingChunkLen shouldEqual 10
         partitions(i).switchBuffers(ingestBlockHolder, true)
       }
@@ -303,6 +305,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     // Now ingest again but don't switch buffers.  Ensure appendingChunkLen is appropriate.
     (0 to 9).foreach { i =>
+      partitions(i).lastTime = -1L
       data.foreach { case d => partitions(i).ingest(d, ingestBlockHolder) }
       partitions(i).appendingChunkLen shouldEqual 10
     }
@@ -342,4 +345,43 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part.appendingChunkLen shouldEqual 0
     chunkSets.map(_.info.numRows) shouldEqual Seq(100, 10)
   }
+
+  it("should drop out of time order ingested samples") {
+    part = makePart(0, dataset1)
+    val data = singleSeriesReaders().take(12)
+    val initTS = data(0).getLong(0)
+    val lastTS = data.last.getLong(0)
+    val minData = data.map(_.getDouble(1))
+
+    // Ingest first 5, then: 8th, 6th, 7th, 9th, 10th
+    data.take(5).foreach { r => part.ingest(r, ingestBlockHolder) }
+    part.ingest(data(7), ingestBlockHolder)
+    part.ingest(data(5), ingestBlockHolder)
+    part.ingest(data(6), ingestBlockHolder)
+    part.ingest(data(8), ingestBlockHolder)
+    part.ingest(data(9), ingestBlockHolder)
+
+    // Try ingesting old sample now at the end.  Verify that end time of chunkInfo is not incorrectly changed.
+    part.ingest(data(2), ingestBlockHolder)
+    // 8 of first 10 ingested, 2 should be dropped.  Switch buffers, and try ingesting out of order again.
+    part.appendingChunkLen shouldEqual 8
+    part.infoLast.numRows shouldEqual 8
+    part.infoLast.endTime shouldEqual data(9).getLong(0)
+
+    part.switchBuffers(ingestBlockHolder)
+    part.appendingChunkLen shouldEqual 0
+
+    // Now try ingesting an old smaple again at first element of next chunk.
+    part.ingest(data(8), ingestBlockHolder)   // This one should be dropped
+    part.appendingChunkLen shouldEqual 0
+    part.ingest(data(10), ingestBlockHolder)
+    part.ingest(data(11), ingestBlockHolder)
+
+    // there should be a frozen chunk of 10 records plus 2 records in currently appending chunks
+    part.numChunks shouldEqual 2
+    part.appendingChunkLen shouldEqual 2
+    val readData1 = part.timeRangeRows(AllChunkScan, Array(1)).map(_.getDouble(0))
+    readData1.toBuffer shouldEqual (minData take 5) ++ (minData drop 7)
+  }
+
 }

--- a/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
@@ -37,6 +37,7 @@ class IngestionBenchmark {
   // sized just big enough for a 1000 entries per container
   val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, schemaWithPredefKeys, 176064)
   val comparator = new RecordComparator(schemaWithPredefKeys)
+  //scalastyle:off
   println("Be patient, generating lots of containers of raw data....")
   dataStream.take(1000*100).grouped(1000).foreach { data => addToBuilder(ingestBuilder, data) }
 

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -118,6 +118,7 @@ class NativeMemoryManager(val upperBoundSizeInBytes: Long) extends MemFactory {
       MemoryIO.getCheckedInstance().freeMemory(addr)
     }
     sizeMapping.clear()
+    usedSoFar.set(0)
   }
 
   def shutdown(): Unit = {

--- a/memory/src/test/scala/filodb.memory/data/OffheapLFSortedIDMapTest.scala
+++ b/memory/src/test/scala/filodb.memory/data/OffheapLFSortedIDMapTest.scala
@@ -362,7 +362,6 @@ class OffheapLFSortedIDMapTest extends NativeVectorTest with ScalaFutures {
     intercept[IndexOutOfBoundsException] { map.last }
     map.iterate.toBuffer shouldEqual Buffer.empty[Long]
     map.sliceToEnd(18L).toBuffer shouldEqual Buffer.empty[Long]
-    map.put(elems(0))
     map.length shouldEqual 0
     map.remove(6L)
   }

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -94,7 +94,9 @@ class SlidingWindowIterator(raw: Iterator[RowReader],
   // this is the object that will be exposed to the RangeFunction
   private val windowSamples = new QueueBasedWindow(windowQueue)
 
-  // TODO This can be removed once we fix order during ingestion. Or is it required to validate anyway?
+  // NOTE: Ingestion now has a facility to drop out of order samples.  HOWEVER, there is one edge case that may happen
+  // which is that the first sample ingested after recovery may not be in order w.r.t. previous persisted timestamp.
+  // So this is retained for now while we consider a more permanent out of order solution.
   private val rawInOrder = new DropOutOfOrderSamplesIterator(raw)
 
   // we need buffered iterator so we can use to peek at next element.

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -94,15 +94,12 @@ class SlidingWindowIterator(raw: Iterator[RowReader],
   // this is the object that will be exposed to the RangeFunction
   private val windowSamples = new QueueBasedWindow(windowQueue)
 
-  // TODO This can be removed once we fix order during ingestion. Or is it required to validate anyway?
-  private val rawInOrder = new DropOutOfOrderSamplesIterator(raw)
-
   // we need buffered iterator so we can use to peek at next element.
   // At same time, do counter correction if necessary
   private val rows = if (rangeFunction.needsCounterCorrection) {
-    new BufferableCounterCorrectionIterator(rawInOrder).buffered
+    new BufferableCounterCorrectionIterator(raw).buffered
   } else {
-    new BufferableIterator(rawInOrder).buffered
+    new BufferableIterator(raw).buffered
   }
 
   // to avoid creation of object per sample, we use a pool
@@ -246,6 +243,8 @@ class BufferableCounterCorrectionIterator(iter: Iterator[RowReader]) extends Ite
   }
 }
 
+// NOTE: This is deprecated, but left here just in case.  Out of order samples are now dropped at ingestion.
+// TODO: remove this
 class DropOutOfOrderSamplesIterator(iter: Iterator[RowReader]) extends Iterator[TransientRow] {
   // Initial -1 time since it will be less than any valid timestamp and will allow first sample to go through
   private val cur = new TransientRow(-1, -1)

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -40,6 +40,8 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
   }
 
   // NOTE: due to max-chunk-size in storeConf = 100, this will make (numRawSamples / 100) chunks
+  // Be sure to reset the builder; it is in an Object so static and shared amongst tests
+  builder.reset()
   tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }.foreach(builder.addFromReader)
   val container = builder.allContainers.head
 
@@ -49,6 +51,10 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
     memStore.setup(timeseriesDataset, 0, TestData.storeConf)
     memStore.ingest(timeseriesDataset.ref, 0, SomeData(container, 0))
     memStore.commitIndexForTesting(timeseriesDataset.ref)
+  }
+
+  override def afterAll(): Unit = {
+    memStore.shutdown()
   }
 
   val dummyDispatcher = new PlanDispatcher {

--- a/query/src/test/scala/filodb/query/exec/SlidingWindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SlidingWindowIteratorSpec.scala
@@ -133,40 +133,14 @@ class SlidingWindowIteratorSpec extends FunSpec with Matchers {
                     1538416644000L->210170299d,
                     1538416649000L->210172635d)
 
-  it ("should ignore out of order samples for RateFunction") {
+  // Out of order samples are now handled by ingestion
+  ignore("should ignore out of order samples for RateFunction") {
     val rawRows = counterSamples.map(s => new TransientRow(s._1, s._2))
     val slidingWinIterator = new SlidingWindowIterator(rawRows.iterator, 1538416154000L, 20000, 1538416649000L,20000,
       RangeFunction(Some(RangeFunctionId.Rate)), queryConfig)
     slidingWinIterator.foreach{ v =>
       // if out of order samples are not removed, counter correction causes rate to spike up to very high value
       v.value should be < 10000d
-    }
-  }
-
-  it ("should drop out of order samples with LastSampleFunction") {
-
-    val samples = Seq(
-      100L->645926d,
-      153L->696377d,
-      270L->759389d,
-      250L->698713d, // out of order, should be dropped
-      280L->762375d,
-      360L->764711d,
-      690L->798373d,
-      430L->765387d, // out of order, should be dropped
-      700L->830709d
-    )
-    val rawRows = samples.map(s => new TransientRow(s._1, s._2))
-    val start = 50L
-    val end = 1000L
-    val step = 5
-    val slidingWinIterator = new SlidingWindowIterator(rawRows.iterator, start, step,
-      end,0, RangeFunction(None), queryConfig)
-    val result = slidingWinIterator.map(v => (v.timestamp, v.value)).toSeq
-    result.map(_._1) shouldEqual (start to end).by(step)
-    result.foreach{ v =>
-      v._2 should not equal 698713d
-      v._2 should not equal 765387d
     }
   }
 

--- a/query/src/test/scala/filodb/query/exec/SlidingWindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SlidingWindowIteratorSpec.scala
@@ -133,14 +133,40 @@ class SlidingWindowIteratorSpec extends FunSpec with Matchers {
                     1538416644000L->210170299d,
                     1538416649000L->210172635d)
 
-  // Out of order samples are now handled by ingestion
-  ignore("should ignore out of order samples for RateFunction") {
+  it ("should ignore out of order samples for RateFunction") {
     val rawRows = counterSamples.map(s => new TransientRow(s._1, s._2))
     val slidingWinIterator = new SlidingWindowIterator(rawRows.iterator, 1538416154000L, 20000, 1538416649000L,20000,
       RangeFunction(Some(RangeFunctionId.Rate)), queryConfig)
     slidingWinIterator.foreach{ v =>
       // if out of order samples are not removed, counter correction causes rate to spike up to very high value
       v.value should be < 10000d
+    }
+  }
+
+  it ("should drop out of order samples with LastSampleFunction") {
+
+    val samples = Seq(
+      100L->645926d,
+      153L->696377d,
+      270L->759389d,
+      250L->698713d, // out of order, should be dropped
+      280L->762375d,
+      360L->764711d,
+      690L->798373d,
+      430L->765387d, // out of order, should be dropped
+      700L->830709d
+    )
+    val rawRows = samples.map(s => new TransientRow(s._1, s._2))
+    val start = 50L
+    val end = 1000L
+    val step = 5
+    val slidingWinIterator = new SlidingWindowIterator(rawRows.iterator, start, step,
+      end,0, RangeFunction(None), queryConfig)
+    val result = slidingWinIterator.map(v => (v.timestamp, v.value)).toSeq
+    result.map(_._1) shouldEqual (start to end).by(step)
+    result.foreach{ v =>
+      v._2 should not equal 698713d
+      v._2 should not equal 765387d
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently new data samples are appended as they are.  During query time, out of order samples are dropped in an iterator.

**New behavior :**

A new field, `lastTime` is added to the `TimeSeriesPartition`.  During ingestion, timestamp of new sample is compared with lastTime and dropped if it is less than lastTime.  A new counter keeps track of dropped samples.

The iterator which dropped out of order samples is skipped during query.

Before:
```
[info] Benchmark                                Mode  Cnt     Score    Error  Units
[info] QueryInMemoryBenchmark.parallelQueries  thrpt   30  1347.586 ± 27.054  ops/s
```

After:
```
[info] Benchmark                                Mode  Cnt     Score    Error  Units
[info] QueryInMemoryBenchmark.parallelQueries  thrpt   30  1370.396 ± 85.834  ops/s
```

**BREAKING CHANGES**

None