### PR TITLE
misc(git): Avoid merging version file during git merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+version.sbt merge=ours


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

During git merge across branches, even version.sbt is getting merged.


**New behavior :**

Adding .gitattribute to avoid merging version.sbt file.
