### PR TITLE
bug(core): Shard metrics has dataset in metric name instead of tag

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
@@ -19,16 +19,16 @@ class ShardHealthStats(ref: DatasetRef,
                        shardMapFunc: => ShardMapper,
                        reportingInterval: FiniteDuration = 5.seconds) {
 
-  val numActive = Kamon.gauge(s"num-active-shards-$ref").refine("dataset", ref.toString)
-  val numRecovering = Kamon.gauge(s"num-recovering-shards-$ref").refine("dataset", ref.toString)
-  val numUnassigned = Kamon.gauge(s"num-unassigned-shards-$ref").refine("dataset", ref.toString)
-  val numAssigned = Kamon.gauge(s"num-assigned-shards-$ref").refine("dataset", ref.toString)
-  val numError = Kamon.gauge(s"num-error-shards-$ref").refine("dataset", ref.toString)
-  val numStopped = Kamon.gauge(s"num-stopped-shards-$ref").refine("dataset", ref.toString)
-  val numDown = Kamon.gauge(s"num-down-shards-$ref").refine("dataset", ref.toString)
-  val numErrorReassignmentsDone = Kamon.counter(s"num-error-reassignments-done-$ref")
+  val numActive = Kamon.gauge(s"num-active-shards").refine("dataset", ref.toString)
+  val numRecovering = Kamon.gauge(s"num-recovering-shards").refine("dataset", ref.toString)
+  val numUnassigned = Kamon.gauge(s"num-unassigned-shards").refine("dataset", ref.toString)
+  val numAssigned = Kamon.gauge(s"num-assigned-shards").refine("dataset", ref.toString)
+  val numError = Kamon.gauge(s"num-error-shards").refine("dataset", ref.toString)
+  val numStopped = Kamon.gauge(s"num-stopped-shards").refine("dataset", ref.toString)
+  val numDown = Kamon.gauge(s"num-down-shards").refine("dataset", ref.toString)
+  val numErrorReassignmentsDone = Kamon.counter(s"num-error-reassignments-done")
                       .refine("dataset", ref.toString)
-  val numErrorReassignmentsSkipped = Kamon.counter(s"num-error-reassignments-skipped-$ref")
+  val numErrorReassignmentsSkipped = Kamon.counter(s"num-error-reassignments-skipped")
                       .refine("dataset", ref.toString)
 
   def update(mapper: ShardMapper): Unit = {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Second part of the fix to move dataset from metric name to tag. 