### PR TITLE
fix(query): fix the assumption that PartitionKey will have only one column of type MapColumn

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -489,9 +489,11 @@ class TimeSeriesShard(val dataset: Dataset,
           // FIXME This is non-performant and temporary fix for fetching label values based on filter criteria.
           // Other strategies needs to be evaluated for making this performant - create facets for predefined fields or
           // have a centralized service/store for serving metadata
-          currVal = dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
-            .find(_._1 equals labelName).map(pair => ZeroCopyUTF8String(pair._2)).head
-          foundValue = true
+          dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
+            .find(_._1 equals labelName).map(pair => {
+            currVal = ZeroCopyUTF8String(pair._2)
+            foundValue = true
+          })
         } else {
           // FIXME partKey is evicted. Get partition key from lucene index
         }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -22,7 +22,7 @@ import filodb.core.{ErrorResponse, _}
 import filodb.core.binaryrecord2._
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
-import filodb.core.query.{ColumnFilter, ColumnInfo, SeqIndexValueConsumer}
+import filodb.core.query.{ColumnFilter, ColumnInfo}
 import filodb.core.store._
 import filodb.memory._
 import filodb.memory.data.{OffheapLFSortedIDMap, OffheapLFSortedIDMapMutator}

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1,7 +1,5 @@
 package filodb.core.memstore
 
-import scala.collection.mutable
-import scala.collection.mutable.Set
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Random, Try}
@@ -465,29 +463,46 @@ class TimeSeriesShard(val dataset: Dataset,
 
   /**
     * This method is to apply column filters and fetch matching time series partitions.
-    * From the the partitions then index values for the indexName will be extracted/accumulated.
     */
   def indexValuesWithFilters(filter: Seq[ColumnFilter],
                              indexName: String,
                              endTime: Long,
                              startTime: Long,
                              limit: Int): Iterator[ZeroCopyUTF8String] = {
-    val result: Set[ZeroCopyUTF8String] = new mutable.HashSet[ZeroCopyUTF8String]()
-    val partIterator = partKeyIndex.partIdsFromFilters(filter, startTime, endTime)
-    while(partIterator.hasNext && result.size < limit) {
-      val partId = partIterator.next()
-      val nextPart = getPartitionFromPartId(partId)
-      if (nextPart != UnsafeUtils.ZeroPointer) {
-        // FIXME This is non-performant and temporary fix for fetching label values based on filter criteria.
-        // Other strategies needs to be evaluated for making this performant - create facets for predefined fields or
-        // have a centralized service/store for serving metadata
-        result ++= dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
-          .find(_._1 equals indexName).map(pair => ZeroCopyUTF8String(pair._2))
-      } else {
-        // FIXME partKey is evicted. Get partition key from lucene index
+    IndexValueResultIterator(partKeyIndex.partIdsFromFilters(filter, startTime, endTime), indexName, limit)
+  }
+
+  /**
+    * Iterator for lazy traversal of partIdIterator, value for the given label will be extracted from the ParitionKey.
+    */
+  case class IndexValueResultIterator(partIterator: IntIterator, labelName: String, limit: Int)
+      extends Iterator[ZeroCopyUTF8String] {
+    var currVal: ZeroCopyUTF8String = _
+    var index = 0
+
+    override def hasNext: Boolean = {
+      var foundValue = false
+      while(partIterator.hasNext && index < limit && !foundValue) {
+        val partId = partIterator.next()
+        val nextPart = getPartitionFromPartId(partId)
+        if (nextPart != UnsafeUtils.ZeroPointer) {
+          // FIXME This is non-performant and temporary fix for fetching label values based on filter criteria.
+          // Other strategies needs to be evaluated for making this performant - create facets for predefined fields or
+          // have a centralized service/store for serving metadata
+          currVal = dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
+            .find(_._1 equals labelName).map(pair => ZeroCopyUTF8String(pair._2)).head
+          foundValue = true
+        } else {
+          // FIXME partKey is evicted. Get partition key from lucene index
+        }
       }
+      foundValue
     }
-    result.toIterator
+
+    override def next(): ZeroCopyUTF8String = {
+      index += 1
+      currVal
+    }
   }
 
   /**

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -477,12 +477,11 @@ class TimeSeriesShard(val dataset: Dataset,
       val partId = partIterator.next()
       val nextPart = getPartitionFromPartId(partId)
       if (nextPart != UnsafeUtils.ZeroPointer) {
-        val consumer = new SeqIndexValueConsumer(indexName)
         // FIXME This is non-performant and temporary fix for fetching label values based on filter criteria.
         // Other strategies needs to be evaluated for making this performant - create facets for predefined fields or
         // have a centralized service/store for serving metadata
-        dataset.partKeySchema.consumeMapItems(nextPart.partKeyBase, nextPart.partKeyOffset, 0, consumer)
-        result ++= consumer.labelValues
+        result ++= dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
+          .find(_._1 equals indexName).map(pair => ZeroCopyUTF8String(pair._2))
       } else {
         // FIXME partKey is evicted. Get partition key from lucene index
       }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -490,9 +490,9 @@ class TimeSeriesShard(val dataset: Dataset,
           // Other strategies needs to be evaluated for making this performant - create facets for predefined fields or
           // have a centralized service/store for serving metadata
           dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
-            .find(_._1 equals labelName).map(pair => {
-            currVal = ZeroCopyUTF8String(pair._2)
-            foundValue = true
+            .find(_._1 equals labelName).foreach(pair => {
+              currVal = ZeroCopyUTF8String(pair._2)
+              foundValue = true
           })
         } else {
           // FIXME partKey is evicted. Get partition key from lucene index

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -1,7 +1,5 @@
 package filodb.core.query
 
-import scala.collection.mutable
-
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import org.joda.time.DateTime
@@ -30,17 +28,6 @@ class SeqMapConsumer extends MapItemConsumer {
     val keyUtf8 = new UTF8Str(keyBase, keyOffset + 2, UTF8StringMedium.numBytes(keyBase, keyOffset))
     val valUtf8 = new UTF8Str(valueBase, valueOffset + 2, UTF8StringMedium.numBytes(valueBase, valueOffset))
     pairs += (keyUtf8 -> valUtf8)
-  }
-}
-
-class SeqIndexValueConsumer(column: String) extends MapItemConsumer {
-  var labelValues = mutable.HashSet[UTF8Str]() //to gather unique label values
-  def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
-    val keyUtf8 = new UTF8Str(keyBase, keyOffset + 2, UTF8StringMedium.numBytes(keyBase, keyOffset))
-    if (column.equals(keyUtf8.toString)) {
-      val valUtf8 = new UTF8Str(valueBase, valueOffset + 2, UTF8StringMedium.numBytes(valueBase, valueOffset))
-      labelValues += valUtf8
-    }
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Fix the assumption that PartitionKey will have only one column of type MapColumn, while serving the Label queries. With the fix, TimeSeriesParition will be decoded based on the PartitionKeySchema
