### PR TITLE
feat(query): Allow metric name as tag in promQL; Allow escape chars in tag values

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -17,13 +17,11 @@ trait Functions extends Base with Operators with Vectors {
 
     def toPeriodicSeriesPlan(timeParams: TimeRangeParams): PeriodicSeriesPlan = {
       val seriesParam = allParams.filter(_.isInstanceOf[Series]).head.asInstanceOf[Series]
-      val otherParams = allParams.filter(!_.equals(seriesParam)).map(_ match {
+      val otherParams = allParams.filter(!_.equals(seriesParam)).map {
         case num: ScalarExpression => num.toScalar
-        case s: InstantExpression => s.realMetricName.replaceAll("^\"|\"$", "")
-        case _ =>
-          throw new IllegalArgumentException("Parameters can be a string or number")
+        case s: InstantExpression  => s.realMetricName.replaceAll("^\"|\"$", "")
+        case _                     => throw new IllegalArgumentException("Parameters can be a string or number")
       }
-      )
 
       val instantFunctionIdOpt = InstantFunctionId.withNameInsensitiveOption(name)
       val filoFunctionIdOpt = FiloFunctionId.withNameInsensitiveOption(name)

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -19,7 +19,7 @@ trait Functions extends Base with Operators with Vectors {
       val seriesParam = allParams.filter(_.isInstanceOf[Series]).head.asInstanceOf[Series]
       val otherParams = allParams.filter(!_.equals(seriesParam)).map(_ match {
         case num: ScalarExpression => num.toScalar
-        case s: InstantExpression => s.metricName.replaceAll("^\"|\"$", "")
+        case s: InstantExpression => s.realMetricName.replaceAll("^\"|\"$", "")
         case _ =>
           throw new IllegalArgumentException("Parameters can be a string or number")
       }

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -84,13 +84,30 @@ trait Vectors extends Scalars with TimeUnits with Base {
   }
 
   sealed trait Vector extends Expression {
+
+    def metricName: Option[String]
+    def labelSelection: Seq[LabelMatch]
+
+    def realMetricName: String = {
+      val nameLabelValue = labelSelection.find(_.label == PromMetricLabel).map(_.value)
+      if (nameLabelValue.nonEmpty && metricName.nonEmpty) {
+        throw new IllegalArgumentException("Metric name should not be set twice")
+      }
+      metricName.orElse(nameLabelValue)
+        .getOrElse(throw new IllegalArgumentException("Metric name is not present"))
+    }
+
     protected def labelMatchesToFilters(labels: Seq[LabelMatch]) =
       labels.map { labelMatch =>
-        labelMatch.labelMatchOp match {
-          case EqualMatch      => ColumnFilter(labelMatch.label, query.Filter.Equals(labelMatch.value))
-          case NotRegexMatch   => ColumnFilter(labelMatch.label, query.Filter.NotEqualsRegex(labelMatch.value))
-          case RegexMatch      => ColumnFilter(labelMatch.label, query.Filter.EqualsRegex(labelMatch.value))
-          case NotEqual(false) => ColumnFilter(labelMatch.label, query.Filter.NotEquals(labelMatch.value))
+        val labelValue = labelMatch.value.replace("\\\\", "\\")
+                                         .replace("\\\"", "\"")
+                                         .replace("\\n", "\n")
+                                         .replace("\\t", "\t")
+          labelMatch.labelMatchOp match {
+          case EqualMatch      => ColumnFilter(labelMatch.label, query.Filter.Equals(labelValue))
+          case NotRegexMatch   => ColumnFilter(labelMatch.label, query.Filter.NotEqualsRegex(labelValue))
+          case RegexMatch      => ColumnFilter(labelMatch.label, query.Filter.EqualsRegex(labelValue))
+          case NotEqual(false) => ColumnFilter(labelMatch.label, query.Filter.NotEquals(labelValue))
           case other: Any      => throw new IllegalArgumentException(s"Unknown match operator $other")
         }
       // Remove the column selector as that is not a real time series filter
@@ -114,18 +131,11 @@ trait Vectors extends Scalars with TimeUnits with Base {
     * appending a set of labels to match in curly braces ({}).
     */
 
-  case class InstantExpression(metricName: Option[String],
-                               labelSelection: Seq[LabelMatch],
+  case class InstantExpression(override val metricName: Option[String],
+                               override val labelSelection: Seq[LabelMatch],
                                offset: Option[Duration]) extends Vector with PeriodicSeries {
 
     val staleDataLookbackSeconds = 5 * 60 // 5 minutes
-
-    private val nameLabelValue = labelSelection.find(_.label == PromMetricLabel).map(_.value)
-    if (nameLabelValue.nonEmpty && metricName.nonEmpty) {
-      throw new IllegalArgumentException("Metric name should not be set twice")
-    }
-    val realMetricName = metricName.orElse(nameLabelValue)
-      .getOrElse(throw new IllegalArgumentException("Metric name is not present"))
 
     private[prometheus] val columnFilters = labelMatchesToFilters(labelSelection)
     private[prometheus] val columns = labelMatchesToColumnName(labelSelection)
@@ -142,12 +152,9 @@ trait Vectors extends Scalars with TimeUnits with Base {
         timeParams.start * 1000, timeParams.step * 1000, timeParams.end * 1000
       )
     }
-  }
 
-  case class MetadataExpression(instantExpression: InstantExpression) extends Vector with Metadata {
-
-    override def toMetadataQueryPlan(timeParams: TimeRangeParams): MetadataQueryPlan = {
-      SeriesKeysByFilters(instantExpression.getColFilters, timeParams.start * 1000, timeParams.end * 1000)
+    def toMetadataPlan(timeParams: TimeRangeParams): SeriesKeysByFilters = {
+      SeriesKeysByFilters(getColFilters, timeParams.start * 1000, timeParams.end * 1000)
     }
   }
 
@@ -158,17 +165,10 @@ trait Vectors extends Scalars with TimeUnits with Base {
     * at the end of a vector selector to specify how far back in time values
     * should be fetched for each resulting range vector element.
     */
-  case class RangeExpression(metricName: Option[String],
-                             labelSelection: Seq[LabelMatch],
+  case class RangeExpression(override val metricName: Option[String],
+                             override val labelSelection: Seq[LabelMatch],
                              window: Duration,
                              offset: Option[Duration]) extends Vector with SimpleSeries {
-    private val nameLabelValue = labelSelection.find(_.label == PromMetricLabel).map(_.value)
-
-    if (nameLabelValue.nonEmpty && metricName.nonEmpty) {
-      throw new IllegalArgumentException("Metric name should not be set twice")
-    }
-    val realMetricName = metricName.orElse(nameLabelValue)
-      .getOrElse(throw new IllegalArgumentException("Metric name is not present"))
 
     private[prometheus] val columnFilters = labelMatchesToFilters(labelSelection)
     private[prometheus] val columns = labelMatchesToColumnName(labelSelection)

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -333,7 +333,7 @@ object Parser extends Expression {
   def metadataQueryToLogicalPlan(query: String, timeParams: TimeRangeParams): LogicalPlan = {
     val expression = parseQuery(query)
     expression match {
-      case p: InstantExpression => MetadataExpression(p).toMetadataQueryPlan(timeParams)
+      case p: InstantExpression => p.toMetadataPlan(timeParams)
       case _ => throw new UnsupportedOperationException()
     }
   }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -322,6 +322,8 @@ class ParserSpec extends FunSpec with Matchers {
         "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(instance,EqualsRegex(.*)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),Absent,List())",
       "absent(sum(nonexistent{job=\"myjob\"}))" ->
         "ApplyInstantFunction(Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),List(),List(),List()),Absent,List())",
+      """{__name__="foo\\\"\n\t",job="myjob"}[5m]""" ->
+        "RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(foo\\\"\n\t)), ColumnFilter(job,Equals(myjob))),List())",
       "{__name__=\"foo\",job=\"myjob\"}" ->
         "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(foo)), ColumnFilter(job,Equals(myjob))),List()),1524855988000,1000000,1524855988000)",
       "{__name__=\"foo\",job=\"myjob\"}[5m]" ->
@@ -332,7 +334,7 @@ class ParserSpec extends FunSpec with Matchers {
 
     val qts: Long = 1524855988L
     queryToLpString.foreach { case (q, e) =>
-      println(s"Parsing $q")
+      info(s"Parsing $q")
       val lp = Parser.queryToLogicalPlan(q, qts)
       lp.toString shouldEqual (e)
     }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -265,7 +265,7 @@ class ParserSpec extends FunSpec with Matchers {
       "sum(http_requests_total) without (instance)" ->
         "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(),List(),List(instance))",
       "count_values(\"version\", build_version)" ->
-        "Aggregate(CountValues,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(build_version))),List()),1524855988000,1000000,1524855988000),List(\"version\"),List(),List())",
+        "Aggregate(CountValues,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(build_version))),List()),1524855988000,1000000,1524855988000),List(Some(\"version\")),List(),List())",
       "label_replace(up{job=\"api-server\",service=\"a:c\"}, \"foo\", \"$1\", \"service\", \"(.*):.*\")" ->
         "ApplyMiscellaneousFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(service,Equals(a:c)), ColumnFilter(__name__,Equals(up))),List()),1524855988000,1000000,1524855988000),LabelReplace,List(foo, $1, service, (.*):.*))",
       "sum(http_requests_total)" ->
@@ -321,12 +321,18 @@ class ParserSpec extends FunSpec with Matchers {
       "absent(nonexistent{job=\"myjob\",instance=~\".*\"})" ->
         "ApplyInstantFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(instance,EqualsRegex(.*)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),Absent,List())",
       "absent(sum(nonexistent{job=\"myjob\"}))" ->
-        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),List(),List(),List()),Absent,List())"
+        "ApplyInstantFunction(Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(myjob)), ColumnFilter(__name__,Equals(nonexistent))),List()),1524855988000,1000000,1524855988000),List(),List(),List()),Absent,List())",
+      "{__name__=\"foo\",job=\"myjob\"}" ->
+        "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(foo)), ColumnFilter(job,Equals(myjob))),List()),1524855988000,1000000,1524855988000)",
+      "{__name__=\"foo\",job=\"myjob\"}[5m]" ->
+        "RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(foo)), ColumnFilter(job,Equals(myjob))),List())",
+      "sum({__name__=\"foo\",job=\"myjob\"})" ->
+        "Aggregate(Sum,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(foo)), ColumnFilter(job,Equals(myjob))),List()),1524855988000,1000000,1524855988000),List(),List(),List())"
     )
 
     val qts: Long = 1524855988L
     queryToLpString.foreach { case (q, e) =>
-      info(s"Parsing $q")
+      println(s"Parsing $q")
       val lp = Parser.queryToLogicalPlan(q, qts)
       lp.toString shouldEqual (e)
     }


### PR DESCRIPTION
**Summary**
* Now allow metric name to be provided as a tag in promQL. Queries such as `{__name__="foo", baz="boo" }` are supported.
* Allow special characters in tag values. This allows possibility of special characters in metric names too.

**Pull Request checklist**
- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

