### PR TITLE
feat(core,query): Debug queries that dont release lock; shut down node with stuck shard

### DIFF
--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -47,7 +47,7 @@ class RangeVectorSpec  extends FunSpec with Matchers {
     val builder = SerializableRangeVector.toBuilder(schema)
 
     // Sharing one builder across multiple input RangeVectors
-    val srvs = rvs.map(rv => SerializableRangeVector(rv, builder, schema))
+    val srvs = rvs.map(rv => SerializableRangeVector(rv, builder, schema, "Unit-test"))
 
     // Now verify each of them
     val observedTs = srvs(0).rows.toSeq.map(_.getLong(0))

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -629,7 +629,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
     // Important TODO / TechDebt: We need to replace Iterators with cursors to better control
     // the chunk iteration, lock acquisition and release. This is much needed for safe memory access.
     try {
-      ChunkMap.validateNoSharedLocks()
+      ChunkMap.validateNoSharedLocks(s"TopkQuery-$k-$bottomK")
       // We limit the results wherever it is materialized first. So it is done here.
       aggRangeVector.rows.take(limit).foreach { row =>
         var i = 1

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -124,7 +124,7 @@ trait ExecPlan extends QueryCommand {
             srv
           case rv: RangeVector =>
             // materialize, and limit rows per RV
-            val srv = SerializableRangeVector(rv, builder, recSchema)
+            val srv = SerializableRangeVector(rv, builder, recSchema, printTree(false))
             numResultSamples += srv.numRows
             // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
             if (numResultSamples > limit)

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -225,7 +225,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val recSchema = SerializableRangeVector.toSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
                                                          ColumnInfo("tdig", ColumnType.StringColumn)))
     val builder = SerializableRangeVector.toBuilder(recSchema)
-    val srv = SerializableRangeVector(result7(0), builder, recSchema)
+    val srv = SerializableRangeVector(result7(0), builder, recSchema, "Unit-Test")
 
     val resultObs7b = RangeVectorAggregator.present(agg7, Observable.now(srv), 1000)
     val finalResult = resultObs7b.toListL.runAsync.futureValue


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Add execPlan as debug information to concurrent hash map when obtaining lock, and clear it along with release of lock.
If there are remnant locks and we aren't able to acquire write lock for long time, we dump the execPlans which stay for long to the log and, most importantly, shutdown the node so that ingestion on shard is not stuck.

**The debugging should be removed in a subsequent PR, hopefully, before we push to integration branch.**
