### PR TITLE
bug(memory): Fix lexicographical byte comparison. Bytes must be unsig…

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/UnsafeUtils.scala
+++ b/memory/src/main/scala/filodb.memory/format/UnsafeUtils.scala
@@ -127,10 +127,10 @@ object UnsafeUtils {
       var pointer1 = offset1 + minLenAligned
       var pointer2 = offset2 + minLenAligned
       for { i <- minLenAligned until minLen optimized } {
-        val res = getByte(base1, pointer1) - getByte(base2, pointer2)
+        val res = (getByte(base1, pointer1) & 0xff) - (getByte(base2, pointer2) & 0xff)
+        if (res != 0) return res
         pointer1 += 1
         pointer2 += 1
-        if (res != 0) return res
       }
       return numBytes1 - numBytes2
     } else wordComp


### PR DESCRIPTION
…ned.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
UTF8 test over random strings fails to compare correctly sometimes.

**New behavior :**
Comparison must be against unsigned bytes. Word comparison already applies the correct bit flip operation.
