### PR TITLE
fix(core): Reset # rows in recycled chunk metadata for consistent metadata<->vectors

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/WriteBufferPool.scala
+++ b/core/src/main/scala/filodb.core/memstore/WriteBufferPool.scala
@@ -75,6 +75,9 @@ class WriteBufferPool(memFactory: MemFactory,
    * The state of the appenders are reset.
    */
   def release(metaAddr: NativePointer, appenders: AppenderArray): Unit = {
+    // IMPORTANT: reset size in ChunkSetInfo metadata so there won't be an inconsistency between appenders and metadata
+    // (in case some reader is still hanging on to this old info)
+    ChunkSetInfo.resetNumRows(metaAddr)
     appenders.foreach(_.reset())
     queue.enqueue((metaAddr, appenders))
     // TODO: check number of buffers in queue, and release baack to free memory.

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -294,7 +294,17 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
       data.foreach { case d => partitions(i).ingest(d, ingestBlockHolder) }
       partitions(i).numChunks shouldEqual 1
       partitions(i).appendingChunkLen shouldEqual 10
+      val infos = partitions(i).infos(AllChunkScan)
+      infos.hasNext shouldEqual true
+      val writeBufInfo = infos.nextInfo
+      writeBufInfo.numRows shouldEqual 10
+
+      // Have to give up read lock
+      infos.close()
       partitions(i).switchBuffers(ingestBlockHolder, true)
+
+      // After switchBuffers, write buffer is recycled, and numRows should be reset
+      writeBufInfo.numRows shouldEqual 0
     }
 
     myBufferPool.poolSize shouldEqual origPoolSize


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Num rows in chunk metadata is not reset immediately when it is recycled.  Could be a race condition when reading old chunk metadata

**New behavior :**

Num rows in chunk metadata is now reset immediately.

