### PR TITLE
 feat(query): Parallelize scanPartitions and all QE work in query threadpool

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -57,8 +57,8 @@ final class QueryActor(memStore: MemStore,
 
   val queryEngine2 = new QueryEngine(dataset, shardMapFunc)
   val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
-  val numSchedThreads = config.getInt("filodb.query.num-threads")
-  implicit val scheduler = Scheduler.fixedPool(s"query-${dataset.ref}", numSchedThreads)
+  val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor") * sys.runtime.availableProcessors)
+  implicit val scheduler = Scheduler.fixedPool(s"query-${dataset.ref}", numSchedThreads.toInt)
 
   private val tags = Map("dataset" -> dataset.ref.toString)
   private val lpRequests = Kamon.counter("queryactor-logicalPlan-requests").refine(tags)

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -235,6 +235,33 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       }
     }
 
+    it("should parse and execute concurrent LogicalPlan queries") {
+      val ref = setupTimeSeries()
+      probe.send(coordinatorActor, IngestRows(ref, 0, records(dataset1, linearMultiSeries().take(40))))
+      probe.expectMsg(Ack(0L))
+
+      memStore.commitIndexForTesting(dataset1.ref)
+
+      val numQueries = 6
+
+      val series2 = (2 to 4).map(n => s"Series $n").toSet.asInstanceOf[Set[Any]]
+      val multiFilter = Seq(ColumnFilter("series", Filter.In(series2)))
+      val q2 = LogicalPlan2Query(ref,
+                 Aggregate(AggregationOperator.Avg,
+                   PeriodicSeries(
+                     RawSeries(AllChunksSelector, multiFilter, Seq("min")), 120000L, 10000L, 130000L)), qOpt)
+      (0 until numQueries).foreach { i => probe.send(coordinatorActor, q2) }
+
+      (0 until numQueries).foreach { _ =>
+        probe.expectMsgPF() {
+          case QueryResult(_, schema, vectors) =>
+            schema shouldEqual timeMinSchema
+            vectors should have length (1)
+            vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
+        }
+      }
+    }
+
     ignore("should aggregate from multiple shards") {
       val ref = setupTimeSeries(2)
       probe.send(coordinatorActor, IngestRows(ref, 0, records(dataset1, linearMultiSeries().take(30))))

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -246,6 +246,11 @@ akka {
       "filodb.query.LogicalPlan" = kryo
     }
 
+    default-dispatcher.fork-join-executor {
+      parallelism-factor = 2.0
+      parallelism-max = 32
+    }
+
     # Just the defaults to start with. TODO optimize and pick the executor needed.
     shard-status-dispatcher {
       type = Dispatcher
@@ -304,27 +309,6 @@ akka {
       threshold = 12.0
       expected-response-after = 5s
     }
-  }
-
-  # Just the defaults to start with. TODO optimize and pick the executor needed.
-  shard-status-dispatcher {
-    # Dispatcher is the name of the event-based dispatcher
-    type = Dispatcher
-    # What kind of ExecutionService to use
-    executor = "fork-join-executor"
-    # Configuration for the fork join pool
-    fork-join-executor {
-      # Min number of threads to cap factor-based parallelism number to
-      parallelism-min = 2
-      # Parallelism (threads) ... ceil(available processors * factor)
-      parallelism-factor = 2.0
-      # Max number of threads to cap factor-based parallelism number to
-      parallelism-max = 10
-    }
-    # Throughput defines the maximum number of messages to be
-    # processed per actor before the thread jumps to the next actor.
-    # Set to 1 for as fair as possible.
-    throughput = 100
   }
 
   # Be sure to terminate/exit JVM process after Akka shuts down.  This is important for the

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -38,6 +38,9 @@ filodb {
 
     # Minimum step required for a query
     min-step = 5 seconds
+
+    # Number of threads in query threadpool.  There is one threadpool per dataset.
+    num-threads = 8
   }
 
   shard-manager {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -39,8 +39,8 @@ filodb {
     # Minimum step required for a query
     min-step = 5 seconds
 
-    # Number of threads in query threadpool.  There is one threadpool per dataset.
-    num-threads = 8
+    # Parallelism (query threadpool per dataset) ... ceil(available processors * factor)
+    threads-factor = 1.0
   }
 
   shard-manager {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -246,6 +246,7 @@ akka {
       "filodb.query.LogicalPlan" = kryo
     }
 
+    # Reduce the number of threads used by default by the fork-join pool, as it's not really doing much work.
     default-dispatcher.fork-join-executor {
       parallelism-factor = 2.0
       parallelism-max = 32

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import scala.collection.mutable
 
 import com.tdunning.math.stats.{ArrayDigest, TDigest}
+import com.typesafe.scalalogging.StrictLogging
 import monix.reactive.Observable
 
 import filodb.core.binaryrecord2.RecordBuilder
@@ -102,7 +103,7 @@ final case class AggregatePresenter(aggrOp: AggregationOperator,
   *
   * This singleton is the facade for the above operations.
   */
-object RangeVectorAggregator {
+object RangeVectorAggregator extends StrictLogging {
 
   /**
     * This method is the facade for map and reduce steps of the aggregation.
@@ -141,6 +142,7 @@ object RangeVectorAggregator {
                      rowAgg: RowAggregator,
                      skipMapPhase: Boolean,
                      grouping: RangeVector => RangeVectorKey): Map[RangeVectorKey, Iterator[rowAgg.AggHolderType]] = {
+    logger.trace(s"mapReduceInternal on ${rvs.size} RangeVectors...")
     var acc = rowAgg.zero
     val mapInto = rowAgg.newRowToMapInto
     rvs.groupBy(grouping).mapValues { rvs =>

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -24,7 +24,7 @@ final case class PeriodicSamplesMapper(start: Long,
                                        end: Long,
                                        window: Option[Long],
                                        functionId: Option[RangeFunctionId],
-                                       funcParams: Seq[Any] = Nil) extends RangeVectorTransformer {
+                                       funcParams: Seq[Any] = Nil) extends RangeVectorTransformer with StrictLogging {
   require(start <= end, "start should be <= end")
   require(step > 0, "step should be > 0")
 
@@ -62,6 +62,7 @@ final case class PeriodicSamplesMapper(start: Long,
         }
       case c: ChunkedRangeFunction[_] =>
         source.map { rv =>
+          logger.trace(s"Creating ChunkedWindowIterator for rv=${rv.key}, step=$step windowLength=$windowLength")
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorD(rv.asInstanceOf[RawDataRangeVector], start, step, end,
                                        windowLength, rangeFuncGen().asChunkedD, queryConfig))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The setup of each query, including `scanPartitions`, Lucene partId lookup, and setting up RangeVectorTransformers, happens single-threaded in the Actor receive loop's threadpool.   The overhead of this setup being run in serial can be significant.

**New behavior :**

1.  The `ExecPlan.execute` method is run entirely inside of a Monix Task, including all setup, `scanPartitions`, etc.  This means these tasks can now be parallelized and execute outside of the Actor loop.
2. All of the QueryEngine tasks and Observables are now run in a separate, configurable threadpool, named query-<dataset>.  This will make it easier to do profiling later too.

### Before

```
[info] Benchmark                                               Mode  Cnt      Score     Error  Units
[info] QueryInMemoryBenchmark.noOverlapQueries                thrpt   40   3724.422 ±  94.726  ops/s
[info] QueryInMemoryBenchmark.singleThreadedMinOverTimeQuery  thrpt   40  13859.802 ± 197.079  ops/s
[info] QueryInMemoryBenchmark.singleThreadedRawQuery          thrpt   40  24375.510 ± 385.174  ops/s
[info] QueryInMemoryBenchmark.singleThreadedSumRateCCQuery    thrpt   40   4626.947 ±  57.162  ops/s
[info] QueryInMemoryBenchmark.someOverlapQueries              thrpt   40   3112.174 ±  88.544  ops/s
```

### After

```
[info] Benchmark                                               Mode  Cnt      Score     Error  Units
[info] QueryInMemoryBenchmark.noOverlapQueries                thrpt   40   9521.884 ± 142.717  ops/s
[info] QueryInMemoryBenchmark.singleThreadedMinOverTimeQuery  thrpt   40  14027.576 ± 128.490  ops/s
[info] QueryInMemoryBenchmark.singleThreadedRawQuery          thrpt   40  23583.630 ± 553.107  ops/s
[info] QueryInMemoryBenchmark.singleThreadedSumRateCCQuery    thrpt   40   4627.667 ±  37.934  ops/s
[info] QueryInMemoryBenchmark.someOverlapQueries              thrpt   40   5756.704 ± 221.029  ops/s
```