### PR TITLE
feat(core): Factory with Cassandra Metastore and Null Column Store

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
@@ -7,6 +7,7 @@ import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.cassandra.metastore.CassandraMetaStore
 import filodb.coordinator.StoreFactory
 import filodb.core.memstore.TimeSeriesMemStore
+import filodb.core.store.NullColumnStore
 
 /**
  * A StoreFactory for a TimeSeriesMemStore backed by a Cassandra ChunkSink for on-demand recovery/persistence
@@ -17,6 +18,21 @@ import filodb.core.memstore.TimeSeriesMemStore
  */
 class CassandraTSStoreFactory(config: Config, sched: Scheduler) extends StoreFactory {
   val colStore = new CassandraColumnStore(config, sched)(sched)
+  val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(sched)
+  val memStore = new TimeSeriesMemStore(config, colStore, metaStore)(sched)
+}
+
+/**
+  * A StoreFactory for a TimeSeriesMemStore with Cassandra for metadata, but NullColumnStore for
+  * disabling write of chunks to a persistent column store. This can be used in environments
+  * where we would like to test in-memory aspects of the store and ignore persistence and
+  * on-demand-paging.
+  *
+  * @param config a Typesafe Config, not at the root but at the "filodb." level
+  * @param sched a Monix Scheduler, recommended to be the standard I/O pool, for scheduling asynchronous I/O
+  */
+class NonPersistentTSStoreFactory(config: Config, sched: Scheduler) extends StoreFactory {
+  val colStore = new NullColumnStore()(sched)
   val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(sched)
   val memStore = new TimeSeriesMemStore(config, colStore, metaStore)(sched)
 }

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -108,7 +108,7 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
       val totalBytes = chunkset.chunks.map(_.limit()).sum
       sinkStats.addChunkWriteStats(chunkset.chunks.length, totalBytes, chunkset.info.numRows)
       sinkStats.chunksetWrite()
-      logger.debug(s"NullColumnStore: [${chunkset.partition}] ${chunkset.info}  ${chunkset.chunks.length} " +
+      logger.trace(s"NullColumnStore: [${chunkset.partition}] ${chunkset.info}  ${chunkset.chunks.length} " +
                    s"chunks with $totalBytes bytes")
       chunkset.listener(chunkset.info)
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

A StoreFactory for a TimeSeriesMemStore with Cassandra for metadata, but NullColumnStore for
disabling write of chunks to a persistent column store. This can be used in environments
where we would like to test in-memory aspects of the store and ignore persistence and
on-demand-paging.