### PR TITLE
fix(core): Add an empty spread-assignment in filodb-defaults.conf

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -26,6 +26,10 @@ filodb {
 
   # # of shards each application/metric is spread out to = 2^spread
   spread-default = 1
+  # default spread can be overriden for a specific sharding key combination.
+  # Eg: If "__name__, _ns" are your sharding key, for a _ns "App-Test001" the spread can be overriden as follows:
+  # spread-assignment = [ { _ns = App-Test001, _spread_ = 5 } ]
+  spread-assignment = []
 
   query {
     # Timeout for query engine subtree/ExecPlans for requests to sub nodes


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Without providing an empty default spread-assignment in filodb-defaults.conf, QueryActor is failing.