### PR TITLE
feat(core): Return extra WriteBuffer memory back for reuse

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -40,6 +40,10 @@
         # Number of bytes of offheap mem to allocate to write buffers for all shards.  Ex. 1000MB, 1G, 2GB
         ingestion-buffer-mem-size = 200MB
 
+        # Maximum numer of write buffers to retain in each shard's WriteBufferPool.  Any extra buffers are released
+        # back to native memory, which helps memory reuse.
+        # max-buffer-pool-size = 10000
+
         # Number of time series to evict at a time.
         # num-partitions-to-evict = 1000
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -132,7 +132,6 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
       ChunkSetInfo.setChunkID(infoAddr, currentChunkID)
       ChunkSetInfo.resetNumRows(infoAddr)    // Must reset # rows otherwise it keeps increasing!
       ChunkSetInfo.setStartTime(infoAddr, ts)
-      ChunkSetInfo.setEndTime(infoAddr, ts)
       currentInfo = ChunkSetInfo(infoAddr)
       currentChunks = newAppenders
       // Don't publish the new chunk just yet. Wait until it has one row.

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -132,6 +132,7 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
       ChunkSetInfo.setChunkID(infoAddr, currentChunkID)
       ChunkSetInfo.resetNumRows(infoAddr)    // Must reset # rows otherwise it keeps increasing!
       ChunkSetInfo.setStartTime(infoAddr, ts)
+      ChunkSetInfo.setEndTime(infoAddr, ts)
       currentInfo = ChunkSetInfo(infoAddr)
       currentChunks = newAppenders
       // Don't publish the new chunk just yet. Wait until it has one row.

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1093,8 +1093,7 @@ class TimeSeriesShard(val dataset: Dataset,
         }
       }
     } catch {
-      case e: OutOfOffheapMemoryException => logger.error(s"Out of offheap memory in dataset=${dataset.ref} " +
-                                             s"shard=$shardNum", e); disableAddPartitions()
+      case e: OutOfOffheapMemoryException => disableAddPartitions()
       case e: Exception                   => logger.error(s"Unexpected ingestion err in dataset=${dataset.ref} " +
                                              s"shard=$shardNum", e); disableAddPartitions()
     }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -267,7 +267,7 @@ class TimeSeriesShard(val dataset: Dataset,
   private val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, dataset.partKeySchema,
     reuseOneContainer = true)
   private val partKeyArray = partKeyBuilder.allContainers.head.base.asInstanceOf[Array[Byte]]
-  private val bufferPool = new WriteBufferPool(bufferMemoryManager, dataset, storeConfig)
+  private[memstore] val bufferPool = new WriteBufferPool(bufferMemoryManager, dataset, storeConfig)
 
   private final val partitionGroups = Array.fill(numGroups)(new EWAHCompressedBitmap)
 

--- a/core/src/main/scala/filodb.core/memstore/WriteBufferPool.scala
+++ b/core/src/main/scala/filodb.core/memstore/WriteBufferPool.scala
@@ -9,6 +9,14 @@ import filodb.core.store.{ChunkSetInfo, StoreConfig}
 import filodb.memory.BinaryRegion.NativePointer
 import filodb.memory.MemFactory
 
+object WriteBufferPool {
+  /**
+   * Number of WriteBuffers to allocate at once.  Usually no reason to change it.
+   * Higher number means higher latency during allocation, but more buffers can be individually allocated.
+   */
+  val AllocStepSize = 200
+}
+
 /**
  * A WriteBufferPool pre-allocates/creates a pool of WriteBuffers for sharing amongst many MemStore Partitions.
  * For efficiency it creates a whole set of BinaryAppendableVectors for all columns, so that
@@ -22,20 +30,19 @@ import filodb.memory.MemFactory
  * 2. End of flush()     - original buffers, now encoded, are released, reset, and can be made available to others
  *
  * @param storeConf the StoreConfig containing parameters for configuring write buffers, etc.
- *
- * TODO: Use MemoryManager etc. and allocate memory from a fixed block instead of specifying max # partitions
  */
 class WriteBufferPool(memFactory: MemFactory,
                       val dataset: Dataset,
                       storeConf: StoreConfig) extends StrictLogging {
   import TimeSeriesPartition._
+  import WriteBufferPool._
 
-  val queue = new MpscUnboundedArrayQueue[(NativePointer, AppenderArray)](storeConf.allocStepSize * 10)
+  val queue = new MpscUnboundedArrayQueue[(NativePointer, AppenderArray)](storeConf.maxBufferPoolSize)
 
   private def allocateBuffers(): Unit = {
-    logger.debug(s"Allocating ${storeConf.allocStepSize} WriteBuffers....")
+    logger.debug(s"Allocating ${AllocStepSize} WriteBuffers....")
     // Fill queue up
-    (0 until storeConf.allocStepSize).foreach { n =>
+    (0 until AllocStepSize).foreach { n =>
       val builders = MemStore.getAppendables(memFactory, dataset, storeConf)
       val info = ChunkSetInfo(memFactory, dataset, 0, 0, Long.MinValue, Long.MaxValue)
       // Point vectors in chunkset metadata to builders addresses
@@ -68,13 +75,18 @@ class WriteBufferPool(memFactory: MemFactory,
    * The state of the appenders are reset.
    */
   def release(metaAddr: NativePointer, appenders: AppenderArray): Unit = {
-    // IMPORTANT: reset size in ChunkSetInfo metadata so there won't be an inconsistency between appenders and metadata
-    // (in case some reader is still hanging on to this old info)
-    ChunkSetInfo.resetNumRows(metaAddr)
-    appenders.foreach(_.reset())
-    queue.add((metaAddr, appenders))
-    // TODO: check number of buffers in queue, and release baack to free memory.
-    //  NOTE: no point to this until the pool shares a single MemFactory amongst multiple shards.  In that case
-    //        we have to decide (w/ concurrency a concern): share a single MemFactory or a single WriteBufferPool?
+    if (poolSize >= storeConf.maxBufferPoolSize) {
+      // pool is at max size, release extra so memory can be shared.  Be sure to release each vector's memory
+      for { colNo <- 0 until dataset.numDataColumns optimized } {
+        memFactory.freeMemory(ChunkSetInfo.getVectorPtr(metaAddr, colNo))
+      }
+      memFactory.freeMemory(metaAddr)
+    } else {
+      // IMPORTANT: reset size in ChunkSetInfo metadata so there won't be an inconsistency
+      // between appenders and metadata (in case some reader is still hanging on to this old info)
+      ChunkSetInfo.resetNumRows(metaAddr)
+      appenders.foreach(_.reset())
+      queue.add((metaAddr, appenders))
+    }
   }
 }

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -19,8 +19,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              shardMemSize: Long,
                              // Number of bytes to allocate to ingestion write buffers per shard
                              ingestionBufferMemSize: Long,
-                             // Number of WriteBuffers to allocate at once
-                             allocStepSize: Int,
+                             maxBufferPoolSize: Int,
                              numToEvict: Int,
                              groupsPerShard: Int,
                              numPagesPerBlock: Int,
@@ -44,7 +43,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "max-blob-buffer-size" -> maxBlobBufferSize,
                                "shard-mem-size" -> shardMemSize,
                                "ingestion-buffer-mem-size" -> ingestionBufferMemSize,
-                               "buffer-alloc-step-size" -> allocStepSize,
+                               "max-buffer-pool-size" -> maxBufferPoolSize,
                                "num-partitions-to-evict" -> numToEvict,
                                "groups-per-shard" -> groupsPerShard,
                                "num-block-pages" -> numPagesPerBlock,
@@ -70,7 +69,7 @@ object StoreConfig {
                                            |max-chunks-size = 400
                                            |max-blob-buffer-size = 15000
                                            |ingestion-buffer-mem-size = 10M
-                                           |buffer-alloc-step-size = 1000
+                                           |max-buffer-pool-size = 10000
                                            |num-partitions-to-evict = 1000
                                            |groups-per-shard = 60
                                            |num-block-pages = 1000
@@ -94,7 +93,7 @@ object StoreConfig {
                 config.getInt("max-blob-buffer-size"),
                 config.getMemorySize("shard-mem-size").toBytes,
                 config.getMemorySize("ingestion-buffer-mem-size").toBytes,
-                config.getInt("buffer-alloc-step-size"),
+                config.getInt("max-buffer-pool-size"),
                 config.getInt("num-partitions-to-evict"),
                 config.getInt("groups-per-shard"),
                 config.getInt("num-block-pages"),

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -39,11 +39,11 @@ object TestData {
   val sourceConf = ConfigFactory.parseString("""
     store {
       max-chunks-size = 100
-      buffer-alloc-step-size = 50
       demand-paged-chunk-retention-period = 10 hours
       shard-mem-size = 50MB
       groups-per-shard = 4
-      ingestion-buffer-mem-size = 10MB
+      ingestion-buffer-mem-size = 80MB
+      max-buffer-pool-size = 250
       flush-interval = 10 minutes
       part-index-flush-max-delay = 10 seconds
       part-index-flush-min-delay = 2 seconds

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -540,4 +540,39 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
                         .asInstanceOf[Seq[TimeSeriesPartition]]
     parts.map(_.partID).toSet shouldEqual (0 to 20).toSet
   }
+
+  it("should return extra WriteBuffers to memoryManager properly") {
+    val numSeries = 300
+    val policy2 = new FixedMaxPartitionsEvictionPolicy(numSeries * 2)
+    val store2 = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy2))
+
+    try {
+      // Ingest >250 partitions.  Note how much memory is left after all the allocations
+      store2.setup(dataset1, 0, TestData.storeConf)
+      val shard = store2.getShardE(dataset1.ref, 0)
+
+      // Ingest normal multi series data with 10 partitions.  Should have 10 partitions.
+      val data = records(dataset1, linearMultiSeries(numSeries = numSeries).take(numSeries))
+      store2.ingest(dataset1.ref, 0, data)
+      store2.commitIndexForTesting(dataset1.ref)
+
+      store2.numPartitions(dataset1.ref, 0) shouldEqual numSeries
+      shard.bufferPool.poolSize shouldEqual 100    // Two allocations of 200 each = 400; used up 300; 400-300=100
+      val afterIngestFree = shard.bufferMemoryManager.numFreeBytes
+
+      // Switch buffers, encode and release/return buffers for all partitions
+      val blockFactory = shard.overflowBlockFactory
+      for { n <- 0 until numSeries } {
+        val part = shard.partitions.get(n)
+        part.switchBuffers(blockFactory, encode = true)
+      }
+
+      // Ensure queue length does not get beyond 250, and some memory was freed (free bytes increases)
+      shard.bufferPool.poolSize shouldEqual 250
+      val nowFree = shard.bufferMemoryManager.numFreeBytes
+      nowFree should be > (afterIngestFree)
+    } finally {
+      store2.shutdown()    // release snd free the memory
+    }
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The `WriteBufferPool` allocates more WriteBuffers from native memory upon request.  When a surge of TSPartitions dies down however, and the WriteBuffers are released and returned to the pool, the memory is never released.  The pool retains a very large number of unused WriteBuffers. After a while, we run out of WriteBuffer memory, and this condition does not change.

**New behavior :**

There is a new `max-buffer-pool-size` setting.  When the `WriteBufferPool` is at this size, any buffers that are returned are released back to native memory instead of being retained in the pool.  This allows the native memory usage to shrink as ingesting partitions shrinks and allows memory to be reused for other purposes, such as for other shards.
