### PR TITLE
debug(coordinator): Log easy-to-read snapshot of entire ShardMapper at NCA startup

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
@@ -58,6 +58,12 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
     _shardMappers foreach { case (ref, map) => subscriber ! CurrentShardSnapshot(ref, map) }
   }
 
+  def logAllMappers(msg: String = ""): Unit = {
+    _shardMappers.foreach { case (ref, mapper) =>
+      logger.info(s"$msg dataset=$ref Current mapper state:\n${mapper.prettyPrint}")
+    }
+  }
+
   /** If the mapper for the provided `datasetRef` has been added, sends an initial
     * current snapshot of partition state, as ingestion will subscribe usually when
     * the cluster is already stable.
@@ -159,7 +165,7 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
   /** Called on MemberRemoved, new status already updated. */
   def removeMember(address: Address): Option[ActorRef] = {
     _coordinators.get(address) map { coordinator =>
-      logger.info(s"Initiated removeMember for coordinator on $address")
+      logger.info(s"Initiated removeMember for coordinator=$coordinator on $address")
       _coordinators remove address
       removeCoordinator(coordinator)
       coordinator
@@ -346,13 +352,15 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
       (dataset, mapper) <- shardMappers
     } yield {
       val allRegisteredNodes = mapper.allNodes
-      allRegisteredNodes -- coordinators // coordinators is the list of recovered nodes
+      val toRemove = allRegisteredNodes -- coordinators // coordinators is the list of recovered nodes
+      logger.info(s"Cleaning up dataset=$dataset stale coordinators $toRemove after recovery")
+      toRemove
     }
     for { coord <- nodesToRemove.flatten } {
-      logger.info(s"Cleaning up stale coordinator $coord after recovery")
       removeCoordinator(coord)
     }
     updateShardMetrics()
+    logAllMappers("After removing stale coordinators")
   }
 
   private def removeCoordinator(coordinator: ActorRef): Unit = {
@@ -363,7 +371,6 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
       assignShardsToNodes(dataset, mapper, resources)
       publishChanges(dataset)
     }
-    logger.info(s"Completed removeMember for coordinator $coordinator")
   }
 
   /**

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -255,6 +255,23 @@ class ShardMapper(val numShards: Int) extends Serializable {
   private[coordinator] def clear(): Unit = {
     for { i <- 0 until numShards } { shardMap(i) = ActorRef.noSender }
   }
+
+  /**
+   * Gives a pretty grid-view summary of the status of each shard, plus a sorted view of shards owned by each
+   * coordinator.
+   */
+  def prettyPrint: String = {
+    val sortedCoords = allNodes.toSeq.sorted
+    "Status legend: U=Unassigned N=Assigned A=Active E=Error R=Recovery S=Stopped D=Down\n----- Status Map-----\n" +
+    statusMap.toSeq.grouped(16).zipWithIndex.map { case (statGroup, i) =>
+      f"  ${i * 16}%4d-${Math.min(i * 16 + 15, numShards)}%4d   " +
+      statGroup.grouped(8).map(_.map(statusToLetter).mkString("")).mkString("  ")
+    }.mkString("\n") +
+    "\n----- Coordinators -----\n" +
+    sortedCoords.map { coord =>
+      f"  $coord%40s\t${shardsForCoord(coord).mkString(", ")}"
+    }.mkString("\n")
+  }
 }
 
 private[filodb] object ShardMapper extends StrictLogging {
@@ -276,4 +293,14 @@ private[filodb] object ShardMapper extends StrictLogging {
 
   final case class ShardError(event: ShardEvent, context: String)
     extends Exception(s"$context [shard=${event.shard}, event=$event]")
+
+  def statusToLetter(status: ShardStatus): String = status match {
+    case ShardStatusUnassigned  => "U"
+    case ShardStatusAssigned    => "N"
+    case ShardStatusActive      => "A"
+    case ShardStatusError       => "E"
+    case s: ShardStatusRecovery => "R"
+    case ShardStatusStopped     => "S"
+    case ShardStatusDown        => "D"
+  }
 }

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -295,7 +295,7 @@ private[filodb] object ShardMapper extends StrictLogging {
     extends Exception(s"$context [shard=${event.shard}, event=$event]")
 
   def statusToLetter(status: ShardStatus): String = status match {
-    case ShardStatusUnassigned  => "U"
+    case ShardStatusUnassigned  => "."
     case ShardStatusAssigned    => "N"
     case ShardStatusActive      => "A"
     case ShardStatusError       => "E"

--- a/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
@@ -118,6 +118,7 @@ class ShardMapperSpec extends ActorTest(ShardMapperSpec.getNewSystem) {
     mapper1.updateFromEvent(IngestionStarted(dataset, 3, ref2)).isSuccess shouldEqual true
     mapper1.activeShards(Seq(1, 2, 3, 4)) shouldEqual Seq(2, 3, 4)
     mapper1.numAssignedShards shouldEqual 3
+    println(mapper1.prettyPrint)
 
     mapper1.updateFromEvent(ShardDown(dataset, 4, ref1)).isSuccess shouldEqual true
     mapper1.activeShards(Seq(1, 2, 3, 4)) shouldEqual Seq(2, 3)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Logs are event-based, after each member is removed or added.  This makes it especially difficult to figure out what the current state is at the startup of a new Singleton.

**New behavior :**

A easy-to-read ShardMapper snapshot for each dataset is logged at multiple points of NCA startup: right after recovery of the map, and after the current Akka Cluster state is received and stale coordinators removed.   It looks like this:

```
Status legend: U=Unassigned N=Assigned A=Active E=Error R=Recovery S=Stopped D=Down
----- Status Map-----
     0-  15   ..AAR...  ........
    16-  31   ........  ........
----- Coordinators -----
  Actor[akka://test/system/testProbe-2#152042117]	2, 4
  Actor[akka://test/system/testProbe-3#-549947007]	3
```