### PR TITLE
fix(core): option to disable new endMap() bulk hash calculation; preserve old PromInputRecord calc

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -325,10 +325,14 @@ final class RecordBuilder(memFactory: MemFactory,
 
   /**
    * Ends creation of a map field.  Recompute the hash for all fields at once.
+   * @param bulkHash if true (default), computes the hash for all key/values.
+   *                 Some users use the older alternate, sortAndComputeHashes() - then set this to false.
    */
-  final def endMap(): Unit = {
-    val mapHash = BinaryRegion.hash32(curBase, mapOffset, (curRecEndOffset - mapOffset).toInt)
-    updatePartitionHash(mapHash)
+  final def endMap(bulkHash: Boolean = true): Unit = {
+    if (bulkHash) {
+      val mapHash = BinaryRegion.hash32(curBase, mapOffset, (curRecEndOffset - mapOffset).toInt)
+      updatePartitionHash(mapHash)
+    }
     mapOffset = -1L
     fieldNo += 1
   }

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -79,7 +79,7 @@ case class PrometheusInputRecord(tags: Map[String, String],
       builder.addMapKeyValue(k.getBytes, v.getBytes)
       builder.updatePartitionHash(hashes(i))
     }
-    builder.endMap()
+    builder.endMap(bulkHash = false)
 
     builder.endRecord()
   }


### PR DESCRIPTION
…InputRecord preserves old hash calculation

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The recent end-to-end Histogram change changed the calculation of the hash inside a PartitionKey.  Namely, for map columns, instead of separately computing hashes for keys and values in a complex API, it greatly simplifies the API by calculating the hash just one time for maps.  This hash is used for comparing new incoming records against existing ones and other purposes.

**New behavior :**

Creates an option for endMap() to disable the one-time hash calculation if users want to use the old method of computing hashes.  The old method is preserved in the PrometheusInputRecord.