### PR TITLE
feat(core): Correct support for intermittently publishing time series

### DIFF
--- a/conf/logback-dev.xml
+++ b/conf/logback-dev.xml
@@ -12,7 +12,10 @@
     <logger name="filodb.core" level="TRACE" />
     <logger name="filodb.memory" level="DEBUG" />
     <logger name="filodb.query" level="DEBUG" />
-    <logger name="com.esotericsoftware.minlog" level="DEBUG" />
+    <logger name="filodb.coordinator.KamonMetricsLogReporter" level="off" />
+    <logger name="filodb.coordinator.KamonSpanLogReporter" level="off" />
+    <logger name="filodb.core.memstore.LuceneMetricsRouter" level="off" />
+    <!-- <logger name="com.esotericsoftware.minlog" level="DEBUG" /> -->
     <!-- <logger name="com.esotericsoftware.kryo.io" level="TRACE" /> -->
 
     <logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="INFO"/>

--- a/conf/logback-dev.xml
+++ b/conf/logback-dev.xml
@@ -8,8 +8,8 @@
         </encoder>
     </appender>
 
-    <logger name="filodb.coordinator" level="TRACE" />
-    <logger name="filodb.core" level="TRACE" />
+    <logger name="filodb.coordinator" level="DEBUG" />
+    <logger name="filodb.core" level="DEBUG" />
     <logger name="filodb.memory" level="DEBUG" />
     <logger name="filodb.query" level="DEBUG" />
     <logger name="filodb.coordinator.KamonMetricsLogReporter" level="off" />

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -59,6 +59,19 @@
 
         # Amount of time to delay before retrying
         # retry-delay = 15s
+
+        # Capacity of Bloom filter used to track evicted partitions.
+        # Tune this based on how much time series churn is expected before a FiloDB node
+        # will be restarted for upgrade/maintenance. Do not take into account churn created by
+        # time series that are purged due to retention. When a time series is not ingesting for retention
+        # period, it is purged, not evicted. Purged PartKeys are not added to Bloom Filter.
+        #
+        # To calculate Bloom Filter size:
+        # console> BloomFilter[String](5000000, falsePositiveRate = 0.01).numberOfBits
+        # res9: Long = 47925292
+        # Thats about 6MB
+        evicted-pk-bloom-filter-capacity = 50000
+
       }
       downsample {
         # can be disabled by setting this flag to false

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -274,9 +274,9 @@ akka {
         # Leave out the hostname, it will be automatically determined.
         # The Akka port will be overridden by filodb.spark.* settings
         port = 0
-        send-buffer-size = 512000b
-        receive-buffer-size = 512000b
-        maximum-frame-size = 10 MiB
+        send-buffer-size = 1024000b
+        receive-buffer-size = 1024000b
+        maximum-frame-size = 25 MiB
       }
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -80,7 +80,7 @@ extends RawToPartitionMaker with StrictLogging {
         val inserted = tsPart.addChunkInfoIfAbsent(chunkID, infoAddr)
 
         if (!inserted) {
-          logger.info(s"Chunks not copied to partId ${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
+          logger.info(s"Chunks not copied to partId=${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
             s"$chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
             s"${ChunkSetInfo.getEndTime(infoBytes)}) partition earliestTime=${tsPart.earliestTime}")
         }

--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -80,9 +80,9 @@ extends RawToPartitionMaker with StrictLogging {
         val inserted = tsPart.addChunkInfoIfAbsent(chunkID, infoAddr)
 
         if (!inserted) {
-          logger.info(s"Chunks not copied to ${tsPart.stringPartition}, already has chunk $chunkID.  " +
-            s"Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, ${ChunkSetInfo.getEndTime(infoBytes)})" +
-            s" partition earliestTime=${tsPart.earliestTime}")
+          logger.info(s"Chunks not copied to partId ${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
+            s"$chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
+            s"${ChunkSetInfo.getEndTime(infoBytes)}) partition earliestTime=${tsPart.earliestTime}")
         }
       }
       tsPart

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -151,7 +151,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
           for { partKeyBytesRef <- partKeyIndex.partKeyFromPartId(id)
                 unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(partKeyBytesRef.offset)
                 group = partKeyGroup(dataset.partKeySchema, partKeyBytesRef.bytes, unsafeKeyOffset, numGroups)
-                part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, 4)) } yield {
+                part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, Some(id), 4)) } yield {
             val stamp = partSetLock.writeLock()
             try {
               partSet.add(part)

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -38,7 +38,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
   // TODO: make this configurable
   private val strategy = OverflowStrategy.BackPressure(1000)
 
-  private def startODPSpan: Span = Kamon.buildSpan(s"odp-cassandra-latency")
+  private def startODPSpan(): Span = Kamon.buildSpan(s"odp-cassandra-latency")
     .withTag("dataset", dataset.name)
     .withTag("shard", shardNum)
     .start()
@@ -88,7 +88,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
           val multiPart = MultiPartitionScan(partKeyBytesToPage, shardNum)
           shardStats.partitionsQueried.increment(partKeyBytesToPage.length)
           if (partKeyBytesToPage.nonEmpty) {
-            val span = startODPSpan
+            val span = startODPSpan()
             rawStore.readRawPartitions(dataset, allDataCols, multiPart, computeBoundingMethod(methods))
               // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
               // In the future optimize this if needed.
@@ -102,7 +102,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
         Observable.fromTask(odpPartTask(indexIt, partKeyBytesToPage, methods, chunkMethod)).flatMap { odpParts =>
           shardStats.partitionsQueried.increment(partKeyBytesToPage.length)
           if (partKeyBytesToPage.nonEmpty) {
-            val span = startODPSpan
+            val span = startODPSpan()
             Observable.fromIterable(partKeyBytesToPage.zip(methods))
               .mapAsync(storeConfig.demandPagingParallelism) { case (partBytes, method) =>
                 rawStore.readRawPartitions(dataset, allDataCols, SinglePartitionScan(partBytes, shardNum), method)
@@ -151,7 +151,7 @@ TimeSeriesShard(dataset, storeConfig, shardNum, rawStore, metastore, evictionPol
           for { partKeyBytesRef <- partKeyIndex.partKeyFromPartId(id)
                 unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(partKeyBytesRef.offset)
                 group = partKeyGroup(dataset.partKeySchema, partKeyBytesRef.bytes, unsafeKeyOffset, numGroups)
-                part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, Some(id), 4)) } yield {
+                part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, id, 4)) } yield {
             val stamp = partSetLock.writeLock()
             try {
               partSet.add(part)

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -418,6 +418,12 @@ class PartKeyLuceneIndex(dataset: Dataset,
   def partIdsFromFilters(columnFilters: Seq[ColumnFilter],
                          startTime: Long,
                          endTime: Long): IntIterator = {
+    partIdsFromFilters2(columnFilters, startTime, endTime).intIterator()
+  }
+
+  def partIdsFromFilters2(columnFilters: Seq[ColumnFilter],
+                         startTime: Long,
+                         endTime: Long): PartIdCollector = {
     val partKeySpan = Kamon.buildSpan("index-partition-lookup-latency")
       .withTag("dataset", dataset.name)
       .withTag("shard", shardNum)
@@ -435,7 +441,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
     val collector = new PartIdCollector() // passing zero for unlimited results
     searcher.search(query, collector)
     partKeySpan.finish()
-    collector.intIterator()
+    collector
   }
 }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -17,7 +17,6 @@ import monix.eval.Task
 import monix.execution.{Scheduler, UncaughtExceptionReporter}
 import monix.execution.atomic.AtomicBoolean
 import monix.reactive.Observable
-import org.apache.lucene.util.BytesRef
 import org.jctools.maps.NonBlockingHashMapLong
 import scalaxy.loops._
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -319,8 +319,8 @@ class TimeSeriesShard(val dataset: Dataset,
   private final val shardDownsampler = new ShardDownsampler(dataset, shardNum, downsampleConfig.enabled,
     downsampleConfig.resolutions, downsamplePublisher, shardStats)
 
-  private case class PartKey(base: Any, offset: Long)
-  private val evictedPartKeys =
+  private[memstore] case class PartKey(base: Any, offset: Long)
+  private[memstore] val evictedPartKeys =
     BloomFilter[PartKey](storeConfig.evictedPkBfCapacity, falsePositiveRate = 0.01)(new CanGenerateHashFrom[PartKey] {
       override def generateHash(from: PartKey): Long = {
         dataset.partKeySchema.partitionHash(from.base, from.offset)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1235,6 +1235,7 @@ class TimeSeriesShard(val dataset: Dataset,
     logger.info(s"Clearing all MemStore state for dataset=${dataset.ref} shard=$shardNum")
     partitions.values.asScala.foreach(removePartition)
     partKeyIndex.reset()
+    // TODO unable to reset/clear bloom filter
     ingested = 0L
     for { group <- 0 until numGroups } {
       partitionGroups(group) = new EWAHCompressedBitmap()
@@ -1243,6 +1244,7 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   def shutdown(): Unit = {
+    evictedPartKeys.dispose()
     reset()   // Not really needed, but clear everything just to be consistent
     logger.info(s"Shutting down dataset=${dataset.ref} shard=$shardNum")
     /* Don't explcitly free the memory just yet. These classes instead rely on a finalize

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -31,7 +31,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              // Use a MultiPartitionScan (instead of single partition at a time) for on-demand paging
                              multiPartitionODP: Boolean,
                              demandPagingParallelism: Int,
-                             demandPagingEnabled: Boolean) {
+                             demandPagingEnabled: Boolean,
+                             evictedPkBfCapacity: Int) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -51,7 +52,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "part-index-flush-min-delay" -> (partIndexFlushMinDelaySeconds + "s"),
                                "multi-partition-odp" -> multiPartitionODP,
                                "demand-paging-parallelism" -> demandPagingParallelism,
-                               "demand-paging-enabled" -> demandPagingEnabled).asJava)
+                               "demand-paging-enabled" -> demandPagingEnabled,
+                               "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -77,6 +79,7 @@ object StoreConfig {
                                            |multi-partition-odp = false
                                            |demand-paging-parallelism = 4
                                            |demand-paging-enabled = true
+                                           |evicted-pk-bloom-filter-capacity = 5000000
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -98,7 +101,8 @@ object StoreConfig {
                 config.as[FiniteDuration]("part-index-flush-min-delay").toSeconds.toInt,
                 config.getBoolean("multi-partition-odp"),
                 config.getInt("demand-paging-parallelism"),
-                config.getBoolean("demand-paging-enabled"))
+                config.getBoolean("demand-paging-enabled"),
+                config.getInt("evicted-pk-bloom-filter-capacity"))
   }
 }
 

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 
 import filodb.core._
 import filodb.core.binaryrecord2.{RecordBuilder, RecordContainer}
-import filodb.core.memstore.TimeSeriesShard.{indexTimeBucketSchema, indexTimeBucketSegmentSize}
+import filodb.core.memstore.TimeSeriesShard.{indexTimeBucketSchema, indexTimeBucketSegmentSize, PartKey}
 import filodb.core.metadata.Dataset
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.store.{FilteredPartitionScan, InMemoryMetaStore, NullColumnStore, SinglePartitionScan}
@@ -453,7 +453,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     var part0 = shard0Partitions.get(0)
     dataset1.partKeySchema.asJavaString(part0.partKeyBase, part0.partKeyOffset, 0) shouldEqual "Series 0"
     val pkBytes = dataset1.partKeySchema.asByteArray(part0.partKeyBase, part0.partKeyOffset)
-    val pk = shard0.PartKey(pkBytes, UnsafeUtils.arayOffset)
+    val pk = PartKey(pkBytes, UnsafeUtils.arayOffset)
     shard0.evictedPartKeys.mightContain(pk) shouldEqual false
 
     // Purposely mark two partitions endTime as occurring a while ago to mark them eligible for eviction

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -436,6 +436,45 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 21
   }
 
+  it("should assign same previously assigned partId when evicted series starts re-ingesting") {
+    memStore.setup(dataset1, 0, TestData.storeConf)
+
+    // Ingest normal multi series data with 10 partitions.  Should have 10 partitions.
+    val data = records(dataset1, linearMultiSeries().take(10))
+    memStore.ingest(dataset1.ref, 0, data)
+
+    memStore.commitIndexForTesting(dataset1.ref)
+
+    val shard0Partitions = memStore.getShard(dataset1.ref, 0).get.partitions
+
+    memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
+    memStore.labelValues(dataset1.ref, 0, "series").toSeq should have length (10)
+    var part0 = shard0Partitions.get(0)
+    dataset1.partKeySchema.asJavaString(part0.partKeyBase, part0.partKeyOffset, 0) shouldEqual "Series 0"
+
+    // Purposely mark two partitions endTime as occurring a while ago to mark them eligible for eviction
+    // We also need to switch buffers so that internally ingestionEndTime() is accurate
+    markPartitionsForEviction(0 to 1)
+
+    // Now, ingest 20 partitions.  First two partitions ingested should be evicted.
+    val data2 = records(dataset1, linearMultiSeries(numSeries = 22).drop(2).take(20))
+    memStore.ingest(dataset1.ref, 0, data2)
+    Thread sleep 1000    // see if this will make things pass sooner
+
+    memStore.numPartitions(dataset1.ref, 0) shouldEqual 20
+
+    // scalastyle:off null
+    shard0Partitions.get(0) shouldEqual null // since partId 0 has been evicted
+
+    // now re-ingest data for evicted partition with partKey "Series 0"
+    val data3 = records(dataset1, linearMultiSeries().take(1))
+    memStore.ingest(dataset1.ref, 0, data3)
+
+    // the partId assigned should still be 0
+    part0 = shard0Partitions.get(0)
+    dataset1.partKeySchema.asJavaString(part0.partKeyBase, part0.partKeyOffset, 0) shouldEqual "Series 0"
+  }
+
   it("should be able to skip ingestion/add partitions if there is no more space left") {
     memStore.setup(dataset1, 0, TestData.storeConf)
 

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -431,7 +431,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
                         .toListL.runAsync
                         .futureValue
                         .asInstanceOf[Seq[TimeSeriesPartition]]
-    parts.map(_.partID) shouldEqual Seq(22)    // newly created partitions get a new ID
+    parts.map(_.partID) shouldEqual Seq(0)    // newly created ODP partitions get earlier partId
     dataset1.partKeySchema.asJavaString(parts.head.partKeyBase, parts.head.partKeyOffset, 0) shouldEqual "Series 0"
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 21
   }

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -97,20 +97,20 @@ object TestTimeseriesProducer extends StrictLogging {
       val endQuery = startQuery + 300
       val query =
         s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus """ +
-        s"""--promql 'heap_usage{dc="DC0",_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
+        s"""--promql 'heap_usage{_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
       logger.info(s"Periodic Samples CLI Query : \n$query")
 
-      val periodQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}""", StandardCharsets.UTF_8.toString)
+      val periodQuery = URLEncoder.encode("""heap_usage{_ns="App-0"}""", StandardCharsets.UTF_8.toString)
       val periodicSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
         s"query=$periodQuery&start=$startQuery&end=$endQuery&step=15"
       logger.info(s"Periodic Samples query URL: \n$periodicSamplesUrl")
 
-      val rawQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}[2m]""",
+      val rawQuery = URLEncoder.encode("""heap_usage{_ns="App-0"}[10m]""",
         StandardCharsets.UTF_8.toString)
       val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$rawQuery&time=$endQuery"
       logger.info(s"Raw Samples query URL: \n$rawSamplesUrl")
 
-      val downsampleSumQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0",__col__="sum"}[2m]""",
+      val downsampleSumQuery = URLEncoder.encode("""heap_usage{_ns="App-0",__col__="sum"}[10m]""",
         StandardCharsets.UTF_8.toString)
       val downsampledSamplesUrl = s"http://localhost:8080/promql/prometheus_ds_1m/api/v1/query?" +
         s"query=$downsampleSumQuery&time=$endQuery"

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -97,20 +97,20 @@ object TestTimeseriesProducer extends StrictLogging {
       val endQuery = startQuery + 300
       val query =
         s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus """ +
-        s"""--promql 'heap_usage{_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
+        s"""--promql 'heap_usage{dc="DC0",_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
       logger.info(s"Periodic Samples CLI Query : \n$query")
 
-      val periodQuery = URLEncoder.encode("""heap_usage{_ns="App-0"}""", StandardCharsets.UTF_8.toString)
+      val periodQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}""", StandardCharsets.UTF_8.toString)
       val periodicSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
         s"query=$periodQuery&start=$startQuery&end=$endQuery&step=15"
       logger.info(s"Periodic Samples query URL: \n$periodicSamplesUrl")
 
-      val rawQuery = URLEncoder.encode("""heap_usage{_ns="App-0"}[10m]""",
+      val rawQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}[2m]""",
         StandardCharsets.UTF_8.toString)
       val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$rawQuery&time=$endQuery"
       logger.info(s"Raw Samples query URL: \n$rawSamplesUrl")
 
-      val downsampleSumQuery = URLEncoder.encode("""heap_usage{_ns="App-0",__col__="sum"}[10m]""",
+      val downsampleSumQuery = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0",__col__="sum"}[2m]""",
         StandardCharsets.UTF_8.toString)
       val downsampledSamplesUrl = s"http://localhost:8080/promql/prometheus_ds_1m/api/v1/query?" +
         s"query=$downsampleSumQuery&time=$endQuery"

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -222,6 +222,7 @@ object FiloBuild extends Build {
     "com.github.rholder.fauxflake" % "fauxflake-core" % "1.1.0",
     "org.scalactic"        %% "scalactic"         % "2.2.6" withJavadoc(),
     "org.apache.lucene"     % "lucene-core"       % "7.3.0" withJavadoc(),
+    "com.github.alexandrnikitin" %% "bloom-filter" % "0.11.0",
     scalaxyDep
   )
 

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -2,6 +2,7 @@ package filodb.query.exec
 
 import monix.reactive.Observable
 import org.agrona.MutableDirectBuffer
+import scalaxy.loops._
 
 import filodb.core.query._
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String}
@@ -75,7 +76,7 @@ case class HistogramQuantileMapper(funcParams: Seq[Any]) extends RangeVectorTran
           val row = new TransientRow()
           override def hasNext: Boolean = samples.forall(_.hasNext)
           override def next(): RowReader = {
-            for { i <- samples.indices } {
+            for { i <- 0 until samples.size optimized } {
               val nxt = samples(i).next()
               buckets(i).rate = nxt.getDouble(1)
               row.timestamp = nxt.getLong(0)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We were assigning duplicate partId when an evicted partKey starts re-ingesting. When this partKey is queried, ODP causes corruption of the shard data structures since partSet cannot hold duplicate TimeSeriesPartition objects for same partKey.

**New behavior :**

Prior to creating a new partition in the ingestion pipeline, the idea here is to convert the partKey from ingestion record to a Seq[ColumnFilter], essentially a Lucene query and look up matching partIds (typically just zero or one). If one is found, use the partId. If more than one is found, then it means that there is another PK that includes the same set of tags as the one in question, but has additional tags. We need to find out the most specific partKey by iterating through the partKey doc-value for each matching partId and then resolve the correct partKey.

However, this may be an expensive lookup that needs to happen in the ingestion pipeline. We could optimize this by placing evicted partKeys in a bloom filter, and do Lucene query only if really necessary.

Other bugs fixed:
* Increased akka serialized message limitation
* ODPed partition was being assigned a new partId incorrectly. Now ODPed partition uses the same partId.


Testing Approach: The changes were manually tested by reproducing the issue locally in an E2E test, and retesting after fix. Added unit test to verify assignment of partId on re-ingestion.