### PR TITLE
bug(coord): NPE seen in ShardManager when processing shard events

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -214,7 +214,7 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
     // Restore previously set up datasets and shards.  This happens in a very specific order so that
     // shard and dataset state can be recovered correctly.  First all the datasets are set up.
     // Then shard state is recovered, and finally cluster membership events are replayed.
-    logger.info(s"Attempting to restore previous ingestion state...")
+    logger.info(s"NodeClusterActor starting. Attempting to restore previous ingestion state...")
     metaStore.readIngestionConfigs()
              .map { configs =>
                initDatasets ++= configs.map(_.ref)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

NPE was seen in ShardManager when performing the following comparison:
`currentCoord.path.address == sender.path.address`

Essentially means that current coordinator for shard was null, and shard was unassigned, and yet we got a shard event. Could this be from the previous assignee of the shard?

This PR prevents the NPE and failure of the actor and logs the information for further debugging, but we still need to understand how this can happen.

@velvia Can you help verify/confirm that sender.path or currentCoord.path cannot be null too ?