### PR TITLE
feat(query): Multi-Level aggregation for queries touching many shards

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -203,9 +203,9 @@ class QueryEngine(dataset: Dataset,
      *
      * Starting off with solution 1 first until (2) or some other approach is decided on.
      */
-    toReduceLevel1.plans.foreach(
+    toReduceLevel1.plans.foreach {
       _.addRangeVectorTransformer(AggregateMapReduce(lp.operator, lp.params, lp.without, lp.by))
-    )
+    }
 
     val toReduceLevel2 =
       if (toReduceLevel1.plans.size >= 16) {

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestProbe
 import org.scalatest.{FunSpec, Matchers}
 
 import filodb.coordinator.ShardMapper
-import filodb.coordinator.client.QueryCommands.{FunctionalSpreadProvider, QueryOptions, SpreadChange, StaticSpreadProvider}
+import filodb.coordinator.client.QueryCommands._
 import filodb.core.MetricsTestData
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.prometheus.ast.TimeStepParams

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -3,8 +3,9 @@ package filodb.coordinator.queryengine2
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import org.scalatest.{FunSpec, Matchers}
+
 import filodb.coordinator.ShardMapper
-import filodb.coordinator.client.QueryCommands.{FunctionalSpreadProvider, QueryOptions, SpreadChange}
+import filodb.coordinator.client.QueryCommands.{FunctionalSpreadProvider, QueryOptions, SpreadChange, StaticSpreadProvider}
 import filodb.core.MetricsTestData
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.prometheus.ast.TimeStepParams
@@ -15,16 +16,10 @@ import filodb.query.exec._
 class QueryEngineSpec extends FunSpec with Matchers {
 
   implicit val system = ActorSystem()
-  val node0 = TestProbe().ref
-  val node1 = TestProbe().ref
-  val node2 = TestProbe().ref
-  val node3 = TestProbe().ref
+  val node = TestProbe().ref
 
-  val mapper = new ShardMapper(4)
-  mapper.registerNode(Seq(0), node0)
-  mapper.registerNode(Seq(1), node1)
-  mapper.registerNode(Seq(2), node2)
-  mapper.registerNode(Seq(3), node3)
+  val mapper = new ShardMapper(32)
+  for { i <- 0 until 32 } mapper.registerNode(Seq(i), node)
 
   private def mapperRef = mapper
 
@@ -90,13 +85,36 @@ class QueryEngineSpec extends FunSpec with Matchers {
 
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual true
     execPlan.children.foreach { l1 =>
+      // Now there should be single level of reduce because we have 2 shards
       l1.isInstanceOf[ReduceAggregateExec] shouldEqual true
       l1.children.foreach { l2 =>
-        val l3 = l2.asInstanceOf[ExecPlan]
-        l3.isInstanceOf[SelectRawPartitionsExec] shouldEqual true
-        l3.rangeVectorTransformers.size shouldEqual 2
-        l3.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-        l3.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
+        l2.isInstanceOf[SelectRawPartitionsExec] shouldEqual true
+        l2.rangeVectorTransformers.size shouldEqual 2
+        l2.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+        l2.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
+      }
+    }
+  }
+
+  it ("should parallelize aggregation") {
+    val logicalPlan = BinaryJoin(summed1, BinaryOperator.DIV, Cardinality.OneToOne, summed2)
+
+    // materialized exec plan
+    val execPlan = engine.materialize(logicalPlan,
+      QueryOptions(), spreadProvider = StaticSpreadProvider(SpreadChange(0, 4)))
+    execPlan.isInstanceOf[BinaryJoinExec] shouldEqual true
+
+    // Now there should be multiple levels of reduce because we have 16 shards
+    execPlan.children.foreach { l1 =>
+      l1.isInstanceOf[ReduceAggregateExec] shouldEqual true
+      l1.children.foreach { l2 =>
+        l2.isInstanceOf[ReduceAggregateExec] shouldEqual true
+        l2.children.foreach { l3 =>
+          l3.isInstanceOf[SelectRawPartitionsExec] shouldEqual true
+          l3.rangeVectorTransformers.size shouldEqual 2
+          l3.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+          l3.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
+        }
       }
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

All aggregations happen at one level, no matter how many shards the query touches.

**New behavior :**

If the metric touches more than a threshold number of shards, we do aggregations at multiple levels.
