### PR TITLE
bug(query): Sub queries are being executed sequentially

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -233,7 +233,7 @@ abstract class NonLeafExecPlan extends ExecPlan {
                                 queryConfig: QueryConfig)
                                (implicit sched: Scheduler,
                                 timeout: FiniteDuration): Observable[RangeVector] = {
-    val childTasks = Observable.fromIterable(children).mapAsync { plan =>
+    val childTasks = Observable.fromIterable(children).mapAsync(Runtime.getRuntime.availableProcessors()) { plan =>
       plan.dispatcher.dispatch(plan).onErrorHandle { case ex: Throwable =>
         qLogger.error(s"queryId: ${id} Execution failed for sub-query ${plan.printTree()}", ex)
         QueryError(id, ex)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Since mapAsync by default has a parallelism of 1, child plans are being executed sequentially.
Fixing parallelism.

**Note that** this PR is targeted directly for integration  branch. Needed for performance stabilization of the branch.