### PR TITLE
fix(query): Limit chunked windowing range to ChunkSetInfo.numRows

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
+++ b/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
@@ -91,7 +91,7 @@ class ShardDownsampler(dataset: Dataset,
           while (pStart <= endTime) {
             // fix the boundary row numbers for the downsample period by looking up the timestamp column
             val startRowNum = tsReader.binarySearch(vecPtr, pStart) & 0x7fffffff
-            val endRowNum = tsReader.ceilingIndex(vecPtr, pEnd)
+            val endRowNum = Math.min(tsReader.ceilingIndex(vecPtr, pEnd), chunkset.numRows - 1)
             builder.startNewRecord()
             // for each downsampler, add downsample column value
             dataset.downsamplers.foreach {

--- a/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
+++ b/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
@@ -91,7 +91,7 @@ class ShardDownsampler(dataset: Dataset,
           while (pStart <= endTime) {
             // fix the boundary row numbers for the downsample period by looking up the timestamp column
             val startRowNum = tsReader.binarySearch(vecPtr, pStart) & 0x7fffffff
-            val endRowNum = Math.min(tsReader.ceilingIndex(vecPtr, pEnd), chunkset.numRows - 1)
+            val endRowNum = tsReader.ceilingIndex(vecPtr, pEnd)
             builder.startNewRecord()
             // for each downsampler, add downsample column value
             dataset.downsamplers.foreach {

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -173,7 +173,7 @@ class CountOverTimeChunkedFunction(var count: Int = 0) extends ChunkedRangeFunct
     // First row >= startTime, so we can just drop bit 31 (dont care if it matches exactly)
     val startRowNum = tsReader.binarySearch(timestampVector, startTime) & 0x7fffffff
     val endRowNum = tsReader.ceilingIndex(timestampVector, endTime)
-    val numRows = endRowNum - startRowNum + 1
+    val numRows = Math.min(endRowNum, info.numRows - 1) - startRowNum + 1
     count += numRows
   }
 }

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -123,7 +123,7 @@ trait ChunkedDoubleRangeFunction extends ChunkedRangeFunction {
     val startRowNum = tsReader.binarySearch(timestampVector, startTime) & 0x7fffffff
     val endRowNum = tsReader.ceilingIndex(timestampVector, endTime)
 
-    addTimeDoubleChunks(doubleVector, dblReader, startRowNum, endRowNum)
+    addTimeDoubleChunks(doubleVector, dblReader, startRowNum, Math.min(endRowNum, info.numRows - 1))
   }
 
   /**
@@ -150,7 +150,7 @@ trait ChunkedLongRangeFunction extends ChunkedRangeFunction {
     val startRowNum = tsReader.binarySearch(timestampVector, startTime) & 0x7fffffff
     val endRowNum = tsReader.ceilingIndex(timestampVector, endTime)
 
-    addTimeLongChunks(longVector, longReader, startRowNum, endRowNum)
+    addTimeLongChunks(longVector, longReader, startRowNum, Math.min(endRowNum, info.numRows - 1))
   }
 
   /**
@@ -284,7 +284,8 @@ abstract class LastSampleChunkedFunction(var timestamp: Long = -1L,
                 startTime: Long, endTime: Long, queryConfig: QueryConfig): Unit = {
     val timestampVector = info.vectorPtr(tsCol)
     val tsReader = bv.LongBinaryVector(timestampVector)
-    val endRowNum = tsReader.ceilingIndex(timestampVector, endTime)
+    // Just in case timestamp vectors are a bit longer than others.
+    val endRowNum = Math.min(tsReader.ceilingIndex(timestampVector, endTime), info.numRows - 1)
 
     // update timestamp only if
     //   1) endRowNum >= 0 (timestamp within chunk)


### PR DESCRIPTION
Sometimes timestamp vector can be longer than official chunk length.  Limit range of chunked window queries.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

binarySearches based on timestamp vector might return an upper bound that is out of range of other vectors if their lengths are not equal.   (The lengths not being equal is an artifact of how ingestion is capped by write buffers).

**New behavior :**

Limit the upper bound to the official length of a chunk based on ChunkSetInfo, not the length of the timestamp vector.
