### PR TITLE
bug(core): Additional safety checks to not free native memory when st…

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -399,6 +399,10 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
   // Free memory (esp offheap) attached to this TSPartition and return buffers to common pool
   def shutdown(): Unit = {
     chunkmapFree()
+  }
+
+  override protected def finalize(): Unit = {
+    memFactory.freeMemory(partKeyOffset)
     if (currentInfo != nullInfo) bufferPool.release(currentInfo.infoAddr, currentChunks)
   }
 }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1277,9 +1277,9 @@ class TimeSeriesShard(val dataset: Dataset,
     } finally {
       partSetLock.unlockWrite(stamp)
     }
-    partitionObj.shutdown()
-    bufferMemoryManager.freeMemory(partitionObj.partKeyOffset)
-    partitions.remove(partitionObj.partID)
+    if (partitions.remove(partitionObj.partID, partitionObj)) {
+      partitionObj.shutdown()
+    }
   }
 
   private def partitionsToEvict(): EWAHCompressedBitmap = {


### PR DESCRIPTION
…ill accessed by other threads.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
