### PR TITLE
bug(core): Shard status metrics did not have dataset tags

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
@@ -19,15 +19,17 @@ class ShardHealthStats(ref: DatasetRef,
                        shardMapFunc: => ShardMapper,
                        reportingInterval: FiniteDuration = 5.seconds) {
 
-  val numActive = Kamon.gauge(s"num-active-shards-$ref")
-  val numRecovering = Kamon.gauge(s"num-recovering-shards-$ref")
-  val numUnassigned = Kamon.gauge(s"num-unassigned-shards-$ref")
-  val numAssigned = Kamon.gauge(s"num-assigned-shards-$ref")
-  val numError = Kamon.gauge(s"num-error-shards-$ref")
-  val numStopped = Kamon.gauge(s"num-stopped-shards-$ref")
-  val numDown = Kamon.gauge(s"num-down-shards-$ref")
+  val numActive = Kamon.gauge(s"num-active-shards-$ref").refine("dataset", ref.toString)
+  val numRecovering = Kamon.gauge(s"num-recovering-shards-$ref").refine("dataset", ref.toString)
+  val numUnassigned = Kamon.gauge(s"num-unassigned-shards-$ref").refine("dataset", ref.toString)
+  val numAssigned = Kamon.gauge(s"num-assigned-shards-$ref").refine("dataset", ref.toString)
+  val numError = Kamon.gauge(s"num-error-shards-$ref").refine("dataset", ref.toString)
+  val numStopped = Kamon.gauge(s"num-stopped-shards-$ref").refine("dataset", ref.toString)
+  val numDown = Kamon.gauge(s"num-down-shards-$ref").refine("dataset", ref.toString)
   val numErrorReassignmentsDone = Kamon.counter(s"num-error-reassignments-done-$ref")
+                      .refine("dataset", ref.toString)
   val numErrorReassignmentsSkipped = Kamon.counter(s"num-error-reassignments-skipped-$ref")
+                      .refine("dataset", ref.toString)
 
   def update(mapper: ShardMapper): Unit = {
     numActive.set(shardMapFunc.statuses.count(_ == ShardStatusActive))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Shard status tags did not have dataset tags. Shard stats were not being reported for clusters with multiple datasets.