### PR TITLE
feat(query): Include partId in query result on verbose option

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/client/FiloKryoSerializers.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/FiloKryoSerializers.scala
@@ -63,7 +63,7 @@ class PartitionRangeVectorKeySerializer extends KryoSerializer[PartitionRangeVec
     val schema = kryo.readObject(input, classOf[RecordSchema2])
     val keyCols = kryo.readClassAndObject(input)
     PartitionRangeVectorKey(partBytes, UnsafeUtils.arayOffset,
-      schema, keyCols.asInstanceOf[Seq[ColumnInfo]], input.readInt, input.readInt)
+      schema, keyCols.asInstanceOf[Seq[ColumnInfo]], input.readInt, input.readInt, input.readInt)
   }
 
   override def write(kryo: Kryo, output: Output, key: PartitionRangeVectorKey): Unit = {
@@ -72,6 +72,7 @@ class PartitionRangeVectorKeySerializer extends KryoSerializer[PartitionRangeVec
     kryo.writeClassAndObject(output, key.partKeyCols)
     output.writeInt(key.sourceShard)
     output.writeInt(key.groupNum)
+    output.writeInt(key.partId)
   }
 }
 

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -136,7 +136,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
 
     // scalastyle:off null
     val rvKey = new PartitionRangeVectorKey(null, defaultPartKey, dataset1.partKeySchema,
-                                            Seq(ColumnInfo("string", ColumnType.StringColumn)), 1, 5)
+                                            Seq(ColumnInfo("string", ColumnType.StringColumn)), 1, 5, 100)
 
     val rowbuf = tuples.map { t =>
       new SeqRowReader(Seq[Any](t._1, t._2))

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1063,6 +1063,7 @@ class TimeSeriesShard(val dataset: Dataset,
             if (endTime == PartKeyLuceneIndex.NOT_FOUND || endTime == Long.MaxValue) {
               logger.warn(s"endTime ${endTime} was not correct. how?", new IllegalStateException())
             } else {
+              logger.debug(s"Evicting partId=${partitionObj.partID} from dataset=${dataset.ref} shard=$shardNum")
               removePartition(partitionObj)
               partsRemoved += 1
               maxEndTime = Math.max(maxEndTime, endTime)

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -21,6 +21,7 @@ import filodb.memory.format.{RowReader, ZeroCopyUTF8String => UTF8Str}
 trait RangeVectorKey extends java.io.Serializable {
   def labelValues: Map[UTF8Str, UTF8Str]
   def sourceShards: Seq[Int]
+  def partIds: Seq[Int]
   override def toString: String = s"/shard:${sourceShards.mkString(",")}/$labelValues"
 }
 
@@ -41,8 +42,10 @@ final case class PartitionRangeVectorKey(partBase: Array[Byte],
                                          partSchema: RecordSchema,
                                          partKeyCols: Seq[ColumnInfo],
                                          sourceShard: Int,
-                                         groupNum: Int) extends RangeVectorKey {
+                                         groupNum: Int,
+                                         partId: Int) extends RangeVectorKey {
   override def sourceShards: Seq[Int] = Seq(sourceShard)
+  override def partIds: Seq[Int] = Seq(partId)
   def labelValues: Map[UTF8Str, UTF8Str] = {
     partKeyCols.zipWithIndex.flatMap { case (c, pos) =>
       c.colType match {
@@ -59,7 +62,9 @@ final case class PartitionRangeVectorKey(partBase: Array[Byte],
   override def toString: String = s"/shard:$sourceShard/${partSchema.stringify(partBase, partOffset)} [grp$groupNum]"
 }
 
-final case class CustomRangeVectorKey(labelValues: Map[UTF8Str, UTF8Str], sourceShards: Seq[Int] = Nil)
+final case class CustomRangeVectorKey(labelValues: Map[UTF8Str, UTF8Str],
+                                      sourceShards: Seq[Int] = Nil,
+                                      partIds: Seq[Int] = Nil)
   extends RangeVectorKey {
 }
 

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -109,7 +109,8 @@ trait ChunkSource extends RawChunkSource {
         val subgroup = TimeSeriesShard.partKeyGroup(dataset.partKeySchema, partition.partKeyBase,
                                                     partition.partKeyOffset, numGroups)
         val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,
-                                              dataset.partKeySchema, partCols, partition.shard, subgroup)
+                                              dataset.partKeySchema, partCols, partition.shard,
+                                              subgroup, partition.partID)
         RawDataRangeVector(key, partition, chunkMethod, ids)
       }
   }

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -18,7 +18,8 @@ class RangeVectorSpec  extends FunSpec with Matchers {
     }.iterator
     override def key: RangeVectorKey = new RangeVectorKey {
       def labelValues: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = Map.empty
-      def sourceShards: Seq[Int] = Seq(0)
+      def sourceShards: Seq[Int] = Nil
+      def partIds: Seq[Int] = Nil
     }
   }
 

--- a/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
+++ b/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
@@ -39,9 +39,10 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
     // [Range Queries](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries)
     path( "api" / "v1" / "query_range") {
       get {
-        parameter('query.as[String], 'start.as[Double], 'end.as[Double], 'step.as[Int]) { (query, start, end, step) =>
+        parameter('query.as[String], 'start.as[Double], 'end.as[Double],
+                  'step.as[Int], 'verbose.as[Boolean].?) { (query, start, end, step, verbose) =>
           val logicalPlan = Parser.queryRangeToLogicalPlan(query, TimeStepParams(start.toLong, step, end.toLong))
-          askQueryAndRespond(dataset, logicalPlan)
+          askQueryAndRespond(dataset, logicalPlan, verbose.getOrElse(false))
         }
       }
     } ~
@@ -51,9 +52,9 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
     // [Instant Queries](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries)
     path( "api" / "v1" / "query") {
       get {
-        parameter('query.as[String], 'time.as[Double]) { (query, time) =>
+        parameter('query.as[String], 'time.as[Double], 'verbose.as[Boolean].?) { (query, time, verbose) =>
           val logicalPlan = Parser.queryToLogicalPlan(query, time.toLong)
-          askQueryAndRespond(dataset, logicalPlan)
+          askQueryAndRespond(dataset, logicalPlan, verbose.getOrElse(false))
         }
       }
     } ~
@@ -99,10 +100,10 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
     }
   }
 
-  private def askQueryAndRespond(dataset: String, logicalPlan: LogicalPlan) = {
+  private def askQueryAndRespond(dataset: String, logicalPlan: LogicalPlan, verbose: Boolean) = {
     val command = LogicalPlan2Query(DatasetRef.fromDotString(dataset), logicalPlan, queryOptions)
     onSuccess(asyncAsk(nodeCoord, command)) {
-      case qr: QueryResult => complete(toPromSuccessResponse(qr))
+      case qr: QueryResult => complete(toPromSuccessResponse(qr, verbose))
       case qr: QueryError => complete(toPromErrorResponse(qr))
       case UnknownDataset => complete(Codes.NotFound ->
         ErrorResponse("badQuery", s"Dataset $dataset is not registered"))

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -93,8 +93,9 @@ object PrometheusModel {
     */
   def toPromResult(srv: SerializableRangeVector, verbose: Boolean): Result = {
     val tags = srv.key.labelValues.map { case (k, v) => (k.toString, v.toString)} ++
-                (if (verbose) Map("shards" -> srv.key.sourceShards.toString(), "partIds" -> srv.key.partIds.toString())
-                else Map())
+                (if (verbose) Map("_shards_" -> srv.key.sourceShards.mkString(","),
+                                  "_partIds_" -> srv.key.partIds.mkString(","))
+                else Map.empty)
 
     Result(tags,
       // remove NaN in HTTP results

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -68,7 +68,7 @@ final case class SelectChunkInfosExec(id: String,
             val subgroup = TimeSeriesShard.partKeyGroup(dataset.partKeySchema, partition.partKeyBase,
                                                         partition.partKeyOffset, numGroups)
             val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,
-                                                  dataset.partKeySchema, partCols, shard, subgroup)
+                                                  dataset.partKeySchema, partCols, shard, subgroup, partition.partID)
             ChunkInfoRangeVector(key, partition, chunkMethod, dataColumn)
           }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Only shard number is included in result range vector

**New behavior :**

if "verbose" option is enabled as query parameter 
* partId is included in range vector result
* partId and shardNum is included 
