### PR TITLE
feat(config): Better default buckets for Kamon-Prometheus

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -358,13 +358,16 @@ kamon {
       16384,
       32768,
       65536,
-      128000,
-      256000,
-      512000
+      131072,
+      262144,
+      524288
     ]
 
-    # Start at 0.1ms so we can measure smaller timings
+    # Start at 0.01ms so we can measure smaller timings
     time-buckets = [
+      0.00001,
+      0.000025,
+      0.00005,
       0.0001,
       0.00025,
       0.0005,

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -338,3 +338,53 @@ kamon.zipkin {
   max.requests = 128
   message.max.bytes = 262144
 }
+
+kamon {
+  prometheus.buckets {
+    # Have more buckets, better resolution really helps esp with heatmaps
+    default-buckets = [
+      4,
+      8,
+      16,
+      32,
+      64,
+      128,
+      256,
+      512,
+      1024,
+      2048,
+      4096,
+      8192,
+      16384,
+      32768,
+      65536,
+      128000,
+      256000,
+      512000
+    ]
+
+    # Start at 0.1ms so we can measure smaller timings
+    time-buckets = [
+      0.0001,
+      0.00025,
+      0.0005,
+      0.001,
+      0.0025,
+      0.005,
+      0.01,
+      0.025,
+      0.05,
+      0.1,
+      0.25,
+      0.5,
+      1,
+      2.5,
+      5,
+      10,
+      25,
+      50,
+      100,
+      250
+    ]
+  }
+}


### PR DESCRIPTION
Better default buckets for Kamon-prometheus.  Larger range for time tracing and more buckets for other histograms.