### PR TITLE
misc: fix for On Demand Chunk page-in span

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -92,7 +92,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
               // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
               // In the future optimize this if needed.
               .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
-              .doOnComplete(span.finish())
+              .doOnComplete(() => span.finish())
               // This is needed so future computations happen in a different thread
               .asyncBoundary(strategy)
           } else { Observable.empty }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -73,42 +73,48 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
       }
     }
     shardStats.partitionsQueried.increment(inMemoryPartitions.length)
-    val span = Kamon.buildSpan(s"odp-cassandra-latency")
-      .withTag("dataset", dataset.name)
-      .withTag("shard", shardNum)
-      .start()
     logger.debug(s"dataset=${dataset.ref} shard=$shardNum Querying ${inMemoryPartitions.length} in memory " +
       s"partitions, ODPing ${methods.length}")
 
     // NOTE: multiPartitionODP mode does not work with AllChunkScan and unit tests; namely missing partitions will not
     // return data that is in memory.  TODO: fix
-    (if (storeConfig.multiPartitionODP) {
-      Observable.fromIterable(inMemoryPartitions) ++
-      Observable.fromTask(odpPartTask(indexIt, partKeyBytesToPage, methods, chunkMethod)).flatMap { odpParts =>
-        val multiPart = MultiPartitionScan(partKeyBytesToPage, shardNum)
-        shardStats.partitionsQueried.increment(partKeyBytesToPage.length)
-        if (partKeyBytesToPage.nonEmpty) {
-          rawStore.readRawPartitions(dataset, allDataCols, multiPart, computeBoundingMethod(methods))
-            // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
-            // In the future optimize this if needed.
-            .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
-            // This is needed so future computations happen in a different thread
-            .asyncBoundary(strategy)
-        } else { Observable.empty }
-      }
-    } else {
-      Observable.fromIterable(inMemoryPartitions) ++
-      Observable.fromTask(odpPartTask(indexIt, partKeyBytesToPage, methods, chunkMethod)).flatMap { odpParts =>
-        shardStats.partitionsQueried.increment(partKeyBytesToPage.length)
-        Observable.fromIterable(partKeyBytesToPage.zip(methods))
-          .mapAsync(storeConfig.demandPagingParallelism) { case (partBytes, method) =>
-            rawStore.readRawPartitions(dataset, allDataCols, SinglePartitionScan(partBytes, shardNum), method)
+    Observable.fromIterable(inMemoryPartitions) ++ {
+      if (storeConfig.multiPartitionODP) {
+        Observable.fromTask(odpPartTask(indexIt, partKeyBytesToPage, methods, chunkMethod)).flatMap { odpParts =>
+          val multiPart = MultiPartitionScan(partKeyBytesToPage, shardNum)
+          shardStats.partitionsQueried.increment(partKeyBytesToPage.length)
+          if (partKeyBytesToPage.nonEmpty) {
+            val span = Kamon.buildSpan(s"odp-cassandra-latency")
+              .withTag("dataset", dataset.name)
+              .withTag("shard", shardNum)
+              .start()
+            rawStore.readRawPartitions(dataset, allDataCols, multiPart, computeBoundingMethod(methods))
+              // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
+              // In the future optimize this if needed.
               .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
-              .defaultIfEmpty(getPartition(partBytes).get)
-              .headL
-          }
+              .doOnComplete(span.finish())
+              // This is needed so future computations happen in a different thread
+              .asyncBoundary(strategy)
+          } else { Observable.empty }
+        }
+      } else {
+        Observable.fromTask(odpPartTask(indexIt, partKeyBytesToPage, methods, chunkMethod)).flatMap { odpParts =>
+          shardStats.partitionsQueried.increment(partKeyBytesToPage.length)
+          Observable.fromIterable(partKeyBytesToPage.zip(methods))
+            .mapAsync(storeConfig.demandPagingParallelism) { case (partBytes, method) =>
+              val span = Kamon.buildSpan(s"odp-cassandra-latency")
+                .withTag("dataset", dataset.name)
+                .withTag("shard", shardNum)
+                .start()
+              rawStore.readRawPartitions(dataset, allDataCols, SinglePartitionScan(partBytes, shardNum), method)
+                .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
+                .doOnComplete(() => span.finish())
+                .defaultIfEmpty(getPartition(partBytes).get)
+                .headL
+            }
+        }
       }
-    }).doOnComplete(() => span.finish())
+    }
   }
 
   // 3. Deal with partitions no longer in memory but still indexed in Lucene.


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

Fix to accurately capture the latency for On Demand Paging of RawChunks. Span is created only if there are partitions that needs to be paged-in from datastore.