### PR TITLE
feat(query): Apply limits on total number of samples

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -35,7 +35,7 @@ class Arguments extends FieldArgs {
   var partitionKeys: Seq[String] = Nil
   var select: Option[Seq[String]] = None
   // max # query items (vectors or tuples) returned. Don't make it too high.
-  var limit: Int = 100
+  var limit: Int = 1000
   var sampleLimit: Int = 200
   var timeoutSeconds: Int = 60
   var outfile: Option[String] = None

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -35,12 +35,12 @@ object QueryCommands {
   final case class QueryOptions(spreadFunc: Seq[ColumnFilter] => Int = { x => 1 },
                                 parallelism: Int = 16,
                                 queryTimeoutSecs: Int = 30,
-                                itemLimit: Int = 100,
+                                sampleLimit: Int = 1000000,
                                 shardOverrides: Option[Seq[Int]] = None)
 
   object QueryOptions {
-    def apply(constSpread: Int, itemLimit: Int): QueryOptions =
-      QueryOptions(spreadFunc = { x => constSpread}, itemLimit = itemLimit)
+    def apply(constSpread: Int, sampleLimit: Int): QueryOptions =
+      QueryOptions(spreadFunc = { x => constSpread}, sampleLimit = sampleLimit)
 
     /**
      * Creates a spreadFunc that looks for a particular filter with keyName Equals a value, and then maps values

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -196,7 +196,7 @@ class QueryEngine(dataset: Dataset,
     val renamedFilters = renameMetricFilter(lp.filters)
     shardsFromFilters(renamedFilters, options).map { shard =>
       val dispatcher = dispatcherForShard(shard)
-      SelectRawPartitionsExec(queryId, submitTime, options.itemLimit, dispatcher, dataset.ref, shard,
+      SelectRawPartitionsExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         renamedFilters, toRowKeyRange(lp.rangeSelector), colIDs)
     }
   }
@@ -220,7 +220,7 @@ class QueryEngine(dataset: Dataset,
                       }
     shardsToHit.map { shard =>
       val dispatcher = dispatcherForShard(shard)
-      exec.LabelValuesExec(queryId, submitTime, options.itemLimit, dispatcher, dataset.ref, shard,
+      exec.LabelValuesExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         filters, labelName, lp.lookbackTimeInMillis)
     }
   }
@@ -232,7 +232,7 @@ class QueryEngine(dataset: Dataset,
     val renamedFilters = renameMetricFilter(lp.filters)
     shardsFromFilters(renamedFilters, options).map { shard =>
       val dispatcher = dispatcherForShard(shard)
-      PartKeysExec(queryId, submitTime, options.itemLimit, dispatcher, dataset.ref, shard,
+      PartKeysExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         renamedFilters, lp.start, lp.end)
     }
   }
@@ -247,7 +247,7 @@ class QueryEngine(dataset: Dataset,
     val renamedFilters = renameMetricFilter(lp.filters)
     shardsFromFilters(renamedFilters, options).map { shard =>
       val dispatcher = dispatcherForShard(shard)
-      SelectChunkInfosExec(queryId, submitTime, options.itemLimit, dispatcher, dataset.ref, shard,
+      SelectChunkInfosExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         renamedFilters, toRowKeyRange(lp.rangeSelector), colID)
     }
   }

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -151,8 +151,8 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
       val srv = SerializableRangeVector(rv, cols)
       val observedTs = srv.rows.toSeq.map(_.getLong(0))
       val observedVal = srv.rows.toSeq.map(_.getDouble(1))
-      observedTs shouldEqual tuples.map(_._1).take(limit)
-      observedVal shouldEqual tuples.map(_._2).take(limit)
+      observedTs shouldEqual tuples.map(_._1)
+      observedVal shouldEqual tuples.map(_._2)
       srv
     }
 

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -148,7 +148,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
         override val rows: Iterator[RowReader] = rowbuf.iterator
         override val key: RangeVectorKey = rvKey
       }
-      val srv = SerializableRangeVector(rv, cols, limit)
+      val srv = SerializableRangeVector(rv, cols)
       val observedTs = srv.rows.toSeq.map(_.getLong(0))
       val observedVal = srv.rows.toSeq.map(_.getDouble(1))
       observedTs shouldEqual tuples.map(_._1).take(limit)
@@ -245,7 +245,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
                       UTF8Str("key2") -> UTF8Str("val2"))
     val key = CustomRangeVectorKey(keysMap)
     val cols = Seq(ColumnInfo("value", ColumnType.DoubleColumn))
-    val ser = SerializableRangeVector(IteratorBackedRangeVector(key, Iterator.empty), cols, 10)
+    val ser = SerializableRangeVector(IteratorBackedRangeVector(key, Iterator.empty), cols)
 
     val schema = ResultSchema(MachineMetricsData.dataset1.infosFromIDs(0 to 0), 1)
 
@@ -262,7 +262,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val schema = new ResultSchema(Seq(new ColumnInfo("app", ColumnType.StringColumn)), 1)
     val cols = Seq(ColumnInfo("value", ColumnType.StringColumn))
     val ser = Seq(SerializableRangeVector(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-      new ZCUTF8IteratorRowReader(expected.toIterator)), cols, 10))
+      new ZCUTF8IteratorRowReader(expected.toIterator)), cols))
 
     val result = QueryResult2("someId", schema, ser)
     val roundTripResult = roundTrip(result).asInstanceOf[QueryResult2]

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -29,7 +29,7 @@ filodb {
     sample-limit = 1000000
 
     # Minimum step required for a query
-    min-step = 10 seconds
+    min-step = 5 seconds
   }
 
   shard-manager {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -27,6 +27,9 @@ filodb {
 
     # Maximum number of samples to return in a query
     sample-limit = 1000000
+
+    # Minimum step required for a query
+    min-step = 10 seconds
   }
 
   shard-manager {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -25,11 +25,8 @@ filodb {
 
     stale-sample-after = 5 minutes
 
-    # Maximum number of RangeVectors returned from any sub-plan QueryResult
-    # vectors-limit = 150
-
-    # Maximum number of samples to return per RangeVector/result time series
-    sample-limit = 200
+    # Maximum number of samples to return in a query
+    sample-limit = 1000000
   }
 
   shard-manager {

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -170,8 +170,7 @@ object SerializableRangeVector extends StrictLogging {
    */
   def apply(rv: RangeVector,
             builder: RecordBuilder,
-            schema: RecordSchema,
-            limit: Int): SerializableRangeVector = {
+            schema: RecordSchema): SerializableRangeVector = {
     var numRows = 0
     val oldContainerOpt = builder.currentContainer
     val startRecordNo = oldContainerOpt.map(_.numRecords).getOrElse(0)
@@ -180,7 +179,7 @@ object SerializableRangeVector extends StrictLogging {
     try {
       OffheapLFSortedIDMap.validateNoSharedLocks()
       val rows = rv.rows
-      while (rows.hasNext && numRows < limit) {
+      while (rows.hasNext) {
         numRows += 1
         builder.addFromReader(rows.next)
       }
@@ -201,9 +200,9 @@ object SerializableRangeVector extends StrictLogging {
    * Creates a SerializableRangeVector out of another RV and ColumnInfo schema.  Convenient but no sharing.
    * Since it wastes space when working with multiple RVs, should be used mostly for testing.
    */
-  def apply(rv: RangeVector, cols: Seq[ColumnInfo], limit: Int): SerializableRangeVector = {
+  def apply(rv: RangeVector, cols: Seq[ColumnInfo]): SerializableRangeVector = {
     val schema = toSchema(cols)
-    apply(rv, toBuilder(schema), schema, limit)
+    apply(rv, toBuilder(schema), schema)
   }
 
   // TODO: make this configurable....

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -54,7 +54,7 @@ filodb {
     ask-timeout = 10 seconds
     stale-sample-after = 5 minutes
     sample-limit = 1000000
-    min-step = 10 seconds
+    min-step = 1 ms
   }
 }
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -53,6 +53,8 @@ filodb {
   query {
     ask-timeout = 10 seconds
     stale-sample-after = 5 minutes
+    sample-limit = 1000000
+    min-step = 10 seconds
   }
 }
 

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -27,13 +27,13 @@ class RangeVectorSpec  extends FunSpec with Matchers {
 
   it("should be able to create and read from SerializableRangeVector") {
     val rv = new TuplesRangeVector(tuples)
-    val srv = SerializableRangeVector(rv, cols, numRawSamples)
+    val srv = SerializableRangeVector(rv, cols)
     val observedTs = srv.rows.toSeq.map(_.getLong(0))
     val observedVal = srv.rows.toSeq.map(_.getDouble(1))
     observedTs shouldEqual tuples.map(_._1)
     observedVal shouldEqual tuples.map(_._2)
 
-    val srv2 = SerializableRangeVector(srv, cols, numRawSamples)
+    val srv2 = SerializableRangeVector(srv, cols)
     val observedTs2 = srv2.rows.toSeq.map(_.getLong(0))
     val observedVal2 = srv2.rows.toSeq.map(_.getDouble(1))
     observedTs2 shouldEqual tuples.map(_._1)
@@ -46,7 +46,7 @@ class RangeVectorSpec  extends FunSpec with Matchers {
     val builder = SerializableRangeVector.toBuilder(schema)
 
     // Sharing one builder across multiple input RangeVectors
-    val srvs = rvs.map(rv => SerializableRangeVector(rv, builder, schema, numRawSamples))
+    val srvs = rvs.map(rv => SerializableRangeVector(rv, builder, schema))
 
     // Now verify each of them
     val observedTs = srvs(0).rows.toSeq.map(_.getLong(0))

--- a/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
+++ b/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
@@ -30,7 +30,7 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
   import filodb.prometheus.query.PrometheusModel._
 
   val queryOptions = QueryOptions(spreadFunc = { _ => settings.queryDefaultSpread },
-                                  itemLimit = settings.querySampleLimit)
+                                  sampleLimit = settings.querySampleLimit)
 
   val route = pathPrefix( "promql" / Segment) { dataset =>
     // Path: /promql/<datasetName>/api/v1/query_range

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -129,7 +129,7 @@ class QueryAndIngestBenchmark extends StrictLogging {
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }
   val queryCommands = logicalPlans.map { plan =>
-    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 10000))
+    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 20000))
   }
 
   private var testProducingFut: Option[Future[Unit]] = None

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -129,7 +129,7 @@ class QueryAndIngestBenchmark extends StrictLogging {
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }
   val queryCommands = logicalPlans.map { plan =>
-    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 100))
+    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 10000))
   }
 
   private var testProducingFut: Option[Future[Unit]] = None

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -119,7 +119,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }
   val queryCommands = logicalPlans.map { plan =>
-    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 10000))
+    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 20000))
   }
 
   @TearDown

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -119,7 +119,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }
   val queryCommands = logicalPlans.map { plan =>
-    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 100))
+    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 10000))
   }
 
   @TearDown
@@ -148,7 +148,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   val qParams2 = TimeStepParams(queryTime/1000, noOverlapStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans2 = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams2) }
   val queryCommands2 = logicalPlans2.map { plan =>
-    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 100))
+    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 10000))
   }
 
   @Benchmark
@@ -168,7 +168,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   }
 
   // Single-threaded query test
-  val qOptions = QueryOptions(1, 100)
+  val qOptions = QueryOptions(1, 10000)
   val logicalPlan = Parser.queryRangeToLogicalPlan(rawQuery, qParams)
   // Pick the children nodes, not the DistConcatExec.  Thus we can run in a single thread this way
   val execPlan = engine.materialize(logicalPlan, qOptions).children.head

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -135,7 +135,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }
   val queryCommands = logicalPlans.map { plan =>
-    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 100))
+    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 10000))
   }
 
   @TearDown

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -135,7 +135,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }
   val queryCommands = logicalPlans.map { plan =>
-    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 10000))
+    LogicalPlan2Query(dataset.ref, plan, QueryOptions(1, 20000))
   }
 
   @TearDown

--- a/query/src/main/scala/filodb/query/QueryConfig.scala
+++ b/query/src/main/scala/filodb/query/QueryConfig.scala
@@ -12,5 +12,4 @@ object QueryConfig {
 class QueryConfig(queryConfig: Config) {
   lazy val askTimeout = queryConfig.as[FiniteDuration]("ask-timeout")
   lazy val staleSampleAfterMs = queryConfig.getDuration("stale-sample-after").toMillis
-  lazy val vectorsLimit = queryConfig.as[Option[Int]]("vectors-limit").getOrElse(QueryConfig.DefaultVectorsLimit)
 }

--- a/query/src/main/scala/filodb/query/QueryConfig.scala
+++ b/query/src/main/scala/filodb/query/QueryConfig.scala
@@ -12,4 +12,5 @@ object QueryConfig {
 class QueryConfig(queryConfig: Config) {
   lazy val askTimeout = queryConfig.as[FiniteDuration]("ask-timeout")
   lazy val staleSampleAfterMs = queryConfig.getDuration("stale-sample-after").toMillis
+  lazy val minStepMs = queryConfig.getDuration("min-step").toMillis
 }

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -45,7 +45,7 @@ trait ExecPlan extends QueryCommand {
   def submitTime: Long
 
   /**
-    * Limit on number of samples
+    * Limit on number of samples returned by this ExecPlan
     */
   def limit: Int
 

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -114,7 +114,7 @@ trait ExecPlan extends QueryCommand {
             numResultSamples += srv.numRows
             // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
             if (numResultSamples > limit)
-              throw new IllegalArgumentException(s"This query results in more than $limit samples. " +
+              throw new BadQueryException(s"This query results in more than $limit samples. " +
                 s"Try applying more filters or reduce time range.")
             srv
           case rv: RangeVector =>
@@ -123,7 +123,7 @@ trait ExecPlan extends QueryCommand {
             numResultSamples += srv.numRows
             // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
             if (numResultSamples > limit)
-              throw new IllegalArgumentException(s"This query results in more than $limit samples. " +
+              throw new BadQueryException(s"This query results in more than $limit samples. " +
                 s"Try applying more filters or reduce time range.")
             srv
         }

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -230,7 +230,7 @@ class AggrOverRangeVectorsSpec extends FunSpec with Matchers with ScalaFutures {
     val recSchema = SerializableRangeVector.toSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
                                                          ColumnInfo("tdig", ColumnType.StringColumn)))
     val builder = SerializableRangeVector.toBuilder(recSchema)
-    val srv = SerializableRangeVector(result7(0), builder, recSchema, 10)
+    val srv = SerializableRangeVector(result7(0), builder, recSchema)
 
     val resultObs7b = RangeVectorAggregator.present(AggregationOperator.Quantile, Seq(0.5), Observable.now(srv), 1000)
     val finalResult = resultObs7b.toListL.runAsync.futureValue

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -67,8 +67,8 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       ColumnInfo("value", ColumnType.DoubleColumn))
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema, 100)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializableRangeVector(rv, schema, 100)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializableRangeVector(rv, schema)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq(lhs, rhs)), queryConfig).toListL.runAsync.futureValue
 
@@ -98,8 +98,8 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       ColumnInfo("value", ColumnType.DoubleColumn))
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema, 100)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializableRangeVector(rv, schema, 100)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializableRangeVector(rv, schema)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq(lhs, rhs)), queryConfig).toListL.runAsync.futureValue
 
@@ -137,8 +137,8 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       ColumnInfo("value", ColumnType.DoubleColumn))
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema, 100)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializableRangeVector(rv, schema, 100)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializableRangeVector(rv, schema)))
     // scalastyle:on
 
     val fut = execPlan.compose(Observable.fromIterable(Seq(lhs, rhs)), queryConfig).toListL.runAsync
@@ -170,8 +170,8 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       ColumnInfo("value", ColumnType.DoubleColumn))
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs2.map(rv => SerializableRangeVector(rv, schema, 100)))
-    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializableRangeVector(rv, schema, 100)))
+    val lhs = QueryResult("someId", null, samplesLhs2.map(rv => SerializableRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializableRangeVector(rv, schema)))
     // scalastyle:on
 
     val fut = execPlan.compose(Observable.fromIterable(Seq(lhs, rhs)), queryConfig).toListL.runAsync


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Apply limit on total number of samples returned from query or sub-query instead
of sample limit per range vector paired with limit on number of range vectors.

New approach allows us to query high cardinality metrics across smaller time ranges.
This is necessary for query-based pre-aggregation.
It even allows us to query large number of samples for few range vectors.

Earlier approach could not handle these use cases.

**BREAKING CHANGES**
Semantics of limit has changed from samples-per-rangevector to total-number-of-samples
Query clients need to raise this limit.
