### PR TITLE
bug(core): The flush done tasks must be run from the ingestion thread.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1190,7 +1190,7 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   /**
-   * Check and evict partitions to free up memory and heap space.  NOTE: This should be called in the ingestion
+   * Check and evict partitions to free up memory and heap space.  NOTE: This must be called in the ingestion
    * stream so that there won't be concurrent other modifications.  Ideally this is called when trying to add partitions
    * @return true if able to evict enough or there was already space, false if not able to evict and not enough mem
    */
@@ -1212,59 +1212,56 @@ class TimeSeriesShard(val dataset: Dataset,
         partitionGroups(group) = partitionGroups(group).andNot(prunedPartitions)
       }
 
-      // Be sure the below executes in the ingestion thread for mutation safety
-      ingestSched.executeTrampolined { () =>
-        // Finally, prune partitions and keyMap data structures
-        logger.info(s"Evicting partitions from dataset=${dataset.ref} shard=$shardNum, watermark=$evictionWatermark...")
-        val intIt = prunedPartitions.intIterator
-        var partsRemoved = 0
-        var partsSkipped = 0
-        var maxEndTime = evictionWatermark
-        while (intIt.hasNext) {
-          val partitionObj = partitions.get(intIt.next)
-          if (partitionObj != UnsafeUtils.ZeroPointer) {
-            // TODO we can optimize fetching of endTime by getting them along with top-k query
-            val endTime = partKeyIndex.endTimeFromPartId(partitionObj.partID)
-            if (partitionObj.ingesting)
-              logger.warn(s"Partition ${partitionObj.partID} is ingesting, but it was eligible for eviction. How?")
-            if (endTime == PartKeyLuceneIndex.NOT_FOUND || endTime == Long.MaxValue) {
-              logger.warn(s"endTime $endTime was not correct. how?", new IllegalStateException())
-            } else {
-              logger.debug(s"Evicting partId=${partitionObj.partID} from dataset=${dataset.ref} shard=$shardNum")
-              // add the evicted partKey to a bloom filter so that we are able to quickly
-              // find out if a partId has been assigned to an ingesting partKey before a more expensive lookup.
-              evictedPartKeys.synchronized {
-                if (!evictedPartKeysDisposed) {
-                  evictedPartKeys.add(PartKey(partitionObj.partKeyBase, partitionObj.partKeyOffset))
-                }
+      // Finally, prune partitions and keyMap data structures
+      logger.info(s"Evicting partitions from dataset=${dataset.ref} shard=$shardNum, watermark=$evictionWatermark...")
+      val intIt = prunedPartitions.intIterator
+      var partsRemoved = 0
+      var partsSkipped = 0
+      var maxEndTime = evictionWatermark
+      while (intIt.hasNext) {
+        val partitionObj = partitions.get(intIt.next)
+        if (partitionObj != UnsafeUtils.ZeroPointer) {
+          // TODO we can optimize fetching of endTime by getting them along with top-k query
+          val endTime = partKeyIndex.endTimeFromPartId(partitionObj.partID)
+          if (partitionObj.ingesting)
+            logger.warn(s"Partition ${partitionObj.partID} is ingesting, but it was eligible for eviction. How?")
+          if (endTime == PartKeyLuceneIndex.NOT_FOUND || endTime == Long.MaxValue) {
+            logger.warn(s"endTime $endTime was not correct. how?", new IllegalStateException())
+          } else {
+            logger.debug(s"Evicting partId=${partitionObj.partID} from dataset=${dataset.ref} shard=$shardNum")
+            // add the evicted partKey to a bloom filter so that we are able to quickly
+            // find out if a partId has been assigned to an ingesting partKey before a more expensive lookup.
+            evictedPartKeys.synchronized {
+              if (!evictedPartKeysDisposed) {
+                evictedPartKeys.add(PartKey(partitionObj.partKeyBase, partitionObj.partKeyOffset))
               }
-              // The previously created PartKey is just meant for bloom filter and will be GCed
-              removePartition(partitionObj)
-              partsRemoved += 1
-              maxEndTime = Math.max(maxEndTime, endTime)
             }
-          } else {
-            partsSkipped += 1
+            // The previously created PartKey is just meant for bloom filter and will be GCed
+            removePartition(partitionObj)
+            partsRemoved += 1
+            maxEndTime = Math.max(maxEndTime, endTime)
           }
+        } else {
+          partsSkipped += 1
         }
-        val elemCount = evictedPartKeys.synchronized {
-          if (!evictedPartKeysDisposed) {
-            evictedPartKeys.approximateElementCount()
-          } else {
-            0
-          }
-        }
-        shardStats.evictedPkBloomFilterSize.set(elemCount)
-        evictionWatermark = maxEndTime + 1
-        // Plus one needed since there is a possibility that all partitions evicted in this round have same endTime,
-        // and there may be more partitions that are not evicted with same endTime. If we didnt advance the watermark,
-        // we would be processing same partIds again and again without moving watermark forward.
-        // We may skip evicting some partitions by doing this, but the imperfection is an acceptable
-        // trade-off for performance and simplicity. The skipped partitions, will ve removed during purge.
-        logger.info(s"dataset=${dataset.ref} shard=$shardNum: evicted $partsRemoved partitions," +
-          s"skipped $partsSkipped, h20=$evictionWatermark")
-        shardStats.partitionsEvicted.increment(partsRemoved)
       }
+      val elemCount = evictedPartKeys.synchronized {
+        if (!evictedPartKeysDisposed) {
+          evictedPartKeys.approximateElementCount()
+        } else {
+          0
+        }
+      }
+      shardStats.evictedPkBloomFilterSize.set(elemCount)
+      evictionWatermark = maxEndTime + 1
+      // Plus one needed since there is a possibility that all partitions evicted in this round have same endTime,
+      // and there may be more partitions that are not evicted with same endTime. If we didnt advance the watermark,
+      // we would be processing same partIds again and again without moving watermark forward.
+      // We may skip evicting some partitions by doing this, but the imperfection is an acceptable
+      // trade-off for performance and simplicity. The skipped partitions, will ve removed during purge.
+      logger.info(s"dataset=${dataset.ref} shard=$shardNum: evicted $partsRemoved partitions," +
+        s"skipped $partsSkipped, h20=$evictionWatermark")
+      shardStats.partitionsEvicted.increment(partsRemoved)
     }
     true
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -814,7 +814,9 @@ class TimeSeriesShard(val dataset: Dataset,
       } catch { case e: Throwable =>
         logger.error(s"Error when wrapping up doFlushSteps in dataset=${dataset.ref} shard=$shardNum", e)
       }
-    }
+    }(ingestSched)
+    // Note: The data structures accessed by flushDoneTasks can only be safely accessed by the
+    //       ingestion thread, hence the onComplete steps are run from that thread.
     Task.fromFuture(result)
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Some corruption has been observed with the the group bitmap data structures. This is one possible cause.

**New behavior :**
The flush done tasks are run from the ingestion thread, which is safe and correct.
