### PR TITLE
bug(core): ODP from Cassandra only if Lucene index indicates that there is data

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
@@ -46,6 +46,7 @@ class MemstoreCassandraSinkSpec extends AllTablesTest {
     memStore.store.sinkStats.chunksetsWritten should be >= 3
     memStore.store.sinkStats.chunksetsWritten should be <= 4
 
+    memStore.commitIndexForTesting(dataset1.ref)
     // Verify data still in MemStore... all of it
     val splits = memStore.getScanSplits(dataset1.ref, 1)
     val agg1 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(splits.head))

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -194,7 +194,6 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, IngestRows(ref, 0, records(dataset1, linearMultiSeries().take(40))))
       probe.expectMsg(Ack(0L))
 
-      memStore.commitIndexForTesting(dataset1.ref)
 
       // Try a filtered partition query
       val series2 = (2 to 4).map(n => s"Series $n").toSet.asInstanceOf[Set[Any]]
@@ -203,6 +202,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                  Aggregate(AggregationOperator.Avg,
                    PeriodicSeries(
                      RawSeries(AllChunksSelector, multiFilter, Seq("min")), 120000L, 10000L, 130000L)), qOpt)
+      memStore.commitIndexForTesting(dataset1.ref)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
         case QueryResult(_, schema, vectors) =>
@@ -347,6 +347,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     probe.send(coordinatorActor, StatusActor.GetCurrentEvents)
     probe.expectMsg(Map(ref -> Seq(IngestionStarted(ref, 0, coordinatorActor))))
 
+    memStore.commitIndexForTesting(dataset6.ref)
     // Also the original aggregator is sum(sum_over_time(....)) which is not quite represented by below plan
     // Below plan is really sum each time bucket
     val q2 = LogicalPlan2Query(ref,

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -436,7 +436,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
 
   def partIdsFromFilters2(columnFilters: Seq[ColumnFilter],
                          startTime: Long,
-                         endTime: Long): PartIdCollector = {
+                         endTime: Long): EWAHCompressedBitmap = {
     val partKeySpan = Kamon.buildSpan("index-partition-lookup-latency")
       .withTag("dataset", dataset.name)
       .withTag("shard", shardNum)
@@ -454,7 +454,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
     val collector = new PartIdCollector() // passing zero for unlimited results
     searcher.search(query, collector)
     partKeySpan.finish()
-    collector
+    collector.result
   }
 }
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -8,7 +8,6 @@ import scala.collection.immutable.HashSet
 
 import com.googlecode.javaewah.{EWAHCompressedBitmap, IntIterator}
 import com.typesafe.scalalogging.StrictLogging
-import debox.Map
 import kamon.Kamon
 import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.document._
@@ -325,15 +324,14 @@ class PartKeyLuceneIndex(dataset: Dataset,
   /**
     * Called when a document is updated with new endTime
     */
-  def startTimeFromPartIds(partIds: IntIterator): PartIdStartTimeCollector = {
+  def startTimeFromPartIds(partIds: Iterator[Int]): debox.Map[Int, Long] = {
     val collector = new PartIdStartTimeCollector()
-
     val booleanQuery = new BooleanQuery.Builder
-    while (partIds.hasNext) {
-      booleanQuery.add(new TermQuery(new Term(PART_ID, partIds.next().toString)), Occur.SHOULD)
+    partIds.foreach { pId =>
+      booleanQuery.add(new TermQuery(new Term(PART_ID, pId.toString)), Occur.SHOULD)
     }
     searcherManager.acquire().search(booleanQuery.build(), collector)
-    collector
+    collector.startTimes
   }
 
   /**

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -625,7 +625,7 @@ class PartIdStartTimeCollector extends SimpleCollector {
   override def collect(doc: Int): Unit = {
     if (partIdDv.advanceExact(doc) && startTimeDv.advanceExact(doc)) {
       val partId = partIdDv.longValue().toInt
-      val startTime = startTimeDv.longValue().toInt
+      val startTime = startTimeDv.longValue()
       startTimes(partId) = startTime
     } else {
       throw new IllegalStateException("This shouldn't happen since every document should have partIdDv and startTimeDv")

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -320,6 +320,10 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
     final def unlock(): Unit = chunkmapReleaseShared()
   }
 
+  /**
+    * startTime of earliest chunk in memory.
+    * Long.MaxValue if no chunk is present
+    */
   final def earliestTime: Long = {
     if (numChunks == 0) {
       Long.MaxValue

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -322,7 +322,7 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
 
   final def earliestTime: Long = {
     if (numChunks == 0) {
-      Long.MinValue
+      Long.MaxValue
     } else {
       // Acquire shared lock to safely access the native pointer.
       chunkmapWithShared(ChunkSetInfo(chunkmapDoGetFirst).startTime)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1232,7 +1232,9 @@ class TimeSeriesShard(val dataset: Dataset,
         val partIdsToPage = InMemPartitionIterator(coll.intIterator())
                            .filter(_.earliestTime > chunkMethod.startTime)
                            .map(_.partID)
-        new InMemPartitionIterator(coll.intIterator(), startTimes = partKeyIndex.startTimeFromPartIds(partIdsToPage))
+        val startTimes = partKeyIndex.startTimeFromPartIds(partIdsToPage)
+        logger.debug(s"QueryStartTime=${chunkMethod.startTime}; StartTimes for relevant partIds: $startTimes")
+        new InMemPartitionIterator(coll.intIterator(), startTimes)
       } else {
         PartitionIterator.fromPartIt(partitions.values.iterator.asScala)
       }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -674,6 +674,7 @@ class TimeSeriesShard(val dataset: Dataset,
   private def addPartKeyToTimebucketRb(indexRb: RecordBuilder, p: TimeSeriesPartition) = {
     var startTime = partKeyIndex.startTimeFromPartId(p.partID)
     if (startTime == -1) startTime = p.earliestTime// can remotely happen since lucene reads are eventually consistent
+    if (startTime == Long.MaxValue) startTime = 0
     val endTime = if (isActivelyIngesting(p.partID)) {
       Long.MaxValue
     } else {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -334,7 +334,6 @@ class TimeSeriesShard(val dataset: Dataset,
   case class InMemPartitionIterator(intIt: IntIterator) extends PartitionIterator {
     var nextPart = UnsafeUtils.ZeroPointer.asInstanceOf[TimeSeriesPartition]
     val skippedPartIDs = debox.Buffer.empty[Int]
-
     private def findNext(): Unit = {
       while (intIt.hasNext && nextPart == UnsafeUtils.ZeroPointer) {
         val nextPartID = intIt.next
@@ -673,8 +672,8 @@ class TimeSeriesShard(val dataset: Dataset,
 
   private def addPartKeyToTimebucketRb(indexRb: RecordBuilder, p: TimeSeriesPartition) = {
     var startTime = partKeyIndex.startTimeFromPartId(p.partID)
-    if (startTime == -1) startTime = p.earliestTime// can remotely happen since lucene reads are eventually consistent
-    if (startTime == Long.MaxValue) startTime = 0
+    if (startTime == -1) startTime = p.earliestTime // can remotely happen since lucene reads are eventually consistent
+    if (startTime == Long.MaxValue) startTime = 0 // if for any reason we cant find the startTime, use 0
     val endTime = if (isActivelyIngesting(p.partID)) {
       Long.MaxValue
     } else {
@@ -958,13 +957,13 @@ class TimeSeriesShard(val dataset: Dataset,
       val filters = dataset.partKeySchema.toStringPairs(partKeyBase, partKeyOffset)
         .map { pair => ColumnFilter(pair._1, Filter.Equals(pair._2)) }
       val matches = partKeyIndex.partIdsFromFilters2(filters, 0, Long.MaxValue)
-      matches.result.cardinality() match {
+      matches.cardinality() match {
         case 0 =>           shardStats.evictedPartKeyBloomFilterFalsePositives.increment()
                             CREATE_NEW_PARTID
         case c if c >= 1 => // NOTE: if we hit one partition, we cannot directly call it out as the result without
                             // verifying the partKey since the matching partition may have had an additional tag
                             if (c > 1) shardStats.evictedPartIdLookupMultiMatch.increment()
-                            val iter = matches.result.intIterator()
+                            val iter = matches.intIterator()
                             var partId = -1
                             do {
                               // find the most specific match for the given ingestion record
@@ -1211,40 +1210,46 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   /**
-    * Returns iterator to iterate partitions identified by the PartitionScanMethod.
-    * Also returns the startTimes for partitions that are not fully in memory
-    * so that caller can make a decision on whether to ODP that partition or not.
+    * Result of a iteratePartitions method call.
+    *
+    * Note that there is a leak in abstraction here we should not be talking about ODP here.
+    * ODPagingShard really should not have been a sub-class of TimeSeriesShard. Instead
+    * composition should have been used instead of inheritance. Overriding the iteratePartitions()
+    * method is the best I could do to keep the leak minimal and not increase scope.
+    *
+    * TODO: clean this all up in a bigger refactoring effort later.
+    *
+    * @param partsInMemoryIter iterates through the in-Memory partitions, some of which may not need ODP.
+    *                          Caller needs to filter further
+    * @param partIdsInMemoryMayNeedOdp has partIds from partsInMemoryIter in memory that may need chunk ODP. Their
+    *                          startTimes from Lucene are included
+    * @param partIdsNotInMemory is a collection of partIds fully not in memory
+    */
+  case class IterationResult(partsInMemoryIter: PartitionIterator,
+                             partIdsInMemoryMayNeedOdp: debox.Map[Int, Long] = debox.Map.empty,
+                             partIdsNotInMemory: debox.Buffer[Int] = debox.Buffer.empty)
+
+  /**
+    * See documentation for IterationResult.
     */
   def iteratePartitions(partMethod: PartitionScanMethod,
-                        chunkMethod: ChunkScanMethod): (PartitionIterator, debox.Map[Int, Long]) = {
-    partMethod match {
-      case SinglePartitionScan(partition, _) => (ByteKeysPartitionIterator(Seq(partition)), debox.Map.empty)
-      case MultiPartitionScan(partKeys, _)   => (ByteKeysPartitionIterator(partKeys), debox.Map.empty)
-      case FilteredPartitionScan(split, filters) =>
-        // TODO: There are other filters that need to be added and translated to Lucene queries
-        if (filters.nonEmpty) {
-          val coll = partKeyIndex.partIdsFromFilters2(filters, chunkMethod.startTime, chunkMethod.endTime)
-
-          // first find out which partitions are being queried for data not in memory
-          val partIdsToPage = InMemPartitionIterator(coll.intIterator())
-            .filter(_.earliestTime > chunkMethod.startTime)
-            .map(_.partID)
-          val startTimes = if (partIdsToPage.nonEmpty) partKeyIndex.startTimeFromPartIds(partIdsToPage)
-                           else debox.Map.empty[Int, Long]
-          logger.debug(s"QueryStartTime=${chunkMethod.startTime}; StartTimes for relevant partIds: $startTimes")
-          // now provide an iterator that additionally supplies the startTimes for
-          // those partitions that may need to be paged
-          (new InMemPartitionIterator(coll.intIterator()), startTimes)
-        } else {
-          (PartitionIterator.fromPartIt(partitions.values.iterator.asScala), debox.Map.empty)
-        }
-    }
+                        chunkMethod: ChunkScanMethod): IterationResult = partMethod match {
+    case SinglePartitionScan(partition, _) => IterationResult(ByteKeysPartitionIterator(Seq(partition)))
+    case MultiPartitionScan(partKeys, _)   => IterationResult(ByteKeysPartitionIterator(partKeys))
+    case FilteredPartitionScan(split, filters) =>
+      // TODO: There are other filters that need to be added and translated to Lucene queries
+      if (filters.nonEmpty) {
+        val indexIt = partKeyIndex.partIdsFromFilters(filters, chunkMethod.startTime, chunkMethod.endTime)
+        IterationResult(new InMemPartitionIterator(indexIt))
+      } else {
+        IterationResult(PartitionIterator.fromPartIt(partitions.values.iterator.asScala))
+      }
   }
 
   def scanPartitions(columnIDs: Seq[Types.ColumnId],
                      partMethod: PartitionScanMethod,
                      chunkMethod: ChunkScanMethod): Observable[ReadablePartition] = {
-    Observable.fromIterator(iteratePartitions(partMethod, chunkMethod)._1.map { p =>
+    Observable.fromIterator(iteratePartitions(partMethod, chunkMethod).partsInMemoryIter.map { p =>
       shardStats.partitionsQueried.increment()
       p
     })


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

If earliestTime in memory for a partition is more than queryStart time, we decide to page from cassandra.

**New behavior :**

We page from cassandra only if Lucene index indicates that partition's startTime is earlier than the earliest time in memory, and the query is for earlier than the earliest time in memory.

The code organization for ODP imo has been less than ideal because there is a lot of things happening and leak in abstraction with non-functional side effects. I do understand everything has been done to reduce object allocation and double iteration of objects. I haven't really changed all of that, but my thinking is that the changes in the PR may add a bit to the chaos.

If you guys have any suggestions on how to make this better without affecting performance, please call it out.
