### PR TITLE
feat(coordinator): Fix port binding issue when running tests.

### DIFF
--- a/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/ClusterSeedDiscovery.scala
+++ b/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/ClusterSeedDiscovery.scala
@@ -38,8 +38,13 @@ abstract class ClusterSeedDiscovery(val cluster: Cluster,
         response = Http(seedsEndpoint).timeout(2000, 2000).asString
         logger.info(s"Seeds endpoint returned a ${response.code}. Response body was ${response.body}")
       } catch {
-        case NonFatal(e) =>
+        case NonFatal(e) => {
+          if (e.isInstanceOf[java.net.ConnectException]) {
+            // Don't bother logging the full the trace for something which is expected.
+            e.setStackTrace(new Array[StackTraceElement](0))
+          }
           logger.info(s"Seeds endpoint $seedsEndpoint failed. This is expected on cluster bootstrap", e)
+        }
       }
       retriesRemaining -= 1
       if (retriesRemaining > 0) Thread.sleep(settings.seedsHttpSleepBetweenRetries.toMillis)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Test suite for coordinator fails randomly, because the Akka port cannot be bound again right away.

**New behavior :**
Added a sleep before the ActorSystem is crated, top hopefully provide enough allowance for the bind to work.