### PR TITLE
misc(core): unit test for testing extractTimebucket with multiple string partition columns

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -120,9 +120,9 @@ class PartKeyLuceneIndex(dataset: Dataset,
       case StringColumn => new Indexer {
         val colName = UTF8Str(c.name)
         def fromPartKey(base: Any, offset: Long, partIndex: Int): Unit = {
-          val strOffset = dataset.partKeySchema.getStringOffset(base, UnsafeUtils.arayOffset, pos)
-          val value = new BytesRef(base.asInstanceOf[Array[Byte]], strOffset + 2,
-            UTF8StringMedium.numBytes(base, UnsafeUtils.arayOffset + strOffset))
+          val strOffset = dataset.partKeySchema.blobOffset(base, offset, pos)
+          val numBytes = dataset.partKeySchema.blobNumBytes(base, offset, pos)
+          val value = new BytesRef(base.asInstanceOf[Array[Byte]], strOffset.toInt - UnsafeUtils.arayOffset, numBytes)
           addIndexEntry(colName.toString, value, partIndex)
         }
         def getNamesValues(key: PartitionKey): Seq[(UTF8Str, UTF8Str)] = ??? // not used

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -294,12 +294,40 @@ object MachineMetricsData {
   val extraTagsLen = extraTags.map { case (k, v) => k.numBytes + v.numBytes }.sum
 }
 
+// A simulation of custom machine metrics data - for testing extractTimeBucket
+object CustomMetricsData {
+
+  val columns = Seq("timestamp:ts", "min:double", "avg:double", "max:double", "count:long")
+
+  //Partition Key with multiple string columns
+  val partitionColumns = Seq("metric:string", "app:string")
+  val metricdataset = Dataset.make("tsdbdata",
+                        partitionColumns,
+                        columns,
+                        Seq("timestamp"),
+                        DatasetOptions(Seq("metric", "app"), "metric", "count")).get
+  val partKeyBuilder = new RecordBuilder(TestData.nativeMem, metricdataset.partKeySchema, 2048)
+  val defaultPartKey = partKeyBuilder.addFromObjects("metric1", "app1")
+
+  //Partition Key with single map columns
+  val partitionColumns2 = Seq("tags:map")
+  val metricdataset2 = Dataset.make("tsdbdata",
+                        partitionColumns2,
+                        columns,
+                        Seq("timestamp"),
+                        DatasetOptions(Seq("__name__"), "__name__", "count")).get
+  val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, metricdataset2.partKeySchema, 2048)
+  val defaultPartKey2 = partKeyBuilder2.addFromObjects(Map(ZeroCopyUTF8String("abc") -> ZeroCopyUTF8String("cba")))
+
+}
+
 object MetricsTestData {
   val timeseriesDataset = Dataset.make("timeseries",
                                   Seq("tags:map"),
                                   Seq("timestamp:ts", "value:double"),
                                   Seq("timestamp"),
                                   DatasetOptions(Seq("__name__", "job"), "__name__", "value")).get
+
   val builder = new RecordBuilder(MemFactory.onHeapFactory, timeseriesDataset.ingestionSchema)
 
   final case class TagsRowReader(tags: Map[String, String]) extends SchemaRowReader {

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -305,6 +305,7 @@ object CustomMetricsData {
                         partitionColumns,
                         columns,
                         Seq("timestamp"),
+                        Seq.empty,
                         DatasetOptions(Seq("metric", "app"), "metric", "count")).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, metricdataset.partKeySchema, 2048)
   val defaultPartKey = partKeyBuilder.addFromObjects("metric1", "app1")
@@ -315,6 +316,7 @@ object CustomMetricsData {
                         partitionColumns2,
                         columns,
                         Seq("timestamp"),
+                        Seq.empty,
                         DatasetOptions(Seq("__name__"), "__name__", "count")).get
   val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, metricdataset2.partKeySchema, 2048)
   val defaultPartKey2 = partKeyBuilder2.addFromObjects(Map(ZeroCopyUTF8String("abc") -> ZeroCopyUTF8String("cba")))

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -13,6 +13,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import filodb.core._
 import filodb.core.binaryrecord2.{RecordBuilder, RecordContainer}
 import filodb.core.memstore.TimeSeriesShard.{indexTimeBucketSchema, indexTimeBucketSegmentSize}
+import filodb.core.metadata.Dataset
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.store.{FilteredPartitionScan, InMemoryMetaStore, NullColumnStore, SinglePartitionScan}
 import filodb.memory.{BinaryRegionLarge, MemFactory}
@@ -230,16 +231,13 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     tsShard.timeBucketBitmaps.keySet.asScala.toSeq.sorted shouldEqual 19.to(25) // 6 buckets retained + one for current
   }
 
-  it("should recover index from time buckets") {
-    import GdeltTestData._
-    memStore.metastore.writeHighestIndexTimeBucket(dataset1.ref, 0, 0)
-    memStore.setup(dataset1, 0, TestData.storeConf.copy(groupsPerShard = 2, demandPagedRetentionPeriod = 1.hour,
-      flushInterval = 10.minutes))
-    val tsShard = memStore.asInstanceOf[TimeSeriesMemStore].getShard(dataset1.ref, 0).get
+  def indexRecoveryTest(dataset: Dataset, partKeys: Seq[Long]): Unit = {
+    memStore.metastore.writeHighestIndexTimeBucket(dataset.ref, 0, 0)
+    memStore.setup(dataset, 0,
+      TestData.storeConf.copy(groupsPerShard = 2, demandPagedRetentionPeriod = 1.hour,
+        flushInterval = 10.minutes))
+    val tsShard = memStore.asInstanceOf[TimeSeriesMemStore].getShard(dataset.ref, 0).get
     val timeBucketRb = new RecordBuilder(MemFactory.onHeapFactory, indexTimeBucketSchema, indexTimeBucketSegmentSize)
-
-    val readers = gdeltLines3.map { line => ArrayStringRowReader(line.split(",")) }
-    val partKeys = partKeyFromRecords(dataset1, records(dataset1, readers.take(10)))
 
     partKeys.zipWithIndex.foreach { case (off, i) =>
       timeBucketRb.startNewRecord()
@@ -250,6 +248,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
       timeBucketRb.endRecord(false)
     }
     tsShard.initTimeBuckets()
+
     timeBucketRb.optimalContainerBytes(true).foreach { bytes =>
       tsShard.extractTimeBucket(new IndexData(1, 0, RecordContainer(bytes)))
     }
@@ -261,71 +260,21 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
       tsShard.partitions.get(i).partKeyBytes shouldEqual expectedPartKey
       tsShard.partSet.getWithPartKeyBR(UnsafeUtils.ZeroPointer, off).get.partID shouldEqual i
     }
+  }
+
+  it("should recover index from time buckets") {
+    import GdeltTestData._
+    val readers = gdeltLines3.map { line => ArrayStringRowReader(line.split(",")) }
+    val partKeys = partKeyFromRecords(dataset1, records(dataset1, readers.take(10)))
+    indexRecoveryTest(dataset1, partKeys)
   }
 
   it("should recover index from time buckets - with two partition columns of type string") {
-    memStore.metastore.writeHighestIndexTimeBucket(CustomMetricsData.metricdataset.ref, 0, 0)
-    memStore.setup(CustomMetricsData.metricdataset, 0,
-      TestData.storeConf.copy(groupsPerShard = 2, demandPagedRetentionPeriod = 1.hour,
-        flushInterval = 10.minutes))
-    val tsShard = memStore.asInstanceOf[TimeSeriesMemStore].getShard(CustomMetricsData.metricdataset.ref, 0).get
-    val timeBucketRb = new RecordBuilder(MemFactory.onHeapFactory, indexTimeBucketSchema, indexTimeBucketSegmentSize)
-
-    val partKeys = Seq(CustomMetricsData.defaultPartKey)
-
-    partKeys.zipWithIndex.foreach { case (off, i) =>
-      timeBucketRb.startNewRecord()
-      timeBucketRb.addLong(i + 10)
-      timeBucketRb.addLong(i + 20)
-      val numBytes = BinaryRegionLarge.numBytes(UnsafeUtils.ZeroPointer, off)
-      timeBucketRb.addBlob(UnsafeUtils.ZeroPointer, off, numBytes + 4)
-      timeBucketRb.endRecord(false)
-    }
-    tsShard.initTimeBuckets()
-
-    timeBucketRb.optimalContainerBytes(true).foreach { bytes =>
-      tsShard.extractTimeBucket(new IndexData(1, 0, RecordContainer(bytes)))
-    }
-    tsShard.commitPartKeyIndexBlocking()
-    partKeys.zipWithIndex.foreach { case (off, i) =>
-      val readPartKey = tsShard.partKeyIndex.partKeyFromPartId(i).get
-      val expectedPartKey = dataset1.partKeySchema.asByteArray(UnsafeUtils.ZeroPointer, off)
-      readPartKey.bytes.drop(readPartKey.offset).take(readPartKey.length) shouldEqual expectedPartKey
-      tsShard.partitions.get(i).partKeyBytes shouldEqual expectedPartKey
-      tsShard.partSet.getWithPartKeyBR(UnsafeUtils.ZeroPointer, off).get.partID shouldEqual i
-    }
+    indexRecoveryTest(CustomMetricsData.metricdataset, Seq(CustomMetricsData.defaultPartKey))
   }
 
   it("should recover index from time buckets - with single partition column of type map") {
-    memStore.metastore.writeHighestIndexTimeBucket(CustomMetricsData.metricdataset2.ref, 0, 0)
-    memStore.setup(CustomMetricsData.metricdataset2, 0,
-      TestData.storeConf.copy(groupsPerShard = 2, demandPagedRetentionPeriod = 1.hour,
-        flushInterval = 10.minutes))
-    val tsShard = memStore.asInstanceOf[TimeSeriesMemStore].getShard(CustomMetricsData.metricdataset2.ref, 0).get
-    val timeBucketRb = new RecordBuilder(MemFactory.onHeapFactory, indexTimeBucketSchema, indexTimeBucketSegmentSize)
-
-    val partKeys = Seq(CustomMetricsData.defaultPartKey2)
-
-    partKeys.zipWithIndex.foreach { case (off, i) =>
-      timeBucketRb.startNewRecord()
-      timeBucketRb.addLong(i + 10)
-      timeBucketRb.addLong(i + 20)
-      val numBytes = BinaryRegionLarge.numBytes(UnsafeUtils.ZeroPointer, off)
-      timeBucketRb.addBlob(UnsafeUtils.ZeroPointer, off, numBytes + 4)
-      timeBucketRb.endRecord(false)
-    }
-    tsShard.initTimeBuckets()
-    timeBucketRb.optimalContainerBytes(true).foreach { bytes =>
-      tsShard.extractTimeBucket(new IndexData(1, 0, RecordContainer(bytes)))
-    }
-    tsShard.commitPartKeyIndexBlocking()
-    partKeys.zipWithIndex.foreach { case (off, i) =>
-      val readPartKey = tsShard.partKeyIndex.partKeyFromPartId(i).get
-      val expectedPartKey = dataset1.partKeySchema.asByteArray(UnsafeUtils.ZeroPointer, off)
-      readPartKey.bytes.drop(readPartKey.offset).take(readPartKey.length) shouldEqual expectedPartKey
-      tsShard.partitions.get(i).partKeyBytes shouldEqual expectedPartKey
-      tsShard.partSet.getWithPartKeyBR(UnsafeUtils.ZeroPointer, off).get.partID shouldEqual i
-    }
+    indexRecoveryTest(CustomMetricsData.metricdataset2, Seq(CustomMetricsData.defaultPartKey2))
   }
 
   import Iterators._


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

Unit Test for validating the failure while extracting time buckets from cassandra. This is causing SEGV errors while instance restarts. It is happening if the schema has multiple string partition columns.