### PR TITLE
bug(query): fix bug in ChunkedWindowIterator to include value present at time, timestamp - staleSampleAfterMs 

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -51,7 +51,7 @@ final case class PeriodicSamplesMapper(start: Long,
       // Chunked: use it and trust it has the right type
       case c: ChunkedRangeFunction =>
         // Really, use the stale lookback window size, not 0 which doesn't make sense
-        val windowLength = window.getOrElse(if (functionId == None) queryConfig.staleSampleAfterMs else 0L)
+        val windowLength = window.getOrElse(if (functionId == None) queryConfig.staleSampleAfterMs + 1 else 0L)
         source.map { rv =>
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIterator(rv.asInstanceOf[RawDataRangeVector], start, step, end,

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -321,7 +321,6 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
       100000, 600000L, 0,
       RangeFunction(None, ColumnType.DoubleColumn, useChunked = false),
       queryConfig)
-
     slidingWinIterator.map(r => (r.getLong(0), r.getDouble(1))).toList.filter(!_._2.isNaN) shouldEqual windowResults
 
     val chunkedWinIt = new ChunkedWindowIterator(rv, 100000L,

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -323,6 +323,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
       queryConfig)
     slidingWinIterator.map(r => (r.getLong(0), r.getDouble(1))).toList.filter(!_._2.isNaN) shouldEqual windowResults
 
+    // ChunkedWindowIterator requires window to be staleSampleAfterMs + 1 when window of SlidingWindowIterator is 0
     val chunkedWinIt = new ChunkedWindowIterator(rv, 100000L,
       100000, 600000L, queryConfig.staleSampleAfterMs + 1,
       RangeFunction(None, ColumnType.DoubleColumn, useChunked = true)

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -301,4 +301,33 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
                                                    .asInstanceOf[ChunkedRangeFunction], queryConfig)()
     chunkedWinIt.map(r => (r.getLong(0), r.getDouble(1))).toList.filter(!_._2.isNaN) shouldEqual windowResults
   }
+
+  it("should not return NaN if value is present at time - staleSampleAfterMs") {
+    val samples = Seq(
+      100000L -> 100d,
+      153000L -> 160d,
+      200000L -> 200d
+    )
+    val windowResults = Seq(
+      100000L -> 100d,
+      200000L -> 200d,
+      300000L -> 200d,
+      400000L -> 200d,
+      500000L -> 200d
+    )
+    val rv = timeValueRV(samples)
+
+    val slidingWinIterator = new SlidingWindowIterator(rv.rows, 100000L,
+      100000, 600000L, 0,
+      RangeFunction(None, ColumnType.DoubleColumn, useChunked = false),
+      queryConfig)
+
+    slidingWinIterator.map(r => (r.getLong(0), r.getDouble(1))).toList.filter(!_._2.isNaN) shouldEqual windowResults
+
+    val chunkedWinIt = new ChunkedWindowIterator(rv, 100000L,
+      100000, 600000L, queryConfig.staleSampleAfterMs + 1,
+      RangeFunction(None, ColumnType.DoubleColumn, useChunked = true)
+        .asInstanceOf[ChunkedRangeFunction], queryConfig)()
+    chunkedWinIt.map(r => (r.getLong(0), r.getDouble(1))).toList.filter(!_._2.isNaN) shouldEqual windowResults
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Query server does not return value present at time: timestamp - staleSampleAfterMs 


**New behavior :**
Increase window by 1 to include value present at at time: timestamp - staleSampleAfterMs 



