### PR TITLE
 fix(memory): Check bounds of sum(), count() vector methods

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -231,8 +231,10 @@ object DeltaDeltaConstDataReader extends LongVectorDataReader {
   // let len = end - start + 1
   //   = initVal + start*slope + initVal + (start+1)*slope + .... + initVal + end*slope
   //   = len * initVal + len*start*slope + ((end-start)*len/2) * slope
-  final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Double =
+  final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Double = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     slopeSum(initValue(vector), slope(vector), start, end)
+  }
 
   private[memory] def slopeSum(initVal: Long, slope: Int, start: Int, end: Int): Double = {
     val len = end - start + 1

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -194,6 +194,7 @@ object DoubleVectorDataReader64 extends DoubleVectorDataReader {
   }
 
   final def count(vector: BinaryVectorPtr, start: Int, end: Int): Int = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     var addr = vector + OffsetData + start * 8
     val untilAddr = vector + OffsetData + end * 8 + 8   // one past the end
     var count = 0

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -173,6 +173,7 @@ object DoubleVectorDataReader64 extends DoubleVectorDataReader {
 
   // end is inclusive
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int, ignoreNaN: Boolean = true): Double = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     var addr = vector + OffsetData + start * 8
     val untilAddr = vector + OffsetData + end * 8 + 8   // one past the end
     var sum: Double = 0d

--- a/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
@@ -297,6 +297,7 @@ trait IntVectorDataReader extends VectorDataReader {
 object OffheapSignedIntVector32 extends IntVectorDataReader {
   final def apply(vector: BinaryVectorPtr, n: Int): Int = UnsafeUtils.getInt(vector + 8 + n * 4)
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Long = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     var addr = vector + 8 + start * 4
     val untilAddr = vector + 8 + end * 4 + 4   // one past the end
     var sum: Long = 0L
@@ -311,6 +312,7 @@ object OffheapSignedIntVector32 extends IntVectorDataReader {
 object OffheapSignedIntVector16 extends IntVectorDataReader {
   final def apply(vector: BinaryVectorPtr, n: Int): Int = UnsafeUtils.getShort(vector + 8 + n * 2).toInt
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Long = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     var addr = vector + 8 + start * 2
     val untilAddr = vector + 8 + end * 2 + 2   // one past the end
     var sum = 0L
@@ -325,6 +327,7 @@ object OffheapSignedIntVector16 extends IntVectorDataReader {
 object OffheapSignedIntVector8 extends IntVectorDataReader {
   final def apply(vector: BinaryVectorPtr, n: Int): Int = UnsafeUtils.getByte(vector + 8 + n).toInt
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Long = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     var addr = vector + 8 + start
     val untilAddr = vector + 8 + end + 1     // one past the end
     var sum = 0L
@@ -340,6 +343,7 @@ object OffheapUnsignedIntVector16 extends IntVectorDataReader {
   final def apply(vector: BinaryVectorPtr, n: Int): Int =
     (UnsafeUtils.getShort(vector + 8 + n * 2) & 0x0ffff).toInt
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Long = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     val startRoundedUp = (start + 3) & ~3
     var sum = defaultSum(vector, start, Math.min(end, startRoundedUp - 1))
     if (startRoundedUp <= end) {
@@ -362,6 +366,7 @@ object OffheapUnsignedIntVector8 extends IntVectorDataReader {
   final def apply(vector: BinaryVectorPtr, n: Int): Int =
     (UnsafeUtils.getByte(vector + 8 + n) & 0x00ff).toInt
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Long = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     val startRoundedUp = (start + 7) & ~7
     var sum = defaultSum(vector, start, Math.min(end, startRoundedUp - 1))
     if (startRoundedUp <= end) {
@@ -386,6 +391,7 @@ object OffheapUnsignedIntVector4 extends IntVectorDataReader {
   final def apply(vector: BinaryVectorPtr, n: Int): Int =
     (UnsafeUtils.getByte(vector + 8 + n/2) >> ((n & 0x01) * 4)).toInt & 0x0f
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Long = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     val startRoundedUp = (start + 7) & ~7
     var sum = defaultSum(vector, start, Math.min(end, startRoundedUp - 1))
     if (startRoundedUp <= end) {
@@ -410,6 +416,7 @@ object OffheapUnsignedIntVector2 extends IntVectorDataReader {
   final def apply(vector: BinaryVectorPtr, n: Int): Int =
     (UnsafeUtils.getByte(vector + 8 + n/4) >> ((n & 0x03) * 2)).toInt & 0x03
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Long = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     val startRoundedUp = (start + 7) & ~7
     var sum = defaultSum(vector, start, Math.min(end, startRoundedUp - 1))
     if (startRoundedUp <= end) {

--- a/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
@@ -192,6 +192,7 @@ object LongVectorDataReader64 extends LongVectorDataReader {
 
   // end is inclusive
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Double = {
+    require(start >= 0 && end < length(vector), s"($start, $end) is out of bounds")
     var addr = vector + OffsetData + start * 8
     val untilAddr = vector + OffsetData + end * 8 + 8   // one past the end
     var sum: Double = 0d

--- a/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
@@ -114,6 +114,24 @@ class DoubleVectorTest extends NativeVectorTest {
       reader.sum(builder.addr, 2, orig.length) shouldEqual (orig.drop(2).sum)
     }
 
+    it("should not allow sum() with out of bound indices") {
+      val orig = Seq(1000, 2001.1, 2999.99, 5123.4, 5250, 6004, 7678)
+      val builder = DoubleVector.appendingVectorNoNA(memFactory, orig.length + 2)
+      orig.foreach(builder.addData)
+      val optimized = builder.optimize(memFactory)
+
+      builder.reader.asDoubleReader.sum(builder.addr, 0, 4) shouldEqual orig.take(5).sum
+
+      intercept[IllegalArgumentException] {
+        builder.reader.asDoubleReader.sum(builder.addr, 1, orig.length)
+      }
+
+      val readVect = DoubleVector(optimized)
+      intercept[IllegalArgumentException] {
+        readVect.sum(optimized, 1, orig.length)
+      }
+    }
+
     it("should support resetting and optimizing AppendableVector multiple times") {
       val cb = DoubleVector.appendingVector(memFactory, 5)
       // Use large numbers on purpose so cannot optimize to Doubles or const


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

It is easy to call methods like sum() and go beyond valid bounds, causing SEGVs

**New behavior :**

Bounds checks on the sum() and count() methods prevent out of bound errors.  Runtime should not be hugely affected as the bounds checks are done just one time per call and not per sample.

