### PR TITLE
bug(query): fix bug in Count to add input value in reduce only when it is not NaN

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -387,20 +387,15 @@ object CountRowAggregator extends RowAggregator {
   def zero: CountHolder = new CountHolder()
   def newRowToMapInto: MutableRowReader = new TransientRow()
   def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = {
-    if (!item.getDouble(1).isNaN) {
-      mapInto.setLong(0, item.getLong(0))
-      mapInto.setDouble(1, 1d)
-    }
-    else {
-      mapInto.setLong(0, item.getLong(0))
-      mapInto.setDouble(1, 0d)
-    }
+    mapInto.setLong(0, item.getLong(0))
+    mapInto.setDouble(1, if (item.getDouble(1).isNaN) 0d else 1d)
     mapInto
   }
   def reduceAggregate(acc: CountHolder, aggRes: RowReader): CountHolder = {
     if (acc.count.isNaN && aggRes.getDouble(1) > 0) acc.count = 0d;
     acc.timestamp = aggRes.getLong(0)
-    acc.count += aggRes.getDouble(1)
+    if (!aggRes.getDouble(1).isNaN)
+      acc.count += aggRes.getDouble(1)
     acc
   }
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Count does not return value when all values on a shard are NaN



**New behavior :**
In reduce add input value to CountHolder only when it is not NaN
