### PR TITLE
bug(query): fix bug in PeriodicSamplesMapper to include value present at time, timestamp - staleSampleAfterMs

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -49,7 +49,9 @@ final case class PeriodicSamplesMapper(start: Long,
     // Generate one range function to check if it is chunked
     val sampleRangeFunc = rangeFuncGen()
     // Really, use the stale lookback window size, not 0 which doesn't make sense
-    val windowLength = window.getOrElse(if (functionId.isEmpty) queryConfig.staleSampleAfterMs else 0L)
+    // Default value for window  should be queryConfig.staleSampleAfterMs + 1 for empty functionId,
+    // so that it returns value present at time - staleSampleAfterMs
+    val windowLength = window.getOrElse(if (functionId.isEmpty) queryConfig.staleSampleAfterMs + 1 else 0L)
 
     sampleRangeFunc match {
       case c: ChunkedRangeFunction[_] if valColType == ColumnType.HistogramColumn =>

--- a/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
@@ -1,0 +1,41 @@
+package filodb.query.exec
+
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
+import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+
+import filodb.core.MetricsTestData
+import filodb.core.query._
+import filodb.query._
+import filodb.query.exec.rangefn.RawDataWindowingSpec
+
+class PeriodicSamplesMapperSpec extends FunSpec with Matchers with ScalaFutures with RawDataWindowingSpec {
+
+  val resultSchema = ResultSchema(MetricsTestData.timeseriesDataset.infosFromIDs(0 to 1), 1)
+
+  val samples = Seq(
+    100000L -> 100d,
+    153000L -> 160d,
+    200000L -> 200d
+  )
+  val expectedResults = List(100000L -> 100d,
+    200000L -> 200d,
+    300000L -> 200d,
+    400000L -> 200d,
+    500000L -> 200d
+  )
+  val rv = timeValueRV(samples)
+
+  it("should return value present at time - staleSampleAfterMs") {
+
+    val periodicSamplesVectorFnMapper = exec.PeriodicSamplesMapper(100000L, 100000, 600000L, None, None)
+    val resultObs = periodicSamplesVectorFnMapper(Observable.fromIterable(Seq(rv)), queryConfig, 1000, resultSchema)
+
+    val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map
+    (r => (r.getLong(0), r.getDouble(1))).filter(!_._2.isNaN))
+
+    resultRows.foreach(_.toList shouldEqual expectedResults)
+
+  }
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Value present at time: timestamp - staleSampleAfterMs is not returned

**New behavior :**
Increase window by 1 to include value present at at time: timestamp - staleSampleAfterMs



