### PR TITLE
fix(memory): Fix DivideByZero exception when DDV has slope=0

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -220,7 +220,9 @@ object DeltaDeltaConstDataReader extends LongVectorDataReader {
 
   // This is O(1) since we can find exactly where on line it is
   final def binarySearch(vector: BinaryVectorPtr, item: Long): Int = {
-    val guess = ((item - initValue(vector) + (slope(vector) - 1)) / slope(vector)).toInt
+    val _slope = slope(vector)
+    val guess = if (_slope == 0) { if (item <= initValue(vector)) 0 else length(vector) }
+                else             { ((item - initValue(vector) + (_slope - 1)) / _slope).toInt }
     if (guess < 0)                         { 0x80000000 }
     else if (guess >= length(vector))      { 0x80000000 | length(vector) }
     else if (item != apply(vector, guess)) { 0x80000000 | guess }


### PR DESCRIPTION
…ope=0 and binarySearch called

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

When `binarySearch` method called on a DeltaDeltaConstVector with slope=0, it throws a DivideByZero exception.

**New behavior :**

When the slope is 0, for a const vector, that means all values are the same.  If the slope is 0 then what we do is either return the first or last item depending on if the value is higher or lower.  