### PR TITLE
misc(core): Reduce zipkin message batchsize

### DIFF
--- a/core/src/main/scala/filodb.core/zipkin/Zipkin.scala
+++ b/core/src/main/scala/filodb.core/zipkin/Zipkin.scala
@@ -128,10 +128,10 @@ class ZipkinReporter extends SpanReporter {
     val zipkinHost = Kamon.config().getString(HostConfigKey)
     val zipkinPort = Kamon.config().getInt(PortConfigKey)
 
-    var url = s"$zipkinEndpoint/api/v2/spans"
-    if (zipkinEndpoint == null || zipkinEndpoint.trim.isEmpty) {
-      url = s"http://$zipkinHost:$zipkinPort/api/v2/spans"
-    }
+    val url = if (zipkinEndpoint == null || zipkinEndpoint.trim.isEmpty)
+                s"http://$zipkinHost:$zipkinPort/api/v2/spans"
+              else
+                s"$zipkinEndpoint/api/v2/spans"
 
     AsyncReporter.create(
       OkHttpSender.newBuilder()

--- a/core/src/main/scala/filodb.core/zipkin/Zipkin.scala
+++ b/core/src/main/scala/filodb.core/zipkin/Zipkin.scala
@@ -138,7 +138,7 @@ class ZipkinReporter extends SpanReporter {
         .encoding(Encoding.JSON)
         .endpoint(url)
         .maxRequests(64)
-        .messageMaxBytes(1 * 512)
+        .messageMaxBytes(1024 * 128)
         .build()
     )
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Zipkin message batch size is 5mb today. This sends more spans in a single request, adding load on zipkin collectors.

**New behavior :**
Reduce the zipkin message batch size to 128kb. I do not think it should be part of a config at the moment. We will add it to config later if required.