### PR TITLE
fix(memory): Fix binarySearch bugs in Long/TS vectors; add more debugging

### DIFF
--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -352,8 +352,8 @@ extends ChunkInfoIterator {
     // if new window end is beyond end of most recent chunkset, add more chunksets (if there are more)
     while (curWindowEnd > lastEndTime && infos.hasNext) {
       val next = infos.nextInfo
-      // Add if next chunkset is within window.  Otherwise keep going
-      if (curWindowStart <= next.endTime) {
+      // Add if next chunkset is within window and not empty.  Otherwise keep going
+      if (curWindowStart <= next.endTime && next.numRows > 0) {
         windowInfos += next.infoAddr
         lastEndTime = Math.max(next.endTime, lastEndTime)
       }

--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -171,7 +171,7 @@ object DeltaDeltaDataReader extends LongVectorDataReader {
       curBase -= _slope
     }
 
-    if (item == (curBase + inReader(inner, elemNo))) return elemNo
+    if (elemNo >= 0 && item == (curBase + inReader(inner, elemNo))) return elemNo
 
     elemNo += 1
     curBase += _slope

--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -157,7 +157,8 @@ object DeltaDeltaDataReader extends LongVectorDataReader {
   def binarySearch(vector: BinaryVectorPtr, item: Long): Int = {
     val _slope = slope(vector)
     val _len   = length(vector)
-    var elemNo = ((item - initValue(vector) + (_slope - 1)) / _slope).toInt
+    var elemNo = if (_slope == 0) { if (item <= initValue(vector)) 0 else length(vector) }
+                 else             { ((item - initValue(vector) + (_slope - 1)) / _slope).toInt }
     if (elemNo < 0) elemNo = 0
     if (elemNo >= _len) elemNo = _len - 1
     var curBase = initValue(vector) + _slope * elemNo

--- a/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
@@ -209,6 +209,7 @@ object LongVectorDataReader64 extends LongVectorDataReader {
    */
   def binarySearch(vector: BinaryVectorPtr, item: Long): Int = {
     var len = length(vector)
+    if (len == 0) return 0x80000000
     var first = 0
     var element = 0L
     while (len > 0) {

--- a/memory/src/test/scala/filodb.memory/format/vectors/LongVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/LongVectorTest.scala
@@ -200,6 +200,21 @@ class LongVectorTest extends NativeVectorTest {
       binReader.binarySearch(optimized, 7677L) shouldEqual 0x80000000 | 6
       binReader.binarySearch(optimized, 7678L) shouldEqual 6
       binReader.binarySearch(optimized, 7679L) shouldEqual 0x80000000 | 7
+
+      binReader.ceilingIndex(optimized, 7679L) shouldEqual 6
+    }
+
+    it("should binarySearch DDV vectors with slope=0") {
+      // Test vector with slope=0
+      val builder2 = LongBinaryVector.appendingVectorNoNA(memFactory, 100)
+      (0 until 16).foreach(x => builder2.addData(1000L + (x % 3)))
+      val optimized2 = builder2.optimize(memFactory)
+      val binReader2 = LongBinaryVector(optimized2)
+      binReader2 shouldEqual DeltaDeltaDataReader
+      DeltaDeltaDataReader.slope(optimized2) shouldEqual 0
+      binReader2.binarySearch(optimized2,  999L) shouldEqual 0x80000000 | 0   // first elem, not equal
+      binReader2.binarySearch(optimized2, 1000L) shouldEqual 0               // first elem, equal
+      binReader2.binarySearch(optimized2, 1001L) shouldEqual 0x80000000 | 16
     }
 
     it("should binarySearch DeltaDeltaConst vectors") {
@@ -214,6 +229,7 @@ class LongVectorTest extends NativeVectorTest {
       binReader.binarySearch(optimized, start) shouldEqual 0               // first elem, equal
       binReader.binarySearch(optimized, start + 1) shouldEqual 0x80000000 | 1
       binReader.binarySearch(optimized, start + 100001) shouldEqual 0x80000000 | 11
+      binReader.binarySearch(optimized, start + orig.length*10000) shouldEqual 0x80000000 | orig.length
 
       // Test vector with slope=0
       val builder2 = LongBinaryVector.appendingVectorNoNA(memFactory, 100)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Multiple bugs in chunked query iteration and binary search of Long/TS vectors are leading to SEGVs and out of bound sum() queries on vectors.

**New behavior :**

Multiple bugs in binary search and sum calculation are fixed.  Additional debugging is added for bound errors in chunked iteration to confirm a theory: that remaining bugs is due to off-by-1 length errors - it is possible for some vectors to be slightly longer than the official ChunkSetInfo chunk length, and queries should not go over that ChunkSetInfo limit.  Right now if the TS vector is longer than the others than it might return out of bounds on the other vectors.
