### PR TITLE
bug(coordinator): Exceptions when starting ingestion, but before the recovery task begins, should be caught and handled.

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -120,8 +120,15 @@ private[filodb] final class IngestionActor(dataset: Dataset,
             // Is aready ingesting, and it must not be stopped.
             shardsToStop.remove(shard)
           } else {
-            // Isn't ingesting, so start it.
-            startIngestion(shard)
+            try {
+              // Isn't ingesting, so start it.
+              startIngestion(shard)
+            } catch {
+              case t: Throwable =>
+                logger.error(s"Error occurred during initialization of ingestion for " +
+                  s"dataset=${dataset.ref} shard=${shard}", t)
+                handleError(dataset.ref, shard, t)
+            }
           }
         } else {
           val status = state.map.statuses(shard)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
When starting the recovery task, any exception (like failing to read from Cassandra) is uncaught. This means that the shard state can be stuck in an assigned state for a long time.

**New behavior :**
Catch the exception and handle it like any other shard error. This then reports an error to the status actor.
