### PR TITLE
bug(kafka): Replace monix-kafka usage in downsampling Kafka producer

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -68,18 +68,17 @@
           kafka {
             bootstrap.servers = "localhost:9092"
             group.id = "filo-db-timeseries-downsample"
+            linger.ms=1000
+            batch.size=786432 // three times record container size
+            acks = "-1"
+            retries = 3
+            max.in.flight.requests.per.connection=1
           }
           # map of millisecond resolution to the kafka topic for publishing downsample data
           # should have one topic per defined resolution above
           topics {
             60000 = "timeseries-dev-ds-1m"
           }
-          # maximum size of in-memory queue of record containers to dispatch to kafka
-          max-queue-size = 5000
-          # minimum size of in-memory queue of record containers to dispatch to kafka
-          min-queue-size = 100
-          # maximum number of containers to consume from in-memory queue at a time
-          consume-batch-size = 100
         }
       }
     }

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -100,12 +100,13 @@ object TestTimeseriesProducer extends StrictLogging {
         s"""--promql 'heap_usage{dc="DC0",_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
       logger.info(s"Periodic Samples CLI Query : \n$query")
 
-      val q = URLEncoder.encode("heap_usage{dc=\"DC0\",_ns=\"App-0\"}", StandardCharsets.UTF_8.toString)
+      val q = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}[2m]""", StandardCharsets.UTF_8.toString)
       val periodicSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
         s"query=$q&start=$startQuery&end=$endQuery&step=15"
       logger.info(s"Periodic Samples query URL: \n$periodicSamplesUrl")
 
-      val q2 = URLEncoder.encode("heap_usage{dc=\"DC0\",_ns=\"App-0\"}[2m]", StandardCharsets.UTF_8.toString)
+      val q2 = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0",__col__="sum"}[2m]""",
+        StandardCharsets.UTF_8.toString)
       val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$q2&time=$endQuery"
       logger.info(s"Raw Samples query URL: \n$rawSamplesUrl")
       val downsampledSamplesUrl = s"http://localhost:8080/promql/prometheus_ds_1m/api/v1/query?" +

--- a/kafka/src/main/scala/filodb/kafka/KafkaDownsamplePublisher.scala
+++ b/kafka/src/main/scala/filodb/kafka/KafkaDownsamplePublisher.scala
@@ -3,39 +3,33 @@ package filodb.kafka
 import java.lang.{Long => JLong}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import monix.execution.{CancelableFuture, Scheduler}
-import monix.kafka.{KafkaProducerConfig, KafkaProducerSink}
-import monix.reactive.Observable
-import org.apache.kafka.clients.producer.ProducerRecord
-import org.jctools.queues.{MessagePassingQueue, MpscGrowableArrayQueue}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.clients.producer.internals.DefaultPartitioner
+import org.apache.kafka.common.serialization.{ByteArraySerializer, LongSerializer}
 
 import filodb.core.{Response, Success}
 import filodb.core.downsample.DownsamplePublisher
 
 class KafkaDownsamplePublisher(downsampleConfig: Config) extends DownsamplePublisher with StrictLogging {
 
-  private val kafkaConfig = KafkaProducerConfig(downsampleConfig.getConfig("publisher-config.kafka"))
-  private implicit val sched = Scheduler.computation(name = "downsample")
+  private val kafkaConfig = propsFromConfig(downsampleConfig.getConfig("publisher-config.kafka"))
 
   private val topics: Map[Int, String] = downsampleConfig.getConfig("publisher-config.topics")
     .entrySet().asScala.map { e => e.getKey.toInt -> e.getValue.unwrapped().toString }.toMap
 
-  private val consumeSize = downsampleConfig.getInt("publisher-config.consume-batch-size")
-  private val minQueueSize = downsampleConfig.getInt("publisher-config.min-queue-size")
-  private val maxQueueSize = downsampleConfig.getInt("publisher-config.max-queue-size")
-  private val queue = new MpscGrowableArrayQueue[ProducerRecord[JLong, Array[Byte]]](minQueueSize, maxQueueSize)
-  private var future: CancelableFuture[Unit] = _
+  private var producer: KafkaProducer[JLong, Array[Byte]] = _
 
   override def publish(shardNum: Int, resolution: Int, records: Seq[Array[Byte]]): Future[Response] = {
     topics.get(resolution) match {
       case Some(topic) =>
         records.foreach { bytes =>
-          queue.offer(new ProducerRecord[JLong, Array[Byte]](topic, shardNum, shardNum.toLong: JLong, bytes))
+          val rec = new ProducerRecord[JLong, Array[Byte]](topic, shardNum, shardNum.toLong: JLong,
+            bytes)
+          producer.send(rec)
         }
         Future.successful(Success)
       case None =>
@@ -43,25 +37,25 @@ class KafkaDownsamplePublisher(downsampleConfig: Config) extends DownsamplePubli
     }
   }
 
-  def start(): Unit = {
-    logger.info(s"Starting Kafka Downsampling Publisher. Will be publishing to $topics ")
-    val producer = KafkaProducerSink[JLong, Array[Byte]](kafkaConfig, sched)
-    future = Observable.repeat(0).map { _: Int =>
-      val records = new ArrayBuffer[ProducerRecord[JLong, Array[Byte]]](consumeSize)
-      val consumer = new MessagePassingQueue.Consumer[ProducerRecord[JLong, Array[Byte]]] {
-        override def accept(el: ProducerRecord[JLong, Array[Byte]]): Unit = {
-          records += el
-        }
-      }
-      queue.drain(consumer, consumeSize)
-      records
-    }.consumeWith(producer)
-     .onErrorRestartIf { case t => logger.error("Error in kafka downsample publisher stream", t); true }
-     .runAsync
+  def propsFromConfig(config: Config): Map[String, Object] = {
+
+    val map = config.entrySet().asScala.map({ entry =>
+      entry.getKey -> entry.getValue.unwrapped()
+    }).toMap
+
+    // immutable properties to be overwritten
+    map ++ Map( "value.serializer" -> classOf[ByteArraySerializer],
+                "key.serializer" -> classOf[LongSerializer],
+                "partitioner.class" -> classOf[DefaultPartitioner])
   }
 
-  def stop(): Unit = {
+  override def start(): Unit = {
+    logger.info(s"Starting Kafka Downsampling Publisher. Will be publishing to $topics with config: $kafkaConfig")
+    producer =  new KafkaProducer(kafkaConfig.asJava)
+  }
+
+  override def stop(): Unit = {
     logger.info("Stopping Kafka Downsampling Publisher")
-    future.cancel()
+    producer.close()
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

No need to use queues and monix-kafka for downsampling since Kafka producer takes care of the batching. 

To use monix-kafka producer, it is necessary for the message source to be transformed into an Observable. The queues were a workaround for that, but it is not necessary anymore since Kafka driver takes care of the batching.

