### PR TITLE
bug(query): Aggregate results were wrong when no data points are available for the instant

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -289,10 +289,10 @@ object RowAggregator {
   * Present: The sum is directly presented
   */
 object SumRowAggregator extends RowAggregator {
-  class SumHolder(var timestamp: Long = 0L, var sum: Double = 0) extends AggregateHolder {
+  class SumHolder(var timestamp: Long = 0L, var sum: Double = Double.NaN) extends AggregateHolder {
     val row = new TransientRow()
     def toRowReader: MutableRowReader = { row.setValues(timestamp, sum); row }
-    def resetToZero(): Unit = sum = 0
+    def resetToZero(): Unit = sum = Double.NaN
   }
   type AggHolderType = SumHolder
   def zero: SumHolder = new SumHolder
@@ -300,7 +300,10 @@ object SumRowAggregator extends RowAggregator {
   def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = item
   def reduceAggregate(acc: SumHolder, aggRes: RowReader): SumHolder = {
     acc.timestamp = aggRes.getLong(0)
-    if (!aggRes.getDouble(1).isNaN) acc.sum += aggRes.getDouble(1)
+    if (!aggRes.getDouble(1).isNaN) {
+      if (acc.sum.isNaN) acc.sum = 0
+      acc.sum += aggRes.getDouble(1)
+    }
     acc
   }
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
@@ -315,10 +318,10 @@ object SumRowAggregator extends RowAggregator {
   * Present: The min is directly presented
   */
 object MinRowAggregator extends RowAggregator {
-  class MinHolder(var timestamp: Long = 0L, var min: Double = Double.MaxValue) extends AggregateHolder {
+  class MinHolder(var timestamp: Long = 0L, var min: Double = Double.NaN) extends AggregateHolder {
     val row = new TransientRow()
     def toRowReader: MutableRowReader = { row.setValues(timestamp, min); row }
-    def resetToZero(): Unit = min = Double.MaxValue
+    def resetToZero(): Unit = min = Double.NaN
   }
   type AggHolderType = MinHolder
   def zero: MinHolder = new MinHolder()
@@ -326,7 +329,11 @@ object MinRowAggregator extends RowAggregator {
   def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = item
   def reduceAggregate(acc: MinHolder, aggRes: RowReader): MinHolder = {
     acc.timestamp = aggRes.getLong(0)
-    if (!aggRes.getDouble(1).isNaN) acc.min = Math.min(acc.min, aggRes.getDouble(1))
+    if (!aggRes.getDouble(1).isNaN) {
+      if (acc.min.isNaN)
+        acc.min = Double.MaxValue
+      acc.min = Math.min(acc.min, aggRes.getDouble(1))
+    }
     acc
   }
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
@@ -341,10 +348,10 @@ object MinRowAggregator extends RowAggregator {
   * Present: The max is directly presented
   */
 object MaxRowAggregator extends RowAggregator {
-  class MaxHolder(var timestamp: Long = 0L, var max: Double = Double.MinValue) extends AggregateHolder {
+  class MaxHolder(var timestamp: Long = 0L, var max: Double = Double.NaN) extends AggregateHolder {
     val row = new TransientRow()
     def toRowReader: MutableRowReader = { row.setValues(timestamp, max); row }
-    def resetToZero(): Unit = max = Double.MinValue
+    def resetToZero(): Unit = max = Double.NaN
   }
   type AggHolderType = MaxHolder
   def zero: MaxHolder = new MaxHolder()
@@ -352,7 +359,10 @@ object MaxRowAggregator extends RowAggregator {
   def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = item
   def reduceAggregate(acc: MaxHolder, aggRes: RowReader): MaxHolder = {
     acc.timestamp = aggRes.getLong(0)
-    if (!aggRes.getDouble(1).isNaN) acc.max = Math.max(acc.max, aggRes.getDouble(1))
+    if (!aggRes.getDouble(1).isNaN) {
+      if (acc.max.isNaN) acc.max = Double.MinValue
+      acc.max = Math.max(acc.max, aggRes.getDouble(1))
+    }
     acc
   }
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
@@ -368,10 +378,10 @@ object MaxRowAggregator extends RowAggregator {
   * Present: The count is directly presented
   */
 object CountRowAggregator extends RowAggregator {
-  class CountHolder(var timestamp: Long = 0L, var count: Long = 0) extends AggregateHolder {
+  class CountHolder(var timestamp: Long = 0L, var count: Double = Double.NaN) extends AggregateHolder {
     val row = new TransientRow()
     def toRowReader: MutableRowReader = { row.setValues(timestamp, count); row }
-    def resetToZero(): Unit = count = 0
+    def resetToZero(): Unit = count = Double.NaN
   }
   type AggHolderType = CountHolder
   def zero: CountHolder = new CountHolder()
@@ -388,8 +398,9 @@ object CountRowAggregator extends RowAggregator {
     mapInto
   }
   def reduceAggregate(acc: CountHolder, aggRes: RowReader): CountHolder = {
+    if (acc.count.isNaN && aggRes.getDouble(1) > 0) acc.count = 0d;
     acc.timestamp = aggRes.getLong(0)
-    acc.count += aggRes.getDouble(1).toLong
+    acc.count += aggRes.getDouble(1)
     acc
   }
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
@@ -406,7 +417,9 @@ object CountRowAggregator extends RowAggregator {
   * Present: The current mean is presented. Count value is dropped from presentation
   */
 object AvgRowAggregator extends RowAggregator {
-  class AvgHolder(var timestamp: Long = 0L, var mean: Double = 0, var count: Long = 0) extends AggregateHolder {
+  class AvgHolder(var timestamp: Long = 0L,
+                  var mean: Double = Double.NaN,
+                  var count: Long = 0) extends AggregateHolder {
     val row = new AvgAggTransientRow()
     def toRowReader: MutableRowReader = {
       row.setLong(0, timestamp)
@@ -414,7 +427,7 @@ object AvgRowAggregator extends RowAggregator {
       row.setLong(2, count)
       row
     }
-    def resetToZero(): Unit = { count = 0; mean = 0 }
+    def resetToZero(): Unit = { count = 0; mean = Double.NaN }
   }
   type AggHolderType = AvgHolder
   def zero: AvgHolder = new AvgHolder()
@@ -427,7 +440,8 @@ object AvgRowAggregator extends RowAggregator {
   }
   def reduceAggregate(acc: AvgHolder, aggRes: RowReader): AvgHolder = {
     acc.timestamp = aggRes.getLong(0)
-    if (aggRes.getLong(2) > 0) {
+    if (!aggRes.getDouble(1).isNaN) {
+      if (acc.mean.isNaN) acc.mean = 0d
       val newMean = (acc.mean * acc.count + aggRes.getDouble(1) * aggRes.getLong(2)) / (acc.count + aggRes.getLong(2))
       acc.mean = newMean
       acc.count += aggRes.getLong(2)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

No of values returned by Mosaic are more than Prometheus are more for Aggregate Functions (Sum, Count,Max, Min,Avg 
Sum, count and avg has value 0, max has value as -1.7976931348623157E308 and min has 1.7976931348623157E308 when no data point is available for the instant


**New behavior :**
Removed values from result when no data point is available for that instant


**BREAKING CHANGES**
None

