### PR TITLE
fix(query): resets function should not return 0 when there is not data for the window

### DIFF
--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
@@ -130,7 +130,9 @@ class ResetsFunction extends RangeFunction {
   }
 
   def removedFromWindow(row: TransientRow, window: Window): Unit = {
-    if (window.size > 0 && row.value > window.head.value) {
+    if (window.size == 0) {
+      resets = Double.NaN
+    } else if (row.value > window.head.value) {
       resets -= 1
     }
   }


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Change `resets` function implementation to reset value back to Double.NaN when window size is zero, making it consistent with Prometheus implementation