### PR TITLE
misc(conf,coordinator,core): Reduce overhead of Kryo debug/trace logging.

### DIFF
--- a/conf/logback-dev.xml
+++ b/conf/logback-dev.xml
@@ -29,6 +29,5 @@
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
-        <!-- Direct logs to Console in PIE. They get moved to Splunk -->
     </root>
 </configuration>

--- a/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
@@ -30,6 +30,10 @@ import filodb.memory.format.ZeroCopyUTF8String
  */
 class KryoInit {
   def customize(kryo: Kryo): Unit = {
+    // Default level used by Kryo is 'trace', which is expensive. It always builds the message,
+    // even if it gets filtered out by the logging framework.
+    com.esotericsoftware.minlog.Log.WARN()
+
     kryo.addDefaultSerializer(classOf[Column.ColumnType], classOf[ColumnTypeSerializer])
     val colTypeSer = new ColumnTypeSerializer
     Column.ColumnType.values.zipWithIndex.foreach { case (ct, i) => kryo.register(ct.getClass, colTypeSer, 100 + i) }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -207,8 +207,8 @@ akka {
 
     # For details of kryo section see https://github.com/romix/akka-kryo-serialization
     kryo {
-      # TODO: turn this off once finished debugging Kryo classes for serialization
-      implicit-registration-logging = "true"
+      implicit-registration-logging = "false"
+      kryo-trace = "false"
 
       kryo-custom-serializer-init = "filodb.coordinator.client.KryoInit"
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Profiling shows a lot of time spent in String.intern (15%), and this is due to reflection lookups. The reflection lookups are caused by Kryo, which is generating tracing and debug messages. Even though they're filtered out from the log, the only way to prevent generation of these messages is to modify a special minlog field.

**New behavior :**
I couldn't find a config setting that can change the minlog field, so I set it to WARN in the customize method. I also updated some config settings which might have an effect, but by themselves they don't appear to do much.
