### PR TITLE
feat(core): Optimize index recovery for long term retention

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -2,6 +2,7 @@ package filodb.core.memstore
 
 import java.util.concurrent.locks.StampedLock
 
+import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Random, Try}
@@ -17,6 +18,7 @@ import monix.eval.Task
 import monix.execution.{Scheduler, UncaughtExceptionReporter}
 import monix.execution.atomic.AtomicBoolean
 import monix.reactive.Observable
+import org.apache.lucene.util.BytesRef
 import org.jctools.maps.NonBlockingHashMapLong
 import scalaxy.loops._
 
@@ -429,16 +431,22 @@ class TimeSeriesShard(val dataset: Dataset,
       .withTag("dataset", dataset.name)
       .withTag("shard", shardNum).start()
 
+    /* We need this map to track partKey->partId because lucene index cannot be looked up
+       using partKey efficiently, and more importantly, it is eventually consistent. */
+    val partIdMap = new mutable.HashMap[BytesRef, Int]()
+
     val earliestTimeBucket = Math.max(0, currentIndexTimeBucket - numTimeBucketsToRetain)
     logger.info(s"Recovering timebuckets $earliestTimeBucket until $currentIndexTimeBucket " +
       s"for dataset=${dataset.ref} shard=$shardNum ")
-    val timeBuckets = for { tb <- earliestTimeBucket until currentIndexTimeBucket } yield {
+    // go through the buckets in reverse order to first one wins and we need not rewrite
+    // entries in lucene
+    val timeBuckets = for { tb <- currentIndexTimeBucket until earliestTimeBucket by -1 } yield {
       colStore.getPartKeyTimeBucket(dataset, shardNum, tb).map { b =>
         new IndexData(tb, b.segmentId, RecordContainer(b.segment.array()))
       }
     }
     val fut = Observable.flatten(timeBuckets: _*)
-      .foreach(tb => extractTimeBucket(tb))(ingestSched)
+      .foreach(tb => extractTimeBucket(tb, partIdMap))(ingestSched)
       .map(_ => completeIndexRecovery())
     fut.onComplete(_ => tracer.finish())
     fut
@@ -450,7 +458,8 @@ class TimeSeriesShard(val dataset: Dataset,
     logger.info(s"Bootstrapped index for dataset=${dataset.ref} shard=$shardNum")
   }
 
-  private[memstore] def extractTimeBucket(segment: IndexData): Unit = {
+  // scalastyle:off method.length
+  private[memstore] def extractTimeBucket(segment: IndexData, partIdMap: mutable.HashMap[BytesRef, Int]): Unit = {
     var numRecordsProcessed = 0
     segment.records.iterate(indexTimeBucketSchema).foreach { row =>
       // read binary record and extract the indexable data fields
@@ -459,44 +468,63 @@ class TimeSeriesShard(val dataset: Dataset,
       val partKeyBaseOnHeap = row.getBlobBase(2).asInstanceOf[Array[Byte]]
       val partKeyOffset = row.getBlobOffset(2)
       val partKeyNumBytes = row.getBlobNumBytes(2)
+      val partKeyBytesRef = new BytesRef(partKeyBaseOnHeap,
+                                         PartKeyLuceneIndex.unsafeOffsetToBytesRefOffset(partKeyOffset),
+                                         partKeyNumBytes)
 
-      // look up partId in partSet if it already exists before assigning new partId.
+      // look up partKey in partIdMap if it already exists before assigning new partId.
       // We cant look it up in lucene because we havent flushed index yet
-      val partId = partSet.getWithPartKeyBR(partKeyBaseOnHeap, partKeyOffset) match {
-        case None =>     val group = partKeyGroup(dataset.partKeySchema, partKeyBaseOnHeap, partKeyOffset, numGroups)
+      if (partIdMap.get(partKeyBytesRef).isEmpty) {
+        val partId = if (endTime == Long.MaxValue) {
+          // this is an actively ingesting partition
+          val group = partKeyGroup(dataset.partKeySchema, partKeyBaseOnHeap, partKeyOffset, numGroups)
           val part = createNewPartition(partKeyBaseOnHeap, partKeyOffset, group, CREATE_NEW_PARTID, 4)
           // In theory, we should not get an OutOfMemPartition here since
           // it should have occurred before node failed too, and with data sropped,
           // index would not be updated. But if for some reason we see it, drop data
           if (part == OutOfMemPartition) {
-            logger.error("Could not accommodate partKey while recovering index. " +
+            logger.error("Could not accommodate partKey $while recovering index. " +
               "WriteBuffer size may not be configured correctly")
-            -1
+            None
           } else {
             val stamp = partSetLock.writeLock()
             try {
               partSet.add(part) // createNewPartition doesn't add part to partSet
+              Some(part.partID)
             } finally {
               partSetLock.unlockWrite(stamp)
             }
-            part.partID
           }
-        case Some(p) =>  p.partID
-      }
-      if (partId != -1) {
-        // upsert into lucene since there can be multiple records for one partKey, and most recent wins.
-        partKeyIndex.upsertPartKey(partKeyBaseOnHeap, partId, startTime, endTime,
-          PartKeyLuceneIndex.unsafeOffsetToBytesRefOffset(partKeyOffset))(partKeyNumBytes)
-        timeBucketBitmaps.get(segment.timeBucket).set(partId)
-        activelyIngesting.synchronized {
-          if (endTime == Long.MaxValue) activelyIngesting.set(partId) else activelyIngesting.clear(partId)
+        } else {
+          // partition assign a new partId to non-ingesting partition,
+          // but no need to create a new TSPartition heap object
+          val id = nextPartitionID
+          incrementPartitionID()
+          Some(id)
         }
+
+        // add newly assigned partId to lucene index
+        partId.foreach { partId =>
+          partIdMap.put(partKeyBytesRef, partId)
+          partKeyIndex.addPartKey(partKeyBaseOnHeap, partId, startTime, endTime,
+            PartKeyLuceneIndex.unsafeOffsetToBytesRefOffset(partKeyOffset))(partKeyNumBytes)
+          timeBucketBitmaps.get(segment.timeBucket).set(partId)
+          activelyIngesting.synchronized {
+            if (endTime == Long.MaxValue) activelyIngesting.set(partId)
+            else activelyIngesting.clear(partId)
+          }
+        }
+      } else {
+        // partId has already been assigned for this partKey because we previously processed a later record in time.
+        // Time buckets are processed in reverse order, and given last one wins and is used for index,
+        // we skip this record and move on.
       }
       numRecordsProcessed += 1
     }
     shardStats.indexRecoveryNumRecordsProcessed.increment(numRecordsProcessed)
-    logger.info(s"Recovered partition keys from timebucket for dataset=${dataset.ref} shard=$shardNum" +
-      s" timebucket=${segment.timeBucket} segment=${segment.segment} numRecordsProcessed=$numRecordsProcessed")
+    logger.info(s"Recovered partKeys for dataset=${dataset.ref} shard=$shardNum" +
+      s" timebucket=${segment.timeBucket} segment=${segment.segment} numRecordsInBucket=$numRecordsProcessed" +
+      s" numPartsInIndex=${partIdMap.size} numIngestingParts=${partitions.size}")
   }
 
   def indexNames: Iterator[String] = partKeyIndex.indexNames

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -1,7 +1,6 @@
 package filodb.core.memstore
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigFactory
@@ -295,7 +294,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     }
     tsShard.initTimeBuckets()
 
-    val partIdMap = new mutable.HashMap[BytesRef, Int]()
+    val partIdMap = debox.Map.empty[BytesRef, Int]
 
     timeBucketRb.optimalContainerBytes(true).foreach { bytes =>
       tsShard.extractTimeBucket(new IndexData(1, 0, RecordContainer(bytes)), partIdMap)

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -102,16 +102,17 @@ trait ExecPlan extends QueryCommand {
     // Lucene index lookup, and On-Demand Paging orchestration work could suck up nontrivial time and
     // we don't want these to happen in a single thread.
     Task {
-      qLogger.debug(s"queryId: ${id} Started ExecPlan ${getClass.getSimpleName} with $args")
+      qLogger.debug(s"queryId: ${id} Setting up ExecPlan ${getClass.getSimpleName} with $args")
       val res = doExecute(source, dataset, queryConfig)
       val schema = schemaOfDoExecute(dataset)
       val finalRes = rangeVectorTransformers.foldLeft((res, schema)) { (acc, transf) =>
-        qLogger.debug(s"queryId: ${id} Started Transformer ${transf.getClass.getSimpleName} with ${transf.args}")
+        qLogger.debug(s"queryId: ${id} Setting up Transformer ${transf.getClass.getSimpleName} with ${transf.args}")
         (transf.apply(acc._1, queryConfig, limit, acc._2), transf.schema(dataset, acc._2))
       }
       val recSchema = SerializableRangeVector.toSchema(finalRes._2.columns, finalRes._2.brSchemas)
       val builder = SerializableRangeVector.toBuilder(recSchema)
       var numResultSamples = 0 // BEWARE - do not modify concurrently!!
+      qLogger.debug(s"queryId: ${id} Materializing SRVs from iterators if necessary")
       finalRes._1
         .map {
           case srv: SerializableRangeVector =>
@@ -261,6 +262,10 @@ abstract class NonLeafExecPlan extends ExecPlan {
   /**
     * Sub-class non-leaf nodes should provide their own implementation of how
     * to compose the sub-query results here.
+    *
+    * @param childResponses observable of a pair. First element of pair is the QueryResponse for
+    *                       a child ExecPlan, the second element is the index of the child plan.
+    *                       There is one response per child plan.
     */
   protected def compose(dataset: Dataset,
                         childResponses: Observable[(QueryResponse, Int)],


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
We attempt to create a TimeSeriesPartition for every partKey in cass index time buckets.
With this reverse lookup of partKey to partId could also be done using partSet.

This was ok for 3 day retention given most partitions are ingesting, but does not scale for long term retention where majority of partitions are not ingesting. If left as is, it would lead to eviction of nodes from the beginning. 

**New behavior :**
* We now have a new partKey->partId on heap map which is used for reverse lookup.
* we create a TimeSeriesPartition object only for currently ingesting partitions.
* We load time buckets in reverse order since we know that last record wins. This way lucene documents do not need to be updated.

The goal of the PR is to
* Reduce number of entries in `partitions` and `partSet` data structures, thereby reducing memory requirements especially for long term datasets. We pay the cost of a temporary map during recovery that holds all partKeys on heap, but is discarded before ingestion starts.
* Optimize the Lucene recovery by scanning through records in reverse order of buckets. This avoids the expensive Lucene upserts - adds become sufficient.
