### PR TITLE
bug(core,cass): partGroups bitmap concurrency; fetchSize for partIndex

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionIndexTable.scala
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-import com.datastax.driver.core.ConsistencyLevel
+import com.datastax.driver.core.{ConsistencyLevel, SimpleStatement}
 import monix.reactive.Observable
 
 import filodb.cassandra.FiloCassandraConnector
@@ -40,15 +40,16 @@ sealed class PartitionIndexTable(val dataset: DatasetRef,
        |) WITH compression = {
                     'sstable_compression': '$sstableCompression'}""".stripMargin
 
-  lazy val readCql = session.prepare(s"SELECT segmentid, segment " +
-    s"FROM $tableString WHERE shard = ? AND timebucket = ? order by segmentid asc")
+  lazy val readCql =s"SELECT segmentid, segment " +
+    s"FROM $tableString WHERE shard = ? AND timebucket = ? order by segmentid asc"
 
   lazy val writePartitionCql = session.prepare(
     s"INSERT INTO $tableString (shard, timebucket, segmentid, segment) VALUES (?, ?, ?, ?) USING TTL ?")
     .setConsistencyLevel(writeConsistencyLevel)
 
   def getPartKeySegments(shard: Int, timeBucket: Int): Observable[PartKeyTimeBucketSegment] = {
-    val it = session.execute(readCql.bind(shard: JInt, timeBucket: JInt))
+    // fetch size should be low since each row is about an MB. Default fetchSize can result in ReadTimeouts at server
+    val it = session.execute(new SimpleStatement(readCql, shard: JInt, timeBucket: JInt).setFetchSize(15))
       .asScala.toIterator.map(row => {
       PartKeyTimeBucketSegment(row.getInt("segmentid"),  row.getBytes("segment"))
     })

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -707,7 +707,8 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   def createFlushTask(flushGroup: FlushGroup): Task[Response] = {
-    val partitionIt = InMemPartitionIterator(partitionGroups(flushGroup.groupNum).intIterator)
+    // clone the bitmap so that reads on the flush thread do not conflict with writes on ingestion thread
+    val partitionIt = InMemPartitionIterator(partitionGroups(flushGroup.groupNum).clone().intIterator)
     doFlushSteps(flushGroup, partitionIt)
   }
 

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -71,7 +71,7 @@ object TestTimeseriesProducer extends StrictLogging {
       s"""--promql 'heap_usage{dc="DC0",_ns="App-0"}' --start $startQuery --end $endQuery --limit 15"""
     logger.info(s"Periodic Samples CLI Query : \n$query")
 
-    val q = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}[2m]""", StandardCharsets.UTF_8.toString)
+    val q = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}""", StandardCharsets.UTF_8.toString)
     val periodicSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query_range?" +
       s"query=$q&start=$startQuery&end=$endQuery&step=15"
     logger.info(s"Periodic Samples query URL: \n$periodicSamplesUrl")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Two bug fixes:
* partitionGroups is modified by ingestion thread and read at same time in flush thread. Fix with copy-on-read for other thread.
* PartitionIndex records are being read with default fetch size of 5000. This may cause read timeouts because each row is 1MB in size. 

