### PR TITLE
bug(query) : comparison operator returns metric even when no values are present

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -3,14 +3,8 @@ package filodb.coordinator.queryengine2
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
-
 import akka.actor.ActorRef
 import com.typesafe.scalalogging.StrictLogging
-import kamon.Kamon
-import monix.eval.Task
-
 import filodb.coordinator.ShardMapper
 import filodb.coordinator.client.QueryCommands.QueryOptions
 import filodb.core.Types
@@ -19,8 +13,13 @@ import filodb.core.metadata.Dataset
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.store._
 import filodb.prometheus.ast.Vectors.PromMetricLabel
-import filodb.query.{exec, _}
 import filodb.query.exec._
+import filodb.query.{exec, _}
+import kamon.Kamon
+import monix.eval.Task
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
 
 /**
   * FiloDB Query Engine is the facade for execution of FiloDB queries.
@@ -113,7 +112,8 @@ class QueryEngine(dataset: Dataset,
 
   private def dispatcherForShard(shard: Int): PlanDispatcher = {
     val targetActor = shardMapperFunc.coordForShard(shard)
-    if (targetActor == ActorRef.noSender) throw new RuntimeException("Not all shards available") // TODO fix this
+    if (targetActor == ActorRef.noSender)
+      throw new RuntimeException(s"Shard: $shard is not available") // TODO fix this
     ActorPlanDispatcher(targetActor)
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -112,8 +112,10 @@ class QueryEngine(dataset: Dataset,
 
   private def dispatcherForShard(shard: Int): PlanDispatcher = {
     val targetActor = shardMapperFunc.coordForShard(shard)
-    if (targetActor == ActorRef.noSender)
+    if (targetActor == ActorRef.noSender) {
+      logger.debug(s"ShardMapper: $shardMapperFunc")
       throw new RuntimeException(s"Shard: $shard is not available") // TODO fix this
+    }
     ActorPlanDispatcher(targetActor)
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -3,8 +3,14 @@ package filodb.coordinator.queryengine2
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
 import akka.actor.ActorRef
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
+import monix.eval.Task
+
 import filodb.coordinator.ShardMapper
 import filodb.coordinator.client.QueryCommands.QueryOptions
 import filodb.core.Types
@@ -13,13 +19,8 @@ import filodb.core.metadata.Dataset
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.store._
 import filodb.prometheus.ast.Vectors.PromMetricLabel
-import filodb.query.exec._
 import filodb.query.{exec, _}
-import kamon.Kamon
-import monix.eval.Task
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
+import filodb.query.exec._
 
 /**
   * FiloDB Query Engine is the facade for execution of FiloDB queries.

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -78,7 +78,7 @@ object PrometheusModel {
 
   def toPromSuccessResponse(qr: filodb.query.QueryResult, verbose: Boolean): SuccessResponse = {
     SuccessResponse(Data(toPromResultType(qr.resultType),
-      qr.result.map(toPromResult(_, verbose)).filter(_.values.size > 0)))
+      qr.result.map(toPromResult(_, verbose)).filter(_.values.nonEmpty)))
   }
 
   def toPromResultType(r: QueryResultType): String = {

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -1,9 +1,8 @@
 package filodb.prometheus.query
 
-import remote.RemoteStorage._
-
 import filodb.core.query.{ColumnFilter, Filter, SerializableRangeVector}
 import filodb.query.{IntervalSelector, LogicalPlan, QueryResultType, RawSeries}
+import remote.RemoteStorage._
 
 object PrometheusModel {
 
@@ -77,7 +76,8 @@ object PrometheusModel {
   }
 
   def toPromSuccessResponse(qr: filodb.query.QueryResult, verbose: Boolean): SuccessResponse = {
-    SuccessResponse(Data(toPromResultType(qr.resultType), qr.result.map(toPromResult(_, verbose))))
+    SuccessResponse(Data(toPromResultType(qr.resultType),
+      qr.result.map(toPromResult(_, verbose)).filter(_.values.size > 0)))
   }
 
   def toPromResultType(r: QueryResultType): String = {

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -1,8 +1,9 @@
 package filodb.prometheus.query
 
+import remote.RemoteStorage._
+
 import filodb.core.query.{ColumnFilter, Filter, SerializableRangeVector}
 import filodb.query.{IntervalSelector, LogicalPlan, QueryResultType, RawSeries}
-import remote.RemoteStorage._
 
 object PrometheusModel {
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Output has RangeVector with metric even when there are no rows present
 ```
{
        "metric": {
          "job": "Test-data-1554428389670",
          "instance": "inst-8",
          "service": "service-9",
          "_ns": "Test-data-1554428389670",
          "code": "566",
          "version": "3.1.86",
          "__name__": "my_counter",
          "mode": "user"
        },
        "values": [
          
        ]
 }
```

**New behavior :**
Remove range vectors which don't have any values
```
{
  "status": "success",
  "data": {
    "resultType": "matrix",
    "result": [
      
    ]
  }
}
```