### PR TITLE
feat(core,kafka): Detailed ingestion logging for matching subset of records

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ and [filodb-discuss](https://groups.google.com/forum/#!forum/filodb-discuss) goo
 - [Code Walkthrough](#code-walkthrough)
 - [Building and Testing](#building-and-testing)
   - [Debugging serialization and queries](#debugging-serialization-and-queries)
+  - [Other debugging tips](#other-debugging-tips)
   - [Benchmarking](#benchmarking)
 - [You can help!](#you-can-help)
 
@@ -707,6 +708,13 @@ Right now both Java and Kryo serialization are used for Akka messaging.  Kryo is
 To dynamically change the log level, you can use the `/admin/loglevel` HTTP API (per host).  Example:
 
     curl -d 'trace' http://localhost:8080/admin/loglevel/com.esotericsoftware.minlog
+
+### Other debugging tips
+
+To debug raw record ingestion and data mismatches:
+
+* Set the `trace-filters` source config setting... see `timeseries-dev-source.conf` and `TimeSeriesShard` `tracedPartFilters`.  This will log every sample for time series matching criteria set in trace-filters.
+* Use the filtering capability in `filodb.kafka.TestConsumer` to print out raw records received from Kafka.
 
 ### Benchmarking
 

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -71,6 +71,11 @@
         # Thats about 6MB
         evicted-pk-bloom-filter-capacity = 50000
 
+        # Uncomment to log at DEBUG ingested samples matching certain filters
+        # Only works for StringColumn fields in the partition key
+        # trace-filters = {
+        #   metric = "bad-metric-to-log"
+        # }
       }
       downsample {
         # can be disabled by setting this flag to false

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -71,8 +71,8 @@
         # Thats about 6MB
         evicted-pk-bloom-filter-capacity = 50000
 
-        # Uncomment to log at DEBUG ingested samples matching certain filters
-        # Only works for StringColumn fields in the partition key
+        # Uncomment to log at DEBUG ingested samples matching these filters on Partition Key columns
+        # Only works for StringColumn fields in the partition key. Scope may be expanded later.
         # trace-filters = {
         #   metric = "bad-metric-to-log"
         # }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -109,7 +109,7 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
    *
    * @param blockHolder the BlockMemFactory to use for encoding chunks in case of WriteBuffer overflow
    */
-  final def ingest(row: RowReader, blockHolder: BlockMemFactory): Unit = {
+  def ingest(row: RowReader, blockHolder: BlockMemFactory): Unit = {
     // NOTE: lastTime is not persisted for recovery.  Thus the first sample after recovery might still be out of order.
     val ts = dataset.timestamp(row)
     if (ts < timestampOfLatestSample) {
@@ -165,7 +165,7 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
    * To guarantee no more writes happen when switchBuffers is called, have ingest() and switchBuffers() be
    * called from a single thread / single synchronous stream.
    */
-  final def switchBuffers(blockHolder: BlockMemFactory, encode: Boolean = false): Boolean =
+  def switchBuffers(blockHolder: BlockMemFactory, encode: Boolean = false): Boolean =
     nonEmptyWriteBuffers && {
       val oldInfo = currentInfo
       val oldAppenders = currentChunks
@@ -391,6 +391,34 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
     if (currentInfo != nullInfo) bufferPool.release(currentInfo.infoAddr, currentChunks)
   }
 }
+
+/**
+ * A variant of the above which logs every sample ingested and buffer switching/encoding event,
+ * for debugging purposes.
+ */
+class TracingTimeSeriesPartition(partID: Int,
+                                 dataset: Dataset,
+                                 partitionKey: BinaryRegion.NativePointer,
+                                 shard: Int,
+                                 bufferPool: WriteBufferPool,
+                                 shardStats: TimeSeriesShardStats,
+                                 memFactory: MemFactory,
+                                 initMapSize: Int) extends
+TimeSeriesPartition(partID, dataset, partitionKey, shard, bufferPool, shardStats, memFactory, initMapSize) {
+  import TimeSeriesPartition._
+
+  override def ingest(row: RowReader, blockHolder: BlockMemFactory): Unit = {
+    _log.debug(s"partID=$partID $stringPartition - ingesting ts=${dataset.timestamp(row)} " +
+               (1 until dataset.dataColumns.length).map(row.getAny).mkString("[", ",", "]"))
+    super.ingest(row, blockHolder)
+  }
+
+  override def switchBuffers(blockHolder: BlockMemFactory, encode: Boolean = false): Boolean = {
+    _log.debug(s"partID=$partID $stringPartition - switchBuffers, encode=$encode")
+    super.switchBuffers(blockHolder, encode)
+  }
+}
+
 
 final case class PartKeyRowReader(records: Iterator[TimeSeriesPartition]) extends Iterator[RowReader] {
   var currVal: TimeSeriesPartition = _

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -394,7 +394,12 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
 
 /**
  * A variant of the above which logs every sample ingested and buffer switching/encoding event,
- * for debugging purposes.
+ * for debugging purposes.  See the trace-filters StoreConfig / ingestion config setting.
+ *
+ * NOTE(velvia): The reason why I used inheritance was not so much memory but just ease of implementation.
+ * With composition we'd need to add in tons of methods and clutter things up quite a bit. If it simply
+ * implemented ReadablePartition that might break things in a bunch of places.
+ * So best way to keep changes small and balance out different needs
  */
 class TracingTimeSeriesPartition(partID: Int,
                                  dataset: Dataset,

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -32,7 +32,9 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              multiPartitionODP: Boolean,
                              demandPagingParallelism: Int,
                              demandPagingEnabled: Boolean,
-                             evictedPkBfCapacity: Int) {
+                             evictedPkBfCapacity: Int,
+                             // filters on ingested records to log in detail
+                             traceFilters: Map[String, String]) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -80,6 +82,7 @@ object StoreConfig {
                                            |demand-paging-parallelism = 4
                                            |demand-paging-enabled = true
                                            |evicted-pk-bloom-filter-capacity = 5000000
+                                           |trace-filters = {}
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -102,7 +105,8 @@ object StoreConfig {
                 config.getBoolean("multi-partition-odp"),
                 config.getInt("demand-paging-parallelism"),
                 config.getBoolean("demand-paging-enabled"),
-                config.getInt("evicted-pk-bloom-filter-capacity"))
+                config.getInt("evicted-pk-bloom-filter-capacity"),
+                config.as[Map[String, String]]("trace-filters"))
   }
 }
 

--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -50,7 +50,7 @@ import filodb.timeseries.TestTimeseriesProducer
  * also be used together to control the # of samples per series and # of time series.
  * To generate Histogram schema test data, one must create the following dataset:
  *   ./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset histogram \
- *      --dataColumns timestamp:ts,sum:long,count:long,h:hist --partitionColumns metric:string,tags:map \
+ *      --dataColumns timestamp:ts,sum:long,count:long,h:hist:counter=true --partitionColumns metric:string,tags:map \
  *      --shardKeyColumns metric --metricColumn metric
  * create a Kafka topic:
  *   kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 4 --topic histogram-dev

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -147,6 +147,8 @@ object TestTimeseriesProducer extends StrictLogging {
    * Generate a stream of random Histogram data, with the metric name "http_request_latency"
    * Schema:  (timestamp:ts, sum:long, count:long, h:hist) for data, plus (metric:string, tags:map)
    * The dataset must match the above schema
+   * Note: the set of "instance" tags is unique for each invocation of genHistogramData.  This helps increase
+   * the cardinality of time series for testing purposes.
    */
   def genHistogramData(startTime: Long, dataset: Dataset, numTimeSeries: Int = 16): Stream[InputRecord] = {
     require(dataset.dataColumns.map(_.columnType) == Seq(TimestampColumn, LongColumn, LongColumn, HistogramColumn))
@@ -160,8 +162,10 @@ object TestTimeseriesProducer extends StrictLogging {
       }
     }
 
+    val instanceBase = System.currentTimeMillis
+
     Stream.from(0).map { n =>
-      val instance = n % numTimeSeries
+      val instance = n % numTimeSeries + instanceBase
       val dc = instance & oneBitMask
       val partition = (instance >> 1) & twoBitMask
       val app = (instance >> 3) & twoBitMask


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

- Filter for `TestConsumer` to dump out raw Kafka ingestion records when a string partition key field matches a given value
- A new dataset/store config that when enabled allows detailed logging of each sample ingested when the partition key has fields matching the config