### PR TITLE
feat(memory, query): histogram_max_quantile - more accurate top quantiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ One major difference FiloDB has from the Prometheus data model is that FiloDB su
   - NOTE: Do NOT use `group by (le)` when summing `HistogramColumns`.  This is not appropriate as the "le" tag is not used.  FiloDB knows how to sum multiple histograms together correctly without grouping tricks.
   - FiloDB prevents many incorrect histogram aggregations in Prometheus when using `HistogramColumn`, such as handling of multiple histogram schemas across time series and across time.
 
-FiloDB offers an improved accuracy `histogram_max_quantile` function designed to work with a max column from the source.  If clients are able to send the max value captured during a window, then we can report more accurate upper quantiles (ie 99%, 99.9%, etc.)
+FiloDB offers an improved accuracy `histogram_max_quantile` function designed to work with a max column from the source.  If clients are able to send the max value captured during a window, then we can report more accurate upper quantiles (ie 99%, 99.9%, etc.) that do not suffer from clipping.
 
 ### Using the FiloDB HTTP API
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ Some special functions exist to aid debugging and for other purposes:
 | function | description    |
 |----------|----------------|
 | `_filodb_chunkmeta_all` | (CLI Only) Returns chunk metadata fields for all chunks matching the time range and filter criteria - ID, # rows, start and end time, as well as the number of bytes and type of encoding used for a particular column.  |
+| `histogram_bucket` | Extract a bucket from a HistogramColumn |
+| `histogram_max_quantile` | More accurate `histogram_quantile` when the max is known |
 
 Example of debugging chunk metadata using the CLI:
 
@@ -399,6 +401,8 @@ One major difference FiloDB has from the Prometheus data model is that FiloDB su
 * Sum over multiple Histogram time series:  `sum(sum_over_time(http_req_latency{app="foo",__col__="hist"}[5m]))` - you could then compute quantile over the sum.
   - NOTE: Do NOT use `group by (le)` when summing `HistogramColumns`.  This is not appropriate as the "le" tag is not used.  FiloDB knows how to sum multiple histograms together correctly without grouping tricks.
   - FiloDB prevents many incorrect histogram aggregations in Prometheus when using `HistogramColumn`, such as handling of multiple histogram schemas across time series and across time.
+
+FiloDB offers an improved accuracy `histogram_max_quantile` function designed to work with a max column from the source.  If clients are able to send the max value captured during a window, then we can report more accurate upper quantiles (ie 99%, 99.9%, etc.)
 
 ### Using the FiloDB HTTP API
 

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -33,7 +33,8 @@ final case class ColumnInfo(name: String, colType: Column.ColumnType)
  */
 final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
                               brSchemas: Map[Int, Seq[ColumnInfo]] = Map.empty,
-                              fixedVectorLen: Option[Int] = None) {
+                              fixedVectorLen: Option[Int] = None,
+                              colIDs: Seq[Int] = Nil) {
   import Column.ColumnType._
 
   def length: Int = columns.length

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -40,6 +40,8 @@ final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
   def length: Int = columns.length
   def isTimeSeries: Boolean = columns.length >= 1 && numRowKeyColumns == 1 &&
                               (columns.head.colType == LongColumn || columns.head.colType == TimestampColumn)
+  def isHD: Boolean = columns.length == 3 &&
+                      columns(1).colType == HistogramColumn && columns(2).colType == DoubleColumn
 }
 
 /**

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -28,8 +28,10 @@ final case class ColumnInfo(name: String, colType: Column.ColumnType)
  * Describes the full schema of result types, including how many initial columns are for row keys.
  * The first ColumnInfo in the schema describes the first vector in Vectors and first field in Tuples, etc.
  * @param brSchemas if any of the columns is a BinaryRecord: map of colNo -> inner BinaryRecord schema
+ * @param numRowKeyColumns the number of row key columns at the start of columnns
  * @param fixedVectorLen if defined, each vector is guaranteed to have exactly this many output elements.
  *                       See PeriodicSampleMapper for an example of how this is used.
+ * @param colIDs the column IDs of the columns, used to access additional columns if needed
  */
 final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
                               brSchemas: Map[Int, Seq[ColumnInfo]] = Map.empty,
@@ -40,8 +42,9 @@ final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
   def length: Int = columns.length
   def isTimeSeries: Boolean = columns.length >= 1 && numRowKeyColumns == 1 &&
                               (columns.head.colType == LongColumn || columns.head.colType == TimestampColumn)
-  def isHD: Boolean = columns.length == 3 &&
-                      columns(1).colType == HistogramColumn && columns(2).colType == DoubleColumn
+  // True if main col is Histogram and extra column is a Double
+  def isHistDouble: Boolean = columns.length == 3 &&
+                              columns(1).colType == HistogramColumn && columns(2).colType == DoubleColumn
 }
 
 /**

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -228,10 +228,12 @@ object MutableHistogram {
 }
 
 /**
- * MaxHistogram improves quantile calculation with a known max value.
+ * MaxHistogram improves quantile calculation accuracy with a known max value recorded from the client.
  * Whereas normally Prom histograms have +Inf as the highest bucket, and we cannot interpolate above the last
  * non-Inf bucket, having a max allows us to interpolate from the rank up to the max.
- * Furthermore, the quantile result can never be above max, regardless of the bucket scheme.
+ * When the max value is lower, we interpolate between the bottom of the bucket and the max value.
+ * Both changes mean that the 0.90+ quantiles return much closer to the max value, instead of interpolating or clipping.
+ * The quantile result can never be above max, regardless of the bucket scheme.
  */
 final case class MaxHistogram(innerHist: MutableHistogram, max: Double) extends HistogramWithBuckets {
   final def buckets: HistogramBuckets = innerHist.buckets

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -60,6 +60,14 @@ class HistogramTest extends NativeVectorTest {
         info(s"For histogram ${h.values.toList} -> quantile = $quantile")
         quantile shouldEqual res
       }
+
+      // Cannot return anything more than 2nd-to-last bucket (ie 64)
+      mutableHistograms(0).quantile(0.95) shouldEqual 64
+    }
+
+    it("should calculate more accurate quantile with MaxHistogram") {
+      val h = MaxHistogram(mutableHistograms(0), 90)
+      h.quantile(0.95) shouldEqual 72.2 +- 0.1   // more accurate due to max!
     }
 
     it("should serialize to and from BinaryHistograms and compare correctly") {

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -68,6 +68,11 @@ class HistogramTest extends NativeVectorTest {
     it("should calculate more accurate quantile with MaxHistogram") {
       val h = MaxHistogram(mutableHistograms(0), 90)
       h.quantile(0.95) shouldEqual 72.2 +- 0.1   // more accurate due to max!
+
+      // Not just last bucket, but should always be clipped at max regardless of bucket scheme
+      val values = Array[Double](10, 15, 17, 20, 25, 25, 25, 25)
+      val h2 = MaxHistogram(MutableHistogram(bucketScheme, values), 10)
+      h2.quantile(0.95) shouldEqual 9.5 +- 0.1   // more accurate due to max!
     }
 
     it("should serialize to and from BinaryHistograms and compare correctly") {

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -24,6 +24,8 @@ object InstantFunctionId extends Enum[InstantFunctionId] {
 
   case object HistogramQuantile extends InstantFunctionId("histogram_quantile")
 
+  case object HistogramMaxQuantile extends InstantFunctionId("histogram_max_quantile")
+
   case object HistogramBucket extends InstantFunctionId("histogram_bucket")
 
   case object Ln extends InstantFunctionId("ln")

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -40,8 +40,7 @@ final case class ReduceAggregateExec(id: String,
         case (QueryResult(_, _, result), _) => Observable.fromIterable(result)
         case (QueryError(_, ex), _)         => throw ex
     }
-    val valColType = RangeVectorTransformer.valueColumnType(schemaOfCompose(dataset))
-    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
+    val aggregator = RowAggregator(aggrOp, aggrParams, schemaOfCompose(dataset))
     RangeVectorAggregator.mapReduce(aggregator, skipMapPhase = true, results, rv => rv.key)
   }
 }
@@ -64,8 +63,7 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {
-    val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
-    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
+    val aggregator = RowAggregator(aggrOp, aggrParams, sourceSchema)
 
     def grouping(rv: RangeVector): RangeVectorKey = {
       val groupBy: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] =
@@ -88,8 +86,7 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
   }
 
   override def schema(dataset: Dataset, source: ResultSchema): ResultSchema = {
-    val valColType = RangeVectorTransformer.valueColumnType(source)
-    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
+    val aggregator = RowAggregator(aggrOp, aggrParams, source)
     // TODO we assume that second column needs to be aggregated. Other dataset types need to be accommodated.
     aggregator.reductionSchema(source)
   }
@@ -104,14 +101,12 @@ final case class AggregatePresenter(aggrOp: AggregationOperator,
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {
-    val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
-    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
+    val aggregator = RowAggregator(aggrOp, aggrParams, sourceSchema)
     RangeVectorAggregator.present(aggregator, source, limit)
   }
 
   override def schema(dataset: Dataset, source: ResultSchema): ResultSchema = {
-    val valColType = RangeVectorTransformer.valueColumnType(source)
-    val aggregator = RowAggregator(aggrOp, aggrParams, valColType)
+    val aggregator = RowAggregator(aggrOp, aggrParams, source)
     aggregator.presentationSchema(source)
   }
 }
@@ -334,12 +329,14 @@ object RowAggregator {
   /**
     * Factory for RowAggregator
     */
-  def apply(aggrOp: AggregationOperator, params: Seq[Any], dataColType: ColumnType): RowAggregator = {
+  def apply(aggrOp: AggregationOperator, params: Seq[Any], schema: ResultSchema): RowAggregator = {
+    val valColType = RangeVectorTransformer.valueColumnType(schema)
     aggrOp match {
       case Min      => MinRowAggregator
       case Max      => MaxRowAggregator
-      case Sum if dataColType == ColumnType.DoubleColumn => SumRowAggregator
-      case Sum if dataColType == ColumnType.HistogramColumn => HistSumRowAggregator
+      case Sum if valColType == ColumnType.DoubleColumn => SumRowAggregator
+      case Sum if valColType == ColumnType.HistogramColumn && schema.isHD => HistMaxSumAggregator
+      case Sum if valColType == ColumnType.HistogramColumn => HistSumRowAggregator
       case Count    => CountRowAggregator
       case Avg      => AvgRowAggregator
       case TopK     => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, false)
@@ -401,6 +398,37 @@ object HistSumRowAggregator extends RowAggregator {
       case h if newHist.numBuckets > 0  => acc.h.add(newHist.asInstanceOf[bv.HistogramWithBuckets])
       case h                            =>
     }
+    acc
+  }
+  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def reductionSchema(source: ResultSchema): ResultSchema = source
+  def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
+}
+
+object HistMaxSumAggregator extends RowAggregator {
+  import filodb.memory.format.{vectors => bv}
+
+  class HistSumMaxHolder(var timestamp: Long = 0L,
+                         var h: bv.MutableHistogram = bv.Histogram.empty,
+                         var m: Double = Double.NaN) extends AggregateHolder {
+    val row = new TransientHistMaxRow()
+    def toRowReader: MutableRowReader = { row.setValues(timestamp, h); row.max = m; row }
+    def resetToZero(): Unit = { h = bv.Histogram.empty; m = 0.0 }
+  }
+  type AggHolderType = HistSumMaxHolder
+  def zero: HistSumMaxHolder = new HistSumMaxHolder
+  def newRowToMapInto: MutableRowReader = new TransientHistMaxRow()
+  def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = item
+  def reduceAggregate(acc: HistSumMaxHolder, aggRes: RowReader): HistSumMaxHolder = {
+    acc.timestamp = aggRes.getLong(0)
+    val newHist = aggRes.getHistogram(1)
+    acc.h match {
+      // sum is mutable histogram, copy to be sure it's our own copy
+      case hist if hist.numBuckets == 0 => acc.h = bv.MutableHistogram(newHist)
+      case h if newHist.numBuckets > 0  => acc.h.add(newHist.asInstanceOf[bv.HistogramWithBuckets])
+      case h                            =>
+    }
+    acc.m = if (acc.m == Double.NaN) aggRes.getDouble(2) else Math.max(acc.m, aggRes.getDouble(2))
     acc
   }
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -326,6 +326,9 @@ trait RowAggregator {
 }
 
 object RowAggregator {
+  def isHistMax(valColType: ColumnType, schema: ResultSchema): Boolean =
+    valColType == ColumnType.HistogramColumn && schema.isHistDouble && schema.columns(2).name == "max"
+
   /**
     * Factory for RowAggregator
     */
@@ -335,7 +338,7 @@ object RowAggregator {
       case Min      => MinRowAggregator
       case Max      => MaxRowAggregator
       case Sum if valColType == ColumnType.DoubleColumn => SumRowAggregator
-      case Sum if valColType == ColumnType.HistogramColumn && schema.isHD => HistMaxSumAggregator
+      case Sum if isHistMax(valColType, schema)            => HistMaxSumAggregator
       case Sum if valColType == ColumnType.HistogramColumn => HistSumRowAggregator
       case Count    => CountRowAggregator
       case Avg      => AvgRowAggregator

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -59,9 +59,10 @@ final case class PeriodicSamplesMapper(start: Long,
     sampleRangeFunc match {
       case c: ChunkedRangeFunction[_] if valColType == ColumnType.HistogramColumn =>
         source.map { rv =>
+          val histRow = if (maxCol.isDefined) new TransientHistMaxRow() else new TransientHistRow()
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorH(rv.asInstanceOf[RawDataRangeVector], start, step, end,
-                                       windowLength, rangeFuncGen().asChunkedH, queryConfig))
+                                       windowLength, rangeFuncGen().asChunkedH, queryConfig, histRow))
         }
       case c: ChunkedRangeFunction[_] =>
         source.map { rv =>

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -45,7 +45,9 @@ final case class PeriodicSamplesMapper(start: Long,
     if (step < queryConfig.minStepMs)
       throw new BadQueryException(s"step should be at least ${queryConfig.minStepMs/1000}s")
     val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
-    val rangeFuncGen = RangeFunction.generatorFor(functionId, valColType, funcParams)
+    val maxCol = if (valColType == ColumnType.HistogramColumn && sourceSchema.colIDs.length > 2)
+                   Some(sourceSchema.colIDs(2)) else None
+    val rangeFuncGen = RangeFunction.generatorFor(functionId, valColType, funcParams, maxCol)
 
     // Generate one range function to check if it is chunked
     val sampleRangeFunc = rangeFuncGen()

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -46,7 +46,7 @@ final case class PeriodicSamplesMapper(start: Long,
       throw new BadQueryException(s"step should be at least ${queryConfig.minStepMs/1000}s")
     val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
     val maxCol = if (valColType == ColumnType.HistogramColumn && sourceSchema.colIDs.length > 2)
-                   Some(sourceSchema.colIDs(2)) else None
+                   sourceSchema.columns.zip(sourceSchema.colIDs).find(_._1.name == "max").map(_._2) else None
     val rangeFuncGen = RangeFunction.generatorFor(functionId, valColType, funcParams, maxCol)
 
     // Generate one range function to check if it is chunked

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -71,7 +71,7 @@ final case class InstantVectorFunctionMapper(function: InstantFunctionId,
           source.map { rv =>
             IteratorBackedRangeVector(rv.key, new H2DoubleInstantFuncIterator(rv.rows, instantFunction.asHToDouble))
           }
-        } else if (instantFunction.isHDToDoubleFunc && sourceSchema.isHD) {
+        } else if (instantFunction.isHistDoubleToDoubleFunc && sourceSchema.isHistDouble) {
           source.map { rv =>
             IteratorBackedRangeVector(rv.key, new HD2DoubleInstantFuncIterator(rv.rows, instantFunction.asHDToDouble))
           }

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -71,6 +71,10 @@ final case class InstantVectorFunctionMapper(function: InstantFunctionId,
           source.map { rv =>
             IteratorBackedRangeVector(rv.key, new H2DoubleInstantFuncIterator(rv.rows, instantFunction.asHToDouble))
           }
+        } else if (instantFunction.isHDToDoubleFunc && sourceSchema.isHD) {
+          source.map { rv =>
+            IteratorBackedRangeVector(rv.key, new HD2DoubleInstantFuncIterator(rv.rows, instantFunction.asHDToDouble))
+          }
         } else {
           throw new UnsupportedOperationException(s"Sorry, function $function is not supported right now")
         }
@@ -126,6 +130,18 @@ private class H2DoubleInstantFuncIterator(rows: Iterator[RowReader],
   final def next(): RowReader = {
     val next = rows.next()
     val newValue = instantFunction(next.getHistogram(1))
+    result.setValues(next.getLong(0), newValue)
+    result
+  }
+}
+
+private class HD2DoubleInstantFuncIterator(rows: Iterator[RowReader],
+                                           instantFunction: HDToDoubleIFunction,
+                                           result: TransientRow = new TransientRow()) extends Iterator[RowReader] {
+  final def hasNext: Boolean = rows.hasNext
+  final def next(): RowReader = {
+    val next = rows.next()
+    val newValue = instantFunction(next.getHistogram(1), next.getDouble(2))
     result.setValues(next.getLong(0), newValue)
     result
   }

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -6,11 +6,22 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.{DatasetRef, Types}
-import filodb.core.metadata.Dataset
+import filodb.core.metadata.{Column, Dataset}
 import filodb.core.query.{ColumnFilter, RangeVector, ResultSchema}
 import filodb.core.store._
 import filodb.query.QueryConfig
 
+object SelectRawPartitionsExec {
+  import Column.ColumnType._
+
+  // Returns Some(colID) the ID of a "max" column if one of given colIDs is a histogram.
+  def histMaxColumn(dataset: Dataset, colIDs: Seq[Types.ColumnId]): Option[Int] = {
+    colIDs.find { id => dataset.dataColumns(id).columnType == HistogramColumn }
+          .flatMap { histColID =>
+            dataset.dataColumns.find { c => c.name == "max" && c.columnType == DoubleColumn }
+          }.map(_.id)
+  }
+}
 
 /**
   * ExecPlan to select raw data from partitions that the given filter resolves to,
@@ -25,11 +36,22 @@ final case class SelectRawPartitionsExec(id: String,
                                          filters: Seq[ColumnFilter],
                                          chunkMethod: ChunkScanMethod,
                                          colIds: Seq[Types.ColumnId]) extends LeafExecPlan {
+  import SelectRawPartitionsExec._
+
   require(colIds.nonEmpty)
 
-  protected def schemaOfDoExecute(dataset: Dataset): ResultSchema =
-    ResultSchema(dataset.infosFromIDs(colIds),
-      colIds.zip(dataset.rowKeyIDs).takeWhile { case (a, b) => a == b }.length)
+  protected def schemaOfDoExecute(dataset: Dataset): ResultSchema = {
+    val numRowKeyCols = colIds.zip(dataset.rowKeyIDs).takeWhile { case (a, b) => a == b }.length
+
+    // Add the max column to the schema together with Histograms for max computation -- just in case it's needed
+    // But make sure the max column isn't already included
+    histMaxColumn(dataset, colIds).filter { mId => !(colIds contains mId) }
+                                  .map { maxColId =>
+      ResultSchema(dataset.infosFromIDs(colIds :+ maxColId), numRowKeyCols, colIDs = (colIds :+ maxColId))
+    }.getOrElse {
+      ResultSchema(dataset.infosFromIDs(colIds), numRowKeyCols, colIDs = colIds)
+    }
+  }
 
   protected def doExecute(source: ChunkSource,
                           dataset: Dataset,

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -40,7 +40,7 @@ final case class SelectRawPartitionsExec(id: String,
 
   require(colIds.nonEmpty)
 
-  protected def schemaOfDoExecute(dataset: Dataset): ResultSchema = {
+  protected[filodb] def schemaOfDoExecute(dataset: Dataset): ResultSchema = {
     val numRowKeyCols = colIds.zip(dataset.rowKeyIDs).takeWhile { case (a, b) => a == b }.length
 
     // Add the max column to the schema together with Histograms for max computation -- just in case it's needed

--- a/query/src/main/scala/filodb/query/exec/TransientRow.scala
+++ b/query/src/main/scala/filodb/query/exec/TransientRow.scala
@@ -55,8 +55,8 @@ final class TransientRow(var timestamp: Long, var value: Double) extends Mutable
   override def toString: String = s"TransientRow(t=$timestamp, v=$value)"
 }
 
-final class TransientHistRow(var timestamp: Long = 0L,
-                             var value: bv.HistogramWithBuckets = bv.Histogram.empty) extends MutableRowReader {
+class TransientHistRow(var timestamp: Long = 0L,
+                       var value: bv.HistogramWithBuckets = bv.Histogram.empty) extends MutableRowReader {
   def setValues(ts: Long, hist: bv.HistogramWithBuckets): Unit = {
     timestamp = ts
     value = hist
@@ -85,6 +85,14 @@ final class TransientHistRow(var timestamp: Long = 0L,
   def getBlobNumBytes(columnNo: Int): Int = throw new IllegalArgumentException()
 
   override def toString: String = s"TransientRow(t=$timestamp, v=$value)"
+}
+
+// 0: Timestamp, 1: Histogram, 2: Max/Double
+final class TransientHistMaxRow(var max: Double = 0.0) extends TransientHistRow() {
+  override def setDouble(columnNo: Int, valu: Double): Unit =
+    if (columnNo == 2) max = valu else throw new IllegalArgumentException()
+  override def getDouble(columnNo: Int): Double =
+    if (columnNo == 2) max else throw new IllegalArgumentException()
 }
 
 final class AvgAggTransientRow extends MutableRowReader {

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -30,7 +30,7 @@ trait EmptyParamsInstantFunction extends DoubleInstantFunction {
 
 sealed trait HistogramInstantFunction {
   def isHToDoubleFunc: Boolean = this.isInstanceOf[HistToDoubleIFunction]
-  def isHDToDoubleFunc: Boolean = this.isInstanceOf[HDToDoubleIFunction]
+  def isHistDoubleToDoubleFunc: Boolean = this.isInstanceOf[HDToDoubleIFunction]
   def asHToDouble: HistToDoubleIFunction = this.asInstanceOf[HistToDoubleIFunction]
   def asHDToDouble: HDToDoubleIFunction = this.asInstanceOf[HDToDoubleIFunction]
   def asHToH: HistToHistIFunction = this.asInstanceOf[HistToHistIFunction]
@@ -278,10 +278,10 @@ case class HistogramMaxQuantileImpl(funcParams: Seq[Any]) extends HDToDoubleIFun
   require(funcParams(0).isInstanceOf[Number], "histogram_quantile parameter must be a number")
   val q = funcParams(0).asInstanceOf[Number].doubleValue()
 
-  final def apply(h: Histogram, d: Double): Double = {
-    val maxHist = h match {
-      case hist: MutableHistogram => MaxHistogram(hist, d)
-      case other: Histogram       => MaxHistogram(MutableHistogram(other), d)
+  final def apply(hist: Histogram, max: Double): Double = {
+    val maxHist = hist match {
+      case h: MutableHistogram => MaxHistogram(h, max)
+      case other: Histogram    => MaxHistogram(MutableHistogram(other), max)
     }
     maxHist.quantile(q)
   }

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -2,7 +2,7 @@ package filodb.query.exec.rangefn
 
 import scalaxy.loops._
 
-import filodb.memory.format.vectors.Histogram
+import filodb.memory.format.vectors.{Histogram, MaxHistogram, MutableHistogram}
 import filodb.query.InstantFunctionId
 import filodb.query.InstantFunctionId.{Log2, Sqrt, _}
 
@@ -30,7 +30,9 @@ trait EmptyParamsInstantFunction extends DoubleInstantFunction {
 
 sealed trait HistogramInstantFunction {
   def isHToDoubleFunc: Boolean = this.isInstanceOf[HistToDoubleIFunction]
+  def isHDToDoubleFunc: Boolean = this.isInstanceOf[HDToDoubleIFunction]
   def asHToDouble: HistToDoubleIFunction = this.asInstanceOf[HistToDoubleIFunction]
+  def asHDToDouble: HDToDoubleIFunction = this.asInstanceOf[HDToDoubleIFunction]
   def asHToH: HistToHistIFunction = this.asInstanceOf[HistToHistIFunction]
 }
 
@@ -45,6 +47,19 @@ trait HistToDoubleIFunction extends HistogramInstantFunction {
     * @return Calculated value
     */
   def apply(value: Histogram): Double
+}
+
+/**
+ * An instant function taking a histogram and double and returning a Double value
+ */
+trait HDToDoubleIFunction extends HistogramInstantFunction {
+  /**
+    * Apply the required instant function against the given value.
+    *
+    * @param value Sample against which the function will be applied
+    * @return Calculated value
+    */
+  def apply(h: Histogram, d: Double): Double
 }
 
 /**
@@ -90,6 +105,7 @@ object InstantFunction {
    */
   def histogram(function: InstantFunctionId, funcParams: Seq[Any]): HistogramInstantFunction = function match {
     case HistogramQuantile    => HistogramQuantileImpl(funcParams)
+    case HistogramMaxQuantile => HistogramMaxQuantileImpl(funcParams)
     case HistogramBucket      => HistogramBucketImpl(funcParams)
     case _                    => throw new UnsupportedOperationException(s"$function not supported.")
   }
@@ -251,6 +267,24 @@ case class HistogramQuantileImpl(funcParams: Seq[Any]) extends HistToDoubleIFunc
   val q = funcParams(0).asInstanceOf[Number].doubleValue()
 
   final def apply(value: Histogram): Double = value.quantile(q)
+}
+
+/**
+ * Histogram max quantile function for Histogram column + extra max (Double) column.
+ * @param funcParams - a single value between 0 and 1, the quantile to calculate.
+ */
+case class HistogramMaxQuantileImpl(funcParams: Seq[Any]) extends HDToDoubleIFunction {
+  require(funcParams.length == 1, "Quantile (between 0 and 1) required for histogram quantile")
+  require(funcParams(0).isInstanceOf[Number], "histogram_quantile parameter must be a number")
+  val q = funcParams(0).asInstanceOf[Number].doubleValue()
+
+  final def apply(h: Histogram, d: Double): Double = {
+    val maxHist = h match {
+      case hist: MutableHistogram => MaxHistogram(hist, d)
+      case other: Histogram       => MaxHistogram(MutableHistogram(other), d)
+    }
+    maxHist.quantile(q)
+  }
 }
 
 /**

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -181,8 +181,9 @@ object RangeFunction {
   def apply(func: Option[RangeFunctionId],
             columnType: ColumnType,
             funcParams: Seq[Any] = Nil,
+            maxCol: Option[Int] = None,
             useChunked: Boolean): BaseRangeFunction =
-    generatorFor(func, columnType, funcParams, useChunked)()
+    generatorFor(func, columnType, funcParams, maxCol, useChunked)()
 
   /**
    * Given a function type and column type, returns a RangeFunctionGenerator
@@ -190,12 +191,13 @@ object RangeFunction {
   def generatorFor(func: Option[RangeFunctionId],
                    columnType: ColumnType,
                    funcParams: Seq[Any] = Nil,
+                   maxCol: Option[Int] = None,
                    useChunked: Boolean = true): RangeFunctionGenerator =
     if (useChunked) columnType match {
       case ColumnType.DoubleColumn => doubleChunkedFunction(func, funcParams)
       case ColumnType.LongColumn   => longChunkedFunction(func, funcParams)
       case ColumnType.TimestampColumn => longChunkedFunction(func, funcParams)
-      case ColumnType.HistogramColumn => histChunkedFunction(func, funcParams)
+      case ColumnType.HistogramColumn => histChunkedFunction(func, funcParams, maxCol)
       case other: ColumnType       => throw new IllegalArgumentException(s"Column type $other not supported")
     } else {
       iteratingFunction(func, funcParams)

--- a/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
@@ -15,7 +15,7 @@ import filodb.core.{TestData, Types}
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn, TimestampColumn}
-import filodb.core.query.{ColumnFilter, Filter}
+import filodb.core.query._
 import filodb.core.store.{AllChunkScan, InMemoryMetaStore, NullColumnStore, TimeRangeChunkScan}
 import filodb.memory.MemFactory
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
@@ -65,6 +65,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
   val mmdTuples = MMD.linearMultiSeries().take(100)
   val mmdSomeData = MMD.records(MMD.dataset1, mmdTuples)
   val histData = MMD.linearHistSeries().take(100)
+  val histMaxData = MMD.histMax(histData)
 
   implicit val execTimeout = 5.seconds
 
@@ -75,9 +76,12 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     memStore.ingest(MMD.dataset1.ref, 0, mmdSomeData)
     memStore.setup(MMD.histDataset, 0, TestData.storeConf)
     memStore.ingest(MMD.histDataset.ref, 0, MMD.records(MMD.histDataset, histData))
+    memStore.setup(MMD.histMaxDS, 0, TestData.storeConf)
+    memStore.ingest(MMD.histMaxDS.ref, 0, MMD.records(MMD.histMaxDS, histMaxData))
     memStore.commitIndexForTesting(timeseriesDataset.ref)
     memStore.commitIndexForTesting(MMD.dataset1.ref)
     memStore.commitIndexForTesting(MMD.histDataset.ref)
+    memStore.commitIndexForTesting(MMD.histMaxDS.ref)
   }
 
   override def afterAll(): Unit = {
@@ -225,6 +229,34 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     resultIt.zip(orig.toIterator).foreach { case (res, origData) => res shouldEqual origData }
   }
 
+  // A lower-level (below coordinator) end to end histogram with max ingestion and querying test
+  it("should aggregate Histogram records with max correctly") {
+    val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)))
+    val execPlan = SelectRawPartitionsExec("hMax", now, numRawSamples, dummyDispatcher, MMD.histMaxDS.ref, 0,
+      filters, AllChunkScan, Seq(0, 4))
+
+    val start = 105000L
+    val step = 20000L
+    val end = 185000L
+    execPlan.addRangeVectorTransformer(new PeriodicSamplesMapper(start, step, end, Some(300 * 1000),  // [5m]
+                                         Some(RangeFunctionId.SumOverTime), Nil))
+
+    val resp = execPlan.execute(memStore, MMD.histMaxDS, queryConfig).runAsync.futureValue
+    val result = resp.asInstanceOf[QueryResult]
+    result.resultSchema.columns.map(_.colType) shouldEqual Seq(TimestampColumn, HistogramColumn, DoubleColumn)
+    result.result.size shouldEqual 1
+    val resultIt = result.result(0).rows.map(r=>(r.getLong(0), r.getHistogram(1), r.getDouble(2)))
+
+    // For now, just validate that we can read "reasonable" results, ie max should be >= value at head of window
+    // Rely on AggrOverTimeFunctionsSpec to actually validate aggregation results
+    val orig = histMaxData.filter(_(5).asInstanceOf[Types.UTF8Map]("dc".utf8) == "0".utf8)
+                       .grouped(2).map(_.head)   // Skip every other one, starting with second, since step=2x pace
+                       .zip((start to end by step).toIterator).map { case (r, t) => (t, r(4), r(3)) }
+    resultIt.zip(orig.toIterator).foreach { case (res, origData) =>
+      res._3 should be >= origData._3.asInstanceOf[Double]
+    }
+  }
+
   it ("should return correct result schema") {
     import ZeroCopyUTF8String._
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
@@ -237,6 +269,23 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     resultSchema.length shouldEqual 2
     resultSchema.columns.map(_.colType) shouldEqual Seq(TimestampColumn, DoubleColumn)
     resultSchema.columns.map(_.name) shouldEqual Seq("timestamp", "value")
+  }
+
+  it("should produce correct schema for histogram RVs with and without max column") {
+    // Histogram dataset, no max column
+    val noMaxPlan = SelectRawPartitionsExec("someQueryId", System.currentTimeMillis, 100, dummyDispatcher,
+                      MMD.histDataset.ref, 0, Nil, AllChunkScan, Seq(0, 3))
+    val expected1 = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn),
+                                     ColumnInfo("h", HistogramColumn)), 1, colIDs = Seq(0, 3))
+    noMaxPlan.schemaOfDoExecute(MMD.histDataset) shouldEqual expected1
+
+    // Histogram dataset with max column - should add max to schema automatically
+    val maxPlan = SelectRawPartitionsExec("someQueryId", System.currentTimeMillis, 100, dummyDispatcher,
+                      MMD.histMaxDS.ref, 0, Nil, AllChunkScan, Seq(0, 4))
+    val expected2 = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn),
+                                     ColumnInfo("h", HistogramColumn),
+                                     ColumnInfo("max", DoubleColumn)), 1, colIDs = Seq(0, 4, 3))
+    maxPlan.schemaOfDoExecute(MMD.histMaxDS) shouldEqual expected2
   }
 
   it("should return chunk metadata from MemStore") {

--- a/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import filodb.core.{MachineMetricsData => MMD, MetricsTestData}
 import filodb.core.query.{CustomRangeVectorKey, RangeVector, RangeVectorKey, ResultSchema}
-import filodb.memory.format.{RowReader, ZeroCopyUTF8String}
+import filodb.memory.format.{RowReader, ZeroCopyUTF8String, vectors => bv}
 import filodb.query._
 import filodb.query.exec.TransientRow
 
@@ -16,6 +16,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
 
   val resultSchema = ResultSchema(MetricsTestData.timeseriesDataset.infosFromIDs(0 to 1), 1)
   val histSchema = ResultSchema(MMD.histDataset.infosFromIDs(Seq(0, 3)), 1)
+  val histMaxSchema = ResultSchema(MMD.histMaxDS.infosFromIDs(Seq(0, 4, 3)), 1, colIDs=Seq(0, 4, 3))
   val ignoreKey = CustomRangeVectorKey(
     Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
   val sampleBase: Array[RangeVector] = Array(
@@ -244,6 +245,22 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     val expected = Seq(0.8, 1.6, 2.4, 3.2, 4.0, 5.6, 7.2, 9.6)
     applyFunctionAndAssertResult(Array(histRV), Array(expected.toIterator),
                                  InstantFunctionId.HistogramQuantile, Seq(0.4), histSchema)
+  }
+
+  it("should compute histogram_max_quantile on Histogram RV") {
+    val (data, histRV) = MMD.histMaxRV(100000L, numSamples = 7)
+    val expected = data.zipWithIndex.map { case (row, i) =>
+      // Calculating the quantile is quite complex... sigh
+      val _max = row(3).asInstanceOf[Double]
+      if ((i % 8) == 0) (_max * 0.9) else {
+        val _hist = row(4).asInstanceOf[bv.MutableHistogram]
+        val rank = 0.9 * _hist.bucketValue(_hist.numBuckets - 1)
+        val ratio = (rank - _hist.bucketValue((i-1) % 8)) / (_hist.bucketValue(i%8) - _hist.bucketValue((i-1) % 8))
+        _hist.bucketTop((i-1) % 8) + ratio * (_max -  _hist.bucketTop((i-1) % 8))
+      }
+    }
+    applyFunctionAndAssertResult(Array(histRV), Array(expected.toIterator),
+                                 InstantFunctionId.HistogramMaxQuantile, Seq(0.9), histMaxSchema)
   }
 
   it("should compute histogram_bucket on Histogram RV") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The `histogram_quantile` function follows the one from Prometheus - quantiles are estimated by linear interpolation between buckets, except for the last bucket where the top bucket is +Inf, so values are clipped at the 2nd-to-last bucket "le".

**New behavior :**

With a supplementary "max" value, which is the maximum value recorded in the client for a histogram, we introduce an innovative `histogram_max_quantile` function which is able to deliver higher accuracy quantiles.

- When the max value is beyond the 2nd-to-last (before +Inf) bucket, instead of just clipping the quantile, we are able to interpolate between the 2nd-to-last bucket top and the max value.
- When the max value is lower, we interpolate between the bottom of the bucket and the max value.

Both changes mean that the 0.90+ quantiles return much closer to the max value, instead of interpolating or clipping.
