### PR TITLE
misc(prometheus): Update sharding key to use "_ns" instead of "app"

### DIFF
--- a/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
@@ -12,10 +12,10 @@ class InfluxRecordSpec extends FunSpec with Matchers {
   // Second one does not
   // Third one is a histogram
   val rawInfluxLPs = Seq(
-    "recovery_row_skipped_total,dataset=timeseries,host=MacBook-Pro-229.local,app=filodb counter=0 1536790212000000000",
+    "recovery_row_skipped_total,dataset=timeseries,host=MacBook-Pro-229.local,_ns=filodb counter=0 1536790212000000000",
     "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1 counter=0 1536790212000000000",
-    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,app=filodb counter=0 1536790212000000000",
-    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,app=filodb counter=0 1536790212000000000",
+    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,_ns=filodb counter=0 1536790212000000000",
+    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,_ns=filodb counter=0 1536790212000000000",
     "memstore_flushes_success_total,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,url=http://localhost:9095 counter=0 1536628260000000000",
     "span_processing_time_seconds,error=false,host=MacBook-Pro-229.local,operation=memstore-recover-index-latency +Inf=2,0.005=0,0.01=0,0.025=0,0.05=0,0.075=0,0.1=1,0.25=2,0.5=2,0.75=2,1=2,10=2,2.5=2,5=2,7.5=2,count=2,sum=0.230162432 1536790212000000000"
   )
@@ -84,7 +84,7 @@ class InfluxRecordSpec extends FunSpec with Matchers {
         dataset.ingestionSchema.consumeMapItems(base, offset, 2, consumer)
         consumer.stringPairs.toMap shouldEqual Map("dataset" -> "timeseries",
                                                    "host" -> "MacBook-Pro-229.local",
-                                                   "app" -> "filodb",
+                                                   "_ns" -> "filodb",
                                                    "__name__" -> "recovery_row_skipped_total")
       }
     }

--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -10,9 +10,9 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
 object FormatConversion {
   // An official Prometheus-format Dataset object with a single timestamp and value
   val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
-                  .copy(options = DatasetOptions(Seq("__name__", "app"),
+                  .copy(options = DatasetOptions(Seq("__name__", "_ns"),
                     "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
-                    Map("exporter" -> "app", "job" -> "app")))
+                    Map("exporter" -> "_ns", "job" -> "_ns")))
 
   /**
    * Extracts a java ArrayList of labels from the TimeSeries


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Labels `__name__` and `app` are being used as sharding key.

**New behavior :**

Labels `__name__` and `_ns` will be used as sharding key.
