### PR TITLE
fix(coordinator): Use random Akka port in some tests to reduce failures

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/FilodbClusterNodeSpec.scala
@@ -34,10 +34,13 @@ trait SocketChecker {
 }
 
 trait FilodbClusterNodeSpec extends AbstractSpec with FilodbClusterNode with ScalaFutures {
+  val port = 22552 + util.Random.nextInt(200)
+
   // Ensure that CoordinatedShutdown does not shutdown the whole test JVM, otherwise Travis CI/CD fails
   override protected lazy val roleConfig = ConfigFactory.parseString(
-        """akka.coordinated-shutdown.run-by-jvm-shutdown-hook=off
+       s"""akka.coordinated-shutdown.run-by-jvm-shutdown-hook=off
           |akka.coordinated-shutdown.exit-jvm = off
+          |akka.remote.netty.tcp.port=$port
         """.stripMargin)
 
   implicit abstract override val patienceConfig: PatienceConfig =
@@ -133,7 +136,7 @@ class ClusterNodeServerSpec extends FilodbClusterNodeSpec {
  * Initiates cluster singleton recovery sequence by populating guardian with some initial non-empty
  * shardmap and subscription state, and checking that it is recovered properly on startup
  */
-class ClusterNodeRecoverySpec extends FilodbClusterNodeSpec with SocketChecker {
+class ClusterNodeRecoverySpec extends FilodbClusterNodeSpec {
   import scala.collection.immutable
   import scala.concurrent.duration._
 
@@ -144,8 +147,6 @@ class ClusterNodeRecoverySpec extends FilodbClusterNodeSpec with SocketChecker {
   import filodb.core.NamesTestData._
   import NodeClusterActor._
   import NodeProtocol._
-
-  waitSocketOpen(2552)
 
   override val role = ClusterRole.Server
 

--- a/coordinator/src/test/scala/filodb.coordinator/ShardSubscriptionsSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardSubscriptionsSpec.scala
@@ -4,7 +4,7 @@ import akka.testkit.TestProbe
 
 import filodb.core.DatasetRef
 
-class ShardSubscriptionsSpec extends AkkaSpec with SocketChecker {
+class ShardSubscriptionsSpec extends AkkaSpec {
 
   private val extension = FilodbCluster(system)
 
@@ -12,8 +12,6 @@ class ShardSubscriptionsSpec extends AkkaSpec with SocketChecker {
   private val dataset2 = DatasetRef("two")
 
   private val subscribers = Set(TestProbe().ref, TestProbe().ref)
-
-  waitSocketOpen(2552)
 
   "ShardSubscription" must {
     "add unseen subscribers, not add seen subscribers" in {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We use a long timeout to reduce failures between tests that run Akka Cluster on a port.

**New behavior :**

Randomize the port used by Akka Cluster in key tests.  Timeout should not be needed anymore.
