### PR TITLE
bug(query): fix bug in topK and bottomK for NaN values

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -535,9 +535,9 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
       // We limit the results wherever it is materialized first. So it is done here.
       aggRangeVector.rows.take(limit).foreach { row =>
         var i = 1
-        while(row.notNull(i)) {
+        while (row.notNull(i)) {
           val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
-          if (rvk.labelValues.size > 0) {
+          if (!(rvk == CustomRangeVectorKey(Map.empty))) {
             val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.toBuilder(recSchema))
             builder.startNewRecord()
             builder.addLong(row.getLong(0))

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -536,8 +536,8 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
       aggRangeVector.rows.take(limit).foreach { row =>
         var i = 1
         while (row.notNull(i)) {
-          val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
-          if (!(rvk == CustomRangeVectorKey(Map.empty))) {
+          if (row.filoUTF8String(i) != CustomRangeVectorKey.emptyAsZcUtf8) {
+            val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
             val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.toBuilder(recSchema))
             builder.startNewRecord()
             builder.addLong(row.getLong(0))

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -537,11 +537,13 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
         var i = 1
         while(row.notNull(i)) {
           val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
-          val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.toBuilder(recSchema))
-          builder.startNewRecord()
-          builder.addLong(row.getLong(0))
-          builder.addDouble(row.getDouble(i + 1))
-          builder.endRecord()
+          if (rvk.labelValues.size > 0) {
+            val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.toBuilder(recSchema))
+            builder.startNewRecord()
+            builder.addLong(row.getLong(0))
+            builder.addDouble(row.getDouble(i + 1))
+            builder.endRecord()
+          }
           i += 2
         }
       }

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -329,11 +329,13 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
     val result5 = resultObs5.toListL.runAsync.futureValue
     result5.size shouldEqual 1
     result5(0).key shouldEqual noKey
+    // mapReduce returns range vector which has all values as Double.Max
     compareIter2(result5(0).rows.map(r=> Set(r.getDouble(2), r.getDouble(4))),
       Seq(Set(1.7976931348623157E308d, 1.7976931348623157E308d), Set(4.4d, 5.4d)).iterator)
     val result5b = resultObs5b.toListL.runAsync.futureValue
     result5b.size shouldEqual 1
     result5b(0).key shouldEqual ignoreKey
+    // present removes the range vector which has all values as Double.Max
     compareIter(result5b(0).rows.map(_.getDouble(1)), Seq(5.4d, 4.4d).iterator)
 
     // TopK

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -129,7 +129,7 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
   }
 
   val ignoreKey = CustomRangeVectorKey(
-    Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
+    Map(ZeroCopyUTF8String("ign ore") -> ZeroCopyUTF8String("ignore")))
 
   val noKey = CustomRangeVectorKey(Map.empty)
   def noGrouping(rv: RangeVector): RangeVectorKey = noKey
@@ -183,22 +183,32 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
       Seq(2.0), false, Observable.fromIterable(samples), noGrouping)
     val resultObs5 = RangeVectorAggregator.mapReduce(AggregationOperator.BottomK,
       Seq(2.0), true, resultObs5a, rv=>rv.key)
+    val resultObs5b = RangeVectorAggregator.present(AggregationOperator.BottomK, Seq(2.0), resultObs5, 1000)
     val result5 = resultObs5.toListL.runAsync.futureValue
     result5.size shouldEqual 1
     result5(0).key shouldEqual noKey
     compareIter2(result5(0).rows.map(r=> Set(r.getDouble(2), r.getDouble(4))),
       Seq(Set(2.1d, 4.6d), Set(4.4, 5.4d)).iterator)
+    val result5b = resultObs5b.toListL.runAsync.futureValue
+    result5b.size shouldEqual 1
+    result5b(0).key shouldEqual ignoreKey
+    compareIter(result5b(0).rows.map(_.getDouble(1)), Seq(4.6d,2.1d,5.4d,4.4d).iterator)
 
     // TopK
     val resultObs6a = RangeVectorAggregator.mapReduce(AggregationOperator.TopK,
       Seq(2.0), false, Observable.fromIterable(samples), noGrouping)
     val resultObs6 = RangeVectorAggregator.mapReduce(AggregationOperator.TopK,
       Seq(2.0), true, resultObs6a, rv=>rv.key)
+    val resultObs6b = RangeVectorAggregator.present(AggregationOperator.TopK, Seq(2.0), resultObs6, 1000)
     val result6 = resultObs6.toListL.runAsync.futureValue
     result6.size shouldEqual 1
     result6(0).key shouldEqual noKey
     compareIter2(result6(0).rows.map(r=> Set(r.getDouble(2), r.getDouble(4))),
       Seq(Set(4.6d, 2.1d), Set(5.6, 5.4d)).iterator)
+    val result6b = resultObs6b.toListL.runAsync.futureValue
+    result6b.size shouldEqual 1
+    result6b(0).key shouldEqual ignoreKey
+    compareIter(result6b(0).rows.map(_.getDouble(1)), Seq(2.1d,4.6d,5.4d,5.6d).iterator)
 
     // Quantile
     val resultObs7a = RangeVectorAggregator.mapReduce(AggregationOperator.Quantile,
@@ -309,6 +319,38 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
     result4.size shouldEqual 1
     result4(0).key shouldEqual noKey
     compareIter(result4(0).rows.map(_.getDouble(1)), Seq(Double.NaN, 5.133333333333333d).iterator)
+
+    // BottomK
+    val resultObs5a = RangeVectorAggregator.mapReduce(AggregationOperator.BottomK,
+      Seq(2.0), false, Observable.fromIterable(samples), noGrouping)
+    val resultObs5 = RangeVectorAggregator.mapReduce(AggregationOperator.BottomK,
+      Seq(2.0), true, resultObs5a, rv=>rv.key)
+    val resultObs5b = RangeVectorAggregator.present(AggregationOperator.BottomK, Seq(2.0), resultObs5, 1000)
+    val result5 = resultObs5.toListL.runAsync.futureValue
+    result5.size shouldEqual 1
+    result5(0).key shouldEqual noKey
+    compareIter2(result5(0).rows.map(r=> Set(r.getDouble(2), r.getDouble(4))),
+      Seq(Set(1.7976931348623157E308d, 1.7976931348623157E308d), Set(4.4d, 5.4d)).iterator)
+    val result5b = resultObs5b.toListL.runAsync.futureValue
+    result5b.size shouldEqual 1
+    result5b(0).key shouldEqual ignoreKey
+    compareIter(result5b(0).rows.map(_.getDouble(1)), Seq(5.4d, 4.4d).iterator)
+
+    // TopK
+    val resultObs6a = RangeVectorAggregator.mapReduce(AggregationOperator.TopK,
+      Seq(2.0), false, Observable.fromIterable(samples), noGrouping)
+    val resultObs6 = RangeVectorAggregator.mapReduce(AggregationOperator.TopK,
+      Seq(2.0), true, resultObs6a, rv=>rv.key)
+    val resultObs6b = RangeVectorAggregator.present(AggregationOperator.TopK, Seq(2.0), resultObs6, 1000)
+    val result6 = resultObs6.toListL.runAsync.futureValue
+    result6.size shouldEqual 1
+    result6(0).key shouldEqual noKey
+    compareIter2(result6(0).rows.map(r=> Set(r.getDouble(2), r.getDouble(4))),
+      Seq(Set(-1.7976931348623157E308d, -1.7976931348623157E308d), Set(5.6, 5.4d)).iterator)
+    val result6b = resultObs6b.toListL.runAsync.futureValue
+    result6b.size shouldEqual 1
+    result6b(0).key shouldEqual ignoreKey
+    compareIter(result6b(0).rows.map(_.getDouble(1)), Seq(5.4d,5.6d).iterator)
 
   }
 

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -129,7 +129,7 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
   }
 
   val ignoreKey = CustomRangeVectorKey(
-    Map(ZeroCopyUTF8String("ign ore") -> ZeroCopyUTF8String("ignore")))
+    Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
 
   val noKey = CustomRangeVectorKey(Map.empty)
   def noGrouping(rv: RangeVector): RangeVectorKey = noKey


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) x
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently when input has NaN, topK returns range vector  with _name_ as null and all samples with value -1.7976931348623157E308  and bottomK returns range vector  with _name_ as null and all samples with value 1.7976931348623157E30 



**New behavior :**

Result does not have the range vector with name as null and sample values as -1.7976931348623157E308 / 1.7976931348623157E308 


