### PR TITLE
fix(memory): Fix edge case for DDV encoding where first value != the rest

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -68,7 +68,10 @@ object DeltaDeltaVector {
             minMax   <- getDeltasMinMax(inputVect, slope)
             nbitsSigned <- getNbitsSignedFromMinMax(minMax, maxNBits)
       } yield {
-        if (minMax.min == minMax.max) {
+        // Min and max == 0 for constant slope otherwise we can have some funny edge cases such as the first value
+        // being diff from all others which are the same (eg 55, 60, 60, ....).  That results in erroneous Const
+        // encoding.
+        if (minMax.min == 0 && minMax.max == 0) {
           const(memFactory, inputVect.length, inputVect(0), slope)
         } else if (approxConst && minMax.min >= MinApproxDelta && minMax.max <= MaxApproxDelta) {
           const(memFactory, inputVect.length, inputVect(0), slope)

--- a/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
@@ -77,6 +77,18 @@ class DoubleVectorTest extends NativeVectorTest {
       BinaryVector.totalBytes(optimized) shouldEqual 24   // Const DeltaDeltaVector (since this is linearly increasing)
     }
 
+    it("should encode some edge cases correctly to DDV") {
+      val orig = Seq(55.0, 60.0) ++ Seq.fill(10)(60.0)
+      val appender = DoubleVector.appendingVectorNoNA(memFactory, 100)
+      orig.foreach(appender.addData)
+      appender.length shouldEqual orig.length
+
+      val optimized = appender.optimize(memFactory)
+      DoubleVector(optimized).length(optimized) shouldEqual orig.length
+      DoubleVector(optimized).toBuffer(optimized).toList shouldEqual orig
+      BinaryVector.totalBytes(optimized) should be > (24)   // Not const DDV!
+    }
+
     it("should be able to optimize off-heap No NA integral vector to DeltaDeltaVector") {
       val builder = DoubleVector.appendingVectorNoNA(memFactory, 100)
       // Use higher numbers to verify they can be encoded efficiently too


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

An edge case in Delta-Delta encoding causes the following value sequence (a, b, b, b...... b) to be encoded incorrectly as a ConstDeltaDelta.  Basically the min and max delta is only sought for the second and subsequent values.

However, even if the first value was included the const delta delta might not have been correct either.

**New behavior :**

Only if the min and max delta == 0, that is all values are exactly on the sloped line, is Const encoding used.
