### PR TITLE
bug(query): topk and bottomk has trailing value 

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -580,6 +580,12 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
         row.setDouble(i + 1, el.value)
         i += 2
       }
+      // Reset remaining values of row to overwrite previous row value
+      while (i < numRowReaderColumns) {
+        row.setString(i, CustomRangeVectorKey.emptyAsZcUtf8)
+        row.setDouble(i + 1, if (bottomK) Double.MaxValue else Double.MinValue)
+        i += 2
+      }
       row
     }
     def resetToZero(): Unit = { heap.clear() }

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -338,8 +338,9 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
   it("topK should not have any trailing value ") {
 
+    // The value before NaN should not get carried over. Topk result for timestamp 1556744173L should have Double.NaN
     val samples: Array[RangeVector] = Array(
-      toRv(Seq((1556744143L, 42d), (1556744158L, 42d),(1556744173L, Double.NaN )))
+      toRv(Seq((1556744143L, 42d), (1556744158L, 42d),(1556744173L, Double.NaN)))
     )
 
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(5.0), ColumnType.DoubleColumn)

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -336,6 +336,25 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     compareIter(result6b(0).rows.map(_.getDouble(1)), Seq(5.4d,5.6d).iterator)
   }
 
+  it("topK should not have any trailing value ") {
+
+    val samples: Array[RangeVector] = Array(
+      toRv(Seq((1556744143L, 42d), (1556744158L, 42d),(1556744173L, Double.NaN )))
+    )
+
+    val agg6 = RowAggregator(AggregationOperator.TopK, Seq(5.0), ColumnType.DoubleColumn)
+    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping)
+    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv
+      .key)
+    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000)
+    val result6 = resultObs6.toListL.runAsync.futureValue
+    result6(0).key shouldEqual noKey
+    val result6b = resultObs6b.toListL.runAsync.futureValue
+    result6b.size shouldEqual 1
+    result6b(0).key shouldEqual ignoreKey
+    compareIter(result6b(0).rows.map(_.getDouble(1)), Seq(42d,42d).iterator)
+  }
+
   import filodb.memory.format.{vectors => bv}
 
   it("should sum histogram RVs") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
If value exists at timestamp t1 and topk query is fired for time (t1-500) to (t1+500), value at t1 continues till t1+500.  Value at t1 should be there only till t1 + staleSampleAfterMs which is 300 by default. This happens because row is not reset and previous value is carried over.

**New behavior :**
Reset remaining values of row to overwrite previous row value

