### PR TITLE
bug(core): Guard access to the evicted partition keys bloom filter, to prevent it from being freed concurrently.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -512,7 +512,9 @@ class TimeSeriesShard(val dataset: Dataset,
           // partition assign a new partId to non-ingesting partition,
           // but no need to create a new TSPartition heap object
           // instead add the partition to evictedPArtKeys bloom filter so that it can be found if necessary
-          evictedPartKeys.add(PartKey(partKeyBaseOnHeap, partKeyOffset))
+          evictedPartKeys.synchronized {
+            evictedPartKeys.add(PartKey(partKeyBaseOnHeap, partKeyOffset))
+          }
           Some(createPartitionID())
         }
 
@@ -995,7 +997,12 @@ class TimeSeriesShard(val dataset: Dataset,
     */
   private def lookupPreviouslyAssignedPartId(partKeyBase: Array[Byte], partKeyOffset: Long): Int = {
     shardStats.evictedPartKeyBloomFilterQueries.increment()
-    if (evictedPartKeys.mightContain(PartKey(partKeyBase, partKeyOffset))) {
+
+    val mightContain = evictedPartKeys.synchronized {
+      evictedPartKeys.mightContain(PartKey(partKeyBase, partKeyOffset))
+    }
+
+    if (mightContain) {
       val filters = dataset.partKeySchema.toStringPairs(partKeyBase, partKeyOffset)
         .map { pair => ColumnFilter(pair._1, Filter.Equals(pair._2)) }
       val matches = partKeyIndex.partIdsFromFilters2(filters, 0, Long.MaxValue)
@@ -1218,7 +1225,9 @@ class TimeSeriesShard(val dataset: Dataset,
               logger.debug(s"Evicting partId=${partitionObj.partID} from dataset=${dataset.ref} shard=$shardNum")
               // add the evicted partKey to a bloom filter so that we are able to quickly
               // find out if a partId has been assigned to an ingesting partKey before a more expensive lookup.
-              evictedPartKeys.add(PartKey(partitionObj.partKeyBase, partitionObj.partKeyOffset))
+              evictedPartKeys.synchronized {
+                evictedPartKeys.add(PartKey(partitionObj.partKeyBase, partitionObj.partKeyOffset))
+              }
               // The previously created PartKey is just meant for bloom filter and will be GCed
               removePartition(partitionObj)
               partsRemoved += 1
@@ -1228,7 +1237,10 @@ class TimeSeriesShard(val dataset: Dataset,
             partsSkipped += 1
           }
         }
-        shardStats.evictedPkBloomFilterSize.set(evictedPartKeys.approximateElementCount())
+        val elemCount = evictedPartKeys.synchronized {
+          evictedPartKeys.approximateElementCount()
+        }
+        shardStats.evictedPkBloomFilterSize.set(elemCount)
         evictionWatermark = maxEndTime + 1
         // Plus one needed since there is a possibility that all partitions evicted in this round have same endTime,
         // and there may be more partitions that are not evicted with same endTime. If we didnt advance the watermark,
@@ -1356,7 +1368,9 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   def shutdown(): Unit = {
-    evictedPartKeys.dispose()
+    evictedPartKeys.synchronized {
+      evictedPartKeys.dispose()
+    }
     reset()   // Not really needed, but clear everything just to be consistent
     logger.info(s"Shutting down dataset=${dataset.ref} shard=$shardNum")
     /* Don't explcitly free the memory just yet. These classes instead rely on a finalize


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
SEGVs have been observed from the bloom filter, and one possible cause is concurrent shutdown. Only the ingestion thread is expected to access it, but shutdown can run from another one.

**New behavior :**
Guard all access with a synchronized block. This won't affect performance because the bloom filter isn't accessed that often, and it's almost always from the ingestion thread. There's no contention.
