### PR TITLE
misc: Don't compile with -Xcheckinit option. It makes all fields lazy…

### DIFF
--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -32,7 +32,6 @@ object FiloSettings extends Build {
       "-unchecked",
       "-feature",
       "-Xfuture",
-      "-Xcheckinit",
       "-Xfatal-warnings",
       "-Ywarn-inaccessible",
       "-Ywarn-dead-code",
@@ -44,6 +43,9 @@ object FiloSettings extends Build {
       "-language:implicitConversions"
       // TODO relocate here: -Ywarn-unused-import, add -Ywarn-numeric-widen
       // TODO in 2.12: remove: -Yinline-warnings, add the new applicable ones
+
+      // Don't enable this option. It makes all fields lazy, hurting performance.
+      //"-Xcheckinit"
     ),
 
     javacOptions ++= Seq(


### PR DESCRIPTION
…, hurting performance.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
All class fields defined outside the constructor are defined as if they were lazy, even though they're not. Lazy fields are slower, due to a volatile bitmap$init field which is accessed all the time.

**New behavior :**
Only fields declared as lazy are actually lazy.
