### PR TITLE
bug(coord): Remove publish snapshot for RecoveryInProgress

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
@@ -449,7 +449,8 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
         // Above condition ensures that we respond to shard events only from the node shard is currently assigned to.
         // Needed to avoid race conditions where IngestionStopped for an old assignment comes after shard is reassigned.
         updateFromShardEvent(event)
-        publishSnapshot(event.ref)
+        // RecoveryInProgress status results in too many messages that really do not need a publish
+        if (!event.isInstanceOf[RecoveryInProgress]) publishSnapshot(event.ref)
         // reassign shard if IngestionError. Exclude previous node since it had error shards.
         event match {
           case _: IngestionError =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

A recent bug fix to send snapshots for missing shard events resulted in publish of too many snapshots especially for RecoveryInProgress events.

This caused flooding of events on NodeClusterActor, and non responsive HTTP cluster status calls.

This also brought to surface some bugs where we were accessing actor context from async thread.

**New behavior :**

* Dont send snapshot on RecoveryInProgress events
* Save context.parent on IngestionActor startup and use that instead of context.parent from future thread.
