### PR TITLE
bug(query): resets function returns zero instead of NaN for empty window

### DIFF
--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
@@ -119,11 +119,12 @@ object DerivFunction extends RangeFunction {
 }
 
 class ResetsFunction extends RangeFunction {
-  var resets = 0
+  var resets = Double.NaN // NaN for windows that do not have data
 
   def addedToWindow(row: TransientRow, window: Window): Unit = {
     val size = window.size
     if (size > 1 && window(size - 2).value > row.value) {
+      if (resets.isNaN) resets = 0
       resets += 1
     }
   }

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -83,6 +83,10 @@ class RateFunctionsSpec extends FunSpec with Matchers {
     val q3 = new IndexedArrayQueue[TransientRow]()
     val gaugeWindowForReset = new QueueBasedWindow(q3)
     val resetsFunction = new ResetsFunction
+
+    resetsFunction.apply(startTs, endTs, gaugeWindowForReset, toEmit, queryConfig)
+    assert(toEmit.value.isNaN) // Empty window should return NaN
+
     gaugeSamples.foreach { case (t, v) =>
       val s = new TransientRow(t, v)
       q3.add(s)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

- Reset function returns 0 instead of NaN for no-data windows
- fix is to return NaN when there are no samples for a time window