### PR TITLE
bug(core): Not purging partition if it has unflushed data

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -152,11 +152,11 @@ class PartKeyLuceneIndex(dataset: Dataset,
     * Use to delete partitions that were ingesting before retention period
     * @return partIds of deleted partitions
     */
-  def partIdsEndedBefore(endedBefore: Long): IntIterator = {
+  def partIdsEndedBefore(endedBefore: Long): EWAHCompressedBitmap = {
     val collector = new PartIdCollector()
     val deleteQuery = LongPoint.newRangeQuery(PartKeyLuceneIndex.END_TIME, 0, endedBefore)
     searcherManager.acquire().search(deleteQuery, collector)
-    collector.intIterator()
+    collector.result
   }
 
   def removePartKeys(partIds: Array[Int]): Unit = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -678,7 +678,7 @@ class TimeSeriesShard(val dataset: Dataset,
       System.currentTimeMillis() - storeConfig.demandPagedRetentionPeriod.toMillis)
     var numDeleted = 0
     val removedParts = new EWAHCompressedBitmap()
-    InMemPartitionIterator(partsToPurge).foreach { p =>
+    InMemPartitionIterator(partsToPurge.intIterator()).foreach { p =>
       if (!p.infosToBeFlushed.hasNext) {
         logger.debug(s"Purging partition with partId=${p.partID} from memory in dataset=${dataset.ref} shard=$shardNum")
         removePartition(p)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -674,16 +674,21 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   private def purgeExpiredPartitions(): Unit = ingestSched.executeTrampolined { () =>
-    val deletedParts = partKeyIndex.removePartKeysEndedBefore(
+    val partsToPurge = partKeyIndex.partIdsEndedBefore(
       System.currentTimeMillis() - storeConfig.demandPagedRetentionPeriod.toMillis)
     var numDeleted = 0
-    InMemPartitionIterator(deletedParts).foreach { p =>
-      logger.debug(s"Purging partition with partId=${p.partID} from memory in dataset=${dataset.ref} shard=$shardNum")
-      removePartition(p)
-      numDeleted += 1
+    val removedParts = new EWAHCompressedBitmap()
+    InMemPartitionIterator(partsToPurge).foreach { p =>
+      if (!p.infosToBeFlushed.hasNext) {
+        logger.debug(s"Purging partition with partId=${p.partID} from memory in dataset=${dataset.ref} shard=$shardNum")
+        removePartition(p)
+        removedParts.set(p.partID)
+        numDeleted += 1
+      }
     }
+    if (!removedParts.isEmpty) partKeyIndex.removePartKeys(removedParts.toArray)
     if (numDeleted > 0) logger.info(s"Purged $numDeleted partitions from memory and " +
-      s"index from dataset=${dataset.ref} shard=$shardNum")
+                        s"index from dataset=${dataset.ref} shard=$shardNum")
     shardStats.purgedPartitions.increment(numDeleted)
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -686,7 +686,7 @@ class TimeSeriesShard(val dataset: Dataset,
         numDeleted += 1
       }
     }
-    if (!removedParts.isEmpty) partKeyIndex.removePartKeys(removedParts.toArray)
+    if (!removedParts.isEmpty) partKeyIndex.removePartKeys(removedParts)
     if (numDeleted > 0) logger.info(s"Purged $numDeleted partitions from memory and " +
                         s"index from dataset=${dataset.ref} shard=$shardNum")
     shardStats.purgedPartitions.increment(numDeleted)

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -120,7 +120,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
   }
 
-  it("should add part keys and fetch partIdsEndedBefore correctly for more than 1024 keys") {
+  it("should add part keys and fetch partIdsEndedBefore and removePartKeys correctly for more than 1024 keys") {
     val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
     val start = 1000
     // we dont care much about the partKey here, but the startTime against partId.
@@ -135,6 +135,14 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
     for { i <- 0 until numPartIds} {
       pIds.get(i) shouldEqual (if (i <= 100) true else false)
     }
+
+    keyIndex.removePartKeys(pIds)
+    keyIndex.commitBlocking()
+
+    for { i <- 0 until numPartIds} {
+      keyIndex.partKeyFromPartId(i).isDefined shouldEqual (if (i <= 100) false else true)
+    }
+
   }
 
   it("should update part keys with endtime and parse filters correctly") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We saw during testing that an intermittently ingesting partition which didnt ingest for retentionPeriod and then ingests could be purged prior to data being flushed because we dont check if unflushed data. 

**New behavior :**

Check if there are unflushed chunks prior to deleting the partition

Also using TermInSetQuery instead of batching - it is more efficient and uses less memory.
