### PR TITLE
bug(akkabootstrapper): Retry fetching seeds endpoint before resorting…

### DIFF
--- a/akka-bootstrapper/src/main/resources/reference.conf
+++ b/akka-bootstrapper/src/main/resources/reference.conf
@@ -8,6 +8,12 @@ akka-bootstrapper {
 
     # The base url of the seeds endpoint. The baseUrl and path put together will form the seeds endpoint, and be used to discover seeds if a cluster already exists. Ends with a slash.
     base-url = "http://localhost:8080/"
+
+    # Number of times we will retry fetching information from seeds endpoint before resorting to creating a new cluster.
+    retries = 5
+
+    # Sleep time between retries
+    sleep-between-retries = 10s
   }
 
   seed-discovery {

--- a/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/AkkaBootstrapperSettings.scala
+++ b/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/AkkaBootstrapperSettings.scala
@@ -24,6 +24,8 @@ final class AkkaBootstrapperSettings(val config: Config) extends StrictLogging {
 
   val seedsBaseUrl = bootstrapper.getString("http-seeds.base-url")
   val seedsPath = bootstrapper.getString("http-seeds.path")
+  val seedsHttpRetries = bootstrapper.getInt("http-seeds.retries")
+  val seedsHttpSleepBetweenRetries = bootstrapper.getDuration("http-seeds.sleep-between-retries")
 
   // used by simple dns srv and consul
   lazy val seedNodeCount: Integer = bootstrapper.getInt("dns-srv.seed-node-count")

--- a/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/ClusterSeedDiscovery.scala
+++ b/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/ClusterSeedDiscovery.scala
@@ -39,14 +39,14 @@ abstract class ClusterSeedDiscovery(val cluster: Cluster,
         logger.info(s"Seeds endpoint returned a ${response.code}. Response body was ${response.body}")
       } catch {
         case NonFatal(e) =>
-          logger.error(s"Seeds endpoint $seedsEndpoint call threw an exception", e)
+          logger.info(s"Seeds endpoint $seedsEndpoint failed. This is expected on cluster bootstrap", e)
       }
-      Thread.sleep(settings.seedsHttpSleepBetweenRetries.toMillis)
       retriesRemaining -= 1
+      if (retriesRemaining > 0) Thread.sleep(settings.seedsHttpSleepBetweenRetries.toMillis)
     } while ((response == null || !response.is2xx) && retriesRemaining > 0)
 
     if (response == null || !response.is2xx) {
-      logger.info(s"Giving up on discovering seeds after ${settings.seedsHttpSleepBetweenRetries} retries. " +
+      logger.info(s"Giving up on discovering seeds after ${settings.seedsHttpRetries} retries. " +
         s"Assuming cluster does not exist. ")
       Seq.empty[Address]
     } else {

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -52,7 +52,10 @@ akka {
 
 akka-bootstrapper {
   seed-discovery.class = "filodb.akkabootstrapper.WhitelistClusterSeedDiscovery"
-  http-seeds.base-url = "http://localhost:8080/"
+  http-seeds {
+    base-url = "http://localhost:8080/"
+    retries = 1
+  }
   seed-discovery.timeout = 1 minute
   whitelist.seeds = [
     "akka.tcp://filo-standalone@127.0.0.1:2552"

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -293,7 +293,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
   it ("should serialize and deserialize result involving Metadata") {
 
     val expected = List(UTF8Str("App-0"), UTF8Str("App-1"))
-    val schema = new ResultSchema(Seq(new ColumnInfo("app", ColumnType.StringColumn)), 1)
+    val schema = new ResultSchema(Seq(new ColumnInfo("_ns", ColumnType.StringColumn)), 1)
     val cols = Seq(ColumnInfo("value", ColumnType.StringColumn))
     val ser = Seq(SerializableRangeVector(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
       new ZCUTF8IteratorRowReader(expected.toIterator)), cols))

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -306,7 +306,7 @@ object CustomMetricsData {
                         columns,
                         Seq("timestamp"),
                         Seq.empty,
-                        DatasetOptions(Seq("metric", "app"), "metric", "count")).get
+                        DatasetOptions(Seq("metric", "_ns"), "metric", "count")).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, metricdataset.partKeySchema, 2048)
   val defaultPartKey = partKeyBuilder.addFromObjects("metric1", "app1")
 

--- a/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
@@ -149,7 +149,7 @@ class DatasetSpec extends FunSpec with Matchers {
     it("should serialize and deserialize") {
       val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, Seq("age"), Seq("dMin(1)"))
                  .copy(options = DatasetOptions.DefaultOptions.copy(
-                   copyTags = Map("exporter" -> "app")))
+                   copyTags = Map("exporter" -> "_ns")))
       Dataset.fromCompactString(ds.asCompactString) shouldEqual ds
 
       val ds2 = ds.copy(options = DatasetOptions.DefaultOptions.copy(shardKeyColumns = Seq("metric")))

--- a/doc/downsampling.md
+++ b/doc/downsampling.md
@@ -38,7 +38,7 @@ Downsampling for prometheus counters will come soon.
 Downsampling is configured at the time of dataset creation. For example:
 
 ```
-./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus --dataColumns timestamp:ts,value:double --partitionColumns tags:map --shardKeyColumns __name__,app --downsamplers "tTime(0),dMin(1),dMax(1),dSum(1),dCount(1),dAvg(1)"
+./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus --dataColumns timestamp:ts,value:double --partitionColumns tags:map --shardKeyColumns __name__,_ns --downsamplers "tTime(0),dMin(1),dMax(1),dSum(1),dCount(1),dAvg(1)"
 ```
 
 In the above example, the data column `value` with index 1 is configured with the dMin, dMax, sSum, dCount and dAvg downsamplers.
@@ -53,7 +53,7 @@ order as the downsample type configuration. For the above example, we would crea
 dataset as:
 
 ```
-./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus_ds_1m --dataColumns timestamp:ts,min:double,max:double,sum:double,count:double,avg:double --partitionColumns tags:map --shardKeyColumns __name__,app
+./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus_ds_1m --dataColumns timestamp:ts,min:double,max:double,sum:double,count:double,avg:double --partitionColumns tags:map --shardKeyColumns __name__,_ns
 ```
 
 Note that there is no downsampling configuration here in the above dataset. Note that partition

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -14,8 +14,8 @@ import org.rogach.scallop._
 
 import filodb.coordinator.{GlobalConfig, ShardMapper}
 import filodb.core.metadata.Dataset
-import filodb.gateway.conversion.PrometheusInputRecord
 import filodb.gateway.GatewayServer
+import filodb.gateway.conversion.PrometheusInputRecord
 import filodb.prometheus.FormatConversion
 
 sealed trait DataOrCommand
@@ -97,12 +97,21 @@ object TestTimeseriesProducer extends StrictLogging {
       val endQuery = startQuery + 300
       val query =
         s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus """ +
-        s"""--promql 'heap_usage{dc="DC0",app="App-0"}' --start $startQuery --end $endQuery --limit 15"""
-      logger.info(s"Sample Query you can use: \n$query")
-      val q = URLEncoder.encode("heap_usage{dc=\"DC0\",app=\"App-0\"}", StandardCharsets.UTF_8.toString)
-      val url = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
+        s"""--promql 'heap_usage{dc="DC0",_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
+      logger.info(s"Periodic Samples CLI Query : \n$query")
+
+      val q = URLEncoder.encode("heap_usage{dc=\"DC0\",_ns=\"App-0\"}", StandardCharsets.UTF_8.toString)
+      val periodicSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
         s"query=$q&start=$startQuery&end=$endQuery&step=15"
-      logger.info(s"Sample URL you can use to query: \n$url")
+      logger.info(s"Periodic Samples query URL: \n$periodicSamplesUrl")
+
+      val q2 = URLEncoder.encode("heap_usage{dc=\"DC0\",_ns=\"App-0\"}[2m]", StandardCharsets.UTF_8.toString)
+      val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$q2&time=$endQuery"
+      logger.info(s"Raw Samples query URL: \n$rawSamplesUrl")
+      val downsampledSamplesUrl = s"http://localhost:8080/promql/prometheus_ds_1m/api/v1/query?" +
+        s"query=$q2&time=$endQuery"
+      logger.info(s"Downsampled Samples query URL: \n$downsampledSamplesUrl")
+
     }
   }
 
@@ -148,7 +157,7 @@ object TestTimeseriesProducer extends StrictLogging {
       val value = 15 + Math.sin(n + 1) + rand.nextGaussian()
 
       val tags = Map("dc"       -> s"DC$dc",
-                     "app"      -> s"App-$app",
+                     "_ns"      -> s"App-$app",
                      "partition" -> s"partition-$partition",
                      "host"     -> s"H$host",
                      "instance" -> s"Instance-$instance")

--- a/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
@@ -23,7 +23,7 @@ class GatewayBenchmark extends StrictLogging {
   val tagMap = Map(
     "__name__" -> "heap_usage",
     "dc"       -> "DC1",
-    "app"      -> "App-123",
+    "_ns"      -> "App-123",
     "partition" -> "partition-2",
     "host"     -> "abc.xyz.company.com",
     "instance" -> s"Instance-123"

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -121,10 +121,10 @@ class QueryAndIngestBenchmark extends StrictLogging {
    * ## ========  Queries ===========
    * They are designed to match all the time series (common case) under a particular metric and job
    */
-  val queries = Seq("heap_usage{app=\"App-2\"}",  // raw time series
-                    """sum(rate(heap_usage{app="App-2"}[5m]))""",
-                    """quantile(0.75, heap_usage{app="App-2"})""",
-                    """sum_over_time(heap_usage{app="App-2"}[5m])""")
+  val queries = Seq("heap_usage{_ns=\"App-2\"}",  // raw time series
+                    """sum(rate(heap_usage{_ns="App-2"}[5m]))""",
+                    """quantile(0.75, heap_usage{_ns="App-2"})""",
+                    """sum_over_time(heap_usage{_ns="App-2"}[5m])""")
   val queryTime = startTime + (5 * 60 * 1000)  // 5 minutes from start until 60 minutes from start
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -108,12 +108,12 @@ class QueryInMemoryBenchmark extends StrictLogging {
    * ## ========  Queries ===========
    * They are designed to match all the time series (common case) under a particular metric and job
    */
-  val rawQuery = "heap_usage{app=\"App-2\"}"
-  val sumQuery = """sum_over_time(heap_usage{app="App-2"}[5m])"""
-  val sumRateQuery = """sum(rate(heap_usage{app="App-2"}[5m]))"""
+  val rawQuery = "heap_usage{_ns=\"App-2\"}"
+  val sumQuery = """sum_over_time(heap_usage{_ns="App-2"}[5m])"""
+  val sumRateQuery = """sum(rate(heap_usage{_ns="App-2"}[5m]))"""
   val queries = Seq(rawQuery,  // raw time series
                     sumRateQuery,
-                    """quantile(0.75, heap_usage{app="App-2"})""",
+                    """quantile(0.75, heap_usage{_ns="App-2"})""",
                     sumQuery)
   val queryTime = startTime + (5 * 60 * 1000)  // 5 minutes from start until 60 minutes from start
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
@@ -189,7 +189,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
     Await.result(f, 60.seconds)
   }
 
-  val minQuery = """min_over_time(heap_usage{app="App-2"}[5m])"""
+  val minQuery = """min_over_time(heap_usage{_ns="App-2"}[5m])"""
   val minLP = Parser.queryRangeToLogicalPlan(minQuery, qParams)
   val minEP = engine.materialize(minLP, qOptions).children.head
 

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -127,10 +127,10 @@ class QueryOnDemandBenchmark extends StrictLogging {
    * ## ========  Queries ===========
    * They are designed to match all the time series (common case) under a particular metric and job
    */
-  val queries = Seq("heap_usage{app=\"App-2\"}",  // raw time series
-                    """quantile(0.75, heap_usage{app="App-2"})""",
-                    """sum(rate(heap_usage{app="App-1"}[5m]))""",
-                    """sum_over_time(heap_usage{app="App-0"}[5m])""")
+  val queries = Seq("heap_usage{_ns=\"App-2\"}",  // raw time series
+                    """quantile(0.75, heap_usage{_ns="App-2"})""",
+                    """sum(rate(heap_usage{_ns="App-1"}[5m]))""",
+                    """sum_over_time(heap_usage{_ns="App-0"}[5m])""")
   val queryTime = startTime + (5 * 60 * 1000)  // 5 minutes from start until 60 minutes from start
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -180,7 +180,7 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
       rangeEnd   = rangeStart + 15.minutes.toMillis
 
       // Print the top values in each shard just for debugging
-      topValuesInShards(client1, "app", 0 to 3)
+      topValuesInShards(client1, "_ns", 0 to 3)
       topValuesInShards(client1, "dc", 0 to 3)
 
       query1Response = runCliQuery(client1, queryTimestamp)

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -146,8 +146,8 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     }
   }
 
-  val query = "heap_usage{dc=\"DC0\",app=\"App-2\"}[1m]"
-  val query1 = "heap_usage{dc=\"DC0\",app=\"App-2\"}"
+  val query = "heap_usage{dc=\"DC0\",_ns=\"App-2\"}[1m]"
+  val query1 = "heap_usage{dc=\"DC0\",_ns=\"App-2\"}"
 
   // queryTimestamp is in millis
   def runCliQuery(client: LocalClient, queryTimestamp: Long): Double = {
@@ -194,7 +194,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
   }
 
   def printChunkMeta(client: LocalClient): Unit = {
-    val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",app=\"App-2\"})"
+    val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",_ns=\"App-2\"})"
     val logicalPlan = Parser.queryRangeToLogicalPlan(chunkMetaQuery, TimeStepParams(0, 60, Int.MaxValue))
     client.logicalPlan2Query(dataset, logicalPlan) match {
       case QueryResult2(_, schema, result) => result.foreach(rv => println(rv.prettyPrint()))
@@ -226,7 +226,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val end = queryTimestamp / 1000 * 1000
     val nameMatcher = LabelMatcher.newBuilder().setName("__name__").setValue("heap_usage")
     val dcMatcher = LabelMatcher.newBuilder().setName("dc").setValue("DC0")
-    val jobMatcher = LabelMatcher.newBuilder().setName("app").setValue("App-2")
+    val jobMatcher = LabelMatcher.newBuilder().setName("_ns").setValue("App-2")
     val query = Query.newBuilder().addMatchers(nameMatcher)
                                   .addMatchers(dcMatcher)
                                   .addMatchers(jobMatcher)


### PR DESCRIPTION
… to creating new cluster

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Testing indicates that seeds endpoint retrieval can fail because of load balancer routing request to a node going down during a rolling upgrade.

This fix puts in place retry logic to ensure that we really solidify the observation of no cluster before creating one.

In addition, a rolling upgrade should not bring a node down while a new node is being brought up. Node downing and upping operations should be disjoint and carried out at different times. 

