### PR TITLE
feat(standalone): Profiler tracks calls to Thread.yield, to indicate …

### DIFF
--- a/standalone/src/main/java/filodb/standalone/SimpleProfiler.java
+++ b/standalone/src/main/java/filodb/standalone/SimpleProfiler.java
@@ -312,10 +312,12 @@ public class SimpleProfiler {
                 return null;
 
             case "java.lang.Thread":
+                /* Track yield, since it's used by the ChunkMap lock.
                 // Reject threads which appeared as doing work only because they yielded.
                 if (elem.getMethodName().equals("yield")) {
                     return null;
                 }
+                */
                 // Sometimes the thread state is runnable for this method. Filter it out.
                 if (elem.getMethodName().equals("sleep")) {
                     return null;


### PR DESCRIPTION
…how much time is spent

contended for ChunkMap locks.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Time spent yielding isn't profiled. This makes it difficult to see how much time is spent waiting for ChunkMap locks.

**New behavior :**
Yield is now profiled.