### PR TITLE
feat(core,memory): Don't free the native memory used by TimeSeriesPartition too soon.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartitionSet.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionSet.scala
@@ -333,6 +333,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
       val j = i & mask
       val status = buckets(j)
       if (status == 3 && items(j) == item) {
+        items(j) = null // allow item to be garbage collected
         buckets(j) = 2
         len -= 1
         true
@@ -513,6 +514,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
     if (lhs.size <= rhs.size) {
       cfor(0)(_ < buckets.length, _ + 1) { i =>
         if (buckets(i) == 3 && !rhs(items(i))) {
+          items(i) = null // allow item to be garbage collected
           buckets(i) = 2
           len -= 1
         }
@@ -561,6 +563,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
     } else {
       cfor(0)(_ < buckets.length, _ + 1) { i =>
         if (buckets(i) == 3 && rhs(items(i))) {
+          items(i) = null // allow item to be garbage collected
           buckets(i) = 2
           len -= 1
         }
@@ -665,6 +668,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
   def filterSelf(p: FiloPartition => Boolean): Unit =
     cfor(0)(_ < buckets.length, _ + 1) { i =>
       if (buckets(i) == 3 && !p(items(i))) {
+        items(i) = null // allow item to be garbage collected
         buckets(i) = 2
         len -= 1
       }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1,5 +1,6 @@
 package filodb.core.memstore
 
+import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Random, Try}

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -239,4 +239,5 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     }
   }
 
+  override def finalize(): Unit = releaseBlocks
 }

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -124,6 +124,8 @@ class NativeMemoryManager(val upperBoundSizeInBytes: Long) extends MemFactory {
   def shutdown(): Unit = {
     freeAll()
   }
+
+  override def finalize(): Unit = shutdown
 }
 
 /**

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -85,7 +85,7 @@
  <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"/>
  <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
  <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
- <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="false"/>
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
  <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Removing partitions can cause SEGVs.

**New behavior :**
Native memory is freed only after garbage collection.
