### PR TITLE
misc(prometheus): Update sharding key to use "_ns" instead of "app"

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -10,9 +10,9 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
 object FormatConversion {
   // An official Prometheus-format Dataset object with a single timestamp and value
   val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
-                  .copy(options = DatasetOptions(Seq("__name__", "app"),
+                  .copy(options = DatasetOptions(Seq("__name__", "_ns"),
                     "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
-                    Map("exporter" -> "app", "job" -> "app")))
+                    Map("exporter" -> "_ns", "app" -> "_ns", "job" -> "_ns")))
 
   /**
    * Extracts a java ArrayList of labels from the TimeSeries


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Labels __name__ and app are being used as sharding key.

**New behavior :**

Labels __name__ and _ns will be used as sharding key.
