### PR TITLE
bug(http): Fix ask timeout values in http promql api

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -33,6 +33,7 @@ filodb {
 
   query {
     # Timeout for query engine subtree/ExecPlans for requests to sub nodes
+    # Higher default until we have a way to really timeout query execution at leaves
     ask-timeout = 120 seconds
 
     stale-sample-after = 5 minutes

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -33,7 +33,7 @@ filodb {
 
   query {
     # Timeout for query engine subtree/ExecPlans for requests to sub nodes
-    ask-timeout = 60 seconds
+    ask-timeout = 120 seconds
 
     stale-sample-after = 5 minutes
 

--- a/http/src/main/scala/filodb/http/HttpSettings.scala
+++ b/http/src/main/scala/filodb/http/HttpSettings.scala
@@ -1,6 +1,9 @@
 package filodb.http
 
+import scala.concurrent.duration.FiniteDuration
+
 import com.typesafe.config.Config
+import net.ceedubs.ficus.Ficus._
 
 class HttpSettings(config: Config) {
   lazy val httpServerBindHost = config.getString("filodb.http.bind-host")
@@ -9,4 +12,5 @@ class HttpSettings(config: Config) {
 
   lazy val queryDefaultSpread = config.getInt("filodb.spread-default")
   lazy val querySampleLimit = config.getInt("filodb.query.sample-limit")
+  lazy val queryAskTimeout = config.as[FiniteDuration]("filodb.query.ask-timeout")
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Actor Asks originating from HTTP API are using 30s timeout. 

**New behavior :**

Actor Asks originating from HTTP API use query timeout in configuration.
Default ask time out increased to 2 minutes 

