### PR TITLE
misc(core): Remove code for old chunk id encoding format.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -121,7 +121,7 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
     if (newChunk) {
       // First row of a chunk, set the start time to it
       val (infoAddr, newAppenders) = bufferPool.obtain()
-      val currentChunkID = newChunkID(ts)
+      val currentChunkID = chunkID(ts)
       ChunkSetInfo.setChunkID(infoAddr, currentChunkID)
       ChunkSetInfo.resetNumRows(infoAddr)    // Must reset # rows otherwise it keeps increasing!
       ChunkSetInfo.setStartTime(infoAddr, ts)

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -41,7 +41,7 @@ object ChunkSet {
   def apply(dataset: Dataset, part: PartitionKey, rows: Seq[RowReader], factory: MemFactory): ChunkSet = {
     require(rows.nonEmpty)
     val startTime = dataset.timestamp(rows.head)
-    val info = ChunkSetInfo(factory, dataset, newChunkID(startTime), rows.length,
+    val info = ChunkSetInfo(factory, dataset, chunkID(startTime), rows.length,
                             startTime,
                             dataset.timestamp(rows.last))
     val filoSchema = Column.toFiloSchema(dataset.dataColumns)

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -13,8 +13,7 @@ package object store {
   val decompressor = new ThreadLocal[LZ4FastDecompressor]()
 
   val msBitOffset   = 21
-  val baseNsBitOffset = 9   // 2 ** 9 = 512
-  val lowerBitsMask   = Math.pow(2, msBitOffset).toInt - 1
+  val lowerBitsMask = Math.pow(2, msBitOffset).toInt - 1
 
   // Assume LZ4 compressor has state and is not thread safe.  Use ThreadLocals.
   private def getCompressor: LZ4Compressor = {

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -2,26 +2,19 @@ package filodb.core
 
 import java.nio.ByteBuffer
 
-import com.github.rholder.fauxflake.IdGenerators
 import net.jpountz.lz4.{LZ4Compressor, LZ4Factory, LZ4FastDecompressor}
 
 import filodb.core.Types._
 import filodb.core.metadata.Dataset
-import filodb.core.SingleKeyTypes.Long64HighBit
 import filodb.memory.format.{RowReader, UnsafeUtils}
 
 package object store {
   val compressor = new ThreadLocal[LZ4Compressor]()
   val decompressor = new ThreadLocal[LZ4FastDecompressor]()
 
-  val machineIdLong = IdGenerators.newSnowflakeIdGenerator.generateId(1)
-  val machineId1024 = (machineIdLong.asLong >> 12) & (0x03ff)
   val msBitOffset   = 21
-  val machIdBitOffset = 11
   val baseNsBitOffset = 9   // 2 ** 9 = 512
-  val nanoBitMask     = Math.pow(2, machIdBitOffset).toInt - 1
   val lowerBitsMask   = Math.pow(2, msBitOffset).toInt - 1
-  val baseTimeMillis  = org.joda.time.DateTime.parse("2016-01-01T00Z").getMillis
 
   // Assume LZ4 compressor has state and is not thread safe.  Use ThreadLocals.
   private def getCompressor: LZ4Compressor = {
@@ -95,32 +88,13 @@ package object store {
   }
 
   /**
-   * 64-bit TimeUUID function designed specifically for generating unique ChunkIDs.  Chunks take a while
-   * to encode so rarely would you be generating more than a few thousand chunks per second.  Format:
-   * bits 63-21 (43 bits):  milliseconds since Jan 1, 2016 - enough for 278.7 years or through 2294
-   * bits 20-11 (10 bits):  SnowFlake-style machine ID from FauxFlake library
-   * bits 10-0  (11 bits):  nanosecond time in 512-ns increments.
-   *
-   * Bit 63 is inverted to allow for easy comparisons using standard signed Long math.
-   *
-   * The TimeUUID function generally increases in time but successive calls are not guaranteed to be strictly
-   * increasing, but if called greater than 512ns apart should be unique.
-   */
-  def timeUUID64: Long = {
-    ((System.currentTimeMillis - baseTimeMillis) << msBitOffset) |
-    (machineId1024 << machIdBitOffset) |
-    ((System.nanoTime >> baseNsBitOffset) & nanoBitMask) ^
-    Long64HighBit
-  }
-
-  /**
-   * New formulation for chunkID based on a combo of the start time for a chunk and the current time in the lower
+   * Formulation for chunkID based on a combo of the start time for a chunk and the current time in the lower
    * bits to disambiguate two chunks which have the same start time.
    *
    * bits 63-21 (43 bits):  milliseconds since Unix Epoch (1/1/1970) - enough for 278.7 years or through 2248
    * bits 20-0  (21 bits):  The lower 21 bits of nanotime for disambiguation
    */
-  @inline final def newChunkID(startTime: Long): Long = chunkID(startTime, System.nanoTime)
+  @inline final def chunkID(startTime: Long): Long = chunkID(startTime, System.nanoTime)
 
   @inline final def chunkID(startTime: Long, currentTime: Long): Long =
     (startTime << msBitOffset) | (currentTime & lowerBitsMask)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

While researching how to implement time bucket based chunk persistence I noticed that we have some unused code which was confusing me. I'm removing it.