### PR TITLE
bug(core): Use ingesting flag to identify partitions to not purge

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -16,7 +16,7 @@ import filodb.core.query.ColumnFilter
 import filodb.core.store._
 import filodb.memory.MemFactory
 import filodb.memory.NativeMemoryManager
-import filodb.memory.format.ZeroCopyUTF8String
+import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 
 class TimeSeriesMemStore(config: Config, val store: ColumnStore, val metastore: MetaStore,
                          evictionPolicy: Option[PartitionEvictionPolicy] = None)
@@ -193,7 +193,8 @@ extends MemStore with StrictLogging {
                      partMethod: PartitionScanMethod,
                      chunkMethod: ChunkScanMethod = AllChunkScan): Observable[ReadablePartition] = {
     val shard = datasets(dataset.ref).get(partMethod.shard)
-    if (shard == null) {
+
+    if (shard == UnsafeUtils.ZeroPointer) {
       throw new IllegalArgumentException(s"Shard ${partMethod.shard} of dataset ${dataset.ref} is not assigned to " +
         s"this node. Was it was recently reassigned to another node? Prolonged occurrence indicates an issue.")
     }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -693,7 +693,7 @@ class TimeSeriesShard(val dataset: Dataset,
     var numDeleted = 0
     val removedParts = new EWAHCompressedBitmap()
     InMemPartitionIterator(partsToPurge.intIterator()).foreach { p =>
-      if (!p.infosToBeFlushed.hasNext) {
+      if (!p.ingesting) {
         logger.debug(s"Purging partition with partId=${p.partID} from memory in dataset=${dataset.ref} shard=$shardNum")
         removePartition(p)
         removedParts.set(p.partID)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Use part.ingesting flag instead of earlier condition to check if partition is eligible for purge
* Return Exception with better error message than NPE when shard is not present on node
