### PR TITLE
feat(query): support for querying subset of series label values - (series metadata)

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -45,7 +45,7 @@ class Arguments extends FieldArgs {
   var port: Int = 2552
   var promql: Option[String] = None
   var matcher: Option[String] = None
-  var labelNames: Option[Seq[String]] = None
+  var labelNames: Seq[String] = Seq.empty
   var labelFilter: Map[String, String] = Map.empty
   var start: Long = System.currentTimeMillis() / 1000 // promql argument is seconds since epoch
   var end: Long = System.currentTimeMillis() / 1000 // promql argument is seconds since epoch
@@ -207,7 +207,7 @@ object CliMain extends ArgMain[Arguments] with CsvImportExport with FilodbCluste
           val remote = Client.standaloneClient(system, args.host.get, args.port)
           val options = QOptions(args.limit, args.sampleLimit, args.everyNSeconds.map(_.toInt),
             timeout, args.shards.map(_.map(_.toInt)), spread)
-          parseLabelValuesQuery(remote, args.labelNames.get, args.labelFilter, args.dataset.get,
+          parseLabelValuesQuery(remote, args.labelNames, args.labelFilter, args.dataset.get,
             getQueryRange(args), options)
 
         case x: Any =>

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -45,7 +45,7 @@ class Arguments extends FieldArgs {
   var port: Int = 2552
   var promql: Option[String] = None
   var matcher: Option[String] = None
-  var labelName: Option[String] = None
+  var labelNames: Option[Seq[String]] = None
   var labelFilter: Map[String, String] = Map.empty
   var start: Long = System.currentTimeMillis() / 1000 // promql argument is seconds since epoch
   var end: Long = System.currentTimeMillis() / 1000 // promql argument is seconds since epoch
@@ -88,7 +88,7 @@ object CliMain extends ArgMain[Arguments] with CsvImportExport with FilodbCluste
     println("  --host <hostname/IP> [--port ...] --command list")
     println("  --host <hostname/IP> [--port ...] --command status --dataset <dataset>")
     println("  --host <hostname/IP> [--port ...] --command timeseriesMetadata --matcher <matcher-query> --dataset <dataset> --start <start> --end <end>")
-    println("  --host <hostname/IP> [--port ...] --command labelValues --labelName <lable-name> --labelFilter <label-filter> --dataset <dataset>")
+    println("  --host <hostname/IP> [--port ...] --command labelValues --labelName <lable-names> --labelFilter <label-filter> --dataset <dataset>")
     println("\nTo change config: pass -Dconfig.file=/path/to/config as first arg or set $FILO_CONFIG_FILE")
     println("  or override any config by passing -Dconfig.path=newvalue as first args")
     println("\nFor detailed debugging, uncomment the TRACE/DEBUG loggers in logback.xml and add these ")
@@ -203,11 +203,11 @@ object CliMain extends ArgMain[Arguments] with CsvImportExport with FilodbCluste
             getQueryRange(args), options)
 
         case Some("labelValues") =>
-          require(args.host.nonEmpty && args.dataset.nonEmpty && args.labelName.nonEmpty, "--host, --dataset and --labelName must be defined")
+          require(args.host.nonEmpty && args.dataset.nonEmpty && args.labelNames.nonEmpty, "--host, --dataset and --labelName must be defined")
           val remote = Client.standaloneClient(system, args.host.get, args.port)
           val options = QOptions(args.limit, args.sampleLimit, args.everyNSeconds.map(_.toInt),
             timeout, args.shards.map(_.map(_.toInt)), spread)
-          parseLabelValuesQuery(remote, args.labelName.get, args.labelFilter, args.dataset.get,
+          parseLabelValuesQuery(remote, args.labelNames.get, args.labelFilter, args.dataset.get,
             getQueryRange(args), options)
 
         case x: Any =>
@@ -348,10 +348,10 @@ object CliMain extends ArgMain[Arguments] with CsvImportExport with FilodbCluste
     executeQuery2(client, dataset, logicalPlan, options)
   }
 
-  def parseLabelValuesQuery(client: LocalClient, labelName: String, constraints: Map[String, String], dataset: String,
+  def parseLabelValuesQuery(client: LocalClient, labelNames: Seq[String], constraints: Map[String, String], dataset: String,
                             timeParams: TimeRangeParams,
                             options: QOptions): Unit = {
-    val logicalPlan = LabelValues(labelName, constraints, 3.days.toMillis)
+    val logicalPlan = LabelValues(labelNames, constraints, 3.days.toMillis)
     executeQuery2(client, dataset, logicalPlan, options)
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -103,7 +103,7 @@ final class QueryActor(memStore: MemStore,
   private def processIndexValues(g: GetIndexValues, originator: ActorRef): Unit = {
     val localShards = memStore.activeShards(g.dataset)
     if (localShards contains g.shard) {
-      originator ! memStore.indexValues(g.dataset, g.shard, g.indexName, g.limit)
+      originator ! memStore.labelValues(g.dataset, g.shard, g.indexName, g.limit)
                            .map { case TermInfo(term, freq) => (term.toString, freq) }
     } else {
       val destNode = shardMapFunc.coordForShard(g.shard)

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -213,8 +213,9 @@ class QueryEngine(dataset: Dataset,
     }.toSeq
     // If the label is PromMetricLabel and is different than dataset's metric name,
     // replace it with dataset's metric name. (needed for prometheus plugins)
-    val labelName = if (PromMetricLabel == lp.labelName && dataset.options.metricColumn != PromMetricLabel)
-      dataset.options.metricColumn else lp.labelName
+    val metricLabelIndex = lp.labelNames.indexOf(PromMetricLabel)
+    val labelNames = if (metricLabelIndex > -1 && dataset.options.metricColumn != PromMetricLabel)
+      lp.labelNames.updated(metricLabelIndex, dataset.options.metricColumn) else lp.labelNames
 
     val shardsToHit = if (shardColumns.toSet.subsetOf(lp.labelConstraints.keySet)) {
                         shardsFromFilters(filters, options)
@@ -225,7 +226,7 @@ class QueryEngine(dataset: Dataset,
     shardsToHit.map { shard =>
       val dispatcher = dispatcherForShard(shard)
       exec.LabelValuesExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
-        filters, labelName, lp.lookbackTimeInMillis)
+        filters, labelNames, lp.lookbackTimeInMillis)
     }
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -13,7 +13,7 @@ import filodb.core.{MachineMetricsData, MetricsTestData, NamesTestData, TestData
 import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.store._
-import filodb.memory.format.{RowReader, SeqRowReader, ZCUTF8IteratorRowReader, ZeroCopyUTF8String => UTF8Str}
+import filodb.memory.format.{RowReader, SeqRowReader, UTF8MapIteratorRowReader, ZeroCopyUTF8String => UTF8Str}
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
 import filodb.query.{QueryResult => QueryResult2, _}
@@ -297,7 +297,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val schema = new ResultSchema(Seq(new ColumnInfo("_ns", ColumnType.MapColumn)), 1)
     val cols = Seq(ColumnInfo("value", ColumnType.MapColumn))
     val ser = Seq(SerializableRangeVector(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-      new ZCUTF8IteratorRowReader(input.toIterator)), cols))
+      new UTF8MapIteratorRowReader(input.toIterator)), cols))
 
     val result = QueryResult2("someId", schema, ser)
     val roundTripResult = roundTrip(result).asInstanceOf[QueryResult2]

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -142,16 +142,16 @@ trait MemStore extends ChunkSource {
    * in order of decreasing frequency/# of series per item.
    * @param topK the number of top items to return
    */
-  def indexValues(dataset: DatasetRef, shard: Int, indexNames: String, topK: Int = 100): Seq[TermInfo]
+  def labelValues(dataset: DatasetRef, shard: Int, labelName: String, topK: Int = 100): Seq[TermInfo]
 
   /**
-    * Returns the values of a given index name for the matching Column Filters
+    * Returns the values of a given label-names for the matching Column Filters
     * that are indexed at the partition level, on the given
     * shard on this node.
     * @return an Iterator for the index values
     */
-  def indexValuesWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                             indexNames: Seq[String], end: Long,
+  def labelValuesWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
+                             labelNames: Seq[String], end: Long,
                              start: Long, limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
 
   /**

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -142,7 +142,7 @@ trait MemStore extends ChunkSource {
    * in order of decreasing frequency/# of series per item.
    * @param topK the number of top items to return
    */
-  def indexValues(dataset: DatasetRef, shard: Int, indexName: String, topK: Int = 100): Seq[TermInfo]
+  def indexValues(dataset: DatasetRef, shard: Int, indexNames: String, topK: Int = 100): Seq[TermInfo]
 
   /**
     * Returns the values of a given index name for the matching Column Filters
@@ -151,7 +151,8 @@ trait MemStore extends ChunkSource {
     * @return an Iterator for the index values
     */
   def indexValuesWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                             indexName: String, end: Long, start: Long, limit: Int): Iterator[ZeroCopyUTF8String]
+                             indexNames: Seq[String], end: Long,
+                             start: Long, limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
 
   /**
     * Returns the indexed TimeSeriesPartitions matching the column filters,

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -150,14 +150,14 @@ extends MemStore with StrictLogging {
       }
     }.getOrElse(Iterator.empty)
 
-  def indexValues(dataset: DatasetRef, shard: Int, indexName: String, topK: Int = 100): Seq[TermInfo] =
-    getShard(dataset, shard).map(_.indexValues(indexName, topK)).getOrElse(Nil)
+  def labelValues(dataset: DatasetRef, shard: Int, labelName: String, topK: Int = 100): Seq[TermInfo] =
+    getShard(dataset, shard).map(_.labelValues(labelName, topK)).getOrElse(Nil)
 
-  def indexValuesWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                             indexNames: Seq[String], end: Long,
+  def labelValuesWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
+                             labelNames: Seq[String], end: Long,
                              start: Long, limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
     = getShard(dataset, shard)
-        .map(_.indexValuesWithFilters(filters, indexNames, end, start, limit)).getOrElse(Iterator.empty)
+        .map(_.labelValuesWithFilters(filters, labelNames, end, start, limit)).getOrElse(Iterator.empty)
 
   def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
                              end: Long, start: Long, limit: Int): Iterator[TimeSeriesPartition] =

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -154,9 +154,10 @@ extends MemStore with StrictLogging {
     getShard(dataset, shard).map(_.indexValues(indexName, topK)).getOrElse(Nil)
 
   def indexValuesWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                             indexName: String, end: Long, start: Long, limit: Int): Iterator[ZeroCopyUTF8String] =
-    getShard(dataset, shard)
-      .map(_.indexValuesWithFilters(filters, indexName, end, start, limit)).getOrElse(Iterator.empty)
+                             indexNames: Seq[String], end: Long,
+                             start: Long, limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
+    = getShard(dataset, shard)
+        .map(_.indexValuesWithFilters(filters, indexNames, end, start, limit)).getOrElse(Iterator.empty)
 
   def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
                              end: Long, start: Long, limit: Int): Iterator[TimeSeriesPartition] =

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -472,23 +472,30 @@ class TimeSeriesShard(val dataset: Dataset,
 
   def indexNames: Iterator[String] = partKeyIndex.indexNames
 
-  def indexValues(indexName: String, topK: Int): Seq[TermInfo] = partKeyIndex.indexValues(indexName, topK)
+  def labelValues(labelName: String, topK: Int): Seq[TermInfo] = partKeyIndex.indexValues(labelName, topK)
 
   /**
     * This method is to apply column filters and fetch matching time series partitions.
+    *
+    * @param filter column filter
+    * @param labelNames labels to return in the response
+    * @param endTime end time
+    * @param startTime start time
+    * @param limit series limit
+    * @return returns an iterator of map of label key value pairs of each matching time series
     */
-  def indexValuesWithFilters(filter: Seq[ColumnFilter],
-                             indexNames: Seq[String],
+  def labelValuesWithFilters(filter: Seq[ColumnFilter],
+                             labelNames: Seq[String],
                              endTime: Long,
                              startTime: Long,
                              limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] = {
-    IndexValueResultIterator(partKeyIndex.partIdsFromFilters(filter, startTime, endTime), indexNames, limit)
+    LabelValueResultIterator(partKeyIndex.partIdsFromFilters(filter, startTime, endTime), labelNames, limit)
   }
 
   /**
     * Iterator for lazy traversal of partIdIterator, value for the given label will be extracted from the ParitionKey.
     */
-  case class IndexValueResultIterator(partIterator: IntIterator, labelNames: Seq[String], limit: Int)
+  case class LabelValueResultIterator(partIterator: IntIterator, labelNames: Seq[String], limit: Int)
     extends Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] {
     var currVal: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = _
     var index = 0

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -27,6 +27,7 @@ import filodb.memory._
 import filodb.memory.data.{OffheapLFSortedIDMap, OffheapLFSortedIDMapMutator}
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 import filodb.memory.format.BinaryVector.BinaryVectorPtr
+import filodb.memory.format.ZeroCopyUTF8String._
 
 class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val tags = Map("shard" -> shardNum.toString, "dataset" -> dataset.toString)
@@ -52,16 +53,16 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val downsampleRecordsCreated = Kamon.counter("memstore-downsample-records-created").refine(tags)
 
   /**
-   * These gauges are intended to be combined with one of the latest offset of Kafka partitions so we can produce
-   * stats on message lag:
-   *   kafka_ingestion_lag = kafka_latest_offset - offsetLatestInMem
-   *   memstore_ingested_to_persisted_lag = offsetLatestInMem - offsetLatestFlushed
-   *   etc.
-   *
-   * NOTE: only positive offsets will be recorded.  Kafka does not give negative offsets, but Kamon cannot record
-   * negative numbers either.
-   * The "latest" vs "earliest" flushed reflects that there are really n offsets, one per flush group.
-   */
+    * These gauges are intended to be combined with one of the latest offset of Kafka partitions so we can produce
+    * stats on message lag:
+    *   kafka_ingestion_lag = kafka_latest_offset - offsetLatestInMem
+    *   memstore_ingested_to_persisted_lag = offsetLatestInMem - offsetLatestFlushed
+    *   etc.
+    *
+    * NOTE: only positive offsets will be recorded.  Kafka does not give negative offsets, but Kamon cannot record
+    * negative numbers either.
+    * The "latest" vs "earliest" flushed reflects that there are really n offsets, one per flush group.
+    */
   val offsetLatestInMem = Kamon.gauge("shard-offset-latest-inmemory").refine(tags)
   val offsetLatestFlushed = Kamon.gauge("shard-offset-flushed-latest").refine(tags)
   val offsetEarliestFlushed = Kamon.gauge("shard-offset-flushed-earliest").refine(tags)
@@ -83,8 +84,8 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
 
 object TimeSeriesShard {
   /**
-   * Writes metadata for TSPartition where every vector is written
-   */
+    * Writes metadata for TSPartition where every vector is written
+    */
   def writeMeta(addr: Long, partitionID: Int, info: ChunkSetInfo, vectors: Array[BinaryVectorPtr]): Unit = {
     UnsafeUtils.setInt(UnsafeUtils.ZeroPointer, addr, partitionID)
     ChunkSetInfo.copy(info, addr + 4)
@@ -94,8 +95,8 @@ object TimeSeriesShard {
   }
 
   /**
-   * Copies serialized ChunkSetInfo bytes from persistent storage / on-demand paging.
-   */
+    * Copies serialized ChunkSetInfo bytes from persistent storage / on-demand paging.
+    */
   def writeMeta(addr: Long, partitionID: Int, bytes: Array[Byte], vectors: Array[BinaryVectorPtr]): Unit = {
     UnsafeUtils.setInt(UnsafeUtils.ZeroPointer, addr, partitionID)
     ChunkSetInfo.copy(bytes, addr + 4)
@@ -105,8 +106,8 @@ object TimeSeriesShard {
   }
 
   val indexTimeBucketSchema = new RecordSchema(Seq(ColumnInfo("startTime", ColumnType.LongColumn),
-                                                   ColumnInfo("endTime", ColumnType.LongColumn),
-                                                   ColumnInfo("partKey", ColumnType.StringColumn)))
+    ColumnInfo("endTime", ColumnType.LongColumn),
+    ColumnInfo("partKey", ColumnType.StringColumn)))
 
   // TODO make configurable if necessary
   val indexTimeBucketTtlPaddingSeconds = 24.hours.toSeconds.toInt
@@ -121,9 +122,9 @@ object TimeSeriesShard {
   val EmptyBitmap = new EWAHCompressedBitmap()
 
   /**
-   * Calculates the flush group of an ingest record or partition key.  Be sure to use the right RecordSchema -
-   * dataset.ingestionSchema or dataset.partKeySchema.l
-   */
+    * Calculates the flush group of an ingest record or partition key.  Be sure to use the right RecordSchema -
+    * dataset.ingestionSchema or dataset.partKeySchema.l
+    */
   def partKeyGroup(schema: RecordSchema, partKeyBase: Any, partKeyOffset: Long, numGroups: Int): Int = {
     Math.abs(schema.partitionHash(partKeyBase, partKeyOffset) % numGroups)
   }
@@ -180,8 +181,8 @@ class TimeSeriesShard(val dataset: Dataset,
   private[memstore] val partitions = new NonBlockingHashMapLong[TimeSeriesPartition](InitialNumPartitions, false)
 
   /**
-   * next partition ID number
-   */
+    * next partition ID number
+    */
   private var nextPartitionID = 0
 
   /**
@@ -237,7 +238,7 @@ class TimeSeriesShard(val dataset: Dataset,
 
   // The off-heap block store used for encoded chunks
   private val blockStore = new PageAlignedBlockManager(blockMemorySize, shardStats.memoryStats, reclaimListener,
-                                                       storeConfig.numPagesPerBlock)
+    storeConfig.numPagesPerBlock)
   private val blockFactoryPool = new BlockMemFactoryPool(blockStore, dataset.blockMetaSize)
 
   // Each shard has a single ingestion stream at a time.  This BlockMemFactory is used for buffer overflow encoding
@@ -253,10 +254,10 @@ class TimeSeriesShard(val dataset: Dataset,
     s"dataset=${dataset.ref} shard=$shardNum")
   protected val bufferMemoryManager = new NativeMemoryManager(bufferMemorySize)
   private val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, dataset.partKeySchema,
-                                                 reuseOneContainer = true)
+    reuseOneContainer = true)
   private val partKeyArray = partKeyBuilder.allContainers.head.base.asInstanceOf[Array[Byte]]
   private val bufferPool = new WriteBufferPool(bufferMemoryManager, dataset, storeConfig.maxChunksSize,
-                                               storeConfig.allocStepSize)
+    storeConfig.allocStepSize)
 
   private final val partitionGroups = Array.fill(numGroups)(new EWAHCompressedBitmap)
   private final val activelyIngesting = new EWAHCompressedBitmap
@@ -275,9 +276,9 @@ class TimeSeriesShard(val dataset: Dataset,
   private var currentIndexTimeBucket: Int = _
 
   /**
-   * Timestamp to start searching for partitions to evict. Advances as more and more partitions are evicted.
-   * Used to ensure we keep searching for newer and newer partitions to evict.
-   */
+    * Timestamp to start searching for partitions to evict. Advances as more and more partitions are evicted.
+    * Used to ensure we keep searching for newer and newer partitions to evict.
+    */
   private[core] var evictionWatermark: Long = 0L
 
   /**
@@ -306,7 +307,7 @@ class TimeSeriesShard(val dataset: Dataset,
     * Helper for downsampling ingested data for long term retention.
     */
   private final val shardDownsampler = new ShardDownsampler(dataset, shardNum, downsampleConfig.enabled,
-                                         downsampleConfig.resolutions, downsamplePublisher, shardStats)
+    downsampleConfig.resolutions, downsamplePublisher, shardStats)
 
   case class InMemPartitionIterator(intIt: IntIterator) extends PartitionIterator {
     var nextPart = UnsafeUtils.ZeroPointer.asInstanceOf[TimeSeriesPartition]
@@ -381,10 +382,10 @@ class TimeSeriesShard(val dataset: Dataset,
   private[memstore] val ingestConsumer = new IngestConsumer()
 
   /**
-   * Ingest new BinaryRecords in a RecordContainer to this shard.
-   * Skips rows if the offset is below the group watermark for that record's group.
-   * Adds new partitions if needed.
-   */
+    * Ingest new BinaryRecords in a RecordContainer to this shard.
+    * Skips rows if the offset is below the group watermark for that record's group.
+    * Adds new partitions if needed.
+    */
   def ingest(container: RecordContainer, offset: Long): Long = {
     ingestConsumer.numActuallyIngested = 0
     ingestConsumer.ingestOffset = offset
@@ -415,8 +416,8 @@ class TimeSeriesShard(val dataset: Dataset,
       }
     }
     val fut = Observable.flatten(timeBuckets: _*)
-                        .foreach(tb => extractTimeBucket(tb))(ingestSched)
-                        .map(_ => completeIndexRecovery())
+      .foreach(tb => extractTimeBucket(tb))(ingestSched)
+      .map(_ => completeIndexRecovery())
     fut.onComplete(_ => tracer.finish())
     fut
   }
@@ -441,18 +442,18 @@ class TimeSeriesShard(val dataset: Dataset,
       // We cant look it up in lucene because we havent flushed index yet
       val partId = partSet.getWithPartKeyBR(partKeyBaseOnHeap, partKeyOffset) match {
         case None =>     val group = partKeyGroup(dataset.partKeySchema, partKeyBaseOnHeap, partKeyOffset, numGroups)
-                         val part = createNewPartition(partKeyBaseOnHeap, partKeyOffset, group, 4)
-                         // In theory, we should not get an OutOfMemPartition here since
-                         // it should have occurred before node failed too, and with data sropped,
-                         // index would not be updated. But if for some reason we see it, drop data
-                         if (part == OutOfMemPartition) {
-                           logger.error("Could not accommodate partKey while recovering index. " +
-                             "WriteBuffer size may not be configured correctly")
-                           -1
-                         } else {
-                           partSet.add(part) // createNewPartition doesnt add part to partSet
-                           part.partID
-                         }
+          val part = createNewPartition(partKeyBaseOnHeap, partKeyOffset, group, 4)
+          // In theory, we should not get an OutOfMemPartition here since
+          // it should have occurred before node failed too, and with data sropped,
+          // index would not be updated. But if for some reason we see it, drop data
+          if (part == OutOfMemPartition) {
+            logger.error("Could not accommodate partKey while recovering index. " +
+              "WriteBuffer size may not be configured correctly")
+            -1
+          } else {
+            partSet.add(part) // createNewPartition doesnt add part to partSet
+            part.partID
+          }
         case Some(p) =>  p.partID
       }
       if (partId != -1) {
@@ -477,19 +478,19 @@ class TimeSeriesShard(val dataset: Dataset,
     * This method is to apply column filters and fetch matching time series partitions.
     */
   def indexValuesWithFilters(filter: Seq[ColumnFilter],
-                             indexName: String,
+                             indexNames: Seq[String],
                              endTime: Long,
                              startTime: Long,
-                             limit: Int): Iterator[ZeroCopyUTF8String] = {
-    IndexValueResultIterator(partKeyIndex.partIdsFromFilters(filter, startTime, endTime), indexName, limit)
+                             limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] = {
+    IndexValueResultIterator(partKeyIndex.partIdsFromFilters(filter, startTime, endTime), indexNames, limit)
   }
 
   /**
     * Iterator for lazy traversal of partIdIterator, value for the given label will be extracted from the ParitionKey.
     */
-  case class IndexValueResultIterator(partIterator: IntIterator, labelName: String, limit: Int)
-      extends Iterator[ZeroCopyUTF8String] {
-    var currVal: ZeroCopyUTF8String = _
+  case class IndexValueResultIterator(partIterator: IntIterator, labelNames: Seq[String], limit: Int)
+    extends Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] {
+    var currVal: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = _
     var index = 0
 
     override def hasNext: Boolean = {
@@ -501,11 +502,11 @@ class TimeSeriesShard(val dataset: Dataset,
           // FIXME This is non-performant and temporary fix for fetching label values based on filter criteria.
           // Other strategies needs to be evaluated for making this performant - create facets for predefined fields or
           // have a centralized service/store for serving metadata
-          dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
-            .find(_._1 equals labelName).foreach(pair => {
-              currVal = ZeroCopyUTF8String(pair._2)
-              foundValue = true
-          })
+          currVal = dataset.partKeySchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
+            .filter(labelNames contains _._1).map(pair => {
+            (pair._1.utf8 -> pair._2.utf8)
+          }).toMap
+          foundValue = currVal.size > 0
         } else {
           // FIXME partKey is evicted. Get partition key from lucene index
         }
@@ -513,7 +514,7 @@ class TimeSeriesShard(val dataset: Dataset,
       foundValue
     }
 
-    override def next(): ZeroCopyUTF8String = {
+    override def next(): Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = {
       index += 1
       currVal
     }
@@ -523,9 +524,9 @@ class TimeSeriesShard(val dataset: Dataset,
     * This method is to apply column filters and fetch matching time series partition keys.
     */
   def partKeysWithFilters(filter: Seq[ColumnFilter],
-                             endTime: Long,
-                             startTime: Long,
-                             limit: Int): Iterator[TimeSeriesPartition] = {
+                          endTime: Long,
+                          startTime: Long,
+                          limit: Int): Iterator[TimeSeriesPartition] = {
     partKeyIndex.partIdsFromFilters(filter, startTime, endTime)
       .map(getPartitionFromPartId, limit)
       .filter(_ != UnsafeUtils.ZeroPointer) // Needed since we have not addressed evicted partitions yet
@@ -691,20 +692,20 @@ class TimeSeriesShard(val dataset: Dataset,
      * We recover future since we want to proceed to publish downsample data even if chunk flush failed.
      * This is done after writeChunksFuture because chunkSetIter is lazy. */
     val pubDownsampleFuture = writeChunksFuture.recover {case _ => Success}
-                                     .flatMap(_=>shardDownsampler.publishToDownsampleDataset(downsampleRecords))
+      .flatMap(_=>shardDownsampler.publishToDownsampleDataset(downsampleRecords))
 
     /* Step 5.2: We flush index time buckets in the one designated group for each shard
      * We recover future since we want to proceed to write time buckets even if chunk flush failed.
      * This is done after writeChunksFuture because chunkSetIter is lazy. */
     val writeIndexTimeBucketsFuture = writeChunksFuture.recover {case _ => Success}
-                                          .flatMap( _=> writeTimeBuckets(flushGroup))
+      .flatMap( _=> writeTimeBuckets(flushGroup))
 
     /* Step 6: Checkpoint after time buckets and chunks are flushed */
     val result = Future.sequence(Seq(writeChunksFuture, writeIndexTimeBucketsFuture, pubDownsampleFuture)).map {
       _.find(_.isInstanceOf[ErrorResponse]).getOrElse(Success)
     }.flatMap {
       case Success           => blockHolder.markUsedBlocksReclaimable()
-                                commitCheckpoint(dataset.ref, shardNum, flushGroup)
+        commitCheckpoint(dataset.ref, shardNum, flushGroup)
       case er: ErrorResponse => Future.successful(er)
     }.recover { case e =>
       logger.error(s"Internal Error when persisting chunks in dataset=${dataset.ref} shard=$shardNum - should " +
@@ -850,7 +851,7 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   private def commitCheckpoint(ref: DatasetRef, shardNum: Int, flushGroup: FlushGroup): Future[Response] =
-    // negative checkpoints are refused by Kafka, and also offsets should be positive
+  // negative checkpoints are refused by Kafka, and also offsets should be positive
     if (flushGroup.flushWatermark > 0) {
       val fut = metastore.writeCheckpoint(ref, shardNum, flushGroup.groupNum, flushGroup.flushWatermark).map { r =>
         shardStats.flushesSuccessful.increment
@@ -896,14 +897,14 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   /**
-   * Retrieves or creates a new TimeSeriesPartition, updating indices, then ingests the sample from record.
-   * partition portion of ingest BinaryRecord is used to look up existing TSPartition.
-   * Copies the partition portion of the ingest BinaryRecord to offheap write buffer memory.
-   * NOTE: ingestion is skipped if there is an error allocating WriteBuffer space.
-   * @param recordBase the base of the ingestion BinaryRecord
-   * @param recordOff the offset of the ingestion BinaryRecord
-   * @param group the group number, from abs(record.partitionHash % numGroups)
-   */
+    * Retrieves or creates a new TimeSeriesPartition, updating indices, then ingests the sample from record.
+    * partition portion of ingest BinaryRecord is used to look up existing TSPartition.
+    * Copies the partition portion of the ingest BinaryRecord to offheap write buffer memory.
+    * NOTE: ingestion is skipped if there is an error allocating WriteBuffer space.
+    * @param recordBase the base of the ingestion BinaryRecord
+    * @param recordOff the offset of the ingestion BinaryRecord
+    * @param group the group number, from abs(record.partitionHash % numGroups)
+    */
   def getOrAddPartitionAndIngest(recordBase: Any, recordOff: Long, group: Int, ingestOffset: Long): Unit =
     try {
       val part: FiloPartition = getOrAddPartition(recordBase, recordOff, group, ingestOffset)
@@ -912,12 +913,12 @@ class TimeSeriesShard(val dataset: Dataset,
     } catch {
       case e: OutOfOffheapMemoryException => disableAddPartitions()
       case e: Exception                   => logger.error(s"Unexpected ingestion err in dataset=${dataset.ref} " +
-                                             s"shard=$shardNum", e); disableAddPartitions()
+        s"shard=$shardNum", e); disableAddPartitions()
     }
 
   protected def createNewPartition(partKeyBase: Array[Byte], partKeyOffset: Long,
                                    group: Int, initMapSize: Int = initInfoMapSize): TimeSeriesPartition =
-    // Check and evict, if after eviction we still don't have enough memory, then don't proceed
+  // Check and evict, if after eviction we still don't have enough memory, then don't proceed
     if (addPartitionsDisabled() || !ensureFreeSpace()) { OutOfMemPartition }
     else {
       // PartitionKey is copied to offheap bufferMemory and stays there until it is freed
@@ -1066,9 +1067,9 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   /**
-   * Please use this for testing only - reclaims ALL used offheap blocks.  Maybe you are trying to test
-   * on demand paging.
-   */
+    * Please use this for testing only - reclaims ALL used offheap blocks.  Maybe you are trying to test
+    * on demand paging.
+    */
   private[filodb] def reclaimAllBlocksTestOnly() = blockStore.reclaimAll()
 
   /**

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -74,7 +74,7 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
     val metadata = memStore.indexValuesWithFilters(timeseriesDataset.ref, 0,
-      filters, "instance", now, now - 5000, 10)
+      filters, Seq("instance"), now, now - 5000, 10)
 
     metadata.hasNext shouldEqual true
     metadata.next.toString shouldEqual "someHost:8787"

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -73,7 +73,7 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
-    val metadata = memStore.indexValuesWithFilters(timeseriesDataset.ref, 0,
+    val metadata = memStore.labelValuesWithFilters(timeseriesDataset.ref, 0,
       filters, Seq("instance"), now, now - 5000, 10)
 
     metadata.hasNext shouldEqual true

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -77,7 +77,7 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
       filters, Seq("instance"), now, now - 5000, 10)
 
     metadata.hasNext shouldEqual true
-    metadata.next.toString shouldEqual "someHost:8787"
+    metadata.next shouldEqual Map("instance".utf8 -> "someHost:8787".utf8)
   }
 
 }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -347,7 +347,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.commitIndexForTesting(dataset1.ref)
 
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
-    memStore.indexValues(dataset1.ref, 0, "series").toSeq should have length (10)
+    memStore.labelValues(dataset1.ref, 0, "series").toSeq should have length (10)
 
     // Purposely mark two partitions endTime as occurring a while ago to mark them eligible for eviction
     // We also need to switch buffers so that internally ingestionEndTime() is accurate
@@ -381,7 +381,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.commitIndexForTesting(dataset1.ref)
 
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
-    memStore.indexValues(dataset1.ref, 0, "series").toSeq should have length (10)
+    memStore.labelValues(dataset1.ref, 0, "series").toSeq should have length (10)
 
     // Purposely mark two partitions endTime as occurring a while ago to mark them eligible for eviction
     // We also need to switch buffers so that internally ingestionEndTime() is accurate
@@ -417,7 +417,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.commitIndexForTesting(dataset1.ref)
 
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
-    memStore.indexValues(dataset1.ref, 0, "series").toSeq should have length (10)
+    memStore.labelValues(dataset1.ref, 0, "series").toSeq should have length (10)
 
     // Don't mark any partitions for eviction
     // Now, ingest 23 partitions.  Last two partitions cannot be added.  Check numpartitions, stats, index

--- a/memory/src/main/scala/filodb.memory/format/RowReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowReader.scala
@@ -232,8 +232,8 @@ final case class SeqRowReader(sequence: Seq[Any]) extends RowReader {
   def getBlobNumBytes(columnNo: Int): Int = ???
 }
 
-final case class ZCUTF8IteratorRowReader(records: Iterator[ZeroCopyUTF8String]) extends Iterator[RowReader] {
-  var currVal: ZeroCopyUTF8String = _
+final case class ZCUTF8IteratorRowReader(records: Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]) extends Iterator[RowReader] {
+  var currVal: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = _
 
   private val rowReader = new RowReader {
     def notNull(columnNo: Int): Boolean = true
@@ -245,9 +245,9 @@ final case class ZCUTF8IteratorRowReader(records: Iterator[ZeroCopyUTF8String]) 
     def getString(columnNo: Int): String = currVal.toString
     def getAny(columnNo: Int): Any = currVal
 
-    def getBlobBase(columnNo: Int): Any = currVal.base
-    def getBlobOffset(columnNo: Int): Long = currVal.offset
-    def getBlobNumBytes(columnNo: Int): Int = currVal.numBytes
+    def getBlobBase(columnNo: Int): Any = ???
+    def getBlobOffset(columnNo: Int): Long = ???
+    def getBlobNumBytes(columnNo: Int): Int = ???
   }
 
   override def hasNext: Boolean = records.hasNext

--- a/memory/src/main/scala/filodb.memory/format/RowReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowReader.scala
@@ -232,7 +232,7 @@ final case class SeqRowReader(sequence: Seq[Any]) extends RowReader {
   def getBlobNumBytes(columnNo: Int): Int = ???
 }
 
-final case class ZCUTF8IteratorRowReader(records: Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]) extends Iterator[RowReader] {
+final case class UTF8MapIteratorRowReader(records: Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]) extends Iterator[RowReader] {
   var currVal: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = _
 
   private val rowReader = new RowReader {

--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -9,7 +9,7 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
  */
 object FormatConversion {
   // An official Prometheus-format Dataset object with a single timestamp and value
-  val dataset = Dataset("timeseries", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
+  val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
                   .copy(options = DatasetOptions(Seq("__name__", "_ns"),
                     "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
                     Map("exporter" -> "_ns", "job" -> "_ns")))

--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -9,7 +9,7 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
  */
 object FormatConversion {
   // An official Prometheus-format Dataset object with a single timestamp and value
-  val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
+  val dataset = Dataset("timeseries", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
                   .copy(options = DatasetOptions(Seq("__name__", "_ns"),
                     "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
                     Map("exporter" -> "_ns", "job" -> "_ns")))

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -39,7 +39,7 @@ case class RawSeries(rangeSelector: RangeSelector,
                      columns: Seq[String]) extends RawSeriesPlan
 
 
-case class LabelValues(labelName: String,
+case class LabelValues(labelNames: Seq[String],
                        labelConstraints: Map[String, String],
                        lookbackTimeInMillis: Long) extends MetadataQueryPlan
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -13,7 +13,7 @@ import filodb.core.metadata.Dataset
 import filodb.core.query._
 import filodb.core.store.ChunkSource
 import filodb.memory.format._
-import filodb.memory.format.ZCUTF8IteratorRowReader
+import filodb.memory.format.UTF8MapIteratorRowReader
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 import filodb.query.Query.qLogger
@@ -92,7 +92,7 @@ final case class LabelValuesDistConcatExec(id: String,
       })
       //distinct -> result may have duplicates in case of labelValues
       IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-        new ZCUTF8IteratorRowReader(metadataResult.toIterator))
+        new UTF8MapIteratorRowReader(metadataResult.toIterator))
     }
     Observable.fromTask(taskOfResults)
   }
@@ -170,7 +170,7 @@ final case class  LabelValuesExec(id: String,
         case false => memStore.indexValuesWithFilters(dataset, shard, filters, columns, end, start, limit)
       }
       Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-        new ZCUTF8IteratorRowReader(response)))
+        new UTF8MapIteratorRowReader(response)))
     } else {
       Observable.empty
     }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -6,14 +6,18 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.DatasetRef
+import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.memstore.{MemStore, PartKeyRowReader}
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
 import filodb.core.query._
 import filodb.core.store.ChunkSource
-import filodb.memory.format.{ZCUTF8IteratorRowReader, ZeroCopyUTF8String}
+import filodb.memory.format._
+import filodb.memory.format.ZCUTF8IteratorRowReader
+import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 import filodb.query.Query.qLogger
+
 
 final case class PartKeysDistConcatExec(id: String,
                                       dispatcher: PlanDispatcher,
@@ -78,13 +82,17 @@ final case class LabelValuesDistConcatExec(id: String,
       case QueryResult(_, _, result) => result
       case QueryError(_, ex)         => throw ex
     }.toListL.map { resp =>
-      var metadataResult = Seq.empty[ZeroCopyUTF8String]
+      var metadataResult = scala.collection.mutable.Set.empty[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
       resp.foreach(rv => {
-        metadataResult ++= rv(0).rows.toSeq.map(rowReader => rowReader.filoUTF8String(0))
+        metadataResult ++= rv(0).rows.toSeq.map(rowReader => {
+          val binaryRowReader = rowReader.asInstanceOf[BinaryRecordRowReader]
+          rv(0).schema.toStringPairs(binaryRowReader.recordBase, binaryRowReader.recordOffset)
+            .map(pair => pair._1.utf8 -> pair._2.utf8).toMap
+        })
       })
       //distinct -> result may have duplicates in case of labelValues
       IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-        new ZCUTF8IteratorRowReader(metadataResult.distinct.toIterator))
+        new ZCUTF8IteratorRowReader(metadataResult.toIterator))
     }
     Observable.fromTask(taskOfResults)
   }
@@ -138,7 +146,7 @@ final case class  LabelValuesExec(id: String,
                                   dataset: DatasetRef,
                                   shard: Int,
                                   filters: Seq[ColumnFilter],
-                                  column: String,
+                                  columns: Seq[String],
                                   lookBackInMillis: Long) extends LeafExecPlan {
 
   protected def doExecute(source: ChunkSource,
@@ -153,8 +161,13 @@ final case class  LabelValuesExec(id: String,
       val end = curr - curr % 1000 // round to the floor second
       val start = end - lookBackInMillis
       val response = filters.isEmpty match {
-        case true => memStore.indexValues(dataset, shard, column, limit).map(_.term).toIterator
-        case false => memStore.indexValuesWithFilters(dataset, shard, filters, column, end, start, limit)
+        // retrieves index values for a single label - no column filter
+        case true if (columns.size == 1) => memStore.indexValues(dataset, shard, columns.head, limit)
+          .map(termInfo => Map(columns.head.utf8 -> termInfo.term))
+          .toIterator
+        case true => throw new BadQueryException("either label name is missing " +
+          "or there are multiple label names without filter")
+        case false => memStore.indexValuesWithFilters(dataset, shard, filters, columns, end, start, limit)
       }
       Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
         new ZCUTF8IteratorRowReader(response)))
@@ -163,11 +176,11 @@ final case class  LabelValuesExec(id: String,
     }
   }
 
-  def args: String = s"shard=$shard, filters=$filters, col=$column, limit=$limit, lookBackInMillis=$lookBackInMillis"
+  def args: String = s"shard=$shard, filters=$filters, col=$columns, limit=$limit, lookBackInMillis=$lookBackInMillis"
 
   /**
     * Schema of QueryResponse returned by running execute()
     */
   def schemaOfDoExecute(dataset: Dataset): ResultSchema =
-    new ResultSchema(Seq(ColumnInfo(column, ColumnType.StringColumn)), 1)
+    new ResultSchema(Seq(ColumnInfo("Labels", ColumnType.MapColumn)), 1)
 }


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

Metadata Execplan is modified to support querying a subset of label values. Earlier implementation has support for querying single label or all the series labels. With this change, a subset of label values can be queried.