### PR TITLE
fix(memory): Fix bug where binarySearch of DDVs was reading memory out of bounds

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -182,7 +182,7 @@ object DeltaDeltaDataReader extends LongVectorDataReader {
       curBase += _slope
     }
 
-    if (item == (curBase + inReader(inner, elemNo))) elemNo else elemNo | 0x80000000
+    if (elemNo < _len && item == (curBase + inReader(inner, elemNo))) elemNo else elemNo | 0x80000000
   }
 
   final def sum(vector: BinaryVectorPtr, start: Int, end: Int): Double = {


### PR DESCRIPTION
…at was out of bounds

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Occasionally a binary search was failing the randomized property testing.

**New behavior :**

The DeltaDelta vector binary search function had a bug as it was reading memory that was out of bounds.  Added a bounds check.  Randomized testing no longer fails.

