### PR TITLE
bug(core): Improve safety of freeing native memory.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -134,7 +134,12 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
                 unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(partKeyBytesRef.offset)
                 group = partKeyGroup(dataset.partKeySchema, partKeyBytesRef.bytes, unsafeKeyOffset, numGroups)
                 part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, 4)) } yield {
-            partSet.add(part)
+            val stamp = partSetLock.writeLock()
+            try {
+              partSet.add(part)
+            } finally {
+              partSetLock.unlockWrite(stamp)
+            }
             callback(partKeyBytesRef.bytes, unsafeKeyOffset)
             part
           }

--- a/core/src/main/scala/filodb.core/memstore/PartitionSet.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionSet.scala
@@ -333,6 +333,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
       val j = i & mask
       val status = buckets(j)
       if (status == 3 && items(j) == item) {
+        items(j) = null // allow item to be garbage collected
         buckets(j) = 2
         len -= 1
         true
@@ -513,6 +514,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
     if (lhs.size <= rhs.size) {
       cfor(0)(_ < buckets.length, _ + 1) { i =>
         if (buckets(i) == 3 && !rhs(items(i))) {
+          items(i) = null // allow item to be garbage collected
           buckets(i) = 2
           len -= 1
         }
@@ -561,6 +563,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
     } else {
       cfor(0)(_ < buckets.length, _ + 1) { i =>
         if (buckets(i) == 3 && rhs(items(i))) {
+          items(i) = null // allow item to be garbage collected
           buckets(i) = 2
           len -= 1
         }
@@ -665,6 +668,7 @@ final class PartitionSet(as: Array[FiloPartition], bs: Array[Byte], n: Int, u: I
   def filterSelf(p: FiloPartition => Boolean): Unit =
     cfor(0)(_ < buckets.length, _ + 1) { i =>
       if (buckets(i) == 3 && !p(items(i))) {
+        items(i) = null // allow item to be garbage collected
         buckets(i) = 2
         len -= 1
       }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1008,6 +1008,7 @@ class TimeSeriesShard(val dataset: Dataset,
    * @param locked true if caller holds partSetLock write lock
    * @return true if able to evict enough or there was already space, false if not able to evict and not enough mem
    */
+  //scalastyle:off method.length
   private[filodb] def ensureFreeSpace(locked: Boolean): Boolean = {
     var lastPruned = EmptyBitmap
     while (evictionPolicy.shouldEvict(partSet.size, bufferMemoryManager)) {
@@ -1061,6 +1062,7 @@ class TimeSeriesShard(val dataset: Dataset,
     }
     true
   }
+  //scalastyle:on
 
   /**
    * Permanently removes the given partition ID from our in-memory data structures

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1084,8 +1084,11 @@ class TimeSeriesShard(val dataset: Dataset,
 
   def shutdown(): Unit = {
     reset()   // Not really needed, but clear everything just to be consistent
-    logger.info(s"Shutting down and releasing offheap memory for shard $shardNum")
+    logger.info(s"Shutting down shard $shardNum")
+    /* Don't explcitly free the memory just yet. These classes instead rely on a finalize
+       method to ensure that no threads are accessing the memory before it's freed.
     bufferMemoryManager.shutdown()
     blockStore.releaseBlocks()
+    */
   }
 }

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -239,4 +239,5 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     }
   }
 
+  override def finalize(): Unit = releaseBlocks
 }

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -124,6 +124,8 @@ class NativeMemoryManager(val upperBoundSizeInBytes: Long) extends MemFactory {
   def shutdown(): Unit = {
     freeAll()
   }
+
+  override def finalize(): Unit = shutdown
 }
 
 /**

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -85,7 +85,7 @@
  <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"/>
  <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
  <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
- <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="false"/>
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
  <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Native memory can be freed too soon, due to various race conditions.

**New behavior :**
Locks are put in place to ensure that partitions are added/removed in a thread-safe fashion, and finalization is used to safely free the memory occupied by an entire shard. Shard removal is rare, and so delayed reclamation due to finalization isn't much of an issue.
