### PR TITLE
bug(core): Including missed time bucket during index recovery

### DIFF
--- a/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
+++ b/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
@@ -28,7 +28,9 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
 
   import FailFastCirceSupport._
   import io.circe.generic.auto._
-
+  // DO NOT REMOVE PromCirceSupport import below assuming it is unused - Intellij removes it in auto-imports :( .
+  // Needed to override Sampl case class Encoder.
+  import PromCirceSupport._
   import filodb.coordinator.client.Client._
   import filodb.prometheus.query.PrometheusModel._
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Recovery of one bucket was missed due to use of `until` instead of `to` when iterating buckets.
I wish we had some unit tests which could catch this kind of an error. However, the indexing population and recovery is too coupled with flushing/ingestion logic that unit testing becomes very difficult. I am very open to suggestions and if there are any ideas, I will take unit testing up in a separate PR.


