### PR TITLE
feat(query): Histogram sum() over RangeVectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,9 @@ One major difference FiloDB has from the Prometheus data model is that FiloDB su
 
 * There is no need to append `_bucket` to the metric name.
 * However, you need to select the histogram column like `__col__="hist"`
-* To compute quantiles:  `histogram_quantile(0.7, rate(http_req_latency{app="foo",__col__="hist"}[5m]))`
+* To compute quantiles:  `histogram_quantile(0.7, sum_over_time(http_req_latency{app="foo",__col__="hist"}[5m]))`
 * To extract a bucket: `histogram_bucket(100.0, http_req_latency{app="foo",__col__="hist"})`
+* Sum over multiple Histogram time series:  `sum(sum_over_time(http_req_latency{app="foo",__col__="hist"}[5m]))` - you could then compute quantile over the sum.
 
 ### Using the FiloDB HTTP API
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -132,6 +132,13 @@ trait HistogramWithBuckets extends Histogram {
   def buckets: HistogramBuckets
   final def numBuckets: Int = buckets.numBuckets
   final def bucketTop(no: Int): Double = buckets.bucketTop(no)
+  final def valueArray: Array[Double] = {
+    val values = new Array[Double](numBuckets)
+    for { b <- 0 until numBuckets optimized } {
+      values(b) = bucketValue(b)
+    }
+    values
+  }
 }
 
 final case class LongHistogram(buckets: HistogramBuckets, values: Array[Long]) extends HistogramWithBuckets {
@@ -190,6 +197,11 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
 object MutableHistogram {
   def empty(buckets: HistogramBuckets): MutableHistogram =
     MutableHistogram(buckets, Array.fill(buckets.numBuckets)(Double.NaN))
+
+  def apply(h: Histogram): MutableHistogram = h match {
+    case hb: HistogramWithBuckets => MutableHistogram(hb.buckets, hb.valueArray)
+    case other: Histogram         => ???
+  }
 }
 
 /**

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -194,6 +194,8 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
     } else {
       throw new UnsupportedOperationException(s"Cannot add histogram of scheme ${other.buckets} to $buckets")
       // TODO: In the future, support adding buckets of different scheme.  Below is an example
+      // NOTE: there are two issues here: below add picks the existing bucket scheme (not commutative)
+      //       and the newer different buckets are lost (one may want more granularity)
       // var ourBucketNo = 0
       // for { b <- 0 until other.numBuckets optimized } {
       //   // Find our first bucket greater than or equal to their bucket

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -388,7 +388,7 @@ class RowHistogramReader(histVect: Ptr.U8) extends HistogramReader {
     require(length > 0 && start >= 0 && end < length)
     val summedHist = MutableHistogram.empty(buckets)
     for { i <- start to end optimized } {
-      summedHist.add(apply(i).asInstanceOf[HistogramWithBuckets])
+      summedHist.addNoCorrection(apply(i).asInstanceOf[HistogramWithBuckets])
     }
     summedHist
   }

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -99,7 +99,6 @@ class HistogramTest extends NativeVectorTest {
       histWNans.values(2) = Double.NaN
 
       hist1.add(histWNans)
-      hist1.makeMonotonic()
       var current = 0d
       hist1.valueArray.foreach { d =>
         d should be >= (current)
@@ -107,7 +106,8 @@ class HistogramTest extends NativeVectorTest {
       }
     }
 
-    it("should add histogram w/ diff bucket scheme and result in monotonically increasing histogram") {
+    // Test this later when different schemas are supported
+    ignore("should add histogram w/ diff bucket scheme and result in monotonically increasing histogram") {
       val hist1 = mutableHistograms(0).copy.asInstanceOf[MutableHistogram]
 
       val scheme2 = GeometricBuckets(2.0, 6.0, 3)

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -91,5 +91,40 @@ class HistogramTest extends NativeVectorTest {
       hist should not equal (hist2)
       hist.values shouldEqual addedBuckets
     }
+
+    it("should correctly add & makeMonotonic histograms containing NaNs") {
+      val hist1 = mutableHistograms(0).copy.asInstanceOf[MutableHistogram]
+      val histWNans = mutableHistograms(1)
+      histWNans.values(0) = Double.NaN
+      histWNans.values(2) = Double.NaN
+
+      hist1.add(histWNans)
+      hist1.makeMonotonic()
+      var current = 0d
+      hist1.valueArray.foreach { d =>
+        d should be >= (current)
+        current = d
+      }
+    }
+
+    it("should add histogram w/ diff bucket scheme and result in monotonically increasing histogram") {
+      val hist1 = mutableHistograms(0).copy.asInstanceOf[MutableHistogram]
+
+      val scheme2 = GeometricBuckets(2.0, 6.0, 3)
+      val hist2 = LongHistogram(scheme2, Array(10L, 20L, 40L))
+
+      hist1.add(hist2)
+      hist1.makeMonotonic()
+
+      hist1.buckets shouldEqual bucketScheme   // scheme does not change - for now
+
+      // New buckets should be increasing, and values should not be less than before
+      var current = 0d
+      hist1.valueArray.zipWithIndex.foreach { case (d, i) =>
+        d should be >= (current)
+        d should be >= rawHistBuckets(0)(i)
+        current = d
+      }
+    }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -333,6 +333,7 @@ object HistSumRowAggregator extends RowAggregator {
       // sum is mutable histogram, copy to be sure it's our own copy
       case hist if hist.numBuckets == 0 => acc.h = bv.MutableHistogram(aggRes.getHistogram(1))
       case hist: bv.MutableHistogram    => hist.add(aggRes.getHistogram(1).asInstanceOf[bv.HistogramWithBuckets])
+                                           hist.makeMonotonic()
     }
     acc
   }

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -12,7 +12,7 @@ import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
 import filodb.core.query._
 import filodb.memory.data.ChunkMap
-import filodb.memory.format.{vectors => bv, RowReader, UnsafeUtils, ZeroCopyUTF8String}
+import filodb.memory.format.{RowReader, UnsafeUtils, ZeroCopyUTF8String}
 import filodb.query._
 import filodb.query.AggregationOperator._
 
@@ -318,6 +318,8 @@ object SumRowAggregator extends RowAggregator {
 }
 
 object HistSumRowAggregator extends RowAggregator {
+  import filodb.memory.format.{vectors => bv}
+
   class HistSumHolder(var timestamp: Long = 0L, var h: bv.Histogram = bv.Histogram.empty) extends AggregateHolder {
     val row = new TransientHistRow()
     def toRowReader: MutableRowReader = { row.setValues(timestamp, h); row }
@@ -333,7 +335,6 @@ object HistSumRowAggregator extends RowAggregator {
       // sum is mutable histogram, copy to be sure it's our own copy
       case hist if hist.numBuckets == 0 => acc.h = bv.MutableHistogram(aggRes.getHistogram(1))
       case hist: bv.MutableHistogram    => hist.add(aggRes.getHistogram(1).asInstanceOf[bv.HistogramWithBuckets])
-                                           hist.makeMonotonic()
     }
     acc
   }

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -12,7 +12,7 @@ import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
 import filodb.core.query._
 import filodb.memory.data.ChunkMap
-import filodb.memory.format.{RowReader, UnsafeUtils, ZeroCopyUTF8String}
+import filodb.memory.format.{vectors => bv, RowReader, UnsafeUtils, ZeroCopyUTF8String}
 import filodb.query._
 import filodb.query.AggregationOperator._
 
@@ -31,13 +31,16 @@ final case class ReduceAggregateExec(id: String,
 
   protected def args: String = s"aggrOp=$aggrOp, aggrParams=$aggrParams"
 
-  protected def compose(childResponses: Observable[(QueryResponse, Int)],
+  protected def compose(dataset: Dataset,
+                        childResponses: Observable[(QueryResponse, Int)],
                         queryConfig: QueryConfig): Observable[RangeVector] = {
     val results = childResponses.flatMap {
         case (QueryResult(_, _, result), _) => Observable.fromIterable(result)
         case (QueryError(_, ex), _)         => throw ex
     }
-    RangeVectorAggregator.mapReduce(aggrOp, aggrParams, skipMapPhase = true, results, rv => rv.key)
+    val valColType = RangeVectorTransformer.valueColumnType(schemaOfCompose(dataset))
+    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
+    RangeVectorAggregator.mapReduce(aggregator, skipMapPhase = true, results, rv => rv.key)
   }
 }
 
@@ -54,12 +57,13 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
 
   protected[exec] def args: String =
     s"aggrOp=$aggrOp, aggrParams=$aggrParams, without=$without, by=$by"
-  val aggregator = RowAggregator(aggrOp, aggrParams)
 
   def apply(source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {
+    val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
+    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
     def grouping(rv: RangeVector): RangeVectorKey = {
       val groupBy: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] =
         if (by.nonEmpty) rv.key.labelValues.filter(lv => byLabels.contains(lv._1))
@@ -67,10 +71,12 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
         else Map.empty
       CustomRangeVectorKey(groupBy)
     }
-    RangeVectorAggregator.mapReduce(aggrOp, aggrParams, skipMapPhase = false, source, grouping)
+    RangeVectorAggregator.mapReduce(aggregator, skipMapPhase = false, source, grouping)
   }
 
   override def schema(dataset: Dataset, source: ResultSchema): ResultSchema = {
+    val valColType = RangeVectorTransformer.valueColumnType(source)
+    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
     // TODO we assume that second column needs to be aggregated. Other dataset types need to be accommodated.
     aggregator.reductionSchema(source)
   }
@@ -80,16 +86,19 @@ final case class AggregatePresenter(aggrOp: AggregationOperator,
                                     aggrParams: Seq[Any]) extends RangeVectorTransformer {
 
   protected[exec] def args: String = s"aggrOp=$aggrOp, aggrParams=$aggrParams"
-  val aggregator = RowAggregator(aggrOp, aggrParams)
 
   def apply(source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {
-    RangeVectorAggregator.present(aggrOp, aggrParams, source, limit)
+    val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
+    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
+    RangeVectorAggregator.present(aggregator, source, limit)
   }
 
   override def schema(dataset: Dataset, source: ResultSchema): ResultSchema = {
+    val valColType = RangeVectorTransformer.valueColumnType(source)
+    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
     aggregator.presentationSchema(source)
   }
 }
@@ -108,12 +117,10 @@ object RangeVectorAggregator {
     * This method is the facade for map and reduce steps of the aggregation.
     * In the reduction-only (non-leaf) phases, skipMapPhase should be true.
     */
-  def mapReduce(aggrOp: AggregationOperator,
-                params: Seq[Any],
+  def mapReduce(rowAgg: RowAggregator,
                 skipMapPhase: Boolean,
                 source: Observable[RangeVector],
                 grouping: RangeVector => RangeVectorKey): Observable[RangeVector] = {
-    val rowAgg = RowAggregator(aggrOp, params) // row aggregator
     // reduce the range vectors using the foldLeft construct. This results in one aggregate per group.
     val task = source.toListL.map { rvs =>
       // now reduce each group and create one result range vector per group
@@ -129,11 +136,9 @@ object RangeVectorAggregator {
   /**
     * This method is the facade for the present step of the aggregation
     */
-  def present(aggrOp: AggregationOperator,
-              params: Seq[Any],
+  def present(aggregator: RowAggregator,
               source: Observable[RangeVector],
               limit: Int): Observable[RangeVector] = {
-    val aggregator = RowAggregator(aggrOp, params)
     source.flatMap(rv => Observable.fromIterable(aggregator.present(rv, limit)))
   }
 
@@ -267,11 +272,12 @@ object RowAggregator {
   /**
     * Factory for RowAggregator
     */
-  def apply(aggrOp: AggregationOperator, params: Seq[Any]): RowAggregator = {
+  def apply(aggrOp: AggregationOperator, params: Seq[Any], dataColType: ColumnType): RowAggregator = {
     aggrOp match {
       case Min      => MinRowAggregator
       case Max      => MaxRowAggregator
-      case Sum      => SumRowAggregator
+      case Sum if dataColType == ColumnType.DoubleColumn => SumRowAggregator
+      case Sum if dataColType == ColumnType.HistogramColumn => HistSumRowAggregator
       case Count    => CountRowAggregator
       case Avg      => AvgRowAggregator
       case TopK     => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, false)
@@ -303,6 +309,30 @@ object SumRowAggregator extends RowAggregator {
     if (!aggRes.getDouble(1).isNaN) {
       if (acc.sum.isNaN) acc.sum = 0
       acc.sum += aggRes.getDouble(1)
+    }
+    acc
+  }
+  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def reductionSchema(source: ResultSchema): ResultSchema = source
+  def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
+}
+
+object HistSumRowAggregator extends RowAggregator {
+  class HistSumHolder(var timestamp: Long = 0L, var h: bv.Histogram = bv.Histogram.empty) extends AggregateHolder {
+    val row = new TransientHistRow()
+    def toRowReader: MutableRowReader = { row.setValues(timestamp, h); row }
+    def resetToZero(): Unit = h = bv.Histogram.empty
+  }
+  type AggHolderType = HistSumHolder
+  def zero: HistSumHolder = new HistSumHolder
+  def newRowToMapInto: MutableRowReader = new TransientHistRow()
+  def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = item
+  def reduceAggregate(acc: HistSumHolder, aggRes: RowReader): HistSumHolder = {
+    acc.timestamp = aggRes.getLong(0)
+    acc.h match {
+      // sum is mutable histogram, copy to be sure it's our own copy
+      case hist if hist.numBuckets == 0 => acc.h = bv.MutableHistogram(aggRes.getHistogram(1))
+      case hist: bv.MutableHistogram    => hist.add(aggRes.getHistogram(1).asInstanceOf[bv.HistogramWithBuckets])
     }
     acc
   }

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -58,7 +58,8 @@ final case class BinaryJoinExec(id: String,
 
   protected def args: String = s"binaryOp=$binaryOp, on=$on, ignoring=$ignoring"
 
-  protected[exec] def compose(childResponses: Observable[(QueryResponse, Int)],
+  protected[exec] def compose(dataset: Dataset,
+                              childResponses: Observable[(QueryResponse, Int)],
                               queryConfig: QueryConfig): Observable[RangeVector] = {
     val taskOfResults = childResponses.map {
       case (QueryResult(_, _, result), i) => (result, i)

--- a/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
@@ -19,7 +19,8 @@ final case class DistConcatExec(id: String,
 
   protected def schemaOfCompose(dataset: Dataset): ResultSchema = children.head.schema(dataset)
 
-  protected def compose(childResponses: Observable[(QueryResponse, Int)],
+  protected def compose(dataset: Dataset,
+                        childResponses: Observable[(QueryResponse, Int)],
                         queryConfig: QueryConfig): Observable[RangeVector] = {
     qLogger.debug(s"DistConcatExec: Concatenating results")
     childResponses.flatMap {

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -244,7 +244,7 @@ abstract class NonLeafExecPlan extends ExecPlan {
         }.map((_, i))
       }
     }
-    compose(childTasks, queryConfig)
+    compose(dataset, childTasks, queryConfig)
   }
 
   final protected def schemaOfDoExecute(dataset: Dataset): ResultSchema = schemaOfCompose(dataset)
@@ -258,7 +258,8 @@ abstract class NonLeafExecPlan extends ExecPlan {
     * Sub-class non-leaf nodes should provide their own implementation of how
     * to compose the sub-query results here.
     */
-  protected def compose(childResponses: Observable[(QueryResponse, Int)],
+  protected def compose(dataset: Dataset,
+                        childResponses: Observable[(QueryResponse, Int)],
                         queryConfig: QueryConfig): Observable[RangeVector]
 
 }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -39,9 +39,9 @@ final case class PartKeysDistConcatExec(id: String,
   /**
     * Compose the sub-query/leaf results here.
     */
-  override protected def compose(childResponses: Observable[(QueryResponse, Int)], queryConfig: QueryConfig):
-      Observable[RangeVector] = {
-
+  protected def compose(dataset: Dataset,
+                        childResponses: Observable[(QueryResponse, Int)],
+                        queryConfig: QueryConfig): Observable[RangeVector] = {
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     val taskOfResults = childResponses.map {
       case (QueryResult(_, _, result), _) => result
@@ -74,9 +74,9 @@ final case class LabelValuesDistConcatExec(id: String,
   /**
     * Compose the sub-query/leaf results here.
     */
-  override protected def compose(childResponses: Observable[(QueryResponse, Int)], queryConfig: QueryConfig):
-  Observable[RangeVector] = {
-
+  protected def compose(dataset: Dataset,
+                        childResponses: Observable[(QueryResponse, Int)],
+                        queryConfig: QueryConfig): Observable[RangeVector] = {
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     val taskOfResults = childResponses.map {
       case (QueryResult(_, _, result), _) => result

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -65,7 +65,8 @@ final case class StitchRvsExec(id: String,
 
   protected def schemaOfCompose(dataset: Dataset): ResultSchema = children.head.schema(dataset)
 
-  protected def compose(childResponses: Observable[(QueryResponse, Int)],
+  protected def compose(dataset: Dataset,
+                        childResponses: Observable[(QueryResponse, Int)],
                         queryConfig: QueryConfig): Observable[RangeVector] = {
     qLogger.debug(s"StitchRvsExec: Stitching results:")
     val stitched = childResponses.map {

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -184,6 +184,8 @@ extends ChunkedRangeFunction[TransientHistRow] {
       // sum is mutable histogram, copy to be sure it's our own copy
       case hist if hist.numBuckets == 0 => h = sum.copy
       case hist: bv.MutableHistogram    => hist.add(sum)
+                                           // Different chunk, schema may change.  Ensure monotonicity
+                                           hist.makeMonotonic()
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -184,8 +184,6 @@ extends ChunkedRangeFunction[TransientHistRow] {
       // sum is mutable histogram, copy to be sure it's our own copy
       case hist if hist.numBuckets == 0 => h = sum.copy
       case hist: bv.MutableHistogram    => hist.add(sum)
-                                           // Different chunk, schema may change.  Ensure monotonicity
-                                           hist.makeMonotonic()
     }
   }
 }

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
-import filodb.memory.format.{vectors => bv, RowReader, ZeroCopyUTF8String}
+import filodb.memory.format.{RowReader, ZeroCopyUTF8String}
 import filodb.query.AggregationOperator
 import filodb.query.exec.rangefn.RawDataWindowingSpec
 
@@ -332,6 +332,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     result6b(0).key shouldEqual ignoreKey
     compareIter(result6b(0).rows.map(_.getDouble(1)), Seq(5.4d,5.6d).iterator)
   }
+
+  import filodb.memory.format.{vectors => bv}
 
   it("should sum histogram RVs") {
     val (data1, rv1) = histogramRV(numSamples = 5)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

Adds the ability to do sum() over HistogramColumn range vectors.
Monotonicity correction and ability to sum histograms of different schemas is also added for proper histogram summing functionality.