### PR TITLE
feat(query):Support for comparison operators

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Operators.scala
@@ -45,27 +45,27 @@ trait Operators {
   }
 
   case class NotEqual(isBool: Boolean) extends Comparision {
-    override def getPlanOperator: BinaryOperator = BinaryOperator.NEQ
+    override def getPlanOperator: BinaryOperator = if (!isBool) BinaryOperator.NEQ else BinaryOperator.NEQ_BOOL
   }
 
   case class Eq(isBool: Boolean) extends Comparision {
-    override def getPlanOperator: BinaryOperator = BinaryOperator.EQL
+    override def getPlanOperator: BinaryOperator = if (!isBool) BinaryOperator.EQL else BinaryOperator.EQL_BOOL
   }
 
   case class Gt(isBool: Boolean) extends Comparision {
-    override def getPlanOperator: BinaryOperator = BinaryOperator.GTR
+    override def getPlanOperator: BinaryOperator = if (!isBool) BinaryOperator.GTR else BinaryOperator.GTR_BOOL
   }
 
   case class Gte(isBool: Boolean) extends Comparision {
-    override def getPlanOperator: BinaryOperator = BinaryOperator.GTE
+    override def getPlanOperator: BinaryOperator = if (!isBool) BinaryOperator.GTE else BinaryOperator.GTE_BOOL
   }
 
   case class Lt(isBool: Boolean) extends Comparision {
-    override def getPlanOperator: BinaryOperator = BinaryOperator.LSS
+    override def getPlanOperator: BinaryOperator = if (!isBool) BinaryOperator.LSS else BinaryOperator.LSS_BOOL
   }
 
   case class Lte(isBool: Boolean) extends Comparision {
-    override def getPlanOperator: BinaryOperator = BinaryOperator.LTE
+    override def getPlanOperator: BinaryOperator = if (!isBool) BinaryOperator.LTE else BinaryOperator.LTE_BOOL
   }
 
   case class LabelMatch(label: String, labelMatchOp: Operator, value: String) extends PromToken

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -158,6 +158,18 @@ object BinaryOperator extends Enum[BinaryOperator] {
 
   case object GTR extends ComparisonOperator
 
+  case object EQL_BOOL extends ComparisonOperator
+
+  case object NEQ_BOOL extends ComparisonOperator
+
+  case object LTE_BOOL extends ComparisonOperator
+
+  case object LSS_BOOL extends ComparisonOperator
+
+  case object GTE_BOOL extends ComparisonOperator
+
+  case object GTR_BOOL extends ComparisonOperator
+
   case object EQLRegex extends BinaryOperator // FIXME when implemented
 
   case object NEQRegex extends BinaryOperator // FIXME when implemented

--- a/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
@@ -17,7 +17,7 @@ object BinaryOperatorFunction {
     */
   //noinspection ScalaStyle
   def factoryMethod(function: BinaryOperator): ScalarFunction = {
-   function match {
+    function match {
 
       case SUB                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = lhs - rhs }
       case ADD                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = lhs + rhs }

--- a/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
@@ -15,27 +15,28 @@ object BinaryOperatorFunction {
     * @param function to be invoked
     * @return the function
     */
+  //noinspection ScalaStyle
   def factoryMethod(function: BinaryOperator): ScalarFunction = {
-    function match {
+   function match {
 
-      case SUB                => new ScalarFunction {
-        override def calculate(lhs: Double, rhs: Double): Double = lhs - rhs
-      }
-      case ADD                => new ScalarFunction {
-        override def calculate(lhs: Double, rhs: Double): Double = lhs + rhs
-      }
-      case MUL                => new ScalarFunction {
-        override def calculate(lhs: Double, rhs: Double): Double = lhs * rhs
-      }
-      case MOD                => new ScalarFunction {
-        override def calculate(lhs: Double, rhs: Double): Double = lhs % rhs
-      }
-      case DIV                => new ScalarFunction {
-        override def calculate(lhs: Double, rhs: Double): Double = lhs / rhs
-      }
-      case POW                => new ScalarFunction {
-        override def calculate(lhs: Double, rhs: Double): Double = math.pow(lhs, rhs)
-      }
+      case SUB                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = lhs - rhs }
+      case ADD                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = lhs + rhs }
+      case MUL                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = lhs * rhs }
+      case MOD                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = lhs % rhs }
+      case DIV                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = lhs / rhs }
+      case POW                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = math.pow(lhs, rhs) }
+      case LSS                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs < rhs)  lhs else Double.NaN }
+      case LTE                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs <= rhs) lhs else Double.NaN }
+      case GTR                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs > rhs)  lhs else Double.NaN }
+      case GTE                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs >= rhs) lhs else Double.NaN }
+      case EQL                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs == rhs) lhs else Double.NaN }
+      case NEQ                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs != rhs) lhs else Double.NaN }
+      case LSS_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs < rhs)  1.0 else 0.0 }
+      case LTE_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs <= rhs) 1.0 else 0.0 }
+      case GTR_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs > rhs)  1.0 else 0.0 }
+      case GTE_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs >= rhs) 1.0 else 0.0 }
+      case EQL_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs == rhs) 1.0 else 0.0 }
+      case NEQ_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs != rhs) 1.0 else 0.0 }
       case _                  => throw new UnsupportedOperationException(s"$function not supported.")
     }
   }

--- a/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
@@ -15,7 +15,8 @@ object BinaryOperatorFunction {
     * @param function to be invoked
     * @return the function
     */
-  //noinspection ScalaStyle
+
+  // scalastyle:off
   def factoryMethod(function: BinaryOperator): ScalarFunction = {
     function match {
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
@@ -52,7 +52,7 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
       override def rows: Iterator[RowReader] = data.iterator
     })
     fireBinaryOperatorTests(samples)
-    fireCompatorOperatorTests(samples)
+    fireComparatorOperatorTests(samples)
 
   }
 
@@ -81,7 +81,7 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
       }
     )
     fireBinaryOperatorTests(samples)
-    fireCompatorOperatorTests(samples)
+    fireComparatorOperatorTests(samples)
 
   }
 
@@ -104,7 +104,7 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
       }
     )
     fireBinaryOperatorTests(samples)
-    fireCompatorOperatorTests(samples)
+    fireComparatorOperatorTests(samples)
   }
 
   private def fireBinaryOperatorTests(samples: Array[RangeVector]): Unit = {
@@ -159,7 +159,7 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
 
   }
 
-  private def fireCompatorOperatorTests(samples: Array[RangeVector]): Unit = {
+  private def fireComparatorOperatorTests(samples: Array[RangeVector]): Unit = {
 
     // GTE - prefix
     val expectedGTE = samples.map(_.rows.map(v => if (scalar >= v.getDouble(1)) scalar else Double.NaN))

--- a/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
@@ -210,20 +210,6 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
     applyBinaryOperationAndAssertResult(samples, expectedNEQ_BOOL, BinaryOperator.NEQ_BOOL, scalar, true)
   }
 
-
-//    it ("should handle unknown functions") {
-//    // sort_desc
-//    the[UnsupportedOperationException] thrownBy {
-//      val binaryOpMapper = exec.ScalarOperationMapper(BinaryOperator.EQL, 10, true)
-//      binaryOpMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
-//    } should have message "EQL not supported."
-//
-//    the[UnsupportedOperationException] thrownBy {
-//      val binaryOpMapper = exec.ScalarOperationMapper(BinaryOperator.GTE, 10, false)
-//      binaryOpMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
-//    } should have message "GTE not supported."
-//  }
-
   it ("should fail with wrong calculation") {
     // ceil
     val expectedVal = sampleBase.map(_.rows.map(v => scala.math.floor(v.getDouble(1))))

--- a/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
@@ -52,6 +52,8 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
       override def rows: Iterator[RowReader] = data.iterator
     })
     fireBinaryOperatorTests(samples)
+    fireCompatorOperatorTests(samples)
+
   }
 
   it ("should handle NaN") {
@@ -79,6 +81,8 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
       }
     )
     fireBinaryOperatorTests(samples)
+    fireCompatorOperatorTests(samples)
+
   }
 
   it ("should handle special cases") {
@@ -100,6 +104,7 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
       }
     )
     fireBinaryOperatorTests(samples)
+    fireCompatorOperatorTests(samples)
   }
 
   private def fireBinaryOperatorTests(samples: Array[RangeVector]): Unit = {
@@ -151,20 +156,73 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
     // power - suffix
     val expectedPow2 = samples.map(_.rows.map(v => math.pow(v.getDouble(1), scalar)))
     applyBinaryOperationAndAssertResult(samples, expectedPow2, BinaryOperator.POW, scalar, false)
+
   }
 
-  it ("should handle unknown functions") {
-    // sort_desc
-    the[UnsupportedOperationException] thrownBy {
-      val binaryOpMapper = exec.ScalarOperationMapper(BinaryOperator.EQL, 10, true)
-      binaryOpMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
-    } should have message "EQL not supported."
+  private def fireCompatorOperatorTests(samples: Array[RangeVector]): Unit = {
 
-    the[UnsupportedOperationException] thrownBy {
-      val binaryOpMapper = exec.ScalarOperationMapper(BinaryOperator.GTE, 10, false)
-      binaryOpMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
-    } should have message "GTE not supported."
+    // GTE - prefix
+    val expectedGTE = samples.map(_.rows.map(v => if (scalar >= v.getDouble(1)) scalar else Double.NaN))
+    applyBinaryOperationAndAssertResult(samples, expectedGTE, BinaryOperator.GTE, scalar, true)
+
+    // GTR - prefix
+    val expectedGTR = samples.map(_.rows.map(v => if (scalar > v.getDouble(1)) scalar else Double.NaN))
+    applyBinaryOperationAndAssertResult(samples, expectedGTR, BinaryOperator.GTR, scalar, true)
+
+    // LTE - prefix
+    val expectedLTE = samples.map(_.rows.map(v => if (scalar <= v.getDouble(1)) scalar else Double.NaN))
+    applyBinaryOperationAndAssertResult(samples, expectedLTE, BinaryOperator.LTE, scalar, true)
+
+    // LTR - prefix
+    val expectedLTR = samples.map(_.rows.map(v => if (scalar < v.getDouble(1)) scalar else Double.NaN))
+    applyBinaryOperationAndAssertResult(samples, expectedLTR, BinaryOperator.LSS, scalar, true)
+
+    // EQL - prefix
+    val expectedEQL = samples.map(_.rows.map(v => if (scalar == v.getDouble(1)) scalar else Double.NaN))
+    applyBinaryOperationAndAssertResult(samples, expectedEQL, BinaryOperator.EQL, scalar, true)
+
+    // NEQ - prefix
+    val expectedNEQ = samples.map(_.rows.map(v => if (scalar != v.getDouble(1)) scalar else Double.NaN))
+    applyBinaryOperationAndAssertResult(samples, expectedNEQ, BinaryOperator.NEQ, scalar, true)
+
+    // GTE_BOOL - prefix
+    val expectedGTE_BOOL = samples.map(_.rows.map(v => if (scalar >= v.getDouble(1)) 1.0 else 0.0))
+    applyBinaryOperationAndAssertResult(samples, expectedGTE_BOOL, BinaryOperator.GTE_BOOL, scalar, true)
+
+    // GTR_BOOL - prefix
+    val expectedGTR_BOOL = samples.map(_.rows.map(v => if (scalar > v.getDouble(1))  1.0 else 0.0))
+    applyBinaryOperationAndAssertResult(samples, expectedGTR_BOOL, BinaryOperator.GTR_BOOL, scalar, true)
+
+    // LTE_BOOL - prefix
+    val expectedLTE_BOOL = samples.map(_.rows.map(v => if (scalar <= v.getDouble(1))  1.0 else 0.0))
+    applyBinaryOperationAndAssertResult(samples, expectedLTE_BOOL, BinaryOperator.LTE_BOOL, scalar, true)
+
+    // LTR_BOOL - prefix
+    val expectedLTR_BOOL = samples.map(_.rows.map(v => if (scalar < v.getDouble(1))  1.0 else 0.0))
+    applyBinaryOperationAndAssertResult(samples, expectedLTR_BOOL, BinaryOperator.LSS_BOOL, scalar, true)
+
+    // EQL_BOOL - prefix
+    val expectedEQL_BOOL = samples.map(_.rows.map(v => if (scalar == v.getDouble(1))  1.0 else 0.0))
+    applyBinaryOperationAndAssertResult(samples, expectedEQL_BOOL, BinaryOperator.EQL_BOOL, scalar, true)
+
+    // NEQ_BOOL - prefix
+    val expectedNEQ_BOOL = samples.map(_.rows.map(v => if (scalar != v.getDouble(1))  1.0 else 0.0))
+    applyBinaryOperationAndAssertResult(samples, expectedNEQ_BOOL, BinaryOperator.NEQ_BOOL, scalar, true)
   }
+
+
+//    it ("should handle unknown functions") {
+//    // sort_desc
+//    the[UnsupportedOperationException] thrownBy {
+//      val binaryOpMapper = exec.ScalarOperationMapper(BinaryOperator.EQL, 10, true)
+//      binaryOpMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+//    } should have message "EQL not supported."
+//
+//    the[UnsupportedOperationException] thrownBy {
+//      val binaryOpMapper = exec.ScalarOperationMapper(BinaryOperator.GTE, 10, false)
+//      binaryOpMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+//    } should have message "GTE not supported."
+//  }
 
   it ("should fail with wrong calculation") {
     // ceil


### PR DESCRIPTION
- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?

Support for comparison operators. 

It allows comparisons between 
1. Two vectors
 [sum(sum_over_time(my_gauge{_ns=\"AppName\"}[5m]))   > sum(count_over_time(my_gauge{_ns=\"AppName\"}[5m]))]
2. Scalar and Vector 
[sum(sum_over_time(my_gauge{_ns=\"AppName\"}[5m])) > 10))

Also support for the bool modifier 
[sum(sum_over_time(my_gauge{_ns=\"AppName\"}[5m]))  > bool 10