### PR TITLE
feat(query): Add support and tests for querying from LongColumns

### DIFF
--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -189,7 +189,7 @@ object GdeltTestData {
 object MachineMetricsData {
   import scala.util.Random.nextInt
 
-  val columns = Seq("timestamp:long", "min:double", "avg:double", "max:double", "p90:double")
+  val columns = Seq("timestamp:long", "min:double", "avg:double", "max:double", "count:long")
 
   def singleSeriesData(initTs: Long = System.currentTimeMillis,
                        incr: Long = 1000): Stream[Product] = {
@@ -198,7 +198,7 @@ object MachineMetricsData {
        Some((45 + nextInt(10)).toDouble),
        Some((60 + nextInt(25)).toDouble),
        Some((100 + nextInt(15)).toDouble),
-       Some((85 + nextInt(12)).toDouble))
+       Some((85 + nextInt(12)).toLong))
     }
   }
 
@@ -239,7 +239,7 @@ object MachineMetricsData {
          (45 + nextInt(10)).toDouble,
          (60 + nextInt(25)).toDouble,
          (99.9 + nextInt(15)).toDouble,
-         (85 + nextInt(12)).toDouble,
+         (85 + nextInt(12)).toLong,
          "Series " + (n % 10))
     }
   }
@@ -251,7 +251,7 @@ object MachineMetricsData {
          (1 + n).toDouble,
          (20 + n).toDouble,
          (99.9 + n).toDouble,
-         (85 + n).toDouble,
+         (85 + n).toLong,
          "Series " + (n % numSeries))
     }
   }
@@ -263,7 +263,7 @@ object MachineMetricsData {
       builder.addDouble(values(1).asInstanceOf[Double])  // min
       builder.addDouble(values(2).asInstanceOf[Double])  // avg
       builder.addDouble(values(3).asInstanceOf[Double]) // max
-      builder.addDouble(values(4).asInstanceOf[Double])  // p90
+      builder.addLong(values(4).asInstanceOf[Long])  // count
       builder.addString(values(5).asInstanceOf[String])  // series (partition key)
 
       if (values.length > 6) {

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -52,7 +52,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       builder.addDouble(1.0)  // min
       builder.addDouble(2.5)  // avg
       builder.addDouble(10.1) // max
-      builder.addDouble(9.4)  // p90
+      builder.addLong(123456L)  // count
       builder.addString("Series 1")   // series (partition key)
 
       intercept[IllegalArgumentException] {
@@ -68,7 +68,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       builder.addDouble(1.0)  // min
       builder.addDouble(2.5)  // avg
       builder.addDouble(10.1) // max
-      builder.addDouble(9.4)  // p90
+      builder.addLong(123456L)  // count
 
       intercept[IllegalArgumentException] {
         builder.addString("ABCDEfghij" * 7000)
@@ -264,7 +264,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       builder.addDouble(1.0)  // min
       builder.addDouble(2.5)  // avg
       builder.addDouble(10.1) // max
-      builder.addDouble(9.4)  // p90
+      builder.addLong(123456L)  // count
       builder.addString("Series 1")   // series (partition key)
       val offset1 = builder.endRecord()
 
@@ -280,7 +280,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       schema1.getDouble(recordAddr, 1) shouldEqual 1.0
       schema1.getDouble(recordAddr, 2) shouldEqual 2.5
       schema1.getDouble(recordAddr, 3) shouldEqual 10.1
-      schema1.getDouble(recordAddr, 4) shouldEqual 9.4
+      schema1.getLong(recordAddr, 4) shouldEqual 123456L
       schema1.utf8StringPointer(recordAddr, 5).compare("Series 1".utf8(nativeMem)) shouldEqual 0
     }
 
@@ -388,7 +388,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
         builder.addDouble(1.0)  // min
         builder.addDouble(2.5)  // avg
         builder.addDouble(10.1) // max
-        builder.addDouble(9.4)  // p90
+        builder.addLong(123456L)  // count
         builder.addString(s"Series $n")   // series (partition key)
         builder.addSortedPairsAsMap(pairs, hashes)
         builder.endRecord()

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -40,11 +40,10 @@ trait RangeVectorTransformer extends java.io.Serializable {
 }
 
 object RangeVectorTransformer {
-  def requireTimeSeries(schema: ResultSchema): Unit = {
+  def valueColumnType(schema: ResultSchema): ColumnType = {
     require(schema.isTimeSeries, "Cannot return periodic data from a dataset that is not time series based")
     require(schema.columns.size == 2, "Cannot return periodic data from a dataset that is not time series based")
-    require(schema.columns(1).colType == ColumnType.DoubleColumn,
-      "Cannot query a non Doubles based value column right now, sorry")
+    schema.columns(1).colType
   }
 }
 

--- a/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
@@ -13,15 +13,18 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import filodb.core.MetricsTestData._
 import filodb.core.TestData
 import filodb.core.binaryrecord.BinaryRecord
+import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
+import filodb.memory.MemFactory
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.query._
 
 class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
   import ZeroCopyUTF8String._
+  import filodb.core.{MachineMetricsData => MMD}
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
@@ -40,15 +43,23 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
   }
 
   // NOTE: due to max-chunk-size in storeConf = 100, this will make (numRawSamples / 100) chunks
+  builder.reset()
   tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }.foreach(builder.addFromReader)
   val container = builder.allContainers.head
+
+  val mmdBuilder = new RecordBuilder(MemFactory.onHeapFactory, MMD.dataset1.ingestionSchema)
+  val mmdTuples = MMD.linearMultiSeries().take(100)
+  val mmdSomeData = MMD.records(MMD.dataset1, mmdTuples)
 
   implicit val execTimeout = 5.seconds
 
   override def beforeAll(): Unit = {
     memStore.setup(timeseriesDataset, 0, TestData.storeConf)
     memStore.ingest(timeseriesDataset.ref, 0, SomeData(container, 0))
+    memStore.setup(MMD.dataset1, 0, TestData.storeConf)
+    memStore.ingest(MMD.dataset1.ref, 0, mmdSomeData)
     memStore.commitIndexForTesting(timeseriesDataset.ref)
+    memStore.commitIndexForTesting(MMD.dataset1.ref)
   }
 
   val dummyDispatcher = new PlanDispatcher {
@@ -93,6 +104,23 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     partKeyRead shouldEqual partKeyLabelValues
   }
 
+  it ("should read raw Long samples from Memstore using IntervalSelector") {
+    import ZeroCopyUTF8String._
+    val filters = Seq(ColumnFilter("series", Filter.Equals("Series 1".utf8)))
+    // read from an interval of 100000ms, resulting in 11 samples
+    val start: BinaryRecord = BinaryRecord(MMD.dataset1, Seq(100000L))
+    val end: BinaryRecord = BinaryRecord(MMD.dataset1, Seq(150000L))
+
+    val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, MMD.dataset1.ref, 0,
+      filters, RowKeyInterval(start, end), Seq(0, 4))
+
+    val resp = execPlan.execute(memStore, MMD.dataset1, queryConfig).runAsync.futureValue
+    val result = resp.asInstanceOf[QueryResult]
+    result.result.size shouldEqual 1
+    val dataRead = result.result(0).rows.map(r=>(r.getLong(0), r.getLong(1))).toList
+    dataRead shouldEqual mmdTuples.filter(_(5) == "Series 1").map(r => (r(0), r(4))).take(5)
+  }
+
   it ("should read periodic samples from Memstore") {
     import ZeroCopyUTF8String._
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
@@ -123,6 +151,27 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
         observed shouldEqual expected.getValue
       }
     }
+  }
+
+  it("should read periodic samples from Long column") {
+    import ZeroCopyUTF8String._
+    val filters = Seq(ColumnFilter("series", Filter.Equals("Series 1".utf8)))
+    val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, MMD.dataset1.ref, 0,
+      filters, AllChunks, Seq(0, 4))
+
+    // Raw data like 101000, 111000, ....
+    val start = 105000L
+    val step = 20000L
+    val end = 185000L
+    execPlan.addRangeVectorTransformer(new PeriodicSamplesMapper(start, step, end, None, None, Nil))
+
+    val resp = execPlan.execute(memStore, MMD.dataset1, queryConfig).runAsync.futureValue
+    val result = resp.asInstanceOf[QueryResult]
+    result.result.size shouldEqual 1
+    val dataRead = result.result(0).rows.map(r=>(r.getLong(0), r.getDouble(1))).toList
+    dataRead.map(_._1) shouldEqual (start to end by step)
+    dataRead.map(_._2) shouldEqual (86 to 166).by(20)
+
   }
 
   it ("should return correct result schema") {


### PR DESCRIPTION
For now we just transform the Long values to Doubles.  Future Chunk-based iterations will take advantage of faster methods.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

One can query raw data from non-Double columns but cannot run any non-raw queries.

**New behavior :**

Non-raw queries from Long columns are now possible.
