### PR TITLE
feat(core): Add key=value optional parameters to each Column definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ FiloDB is designed to scale to ingest and query millions of discrete time series
 
 The **partition key** differentiates time series and also controls distribution of time series across the cluster.  For more information on sharding, see the sharding section below.  Components of a partition key, including individual key/values of `MapColumn`s, are indexed and used for filtering in queries.
 
+The data points use a configurable schema consisting of multiple columns.  Each column definition consists of `name:columntype`, with optional parameters. For examples, see the examples below, or see the introductory walk-through above where two datasets are created.
+
 ### Prometheus FiloDB Schema for Operational Metrics
 
 * Partition key = `tags:map`

--- a/core/src/main/scala/filodb.core/metadata/Column.scala
+++ b/core/src/main/scala/filodb.core/metadata/Column.scala
@@ -1,7 +1,9 @@
 package filodb.core.metadata
 
 import scala.reflect.ClassTag
+import scala.util.Try
 
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import enumeratum.{Enum, EnumEntry}
 import org.scalactic._
@@ -20,6 +22,7 @@ trait Column {
   def name: String
   def columnType: Column.ColumnType
   def extractor: TypedFieldExtractor[_]
+  def params: Config
 
   // More type safe than just using ==, if we ever change the type of ColumnId
   // TODO(velvia): remove this and just use id
@@ -31,12 +34,17 @@ trait Column {
  */
 case class DataColumn(id: Int,
                       name: String,
-                      columnType: Column.ColumnType) extends Column {
+                      columnType: Column.ColumnType,
+                      params: Config = ConfigFactory.empty) extends Column {
+  import collection.JavaConverters._
+
   // Use this for efficient serialization over the wire.
   // We leave out the dataset because that is almost always inferred from context.
   // NOTE: this is one reason why column names cannot have commas
-  override def toString: String =
-    s"[$id,$name,$columnType]"
+  override def toString: String = {
+    val paramStrs = params.entrySet.asScala.map { e => s"${e.getKey}=${e.getValue.render}" }
+    (Seq(id, name, columnType).map(_.toString) ++ paramStrs).mkString("[", ",", "]")
+  }
 
   def extractor: TypedFieldExtractor[_] = columnType.keyType.extractor
 }
@@ -47,7 +55,8 @@ object DataColumn {
    */
   def fromString(str: String): DataColumn = {
     val parts = str.drop(1).dropRight(1).split(',')
-    DataColumn(parts(0).toInt, parts(1), Column.ColumnType.withName(parts(2)))
+    val params = ConfigFactory.parseString(parts.drop(3).mkString("\n"))
+    DataColumn(parts(0).toInt, parts(1), Column.ColumnType.withName(parts(2)), params)
   }
 }
 
@@ -92,7 +101,7 @@ object Column extends StrictLogging {
    */
   def columnsToKeyType(columns: Seq[Column]): KeyType = columns match {
     case Nil      => throw new IllegalArgumentException("Empty columns supplied")
-    case Seq(DataColumn(_, _, columnType))  => columnType.keyType
+    case Seq(DataColumn(_, _, columnType, _)         )  => columnType.keyType
     case Seq(ComputedColumn(_, _, _, columnType, _, _)) => columnType.keyType
     case cols: Seq[Column] =>
       val keyTypes = cols.map { col => columnsToKeyType(Seq(col)).asInstanceOf[SingleKeyType] }
@@ -103,7 +112,7 @@ object Column extends StrictLogging {
    * Converts a list of data columns to Filo VectorInfos for building Filo vectors
    */
   def toFiloSchema(columns: Seq[Column]): Seq[VectorInfo] = columns.collect {
-    case DataColumn(_, name, colType) => VectorInfo(name, colType.clazz)
+    case DataColumn(_, name, colType, _) => VectorInfo(name, colType.clazz)
   }
 
   import OptionSugar._
@@ -126,24 +135,27 @@ object Column extends StrictLogging {
    * @param nextId the next column ID to use
    * @return Good(DataColumn) or Bad(BadSchema)
    */
-  def validateColumn(name: String, typeName: String, nextId: Int): DataColumn Or One[BadSchema] =
+  def validateColumn(name: String, typeName: String, nextId: Int, params: Config): DataColumn Or One[BadSchema] =
     for { nothing <- validateColumnName(name)
           colType <- typeNameToColType.get(typeName).toOr(One(BadColumnType(typeName))) }
-    yield { DataColumn(nextId, name, colType) }
+    yield { DataColumn(nextId, name, colType, params) }
 
   import Accumulation._
+  import TrySugar._
 
   /**
-   * Creates and validates a set of DataColumns from a list of "columnName:columnType" strings
-   * @param nameTypeList a Seq of "columnName:columnType" strings. Valid types are in ColumnType
+   * Creates and validates a set of DataColumns from a list of "columnName:columnType:params" strings
+   * @param nameTypeList a Seq of "columnName:columnType:params" strings. Valid types are in ColumnType
    * @param startingId   column IDs are assigned starting with startingId incrementally
    */
   def makeColumnsFromNameTypeList(nameTypeList: Seq[String], startingId: Int = 0): Seq[Column] Or BadSchema =
     nameTypeList.zipWithIndex.map { case (nameType, idx) =>
       val parts = nameType.split(':')
-      for { nameAndType <- if (parts.size == 2) Good((parts(0), parts(1))) else Bad(One(NotNameColonType(nameType)))
+      for { nameAndType <- if (parts.size >= 2) Good((parts(0), parts(1))) else Bad(One(NotNameColonType(nameType)))
+            params      <- Try(ConfigFactory.parseString(parts.drop(2).mkString("\n"))).toOr
+                                            .badMap(x => One(BadColumnParams(x.toString)))
             (name, colType) = nameAndType
-            col         <- validateColumn(name, colType, startingId + idx) }
+            col         <- validateColumn(name, colType, startingId + idx, params) }
       yield { col }
     }.combined.badMap { errs => ColumnErrors(errs.toSeq) }
 }

--- a/core/src/main/scala/filodb.core/metadata/ComputedColumn.scala
+++ b/core/src/main/scala/filodb.core/metadata/ComputedColumn.scala
@@ -2,6 +2,7 @@ package filodb.core.metadata
 
 import scala.language.existentials
 
+import com.typesafe.config.Config
 import org.scalactic._
 
 import filodb.core.KeyType
@@ -17,6 +18,7 @@ case class ComputedColumn(id: Int,
                           sourceIndices: Seq[Int],    // index into schema of source column
                           val extractor: TypedFieldExtractor[_]) extends Column {
   def name: String = expr
+  def params: Config = ???
 }
 
 object ComputedColumn {

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -256,6 +256,7 @@ object Dataset {
   case class BadColumnType(colType: String) extends BadSchema
   case class BadColumnName(colName: String, reason: String) extends BadSchema
   case class NotNameColonType(nameTypeString: String) extends BadSchema
+  case class BadColumnParams(msg: String) extends BadSchema
   case class ColumnErrors(errs: Seq[BadSchema]) extends BadSchema
   case class UnknownRowKeyColumn(keyColumn: String) extends BadSchema
   case class IllegalMapColumn(reason: String) extends BadSchema
@@ -328,8 +329,8 @@ object Dataset {
   /**
    * Creates and validates a new Dataset
    * @param name The name of the dataset
-   * @param partitionColNameTypes list of partition columns in name:type form
-   * @param dataColNameTypes list of data columns in name:type form
+   * @param partitionColNameTypes list of partition columns in name:type[:params] form
+   * @param dataColNameTypes list of data columns in name:type[:params] form
    * @param keyColumnNames   the key column names, no :type
    * @return Good(Dataset) or Bad(BadSchema)
    */

--- a/core/src/main/scala/filodb.core/query/KeyFilter.scala
+++ b/core/src/main/scala/filodb.core/query/KeyFilter.scala
@@ -84,7 +84,7 @@ object KeyFilter {
   def mapColumns(columns: Seq[Column],
                  columnNames: Seq[String]): Map[String, (Int, Column)] = {
     columns.zipWithIndex.collect {
-      case d @ (DataColumn(_, name, _), idx)           => name -> (idx -> d._1)
+      case d @ (DataColumn(_, name, _, _), idx)           => name -> (idx -> d._1)
     }.toMap.filterKeys { name => columnNames.contains(name) }
   }
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -297,7 +297,7 @@ object MachineMetricsData {
   val extraTagsLen = extraTags.map { case (k, v) => k.numBytes + v.numBytes }.sum
 
   val histDataset = Dataset("histogram", Seq("tags:map"),
-                            Seq("timestamp:ts", "count:long", "sum:long", "h:hist"))
+                            Seq("timestamp:ts", "count:long", "sum:long", "h:hist:counter=false"))
 
   var histBucketScheme: bv.HistogramBuckets = _
   def linearHistSeries(startTs: Long = 100000L, numSeries: Int = 10, timeStep: Int = 1000, numBuckets: Int = 8):

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -57,7 +57,7 @@ object TestData {
 object NamesTestData {
   def mapper(rows: Seq[Product]): Seq[RowReader] = rows.map(TupleRowReader)
 
-  val dataColSpecs = Seq("first:string", "last:string", "age:long")
+  val dataColSpecs = Seq("first:string", "last:string", "age:long:interval=10")
   val dataset = Dataset("dataset", Seq("seg:int"), dataColSpecs, "age")
 
   // NOTE: first 3 columns are the data columns, thus names could be used for either complete record

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -26,7 +26,7 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
 
   val customDataset = Dataset.make("custom2",
     Seq("name:string", "namespace:string", "instance:string"),
-    Seq("timestamp:ts", "count:double", "min:double", "max:double", "total:double", "avg:double", "h:hist"),
+    Seq("timestamp:ts", "count:double", "min:double", "max:double", "total:double", "avg:double", "h:hist:counter=false"),
     Seq("timestamp"),
     Seq("tTime(0)", "dSum(1)", "dMin(2)", "dMax(3)", "dSum(4)", "dAvgAc(5@1)", "hSum(6)"),
     DatasetOptions(Seq("name", "namespace"), "name", "total")).get

--- a/core/src/test/scala/filodb.core/metadata/ColumnSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/ColumnSpec.scala
@@ -1,5 +1,7 @@
 package filodb.core.metadata
 
+import com.typesafe.config.ConfigFactory
+
 import org.scalatest.{FunSpec, Matchers}
 
 class ColumnSpec extends FunSpec with Matchers {
@@ -8,6 +10,10 @@ class ColumnSpec extends FunSpec with Matchers {
 
   val firstColumn = DataColumn(0, "first", ColumnType.StringColumn)
   val ageColumn = DataColumn(2, "age", ColumnType.IntColumn)
+  val histColumnOpts = DataColumn(3, "hist", ColumnType.HistogramColumn,
+                                  ConfigFactory.parseString("counter = true"))
+  val histColumn2 = DataColumn(4, "h2", ColumnType.HistogramColumn,
+                               ConfigFactory.parseString("counter = true\nsize=20000"))
 
   describe("Column validations") {
     it("should check that regular column names don't have : in front") {
@@ -33,6 +39,8 @@ class ColumnSpec extends FunSpec with Matchers {
     it("should serialize and deserialize properly") {
       DataColumn.fromString(firstColumn.toString) should equal (firstColumn)
       DataColumn.fromString(ageColumn.toString) should equal (ageColumn)
+      DataColumn.fromString(histColumnOpts.toString) should equal (histColumnOpts)
+      DataColumn.fromString(histColumn2.toString) should equal (histColumn2)
     }
   }
 }

--- a/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
@@ -21,6 +21,15 @@ class DatasetSpec extends FunSpec with Matchers {
       }
     }
 
+    it("should return BadColumnParams if name:type:params portion not valid key=value pairs") {
+      val resp1 = Dataset.make("dataset", Seq("part:string"), dataColSpecs :+ "column2:a:b", Seq("age"))
+      resp1.isBad shouldEqual true
+      resp1.swap.get shouldBe a[ColumnErrors]
+      val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
+      errors should have length 1
+      errors.head shouldBe a[BadColumnParams]
+    }
+
     it("should return BadColumnName if illegal chars in column name") {
       val resp1 = Dataset.make("dataset", Seq("part:string"), Seq("col, umn1:string"), Seq("age"))
       resp1.isBad shouldEqual true

--- a/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
@@ -30,6 +30,22 @@ class DatasetSpec extends FunSpec with Matchers {
       errors.head shouldBe a[BadColumnParams]
     }
 
+    it("should return BadColumnParams if required param config not specified") {
+      val resp1 = Dataset.make("dataset", Seq("part:string"), dataColSpecs :+ "h:hist:foo=bar", Seq("age"))
+      resp1.isBad shouldEqual true
+      resp1.swap.get shouldBe a[ColumnErrors]
+      val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
+      errors should have length 1
+      errors.head shouldBe a[BadColumnParams]
+
+      val resp2 = Dataset.make("dataset", Seq("part:string"), dataColSpecs :+ "h:hist:counter=bar", Seq("age"))
+      resp2.isBad shouldEqual true
+      resp2.swap.get shouldBe a[ColumnErrors]
+      val errors2 = resp2.swap.get.asInstanceOf[ColumnErrors].errs
+      errors2 should have length 1
+      errors2.head shouldBe a[BadColumnParams]
+    }
+
     it("should return BadColumnName if illegal chars in column name") {
       val resp1 = Dataset.make("dataset", Seq("part:string"), Seq("col, umn1:string"), Seq("age"))
       resp1.isBad shouldEqual true

--- a/spark/src/main/scala/filodb.spark/TypeConverters.scala
+++ b/spark/src/main/scala/filodb.spark/TypeConverters.scala
@@ -14,7 +14,7 @@ object TypeConverters {
   )
 
   def columnsToSqlFields(columns: Seq[Column]): Seq[StructField] =
-    columns.map { case DataColumn(_, name, colType) =>
+    columns.map { case DataColumn(_, name, colType, _) =>
       StructField(name, colTypeToSqlType(colType), true)
     }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, the only way to distinguish different columns besides the name is the columnType attribute.  There is no way to annotate, for example, if a DoubleColumn is a counter or a gauge.

**New behavior :**

This PR adds the capability to add one or more key=value attributes to a Column definition.  They can be added at definition time like this:

    value:double:counter=true
    timestamp:ts:interval=10

The attributes are made available as a new params field in the Column trait and properly serialized in the column and dataset definitions.  Old column definitions are still backwards compatible and parse to empty params.

The intention is to use this as a foundation for a couple uses:
- Whether a histogram column is increasing (Prom-counter like) with each sample or not
- Whether a value is a gauge or counter.   Counters might result in different kind of encoding or counter correction strategy
- expected interval of samples for timestamp columns.  This might lead to smaller or more efficient write buffers in the future.

The parameters are validated at dataset definition time.  HistogramColumns now require a counter=true/false.

#### Breaking changes

Datasets including histogram columns now need to have a `counter=true/false` in the params.
