### PR TITLE
misc: fix chunks-paged-in metric type to capture counter instead of gauge

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -69,7 +69,7 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val numPartitions = Kamon.gauge("num-partitions").refine(tags)
   val numActivelyIngestingParts = Kamon.gauge("num-ingesting-partitions").refine(tags)
 
-  val numChunksPagedIn = Kamon.gauge("chunks-paged-in").refine(tags)
+  val numChunksPagedIn = Kamon.counter("chunks-paged-in").refine(tags)
   val partitionsPagedFromColStore = Kamon.counter("memstore-partitions-paged-in").refine(tags)
   val partitionsQueried = Kamon.counter("memstore-partitions-queried").refine(tags)
   val purgedPartitions = Kamon.counter("memstore-partitions-purged").refine(tags)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

`chunks-paged-in` metric is changed to counter to capture number of raw chunks paged into memory from datastore.