### PR TITLE
fix(memory, query): Fix exceptions in Histogram summing

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -116,16 +116,7 @@ trait Histogram extends Ordered[Histogram] {
 }
 
 object Histogram {
-  val empty = new Histogram {
-    final def numBuckets: Int = 0
-    final def bucketTop(no: Int): Double = ???
-    final def bucketValue(no: Int): Double = ???
-    final def serialize(intoBuf: Option[MutableDirectBuffer] = None): MutableDirectBuffer = {
-      val buf = intoBuf.getOrElse(BinaryHistogram.histBuf)
-      BinaryHistogram.writeNonIncreasing(HistogramBuckets.emptyBuckets, Array[Long](), buf)
-      buf
-    }
-  }
+  val empty = MutableHistogram(HistogramBuckets.emptyBuckets, Array.empty)
 }
 
 trait HistogramWithBuckets extends Histogram {
@@ -176,7 +167,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
   /**
    * Copies this histogram as a new copy so it can be used for aggregation or mutation. Allocates new storage.
    */
-  final def copy: Histogram = MutableHistogram(buckets, values.clone)
+  final def copy: MutableHistogram = MutableHistogram(buckets, values.clone)
 
   /**
    * Adds the values from another Histogram.

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -279,7 +279,7 @@ class AppendableHistogramVector(factory: MemFactory,
 
 trait HistogramReader extends VectorDataReader {
   def buckets: HistogramBuckets
-  def apply(index: Int): Histogram
+  def apply(index: Int): HistogramWithBuckets
   def sum(start: Int, end: Int): MutableHistogram
 }
 
@@ -372,7 +372,7 @@ class RowHistogramReader(histVect: Ptr.U8) extends HistogramReader {
   def length(addr: BinaryVectorPtr): Int = length
 
   // WARNING: histogram returned is shared between calls, do not reuse!
-  final def apply(index: Int): Histogram = {
+  final def apply(index: Int): HistogramWithBuckets = {
     require(length > 0)
     val histPtr = locate(index)
     val histLen = histPtr.asU16.getU16

--- a/query/src/main/scala/filodb/query/exec/TransientRow.scala
+++ b/query/src/main/scala/filodb/query/exec/TransientRow.scala
@@ -56,8 +56,8 @@ final class TransientRow(var timestamp: Long, var value: Double) extends Mutable
 }
 
 final class TransientHistRow(var timestamp: Long = 0L,
-                             var value: bv.Histogram = bv.Histogram.empty) extends MutableRowReader {
-  def setValues(ts: Long, hist: bv.Histogram): Unit = {
+                             var value: bv.HistogramWithBuckets = bv.Histogram.empty) extends MutableRowReader {
+  def setValues(ts: Long, hist: bv.HistogramWithBuckets): Unit = {
     timestamp = ts
     value = hist
   }

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -166,7 +166,7 @@ class SumOverTimeChunkedFunctionL extends SumOverTimeChunkedFunction() with Chun
   }
 }
 
-class SumOverTimeChunkedFunctionH(var h: bv.Histogram = bv.Histogram.empty)
+class SumOverTimeChunkedFunctionH(var h: bv.MutableHistogram = bv.Histogram.empty)
 extends ChunkedRangeFunction[TransientHistRow] {
   override final def reset(): Unit = { h = bv.Histogram.empty }
   final def apply(endTimestamp: Long, sampleToEmit: TransientHistRow): Unit = {

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -315,7 +315,7 @@ extends LastSampleChunkedFunction[TransientRow] {
 }
 
 // LastSample function for Histogram columns
-class LastSampleChunkedFunctionH(var value: bv.Histogram = bv.Histogram.empty)
+class LastSampleChunkedFunctionH(var value: bv.HistogramWithBuckets = bv.Histogram.empty)
 extends LastSampleChunkedFunction[TransientHistRow] {
   override final def reset(): Unit = { timestamp = -1L; value = bv.Histogram.empty }
   final def apply(endTimestamp: Long, sampleToEmit: TransientHistRow): Unit = {


### PR DESCRIPTION
They were caused by some type misalignment.  Now everything in aggregations is a HistogramWithBuckets.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Exceptions seen such as 
```
error='java.lang.ClassCastException: filodb.memory.format.vectors.Histogram$$anon$1 cannot be cast to filodb.memory.format.vectors.HistogramWithBuckets
	at filodb.query.exec.HistSumRowAggregator$.reduceAggregate(AggrOverRangeVectors.scala:339)
	at filodb.query.exec.HistSumRowAggregator$.reduceAggregate(AggrOverRangeVectors.scala:322)
	at filodb.query.exec.RowAggregator$class.reduceMappedRow(AggrOverRangeVectors.scala:237)
	at filodb.query.exec.HistSumRowAggregator$.reduceMappedRow(AggrOverRangeVectors.scala:
```

**New behavior :**

A whole bunch of types changed to prevent cast issues:
- Histogram aggregators and `HistTransientRow` now use `HistogramWithBuckets` and `MutableHistogram` types
- `Histogram.empty` is itself a `MutableHistogram` now instead of anon extension of `Histogram`
- Better checks in histogram aggregator and better tests
