### PR TITLE
 feat(query): Handling spread changes over time in Query Engine - Iteration 1

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -68,7 +68,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     clusterMeta.checkSchemaAgreement()
     for { ctResp    <- chunkTable.initialize()
           rmtResp   <- indexTable.initialize()
-          pitResp   <- partIndexTable.initialize() } yield rmtResp
+          pitResp   <- partIndexTable.initialize() } yield pitResp
   }
 
   def truncate(dataset: DatasetRef): Future[Response] = {
@@ -79,7 +79,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     clusterMeta.checkSchemaAgreement()
     for { ctResp    <- chunkTable.clearAll()
           rmtResp   <- indexTable.clearAll()
-          pitResp   <- partIndexTable.clearAll() } yield rmtResp
+          pitResp   <- partIndexTable.clearAll() } yield pitResp
   }
 
   def dropDataset(dataset: DatasetRef): Future[Response] = {
@@ -94,7 +94,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       chunkTableCache.remove(dataset)
       indexTableCache.remove(dataset)
       partitionIndexTableCache.remove(dataset)
-      rmtResp
+      pitResp
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -35,6 +35,10 @@ object QueryCommands {
 
   final case class SpreadChange(time: Long = 0L, spread: Int = 1)
 
+  /**
+    * This class provides general query processing parameters
+    * @param spreadFunc a function that returns chronologically ordered spread changes for the filter
+    */
   final case class QueryOptions(spreadFunc: Seq[ColumnFilter] => Seq[SpreadChange] = { _ => Seq(SpreadChange()) },
                                 parallelism: Int = 16,
                                 queryTimeoutSecs: Int = 30,

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -32,7 +32,8 @@ object QueryCommands {
                                   limit: Int = 100,
                                   submitTime: Long = System.currentTimeMillis()) extends QueryCommand
 
-  final case class QueryOptions(spreadFunc: Seq[ColumnFilter] => Int = { x => 1 },
+  final case class QueryOptions(spreadFunc: Seq[ColumnFilter] => Int = { _ => 1 },
+                                spreadIncreased: Seq[ColumnFilter] => Boolean = { _ => false },
                                 parallelism: Int = 16,
                                 queryTimeoutSecs: Int = 30,
                                 sampleLimit: Int = 1000000,

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -32,8 +32,10 @@ object QueryCommands {
                                   limit: Int = 100,
                                   submitTime: Long = System.currentTimeMillis()) extends QueryCommand
 
-  final case class QueryOptions(spreadFunc: Seq[ColumnFilter] => Int = { _ => 1 },
-                                spreadIncreased: Seq[ColumnFilter] => Boolean = { _ => false },
+
+  final case class SpreadChange(time: Long = 0L, spread: Int = 1)
+
+  final case class QueryOptions(spreadFunc: Seq[ColumnFilter] => Seq[SpreadChange] = { _ => Seq(SpreadChange()) },
                                 parallelism: Int = 16,
                                 queryTimeoutSecs: Int = 30,
                                 sampleLimit: Int = 1000000,
@@ -41,7 +43,7 @@ object QueryCommands {
 
   object QueryOptions {
     def apply(constSpread: Int, sampleLimit: Int): QueryOptions =
-      QueryOptions(spreadFunc = { x => constSpread}, sampleLimit = sampleLimit)
+      QueryOptions(spreadFunc = { _ => Seq(SpreadChange(spread = constSpread))}, sampleLimit = sampleLimit)
 
     /**
      * Creates a spreadFunc that looks for a particular filter with keyName Equals a value, and then maps values
@@ -49,20 +51,20 @@ object QueryCommands {
      */
     def simpleMapSpreadFunc(keyName: String,
                             spreadMap: collection.Map[String, Int],
-                            defaultSpread: Int): Seq[ColumnFilter] => Int = {
+                            defaultSpread: Int): Seq[ColumnFilter] => Seq[SpreadChange] = {
       filters: Seq[ColumnFilter] =>
-        filters.collect {
+        filters.collectFirst {
           case ColumnFilter(key, Filter.Equals(filtVal: String)) if key == keyName => filtVal
-        }.headOption.map { tagValue =>
-          spreadMap.getOrElse(tagValue, defaultSpread)
-        }.getOrElse(defaultSpread)
+        }.map { tagValue =>
+          Seq(SpreadChange(spread = spreadMap.getOrElse(tagValue, defaultSpread)))
+        }.getOrElse(Seq(SpreadChange(defaultSpread)))
     }
 
     import collection.JavaConverters._
 
     def simpleMapSpreadFunc(keyName: String,
                             spreadMap: java.util.Map[String, Int],
-                            defaultSpread: Int): Seq[ColumnFilter] => Int =
+                            defaultSpread: Int): Seq[ColumnFilter] => Seq[SpreadChange] =
       simpleMapSpreadFunc(keyName, spreadMap.asScala, defaultSpread)
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine/Utils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine/Utils.scala
@@ -74,7 +74,7 @@ object Utils extends StrictLogging {
           val shardCols = dataset.options.shardKeyColumns
           if (shardCols.length > 0) {
             shardHashFromFilters(filters, shardCols, dataset) match {
-              case Some(shardHash) => shardMap.queryShards(shardHash, options.spreadFunc(filters))
+              case Some(shardHash) => shardMap.queryShards(shardHash, options.spreadFunc(filters).last.spread)
               case None            => throw new IllegalArgumentException(s"Must specify filters for $shardCols")
             }
           } else {

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -65,12 +65,12 @@ class QueryEngine(dataset: Dataset,
       case (many, planNotes) =>
         val targetActor = pickDispatcher(many)
         many(0) match {
-          case lve: LabelValuesExec =>
-            val topPlan = LabelValuesDistConcatExec(queryId, targetActor, many)
+          case lve: LabelValuesExec =>LabelValuesDistConcatExec(queryId, targetActor, many)
+          case ske: PartKeysExec => PartKeysDistConcatExec(queryId, targetActor, many)
+          case ep: ExecPlan =>
+            val topPlan = DistConcatExec(queryId, targetActor, many)
             if (planNotes.stitch) topPlan.addRangeVectorTransformer(new StitchRvsMapper())
             topPlan
-          case ske: PartKeysExec => PartKeysDistConcatExec(queryId, targetActor, many)
-          case ep: ExecPlan => DistConcatExec(queryId, targetActor, many)
         }
     }
     logger.debug(s"Materialized logical plan for dataset=${dataset.ref}:" +

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -21,6 +21,13 @@ import filodb.prometheus.ast.Vectors.PromMetricLabel
 import filodb.query.{exec, _}
 import filodb.query.exec._
 
+
+/**
+  * This is a container for any state to be passed up to parent nodes for easier query planning.
+  * Not for runtime use.
+  */
+case class PlanNotes(var stitch: Boolean = false)
+
 /**
   * FiloDB Query Engine is the facade for execution of FiloDB queries.
   * It is meant for use inside FiloDB nodes to execute materialized
@@ -52,12 +59,16 @@ class QueryEngine(dataset: Dataset,
                   options: QueryOptions): ExecPlan = {
     val queryId = UUID.randomUUID().toString
     val materialized = walkLogicalPlanTree(rootLogicalPlan, queryId, System.currentTimeMillis(), options) match {
-      case Seq(justOne) =>
+      case (Seq(justOne), planNotes) =>
+        if (planNotes.stitch) justOne.addRangeVectorTransformer(new StitchRvsMapper())
         justOne
-      case many =>
+      case (many, planNotes) =>
         val targetActor = pickDispatcher(many)
         many(0) match {
-          case lve: LabelValuesExec => LabelValuesDistConcatExec(queryId, targetActor, many)
+          case lve: LabelValuesExec =>
+            val topPlan = LabelValuesDistConcatExec(queryId, targetActor, many)
+            if (planNotes.stitch) topPlan.addRangeVectorTransformer(new StitchRvsMapper())
+            topPlan
           case ske: PartKeysExec => PartKeysDistConcatExec(queryId, targetActor, many)
           case ep: ExecPlan => DistConcatExec(queryId, targetActor, many)
         }
@@ -112,7 +123,7 @@ class QueryEngine(dataset: Dataset,
   private def walkLogicalPlanTree(logicalPlan: LogicalPlan,
                                   queryId: String,
                                   submitTime: Long,
-                                  options: QueryOptions): Seq[ExecPlan] = {
+                                  options: QueryOptions): (Seq[ExecPlan], PlanNotes) = {
     logicalPlan match {
       case lp: RawSeries =>                   materializeRawSeries(queryId, submitTime, options, lp)
       case lp: RawChunkMeta =>                materializeRawChunkMeta(queryId, submitTime, options, lp)
@@ -130,81 +141,109 @@ class QueryEngine(dataset: Dataset,
   private def materializeScalarVectorBinOp(queryId: String,
                                            submitTime: Long,
                                            options: QueryOptions,
-                                           lp: ScalarVectorBinaryOperation): Seq[ExecPlan] = {
-    val vectors = walkLogicalPlanTree(lp.vector, queryId, submitTime, options)
+                                           lp: ScalarVectorBinaryOperation): (Seq[ExecPlan], PlanNotes) = {
+    val (vectors, planNotes) = walkLogicalPlanTree(lp.vector, queryId, submitTime, options)
     vectors.foreach(_.addRangeVectorTransformer(ScalarOperationMapper(lp.operator, lp.scalar, lp.scalarIsLhs)))
-    vectors
+    (vectors, planNotes)
   }
 
   private def materializeBinaryJoin(queryId: String,
                                     submitTime: Long,
                                     options: QueryOptions,
-                                    lp: BinaryJoin): Seq[ExecPlan] = {
-    val lhs = walkLogicalPlanTree(lp.lhs, queryId, submitTime, options)
-    val rhs = walkLogicalPlanTree(lp.rhs, queryId, submitTime, options)
+                                    lp: BinaryJoin): (Seq[ExecPlan], PlanNotes) = {
+    val (lhs, lhsPlanNotes) = walkLogicalPlanTree(lp.lhs, queryId, submitTime, options)
+    val stitchedLhs = if (lhsPlanNotes.stitch) Seq(StitchRvsExec(queryId, pickDispatcher(lhs), lhs))
+                      else lhs
+    val (rhs, rhsPlanNotes) = walkLogicalPlanTree(lp.rhs, queryId, submitTime, options)
+    val stitchedRhs = if (rhsPlanNotes.stitch) Seq(StitchRvsExec(queryId, pickDispatcher(rhs), rhs))
+                      else rhs
+    // TODO Currently we create separate exec plan node for stitching.
+    // Ideally, we can go one step further and add capability to NonLeafNode plans to pre-process
+    // and transform child results individually before composing child results together.
+    // In theory, more efficient to use transformer than to have separate exec plan node to avoid IO.
+    // In the interest of keeping it simple, deferring decorations to the ExecPlan. Add only if needed after measuring.
+
     val targetActor = pickDispatcher(lhs ++ rhs)
-    Seq(BinaryJoinExec(queryId, targetActor, lhs, rhs, lp.operator, lp.cardinality, lp.on, lp.ignoring))
+    val joined = Seq(BinaryJoinExec(queryId, targetActor, stitchedLhs, stitchedRhs, lp.operator, lp.cardinality,
+                                    lp.on, lp.ignoring))
+    lhsPlanNotes.stitch = false
+    (joined, lhsPlanNotes)
   }
 
   private def materializeAggregate(queryId: String,
                                    submitTime: Long,
                                    options: QueryOptions,
-                                   lp: Aggregate): Seq[ExecPlan] = {
-    val toReduce = walkLogicalPlanTree(lp.vectors, queryId, submitTime, options) // Now we have one exec plan per shard
+                                   lp: Aggregate): (Seq[ExecPlan], PlanNotes) = {
+    val (toReduce, planNotes) = walkLogicalPlanTree(lp.vectors, queryId, submitTime, options)
+    // Now we have one exec plan per shard
+    planNotes.stitch = false // since reduction is done, no need for stitching
+    /*
+     * Note that in order for same overlapping RVs to not be double counted when spread is increased,
+     * one of the following must happen
+     * 1. Step instants must be chosen so time windows dont span shards.
+     * 2. We pump data into multiple shards for sometime so atleast one shard will fully contain any time window
+     *
+     * Pulling all data into one node and stich before reducing (not feasible, doesnt scale). So we will
+     * not stitch
+     *
+     * Starting off with solution 1 first until (2) or some other approach is decided on.
+     */
     toReduce.foreach(_.addRangeVectorTransformer(AggregateMapReduce(lp.operator, lp.params, lp.without, lp.by)))
     // One could do another level of aggregation per node too. Ignoring for now
     val reduceDispatcher = pickDispatcher(toReduce)
     val reducer = ReduceAggregateExec(queryId, reduceDispatcher, toReduce, lp.operator, lp.params)
     reducer.addRangeVectorTransformer(AggregatePresenter(lp.operator, lp.params))
-    Seq(reducer)
+    (Seq(reducer), planNotes)
   }
 
   private def materializeApplyInstantFunction(queryId: String,
                                               submitTime: Long,
                                               options: QueryOptions,
-                                              lp: ApplyInstantFunction): Seq[ExecPlan] = {
-    val vectors = walkLogicalPlanTree(lp.vectors, queryId, submitTime, options)
+                                              lp: ApplyInstantFunction): (Seq[ExecPlan], PlanNotes) = {
+    val (vectors, planNotes) = walkLogicalPlanTree(lp.vectors, queryId, submitTime, options)
     vectors.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(lp.function, lp.functionArgs)))
-    vectors
+    (vectors, planNotes)
   }
 
   private def materializePeriodicSeriesWithWindowing(queryId: String,
                                                      submitTime: Long,
                                                      options: QueryOptions,
-                                                     lp: PeriodicSeriesWithWindowing): Seq[ExecPlan] = {
-    val rawSeries = walkLogicalPlanTree(lp.rawSeries, queryId, submitTime, options)
+                                                     lp: PeriodicSeriesWithWindowing): (Seq[ExecPlan], PlanNotes) ={
+    val (rawSeries, planNotes) = walkLogicalPlanTree(lp.rawSeries, queryId, submitTime, options)
     rawSeries.foreach(_.addRangeVectorTransformer(PeriodicSamplesMapper(lp.start, lp.step,
       lp.end, Some(lp.window), Some(lp.function), lp.functionArgs)))
-    rawSeries
+    (rawSeries, planNotes)
   }
 
   private def materializePeriodicSeries(queryId: String,
                                         submitTime: Long,
                                        options: QueryOptions,
-                                       lp: PeriodicSeries): Seq[ExecPlan] = {
-    val rawSeries = walkLogicalPlanTree(lp.rawSeries, queryId, submitTime, options)
+                                       lp: PeriodicSeries): (Seq[ExecPlan], PlanNotes) = {
+    val (rawSeries, planNotes) = walkLogicalPlanTree(lp.rawSeries, queryId, submitTime, options)
     rawSeries.foreach(_.addRangeVectorTransformer(PeriodicSamplesMapper(lp.start, lp.step, lp.end,
       None, None, Nil)))
-    rawSeries
+    (rawSeries, planNotes)
   }
 
   private def materializeRawSeries(queryId: String,
                                    submitTime: Long,
                                    options: QueryOptions,
-                                   lp: RawSeries): Seq[ExecPlan] = {
+                                   lp: RawSeries): (Seq[ExecPlan], PlanNotes) = {
     val colIDs = getColumnIDs(dataset, lp.columns)
     val renamedFilters = renameMetricFilter(lp.filters)
-    shardsFromFilters(renamedFilters, options).map { shard =>
+    val planNotes = PlanNotes(options.spreadIncreased(renamedFilters))
+    val execPlans = shardsFromFilters(renamedFilters, options).map { shard =>
       val dispatcher = dispatcherForShard(shard)
       SelectRawPartitionsExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         renamedFilters, toRowKeyRange(lp.rangeSelector), colIDs)
     }
+    (execPlans, planNotes)
   }
 
   private def materializeLabelValues(queryId: String,
                                       submitTime: Long,
                                       options: QueryOptions,
-                                      lp: LabelValues): Seq[LabelValuesExec] = {
+                                      lp: LabelValues): (Seq[ExecPlan], PlanNotes) = {
     val filters = lp.labelConstraints.map { case (k, v) =>
       new ColumnFilter(k, Filter.Equals(v))
     }.toSeq
@@ -220,17 +259,18 @@ class QueryEngine(dataset: Dataset,
                         mdNoShardKeyFilterRequests.increment()
                         shardMapperFunc.assignedShards
                       }
-    shardsToHit.map { shard =>
+    val metaExec = shardsToHit.map { shard =>
       val dispatcher = dispatcherForShard(shard)
       exec.LabelValuesExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         filters, labelNames, lp.lookbackTimeInMillis)
     }
+    (metaExec, PlanNotes())
   }
 
   private def materializeSeriesKeysByFilters(queryId: String,
                                      submitTime: Long,
                                      options: QueryOptions,
-                                     lp: SeriesKeysByFilters): Seq[PartKeysExec] = {
+                                     lp: SeriesKeysByFilters): (Seq[ExecPlan], PlanNotes) = {
     val renamedFilters = renameMetricFilter(lp.filters)
     val filterCols = lp.filters.map(_.column).toSet
     val shardsToHit = if (shardColumns.toSet.subsetOf(filterCols)) {
@@ -239,26 +279,28 @@ class QueryEngine(dataset: Dataset,
                         mdNoShardKeyFilterRequests.increment()
                         shardMapperFunc.assignedShards
                       }
-    shardsToHit.map { shard =>
+    val metaExec = shardsToHit.map { shard =>
       val dispatcher = dispatcherForShard(shard)
       PartKeysExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         renamedFilters, lp.start, lp.end)
     }
+    (metaExec, PlanNotes())
   }
 
   private def materializeRawChunkMeta(queryId: String,
                                       submitTime: Long,
                                       options: QueryOptions,
-                                      lp: RawChunkMeta): Seq[ExecPlan] = {
+                                      lp: RawChunkMeta): (Seq[ExecPlan], PlanNotes) = {
     // Translate column name to ID and validate here
     val colName = if (lp.column.isEmpty) dataset.options.valueColumn else lp.column
     val colID = dataset.colIDs(colName).get.head
     val renamedFilters = renameMetricFilter(lp.filters)
-    shardsFromFilters(renamedFilters, options).map { shard =>
+    val meta = shardsFromFilters(renamedFilters, options).map { shard =>
       val dispatcher = dispatcherForShard(shard)
       SelectChunkInfosExec(queryId, submitTime, options.sampleLimit, dispatcher, dataset.ref, shard,
         renamedFilters, toRowKeyRange(lp.rangeSelector), colID)
     }
+    (meta, PlanNotes())
   }
 
   /**

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -88,7 +88,7 @@ class QueryEngine(dataset: Dataset,
               s"$shardCol, shard key hashing disabled")
         }
       }
-      val metric = shardVals.filter(_._1 == dataset.options.metricColumn).headOption
+      val metric = shardVals.find(_._1 == dataset.options.metricColumn)
                             .map(_._2)
                             .getOrElse(throw new BadQueryException(s"Could not find metric value"))
       val shardValues = shardVals.filterNot(_._1 == dataset.options.metricColumn).map(_._2)

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -189,7 +189,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val to = System.currentTimeMillis()
     val from = to - 50000
 
-    val intervalSelector = IntervalSelector(Seq(from), Seq(to))
+    val intervalSelector = IntervalSelector(from, to)
 
     val raw1 = RawSeries(rangeSelector = intervalSelector, filters= f1, columns = Seq("value"))
     val windowed1 = PeriodicSeriesWithWindowing(raw1, from, 1000, to, 5000, RangeFunctionId.Rate)

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -46,7 +46,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
   val to = System.currentTimeMillis()
   val from = to - 50000
 
-  val intervalSelector = IntervalSelector(Seq(from), Seq(to))
+  val intervalSelector = IntervalSelector(from, to)
 
   val raw1 = RawSeries(rangeSelector = intervalSelector, filters= f1, columns = Seq("value"))
   val windowed1 = PeriodicSeriesWithWindowing(raw1, from, 1000, to, 5000, RangeFunctionId.Rate)

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -94,7 +94,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
               // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
               // In the future optimize this if needed.
               .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
-              .doOnComplete(() => span.finish())
+              .doOnTerminate(ex => span.finish())
               // This is needed so future computations happen in a different thread
               .asyncBoundary(strategy)
           } else { Observable.empty }
@@ -111,7 +111,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
                   .defaultIfEmpty(getPartition(partBytes).get)
                   .headL
               }
-              .doOnComplete(() => span.finish())
+              .doOnTerminate(ex => span.finish())
           } else {
             Observable.empty
           }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -14,7 +14,9 @@ import filodb.memory.data.ChunkMap
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String => UTF8Str}
 
 /**
-  * Identifier for a single RangeVector
+  * Identifier for a single RangeVector.
+  * Sub-classes must be a case class or override equals/hashcode since this class is used in a
+  * hash table.
   */
 trait RangeVectorKey extends java.io.Serializable {
   def labelValues: Map[UTF8Str, UTF8Str]

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -100,17 +100,20 @@ object TestTimeseriesProducer extends StrictLogging {
         s"""--promql 'heap_usage{dc="DC0",_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
       logger.info(s"Periodic Samples CLI Query : \n$query")
 
-      val q = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}[2m]""", StandardCharsets.UTF_8.toString)
+      val periodQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}""", StandardCharsets.UTF_8.toString)
       val periodicSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
-        s"query=$q&start=$startQuery&end=$endQuery&step=15"
+        s"query=$periodQuery&start=$startQuery&end=$endQuery&step=15"
       logger.info(s"Periodic Samples query URL: \n$periodicSamplesUrl")
 
-      val q2 = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0",__col__="sum"}[2m]""",
+      val rawQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}[2m]""",
         StandardCharsets.UTF_8.toString)
-      val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$q2&time=$endQuery"
+      val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$rawQuery&time=$endQuery"
       logger.info(s"Raw Samples query URL: \n$rawSamplesUrl")
+
+      val downsampleSumQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0",__col__="sum"}[2m]""",
+        StandardCharsets.UTF_8.toString)
       val downsampledSamplesUrl = s"http://localhost:8080/promql/prometheus_ds_1m/api/v1/query?" +
-        s"query=$q2&time=$endQuery"
+        s"query=$downsampleSumQuery&time=$endQuery"
       logger.info(s"Downsampled Samples query URL: \n$downsampledSamplesUrl")
 
     }

--- a/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
+++ b/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
@@ -14,7 +14,7 @@ import org.xerial.snappy.Snappy
 import remote.RemoteStorage.ReadRequest
 
 import filodb.coordinator.client.IngestionCommands.UnknownDataset
-import filodb.coordinator.client.QueryCommands.{LogicalPlan2Query, QueryOptions}
+import filodb.coordinator.client.QueryCommands.{LogicalPlan2Query, QueryOptions, SpreadChange}
 import filodb.core.DatasetRef
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
@@ -29,7 +29,7 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
   import filodb.coordinator.client.Client._
   import filodb.prometheus.query.PrometheusModel._
 
-  val queryOptions = QueryOptions(spreadFunc = { _ => settings.queryDefaultSpread },
+  val queryOptions = QueryOptions(spreadFunc = { _ => Seq(SpreadChange(settings.queryDefaultSpread)) },
                                   sampleLimit = settings.querySampleLimit)
 
   val route = pathPrefix( "promql" / Segment) { dataset =>

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Base.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Base.scala
@@ -44,7 +44,7 @@ trait Base {
    * timeParam.start is in seconds, startOffset is in millis
    */
   def timeParamToSelector(timeParam: TimeRangeParams, startOffset: Long): RangeSelector = timeParam match {
-    case TimeStepParams(start, step, end) => IntervalSelector(Seq(start * 1000 - startOffset), Seq(end * 1000))
+    case TimeStepParams(start, step, end) => IntervalSelector(start * 1000 - startOffset, end * 1000)
     case InMemoryParam(_)                 => InMemoryChunksSelector
     case WriteBuffersParam(_)             => WriteBufferSelector
   }

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -325,9 +325,8 @@ object Parser extends Expression {
   }
 
   def queryToLogicalPlan(query: String, queryTimestamp: Long): LogicalPlan = {
-    // step does not matter here in instant query.
-    // Since we have some min validation on the server, pass Long.MaxValue / 1000 seconds for step.
-    val defaultQueryParams = TimeStepParams(queryTimestamp, Long.MaxValue / 1000, queryTimestamp)
+    // step does not matter here in instant query - just use a dummy value more than minStep
+    val defaultQueryParams = TimeStepParams(queryTimestamp, 1000, queryTimestamp)
     queryRangeToLogicalPlan(query, defaultQueryParams)
   }
 

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -32,7 +32,7 @@ object PrometheusModel {
   def toFiloDBLogicalPlans(readRequest: ReadRequest): Seq[LogicalPlan] = {
     for { i <- 0 until readRequest.getQueriesCount } yield {
       val q = readRequest.getQueries(i)
-      val interval = IntervalSelector(Seq(q.getStartTimestampMs), Seq(q.getEndTimestampMs))
+      val interval = IntervalSelector(q.getStartTimestampMs, q.getEndTimestampMs)
       val filters = for { j <- 0 until q.getMatchersCount } yield {
         val m = q.getMatchers(j)
         val filter = m.getType match {

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -245,15 +245,15 @@ class ParserSpec extends FunSpec with Matchers {
   it("Should be able to make logical plans for Series Expressions") {
     val queryToLpString = Map(
       "primary:instance-001:no.ofrequests{job=\"my-job\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(my-job)), ColumnFilter(__name__,Equals(primary:instance-001:no.ofrequests))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(my-job)), ColumnFilter(__name__,Equals(primary:instance-001:no.ofrequests))),List()),1524855988000,1000000,1524855988000)",
       "absent(nonexistent{job=\"myjob\"})" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),Absent,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),Absent,List())",
       "rate(http_requests_total[5m] offset 1w)" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Rate,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\",group=\"canary\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(group,Equals(canary)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(group,Equals(canary)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000)",
       "http_requests_total{job=\"prometheus\",__col__=\"min\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(min)),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(min)),1524855988000,1000000,1524855988000)",
       // Internal FiloDB debug function
       "_filodb_chunkmeta_all(http_requests_total{job=\"prometheus\"})" ->
         "RawChunkMeta(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),)",
@@ -261,67 +261,67 @@ class ParserSpec extends FunSpec with Matchers {
         "RawChunkMeta(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),avg)",
 
       "sum(http_requests_total) by (application, group)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(application, group),List())",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(),List(application, group),List())",
       "sum(http_requests_total) without (instance)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List(instance))",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(),List(),List(instance))",
       "count_values(\"version\", build_version)" ->
-        "Aggregate(CountValues,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(build_version))),List()),1524855988000,9223372036854775000,1524855988000),List(\"version\"),List(),List())",
+        "Aggregate(CountValues,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(build_version))),List()),1524855988000,1000000,1524855988000),List(\"version\"),List(),List())",
       "label_replace(up{job=\"api-server\",service=\"a:c\"}, \"foo\", \"$1\", \"service\", \"(.*):.*\")" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(service,Equals(a:c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,9223372036854775000,1524855988000),LabelReplace,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(service,Equals(a:c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,1000000,1524855988000),LabelReplace,List())",
       "sum(http_requests_total)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List())",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(),List(),List())",
       "label_join(up{job=\"api-server\",src1=\"a\",src2=\"b\",src3=\"c\"}, \"foo\", \",\", \"src1\", \"src2\", \"src3\")" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(src1,Equals(a)), ColumnFilter(src2,Equals(b)), ColumnFilter(src3,Equals(c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,9223372036854775000,1524855988000),LabelJoin,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(src1,Equals(a)), ColumnFilter(src2,Equals(b)), ColumnFilter(src3,Equals(c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,1000000,1524855988000),LabelJoin,List())",
       "histogram_quantile(0.9, sum(rate(http_request_duration_seconds_bucket[10m])) by (le))" ->
-        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),List(),List(le),List()),HistogramQuantile,List(0.9))",
+        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,1000000,1524855988000,600000,Rate,List()),List(),List(le),List()),HistogramQuantile,List(0.9))",
       "delta(cpu_temp_celsius{host=\"zeus\"}[2h])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524848788000,1524855988000),List(ColumnFilter(host,Equals(zeus)), ColumnFilter(__name__,Equals(cpu_temp_celsius))),List()),1524855988000,9223372036854775000,1524855988000,7200000,Delta,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524848788000,1524855988000),List(ColumnFilter(host,Equals(zeus)), ColumnFilter(__name__,Equals(cpu_temp_celsius))),List()),1524855988000,1000000,1524855988000,7200000,Delta,List())",
       "method_code:http_errors:rate5m{code=\"500\"} / ignoring(code) method:http_requests:rate5m" ->
-        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(code,Equals(500)), ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),DIV,OneToOne,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),List(),List())",
+        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(code,Equals(500)), ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,1000000,1524855988000),DIV,OneToOne,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,1000000,1524855988000),List(),List())",
       "histogram_quantile(0.9, rate(http_request_duration_seconds_bucket[10m]))" ->
-        "ApplyInstantFunction(PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),HistogramQuantile,List(0.9))",
+        "ApplyInstantFunction(PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,1000000,1524855988000,600000,Rate,List()),HistogramQuantile,List(0.9))",
       "histogram_quantile(0.9, sum(rate(http_request_duration_seconds_bucket[10m])) by (job, le))" ->
-        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),List(),List(job, le),List()),HistogramQuantile,List(0.9))",
+        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,1000000,1524855988000,600000,Rate,List()),List(),List(job, le),List()),HistogramQuantile,List(0.9))",
       "http_requests_total" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000)",
       "http_requests_total ^ 5" ->
-        "ScalarVectorBinaryOperation(POW,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false)",
+        "ScalarVectorBinaryOperation(POW,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),false)",
 
       //FIXME Operator precedence is not implemented
       "10 + http_requests_total * 5" ->
-        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false),true)",
+        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),false),true)",
       "10 + (http_requests_total * 5)" ->
-        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false),true)",
+        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),false),true)",
       "(10 + http_requests_total) * 5" ->
-        "ScalarVectorBinaryOperation(MUL,5.0,ScalarVectorBinaryOperation(ADD,10.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),true),false)",
+        "ScalarVectorBinaryOperation(MUL,5.0,ScalarVectorBinaryOperation(ADD,10.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),true),false)",
       "topk(5, http_requests_total)" ->
-        "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(5.0),List(),List())",
+        "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(5.0),List(),List())",
       "irate(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Irate,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Irate,List())",
       "idelta(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Idelta,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Idelta,List())",
       "resets(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Resets,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Resets,List())",
       "deriv(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Deriv,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Deriv,List())",
       "rate(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Rate,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\"}[5m]" ->
         "RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List())",
       "http_requests_total offset 5m" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000)",
       "http_requests_total{environment=~\"staging|testing|development\",method!=\"GET\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(environment,EqualsRegex(staging|testing|development)), ColumnFilter(method,NotEquals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(environment,EqualsRegex(staging|testing|development)), ColumnFilter(method,NotEquals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000)",
       "method_code:http_errors:rate5m / ignoring(code) group_left method:http_requests:rate5m" ->
-        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),DIV,OneToMany,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),List(),List())",
+        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,1000000,1524855988000),DIV,OneToMany,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,1000000,1524855988000),List(),List())",
       "increase(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Increase,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Increase,List())",
       "sum(http_requests_total{method=\"GET\"} offset 5m)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(method,Equals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List())",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(method,Equals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(),List(),List())",
       "absent(nonexistent{job=\"myjob\",instance=~\".*\"})" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(instance,EqualsRegex(.*)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),Absent,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(instance,EqualsRegex(.*)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),Absent,List())",
       "absent(sum(nonexistent{job=\"myjob\"}))" ->
-        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List()),Absent,List())"
+        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),List(),List(),List()),Absent,List())"
     )
 
     val qts: Long = 1524855988L

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -245,83 +245,83 @@ class ParserSpec extends FunSpec with Matchers {
   it("Should be able to make logical plans for Series Expressions") {
     val queryToLpString = Map(
       "primary:instance-001:no.ofrequests{job=\"my-job\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(my-job)), ColumnFilter(__name__,Equals(primary:instance-001:no.ofrequests))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(my-job)), ColumnFilter(__name__,Equals(primary:instance-001:no.ofrequests))),List()),1524855988000,9223372036854775000,1524855988000)",
       "absent(nonexistent{job=\"myjob\"})" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),Absent,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),Absent,List())",
       "rate(http_requests_total[5m] offset 1w)" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Rate,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\",group=\"canary\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(group,Equals(canary)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(group,Equals(canary)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
       "http_requests_total{job=\"prometheus\",__col__=\"min\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(min)),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(min)),1524855988000,9223372036854775000,1524855988000)",
       // Internal FiloDB debug function
       "_filodb_chunkmeta_all(http_requests_total{job=\"prometheus\"})" ->
-        "RawChunkMeta(IntervalSelector(List(1524855988000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),)",
+        "RawChunkMeta(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),)",
       "_filodb_chunkmeta_all(http_requests_total{job=\"prometheus\",__col__=\"avg\"})" ->
-        "RawChunkMeta(IntervalSelector(List(1524855988000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),avg)",
+        "RawChunkMeta(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),avg)",
 
       "sum(http_requests_total) by (application, group)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(application, group),List())",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(application, group),List())",
       "sum(http_requests_total) without (instance)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List(instance))",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List(instance))",
       "count_values(\"version\", build_version)" ->
-        "Aggregate(CountValues,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(build_version))),List()),1524855988000,9223372036854775000,1524855988000),List(\"version\"),List(),List())",
+        "Aggregate(CountValues,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(build_version))),List()),1524855988000,9223372036854775000,1524855988000),List(\"version\"),List(),List())",
       "label_replace(up{job=\"api-server\",service=\"a:c\"}, \"foo\", \"$1\", \"service\", \"(.*):.*\")" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(service,Equals(a:c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,9223372036854775000,1524855988000),LabelReplace,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(service,Equals(a:c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,9223372036854775000,1524855988000),LabelReplace,List())",
       "sum(http_requests_total)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List())",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List())",
       "label_join(up{job=\"api-server\",src1=\"a\",src2=\"b\",src3=\"c\"}, \"foo\", \",\", \"src1\", \"src2\", \"src3\")" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(src1,Equals(a)), ColumnFilter(src2,Equals(b)), ColumnFilter(src3,Equals(c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,9223372036854775000,1524855988000),LabelJoin,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(src1,Equals(a)), ColumnFilter(src2,Equals(b)), ColumnFilter(src3,Equals(c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,9223372036854775000,1524855988000),LabelJoin,List())",
       "histogram_quantile(0.9, sum(rate(http_request_duration_seconds_bucket[10m])) by (le))" ->
-        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855388000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),List(),List(le),List()),HistogramQuantile,List(0.9))",
+        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),List(),List(le),List()),HistogramQuantile,List(0.9))",
       "delta(cpu_temp_celsius{host=\"zeus\"}[2h])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524848788000),List(1524855988000)),List(ColumnFilter(host,Equals(zeus)), ColumnFilter(__name__,Equals(cpu_temp_celsius))),List()),1524855988000,9223372036854775000,1524855988000,7200000,Delta,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524848788000,1524855988000),List(ColumnFilter(host,Equals(zeus)), ColumnFilter(__name__,Equals(cpu_temp_celsius))),List()),1524855988000,9223372036854775000,1524855988000,7200000,Delta,List())",
       "method_code:http_errors:rate5m{code=\"500\"} / ignoring(code) method:http_requests:rate5m" ->
-        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(code,Equals(500)), ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),DIV,OneToOne,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),List(),List())",
+        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(code,Equals(500)), ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),DIV,OneToOne,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),List(),List())",
       "histogram_quantile(0.9, rate(http_request_duration_seconds_bucket[10m]))" ->
-        "ApplyInstantFunction(PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855388000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),HistogramQuantile,List(0.9))",
+        "ApplyInstantFunction(PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),HistogramQuantile,List(0.9))",
       "histogram_quantile(0.9, sum(rate(http_request_duration_seconds_bucket[10m])) by (job, le))" ->
-        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855388000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),List(),List(job, le),List()),HistogramQuantile,List(0.9))",
+        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855388000,1524855988000),List(ColumnFilter(__name__,Equals(http_request_duration_seconds_bucket))),List()),1524855988000,9223372036854775000,1524855988000,600000,Rate,List()),List(),List(job, le),List()),HistogramQuantile,List(0.9))",
       "http_requests_total" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
       "http_requests_total ^ 5" ->
-        "ScalarVectorBinaryOperation(POW,5.0,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false)",
+        "ScalarVectorBinaryOperation(POW,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false)",
 
       //FIXME Operator precedence is not implemented
       "10 + http_requests_total * 5" ->
-        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false),true)",
+        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false),true)",
       "10 + (http_requests_total * 5)" ->
-        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false),true)",
+        "ScalarVectorBinaryOperation(ADD,10.0,ScalarVectorBinaryOperation(MUL,5.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),false),true)",
       "(10 + http_requests_total) * 5" ->
-        "ScalarVectorBinaryOperation(MUL,5.0,ScalarVectorBinaryOperation(ADD,10.0,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),true),false)",
+        "ScalarVectorBinaryOperation(MUL,5.0,ScalarVectorBinaryOperation(ADD,10.0,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),true),false)",
       "topk(5, http_requests_total)" ->
-        "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(5.0),List(),List())",
+        "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(5.0),List(),List())",
       "irate(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Irate,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Irate,List())",
       "idelta(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Idelta,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Idelta,List())",
       "resets(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Resets,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Resets,List())",
       "deriv(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Deriv,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Deriv,List())",
       "rate(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Rate,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\"}[5m]" ->
-        "RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List())",
+        "RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List())",
       "http_requests_total offset 5m" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
       "http_requests_total{environment=~\"staging|testing|development\",method!=\"GET\"}" ->
-        "PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(environment,EqualsRegex(staging|testing|development)), ColumnFilter(method,NotEquals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(environment,EqualsRegex(staging|testing|development)), ColumnFilter(method,NotEquals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000)",
       "method_code:http_errors:rate5m / ignoring(code) group_left method:http_requests:rate5m" ->
-        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),DIV,OneToMany,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),List(),List())",
+        "BinaryJoin(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method_code:http_errors:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),DIV,OneToMany,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(method:http_requests:rate5m))),List()),1524855988000,9223372036854775000,1524855988000),List(),List())",
       "increase(http_requests_total{job=\"api-server\"}[5m])" ->
-        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Increase,List())",
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000,300000,Increase,List())",
       "sum(http_requests_total{method=\"GET\"} offset 5m)" ->
-        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(method,Equals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List())",
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(method,Equals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List())",
       "absent(nonexistent{job=\"myjob\",instance=~\".*\"})" ->
-        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(instance,EqualsRegex(.*)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),Absent,List())",
+        "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(instance,EqualsRegex(.*)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),Absent,List())",
       "absent(sum(nonexistent{job=\"myjob\"}))" ->
-        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(List(1524855688000),List(1524855988000)),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List()),Absent,List())"
+        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,9223372036854775000,1524855988000),List(),List(),List()),Absent,List())"
     )
 
     val qts: Long = 1524855988L

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -26,7 +26,7 @@ case object AllChunksSelector extends RangeSelector
 case object WriteBufferSelector extends RangeSelector
 case object InMemoryChunksSelector extends RangeSelector
 case object EncodedChunksSelector extends RangeSelector
-case class IntervalSelector(from: Seq[Any], to: Seq[Any]) extends RangeSelector
+case class IntervalSelector(from: Long, to: Long) extends RangeSelector
 
 /**
   * Concrete logical plan to query for raw data in a given range

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -65,8 +65,8 @@ final case class BinaryJoinExec(id: String,
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map { resp =>
       require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
-      val lhsRvs = resp.filter(_._2 < lhs.size).map(_._1).flatten
-      val rhsRvs = resp.filter(_._2 >= lhs.size).map(_._1).flatten
+      val lhsRvs = resp.filter(_._2 < lhs.size).flatMap(_._1)
+      val rhsRvs = resp.filter(_._2 >= lhs.size).flatMap(_._1)
 
       // figure out which side is the "one" side
       val (oneSide, otherSide, lhsIsOneSide) =

--- a/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
@@ -2,19 +2,10 @@ package filodb.query.exec
 
 import monix.reactive.Observable
 
-import filodb.core.binaryrecord.BinaryRecord
 import filodb.core.metadata.Dataset
 import filodb.core.query._
 import filodb.query._
 import filodb.query.Query.qLogger
-
-sealed trait RowKeyRange
-
-case class RowKeyInterval(from: BinaryRecord, to: BinaryRecord) extends RowKeyRange
-case object AllChunks extends RowKeyRange
-case object WriteBuffers extends RowKeyRange
-case object InMemoryChunks extends RowKeyRange
-case object EncodedChunks extends RowKeyRange
 
 /**
   * Simply concatenate results from child ExecPlan objects
@@ -22,7 +13,7 @@ case object EncodedChunks extends RowKeyRange
 final case class DistConcatExec(id: String,
                                 dispatcher: PlanDispatcher,
                                 children: Seq[ExecPlan]) extends NonLeafExecPlan {
-  require(!children.isEmpty)
+  require(children.nonEmpty)
 
   protected def args: String = ""
 

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -31,7 +31,7 @@ case class HistogramQuantileMapper(funcParams: Seq[Any]) extends RangeVectorTran
     * @param le the less-than-equals boundary for histogram bucket
     * @param rate number of occurrences for the bucket per second
     */
-  case class Bucket(val le: Double, var rate: Double) {
+  case class Bucket(le: Double, var rate: Double) {
     override def toString: String = s"$le->$rate"
   }
 
@@ -75,7 +75,7 @@ case class HistogramQuantileMapper(funcParams: Seq[Any]) extends RangeVectorTran
           val row = new TransientRow()
           override def hasNext: Boolean = samples.forall(_.hasNext)
           override def next(): RowReader = {
-            for { i <- 0 until samples.length } {
+            for { i <- samples.indices } {
               val nxt = samples(i).next()
               buckets(i).rate = nxt.getDouble(1)
               row.timestamp = nxt.getLong(0)
@@ -115,7 +115,7 @@ case class HistogramQuantileMapper(funcParams: Seq[Any]) extends RangeVectorTran
     * Similar to prometheus implementation for consistent results.
     */
   private def histogramQuantile(q: Double, buckets: Array[Bucket]): Double = {
-    if (!buckets.last.le.isPosInfinity) return Double.NaN
+    if (!buckets.last.le.isPosInfinity) Double.NaN
     else {
       makeMonotonic(buckets)
       PromRateHistogram(buckets).quantile(q)

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -49,7 +49,7 @@ final case class PeriodicSamplesMapper(start: Long,
     // Generate one range function to check if it is chunked
     val sampleRangeFunc = rangeFuncGen()
     // Really, use the stale lookback window size, not 0 which doesn't make sense
-    val windowLength = window.getOrElse(if (functionId == None) queryConfig.staleSampleAfterMs else 0L)
+    val windowLength = window.getOrElse(if (functionId.isEmpty) queryConfig.staleSampleAfterMs else 0L)
 
     sampleRangeFunc match {
       case c: ChunkedRangeFunction[_] if valColType == ColumnType.HistogramColumn =>

--- a/query/src/main/scala/filodb/query/exec/RowKeyRange.scala
+++ b/query/src/main/scala/filodb/query/exec/RowKeyRange.scala
@@ -1,0 +1,12 @@
+package filodb.query.exec
+
+import filodb.core.binaryrecord.BinaryRecord
+
+sealed trait RowKeyRange
+
+case class RowKeyInterval(from: BinaryRecord, to: BinaryRecord) extends RowKeyRange
+case object AllChunks extends RowKeyRange
+case object WriteBuffers extends RowKeyRange
+case object InMemoryChunks extends RowKeyRange
+case object EncodedChunks extends RowKeyRange
+

--- a/query/src/main/scala/filodb/query/exec/StitchConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchConcatExec.scala
@@ -1,0 +1,85 @@
+package filodb.query.exec
+
+import scala.collection.mutable
+
+import monix.reactive.Observable
+
+import filodb.core.metadata.Dataset
+import filodb.core.query._
+import filodb.memory.format.RowReader
+import filodb.query._
+import filodb.query.Query.qLogger
+
+object StitchConcatExec {
+
+  def merge(vectors: Seq[Iterator[RowReader]]): Iterator[RowReader] = {
+    // This is an n-way merge without using a heap.
+    // Heap is not used since n is expected to be very small (almost always just 1 or 2)
+    new Iterator[RowReader] {
+      val bVectors = vectors.map(_.buffered)
+      val mins = new mutable.ArrayBuffer[BufferedIterator[RowReader]](2)
+      val noResult = new TransientRow(0, 0)
+      override def hasNext: Boolean = bVectors.exists(_.hasNext)
+
+      override def next(): RowReader = {
+        mins.clear()
+        var minT = Long.MaxValue
+        bVectors.foreach { r =>
+          if (r.hasNext) {
+            val t = r.head.getLong(0)
+            if (mins.size == 0) {
+              minT = t
+              mins += r
+            }
+            else if (t < minT) {
+              mins.clear()
+              mins += r
+              minT = t
+            } else if (t == minT) {
+              mins += r
+            }
+          }
+        }
+        if (mins.size == 1) mins.head.next()
+        else if (mins.isEmpty) throw new IllegalStateException("next was called when no element")
+        else {
+          mins.foreach(it => if (it.hasNext) it.next()) // move iterator forward
+          noResult.timestamp = minT
+          noResult.value = Double.NaN // until we have a different indicator for "unable-to-calculate" use NaN
+          noResult
+        }
+      }
+    }
+  }
+}
+
+/**
+  * Use when data for same time series spans multiple shards, or clusters.
+  */
+final case class StitchConcatExec(id: String,
+                                dispatcher: PlanDispatcher,
+                                children: Seq[ExecPlan]) extends NonLeafExecPlan {
+  require(children.nonEmpty)
+
+  protected def args: String = ""
+
+  protected def schemaOfCompose(dataset: Dataset): ResultSchema = children.head.schema(dataset)
+
+  protected def compose(childResponses: Observable[(QueryResponse, Int)],
+                        queryConfig: QueryConfig): Observable[RangeVector] = {
+    qLogger.debug(s"StitchConcatExec: Stitching results:")
+    val stitched = childResponses.map {
+      case (QueryResult(_, _, result), _) => result
+      case (QueryError(_, ex), _)         => throw ex
+    }.toListL.map(_.flatten).map { srvs =>
+      val groups = srvs.groupBy(_.key)
+      groups.mapValues { toMerge =>
+        val rows = StitchConcatExec.merge(toMerge.map(_.rows))
+        val key = toMerge.head.key
+        IteratorBackedRangeVector(key, rows)
+      }.values
+    }.map(Observable.fromIterable)
+    Observable.fromTask(stitched).flatten
+  }
+}
+

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -83,26 +83,26 @@ final case class StitchRvsExec(id: String,
   }
 }
 
-///**
-//  * Range Vector Transformer version of StitchRvsExec
-//  */
-//final case class StitchRvsMapper() extends RangeVectorTransformer {
-//
-//  def apply(source: Observable[RangeVector],
-//            queryConfig: QueryConfig,
-//            limit: Int,
-//            sourceSchema: ResultSchema): Observable[RangeVector] = {
-//    qLogger.debug(s"StitchRvsMapper: Stitching results:")
-//    val stitched = source.toListL.map { rvs =>
-//      val groups = rvs.groupBy(_.key)
-//      groups.mapValues { toMerge =>
-//        val rows = StitchRvsExec.merge(toMerge.map(_.rows))
-//        val key = toMerge.head.key
-//        IteratorBackedRangeVector(key, rows)
-//      }.values
-//    }.map(Observable.fromIterable)
-//    Observable.fromTask(stitched).flatten
-//  }
-//
-//  override protected[query] def args: String = ""
-//}
+/**
+  * Range Vector Transformer version of StitchRvsExec
+  */
+final case class StitchRvsMapper() extends RangeVectorTransformer {
+
+  def apply(source: Observable[RangeVector],
+            queryConfig: QueryConfig,
+            limit: Int,
+            sourceSchema: ResultSchema): Observable[RangeVector] = {
+    qLogger.debug(s"StitchRvsMapper: Stitching results:")
+    val stitched = source.toListL.map { rvs =>
+      val groups = rvs.groupBy(_.key)
+      groups.mapValues { toMerge =>
+        val rows = StitchRvsExec.merge(toMerge.map(_.rows))
+        val key = toMerge.head.key
+        IteratorBackedRangeVector(key, rows)
+      }.values
+    }.map(Observable.fromIterable)
+    Observable.fromTask(stitched).flatten
+  }
+
+  override protected[query] def args: String = ""
+}

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -23,19 +23,19 @@ object StitchRvsExec {
 
       override def next(): RowReader = {
         mins.clear()
-        var minT = Long.MaxValue
+        var minTime = Long.MaxValue
         bVectors.foreach { r =>
           if (r.hasNext) {
             val t = r.head.getLong(0)
             if (mins.size == 0) {
-              minT = t
+              minTime = t
               mins += r
             }
-            else if (t < minT) {
+            else if (t < minTime) {
               mins.clear()
               mins += r
-              minT = t
-            } else if (t == minT) {
+              minTime = t
+            } else if (t == minTime) {
               mins += r
             }
           }
@@ -44,7 +44,7 @@ object StitchRvsExec {
         else if (mins.isEmpty) throw new IllegalStateException("next was called when no element")
         else {
           mins.foreach(it => if (it.hasNext) it.next()) // move iterator forward
-          noResult.timestamp = minT
+          noResult.timestamp = minTime
           noResult.value = Double.NaN // until we have a different indicator for "unable-to-calculate" use NaN
           noResult
         }

--- a/query/src/test/scala/filodb/query/exec/StitchConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchConcatExecSpec.scala
@@ -1,0 +1,170 @@
+package filodb.query.exec
+
+import scala.annotation.tailrec
+
+import org.scalatest.{FunSpec, Matchers}
+
+// scalastyle:off null
+class StitchConcatExecSpec extends FunSpec with Matchers {
+  val error = 0.0000001d
+
+  it ("should merge with two overlapping RVs correctly") {
+    val rvs = Seq (
+      Seq(  (10L, 3d),
+            (20L, 3d),
+            (30L, 3d),
+            (40L, 3d),
+            (50L, 3d)
+      ),
+      Seq(  (30L, 4d),
+            (50L, 4d),
+            (60L, 3d),
+            (70L, 3d),
+            (80L, 3d),
+            (90L, 3d),
+            (100L, 3d)
+      )
+    )
+    val expected =
+      Seq(  (10L, 3d),
+            (20L, 3d),
+            (30L, Double.NaN),
+            (40L, 3d),
+            (50L, Double.NaN),
+            (60L, 3d),
+            (70L, 3d),
+            (80L, 3d),
+            (90L, 3d),
+            (100L, 3d)
+      )
+    mergeAndValidate(rvs, expected)
+  }
+
+  it ("should merge one RV correctly") {
+    val input =       Seq(  (10L, 3d),
+      (20L, 3d),
+      (30L, Double.NaN),
+      (40L, 3d),
+      (50L, Double.NaN),
+      (60L, 3d),
+      (70L, 3d),
+      (80L, 3d),
+      (90L, 3d),
+      (100L, 3d)
+    )
+    mergeAndValidate(Seq(input), input)
+  }
+  it ("should merge with three overlapping RVs correctly") {
+    val rvs = Seq (
+      Seq(  (10L, 3d),
+        (20L, 3d),
+        (30L, 3d),
+        (40L, 3d),
+        (50L, 3d)
+      ),
+      Seq(  (30L, 4d),
+        (50L, 4d),
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      ),
+      Seq(  (30L, 4d),
+        (55L, 3d)
+      )
+    )
+    val expected =
+      Seq(  (10L, 3d),
+        (20L, 3d),
+        (30L, Double.NaN),
+        (40L, 3d),
+        (50L, Double.NaN),
+        (55L, 3d),
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      )
+    mergeAndValidate(rvs, expected)
+  }
+
+
+  it ("should merge with no overlap correctly") {
+    val rvs = Seq (
+      Seq(
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      ),
+      Seq(  (10L, 3d),
+        (20L, 3d),
+        (30L, 3d),
+        (40L, 3d),
+        (50L, 3d)
+      )
+    )
+    val expected =
+      Seq(  (10L, 3d),
+        (20L, 3d),
+        (30L, 3d),
+        (40L, 3d),
+        (50L, 3d),
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      )
+    mergeAndValidate(rvs, expected)
+  }
+
+
+  it ("should merge with one empty rv correctly") {
+    val rvs = Seq (
+      Seq(
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      ),
+      Seq()
+    )
+    val expected =
+      Seq(
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      )
+    mergeAndValidate(rvs, expected)
+  }
+
+  def mergeAndValidate(rvs: Seq[Seq[(Long, Double)]], expected: Seq[(Long, Double)]): Unit = {
+    val inputSeq = rvs.map { rows => rows.iterator.map(r => new TransientRow(r._1, r._2)) }
+    val result = StitchConcatExec.merge(inputSeq).map(r => (r.getLong(0), r.getDouble(1)))
+    compareIter(result, expected.toIterator)
+  }
+
+  @tailrec
+  final private def compareIter(it1: Iterator[(Long, Double)], it2: Iterator[(Long, Double)]) : Unit = {
+    (it1.hasNext, it2.hasNext) match{
+      case (true, true) =>
+        val v1 = it1.next()
+        val v2 = it2.next()
+        v1._1 shouldEqual v2._1
+        if (v1._2.isNaN) v2._2.isNaN shouldEqual true
+        else Math.abs(v1._2-v2._2) should be < error
+        compareIter(it1, it2)
+      case (false, false) => Unit
+      case _ => fail("Unequal lengths")
+    }
+  }
+
+}
+

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -5,7 +5,7 @@ import scala.annotation.tailrec
 import org.scalatest.{FunSpec, Matchers}
 
 // scalastyle:off null
-class StitchConcatExecSpec extends FunSpec with Matchers {
+class StitchRvsExecSpec extends FunSpec with Matchers {
   val error = 0.0000001d
 
   it ("should merge with two overlapping RVs correctly") {
@@ -147,7 +147,7 @@ class StitchConcatExecSpec extends FunSpec with Matchers {
 
   def mergeAndValidate(rvs: Seq[Seq[(Long, Double)]], expected: Seq[(Long, Double)]): Unit = {
     val inputSeq = rvs.map { rows => rows.iterator.map(r => new TransientRow(r._1, r._2)) }
-    val result = StitchConcatExec.merge(inputSeq).map(r => (r.getLong(0), r.getDouble(1)))
+    val result = StitchRvsExec.merge(inputSeq).map(r => (r.getLong(0), r.getDouble(1)))
     compareIter(result, expected.toIterator)
   }
 

--- a/stress/src/main/scala/filodb.stress/MemStoreStress.scala
+++ b/stress/src/main/scala/filodb.stress/MemStoreStress.scala
@@ -68,7 +68,7 @@ object MemStoreStress extends App {
   // use observables (a stream of queries) to handle queries
   val startTime = DateTime.parse("2013-01-01T00Z").getMillis
   val endTime = DateTime.parse("2013-02-01T00Z").getMillis
-  val interval = IntervalSelector(Seq(startTime), Seq(endTime))
+  val interval = IntervalSelector(startTime, endTime)
   val ref = DatasetRef("nyc_taxi")
   var startMs = 0L
   var endMs = 0L


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
If spread for a namespace/application changes over time, and query spans the time when the spread changed, we get two range vectors with same key that could possibility overlap in time depending on how ingestion is done. This can cause incorrect query results, affects join functionality and aggregation, time window result calculation etc.

**New Expectations from Gateway**
1. Require that spread changes be scheduled by the gateway for a specific time in the future to prevent overlap of the same time series on two shards.
2. Require that gateway ingest NaN into old shard to prevent staleness feature that "holds" a value for five minutes and can produce wrong aggregations.

**New behavior :**
1. spreadFunc in QueryOptions now receives all changes in spread as opposed to the current value
2. Query Planner schedules the RV stitching prior to a join, and finally just before sending out final result. We return an NaN instead of a wrong result if overlap is seen during stitching.

**Known Limitations in this First Iteration Solution**
Time windows aka lookback windows in queries may now span multiple shards due to spread change. This involves a more detailed solution and is out of the scope of this PR. As a first solution, we rely on spread change to be scheduled at the 0th minute of the hour so that the time window spanning across shards are minimized. 

We will progressively fix these limitations in subsequent iterations. 

**BREAKING CHANGES**

Logical Plan and Query Engine changes require redeployment of components using them.