### PR TITLE
feat(memory): delta encoding for increasing/Prom histograms

### DIFF
--- a/doc/compression.md
+++ b/doc/compression.md
@@ -8,6 +8,7 @@
   - [Predictive NibblePacking](#predictive-nibblepacking)
     - [Example](#example)
   - [Histograms](#histograms)
+    - [2D Delta Compression](#2d-delta-compression)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -1,12 +1,15 @@
 package filodb.jmh
 
+import scala.language.postfixOps
+
 import java.util.concurrent.TimeUnit
 
 import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.config.ConfigFactory
 import org.agrona.concurrent.UnsafeBuffer
-import org.agrona.ExpandableArrayBuffer
+import org.agrona.{ExpandableArrayBuffer, ExpandableDirectByteBuffer}
 import org.openjdk.jmh.annotations.{Level => JMHLevel, _}
+import scalaxy.loops._
 
 import filodb.core.{MachineMetricsData, MetricsTestData, TestData}
 import filodb.core.binaryrecord2.RecordBuilder
@@ -157,5 +160,38 @@ class HistogramIngestBenchmark {
     bufSlice.wrap(buf, 0, bytesWritten)
     val res = NibblePack.unpackToSink(bufSlice, sink, inputs.size)
     require(res == NibblePack.Ok)
+  }
+
+  // Add additional inputs for 2D Delta benchmark
+  val numInputs = 100
+  val increasingBuf = new ExpandableDirectByteBuffer()
+  var lastPos = 0
+  val increasingHistPos = (0 until numInputs).map { i =>
+    val longs = inputs.zipWithIndex.map { case (a, j) => a + i + j }
+    lastPos = NibblePack.packDelta(longs, increasingBuf, lastPos)
+    lastPos
+  }.toArray
+
+  // Now, use DeltaDiffPackSink to recompress to deltas from initial inputs
+  val outBuf = new ExpandableDirectByteBuffer()
+  val ddsink = NibblePack.DeltaDiffPackSink(new Array[Long](inputs.size), outBuf)
+  val ddSlice = new UnsafeBuffer(buf, 0, bytesWritten)
+
+  // Simulates DeltaDiffPackSink for many inputs... decompressing and recompressing delta of deltas
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(100)
+  def nibble2DDeltaRepack(): Unit = {
+    ddsink.writePos = 0
+    java.util.Arrays.fill(ddsink.lastHistDeltas, 0)
+    var lastPos = 0
+    for { i <- 0 until numInputs optimized } {
+      ddSlice.wrap(increasingBuf, lastPos, increasingHistPos(i) - lastPos)
+      val res = NibblePack.unpackToSink(ddSlice, ddsink, inputs.size)
+      require(res == NibblePack.Ok)
+      lastPos = increasingHistPos(i)
+      ddsink.finish
+    }
   }
 }

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -192,7 +192,7 @@ class HistogramIngestBenchmark {
       val res = NibblePack.unpackToSink(ddSlice, ddsink, inputs.size)
       require(res == NibblePack.Ok)
       lastPos = increasingHistPos(i)
-      ddsink.finish
+      ddsink.reset()
     }
   }
 }

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -158,6 +158,7 @@ class HistogramIngestBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   def nibbleUnpackDelta64(): Unit = {
     bufSlice.wrap(buf, 0, bytesWritten)
+    sink.reset()
     val res = NibblePack.unpackToSink(bufSlice, sink, inputs.size)
     require(res == NibblePack.Ok)
   }

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -1,13 +1,13 @@
 package filodb.jmh
 
-import scala.language.postfixOps
-
 import java.util.concurrent.TimeUnit
+
+import scala.language.postfixOps
 
 import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.config.ConfigFactory
-import org.agrona.concurrent.UnsafeBuffer
 import org.agrona.{ExpandableArrayBuffer, ExpandableDirectByteBuffer}
+import org.agrona.concurrent.UnsafeBuffer
 import org.openjdk.jmh.annotations.{Level => JMHLevel, _}
 import scalaxy.loops._
 

--- a/memory/src/main/scala/filodb.memory/format/Ptr.scala
+++ b/memory/src/main/scala/filodb.memory/format/Ptr.scala
@@ -1,5 +1,8 @@
 package filodb.memory.format
 
+// A value class for unsigned 8-bit numbers, intended for safe byte/low-level access
+final case class IntU8 private(n: Int) extends AnyVal
+
 /**
  * Strongly typed native memory pointer types / value classes.
  * Do not incur allocations as long as value class rules are followed.

--- a/memory/src/main/scala/filodb.memory/format/Section.scala
+++ b/memory/src/main/scala/filodb.memory/format/Section.scala
@@ -1,5 +1,9 @@
 package filodb.memory.format
 
+// Value type for section type, must be a byte
+// Use of this value class helps prevent type coercion errors from using just an Int
+final private[format] case class SectionType(n: Int) extends AnyVal
+
 /**
  * A Section is a subdivision of a BinaryVector, typically used for variable-length data.  It contains a
  * fixed header with length and # elements, which lets cursors skip quickly over sections.
@@ -7,12 +11,21 @@ package filodb.memory.format
  * The design of the data is such that a single writer updates fields but multiple readers can read.
  * Thus we have to be careful about the order in which updates are written.
  * Basically, we want the data in all fields to be consistent.
+ *
+ * Offset
+ * +0     u16  Number of bytes in this section, following 4-byte section header
+ * +2     u8   Number of elements (max 255)
+ * +3     u8   Type of section
+ *                0: Normal section
+ *                1: Drop (for increasing counters)
  */
 final case class Section private(addr: Long) extends AnyVal {
   // not including length bytes
   final def sectionNumBytes: Int = Ptr.U16(addr).getU16
 
   final def numElements: Int = Ptr.U8(addr).add(2).getU8
+
+  final def sectionType: SectionType = SectionType(Ptr.U8(addr).add(3).getU8)
 
   // Ptr to first record of section
   final def firstElem: Ptr.U8 = Ptr.U8(addr) + 4
@@ -38,25 +51,36 @@ final case class Section private(addr: Long) extends AnyVal {
     require(num >= 0 && num <= 255)
     Ptr.U8(addr).add(2).asMut.set(num)
   }
+
+  final def setType(typ: SectionType): Unit = {
+    Ptr.U8(addr).add(3).asMut.set(typ.n)
+  }
+
+  def debugString: String = s"Section@$addr: {numBytes=$sectionNumBytes, len=$numElements, type=$sectionType}"
 }
 
 object Section {
   def fromPtr(addr: Ptr.U8): Section = Section(addr.addr)
 
-  def init(sectionAddr: Ptr.U8): Section = {
+  def init(sectionAddr: Ptr.U8, typ: SectionType = TypeNormal): Section = {
     val newSect = Section(sectionAddr.addr)
     newSect.setNumElements(0)
+    newSect.setType(typ)
     sectionAddr.asU16.asMut.set(0)
     newSect
   }
+
+  val TypeNormal = SectionType(0)
+  val TypeDrop   = SectionType(1)
 }
 
 /**
  * A writer which manages sections as blobs and elements are added to it, rolling over to a new section as needed.
+ * Each element has a 2-byte length prefix.
  */
 trait SectionWriter {
   // Max # of elements per section, should be no more than 255.  Usually 64?
-  def maxElementsPerSection: Int
+  def maxElementsPerSection: IntU8
 
   // Call to initialize the section writer with the address of the first section and how many bytes left
   def initSectionWriter(firstSectionAddr: Ptr.U8, remainingBytes: Int): Unit = {
@@ -71,7 +95,7 @@ trait SectionWriter {
   protected def needNewSection(numBytes: Int): Boolean = {
     // Check remaining length/space.  A section must be less than 2^16 bytes long. Create new section if needed
     val newNumBytes = curSection.sectionNumBytes + numBytes
-    curSection.numElements >= maxElementsPerSection || newNumBytes >= 65536
+    curSection.numElements >= maxElementsPerSection.n || newNumBytes >= 65536
   }
 
   // Appends a blob, writing a 2-byte length prefix before it.
@@ -82,7 +106,19 @@ trait SectionWriter {
         bytesLeft -= 4
       } else return VectorTooSmall(4 + numBytes, bytesLeft)
     }
+    addBlobInner(base, offset, numBytes)
+  }
 
+  // Appends a blob, forcing creation of a new section too
+  protected def newSectionWithBlob(base: Any, offset: Long, numBytes: Int, sectType: SectionType): AddResponse = {
+    if (bytesLeft >= (4 + numBytes)) {
+      curSection = Section.init(curSection.endAddr, sectType)
+      bytesLeft -= 4
+    } else return VectorTooSmall(4 + numBytes, bytesLeft)
+    addBlobInner(base, offset, numBytes)
+  }
+
+  private def addBlobInner(base: Any, offset: Long, numBytes: Int): AddResponse =
     // Copy bytes to end address, update variables
     if (bytesLeft >= (numBytes + 2)) {
       val writeAddr = curSection.endAddr
@@ -92,5 +128,89 @@ trait SectionWriter {
       curSection.update(numBytes + 2, 1)
       Ack
     } else VectorTooSmall(numBytes + 2, bytesLeft)
+}
+
+/**
+ * Methods to help navigate elements with 2-byte length prefixes within sections.
+ */
+trait SectionReader {
+  var curSection: Section = _
+  var curElemNo = -1
+  var sectStartingElemNo = 0
+  var curHist: Ptr.U8 = _
+
+  // Number of elements in the vector
+  def length: Int
+  def firstSectionAddr: Ptr.U8
+
+  // "End" address, the first address beyond the last byte of this vector
+  def endAddr: Ptr.U8
+
+  // Initializes internal state when reading from a new section.  Override to add anything else needed.
+  protected def setSection(sectAddr: Ptr.U8, newElemNo: Int = 0): Unit = {
+    curSection = Section.fromPtr(sectAddr)
+    curHist = curSection.firstElem
+    curElemNo = newElemNo
+    sectStartingElemNo = newElemNo
   }
+
+  protected def initialize(): Unit =
+    if (curElemNo < 0) {   // first time initialization
+      setSection(firstSectionAddr)
+      curElemNo = 0
+    }
+
+  // Assume that most read patterns move the "cursor" or element # forward.  Since we track the current section
+  // moving forward or jumping to next section is easy.  Jumping backwards within current section is not too bad -
+  // we restart at beg of current section.  Going back before current section is expensive, then we start over.
+  def locate(elemNo: Int): Ptr.U8 = {
+    require(elemNo >= 0 && elemNo < length, s"$elemNo is out of vector bounds [0, $length)")
+    initialize()
+    if (elemNo == curElemNo) {
+      curHist
+    } else if (elemNo > curElemNo) {
+      // Jump forward to next section until we are in section containing elemNo.  BUT, don't jump beyond cur length
+      while (elemNo >= (sectStartingElemNo + curSection.numElements) && curSection.endAddr.addr < endAddr.addr) {
+        setSection(curSection.endAddr, sectStartingElemNo + curSection.numElements)
+      }
+
+      curHist = skipAhead(curHist, elemNo - curElemNo)
+      curElemNo = elemNo
+      curHist
+    } else {  // go backwards then go forwards
+      // Is it still within current section?  If so restart search at beg of section
+      if (elemNo >= sectStartingElemNo) {
+        curElemNo = sectStartingElemNo
+        curHist = curSection.firstElem
+      } else {
+        // Otherwise restart search at beginning
+        setSection(firstSectionAddr)
+      }
+      locate(elemNo)
+    }
+  }
+
+  // Skips ahead numElems elements starting at startPtr and returns the new pointer.  NOTE: numElems might be 0.
+  def skipAhead(startPtr: Ptr.U8, numElems: Int): Ptr.U8 = {
+    require(numElems >= 0)
+    var togo = numElems
+    var ptr = startPtr
+    while (togo > 0) {
+      ptr += ptr.asU16.getU16 + 2
+      togo -= 1
+    }
+    ptr
+  }
+
+  def iterateSections: Iterator[Section] = new Iterator[Section] {
+    var curSect = Section.fromPtr(firstSectionAddr)
+    final def hasNext: Boolean = curSect.endAddr.addr <= endAddr.addr
+    final def next: Section = {
+      val sect = curSect
+      curSect = Section.fromPtr(curSect.endAddr)
+      sect
+    }
+  }
+
+  def dumpAllSections: String = iterateSections.map(_.debugString).mkString("\n")
 }

--- a/memory/src/main/scala/filodb.memory/format/Section.scala
+++ b/memory/src/main/scala/filodb.memory/format/Section.scala
@@ -67,11 +67,16 @@ trait SectionWriter {
   var curSection: Section = _
   var bytesLeft: Int = 0
 
-  // Appends a blob, writing a 2-byte length prefix before it.
-  protected def appendBlob(base: Any, offset: Long, numBytes: Int): AddResponse = {
+  // Returns true if appending numBytes will start a new section
+  protected def needNewSection(numBytes: Int): Boolean = {
     // Check remaining length/space.  A section must be less than 2^16 bytes long. Create new section if needed
     val newNumBytes = curSection.sectionNumBytes + numBytes
-    if (curSection.numElements >= maxElementsPerSection || newNumBytes >= 65536) {
+    curSection.numElements >= maxElementsPerSection || newNumBytes >= 65536
+  }
+
+  // Appends a blob, writing a 2-byte length prefix before it.
+  protected def appendBlob(base: Any, offset: Long, numBytes: Int): AddResponse = {
+    if (needNewSection(numBytes)) {
       if (bytesLeft >= (4 + numBytes)) {
         curSection = Section.init(curSection.endAddr)
         bytesLeft -= 4

--- a/memory/src/main/scala/filodb.memory/format/Section.scala
+++ b/memory/src/main/scala/filodb.memory/format/Section.scala
@@ -44,7 +44,7 @@ final case class Section private(addr: Long) extends AnyVal {
     val newNumElements = numElements + addedElements
     val newNumBytes = sectionNumBytes + addedBytes
     require(newNumElements <= 255 && newNumBytes <= 65535)
-    Ptr.I32(addr).asMut.set(newNumBytes | (newNumElements << 16))
+    Ptr.I32(addr).asMut.set(newNumBytes | (newNumElements << 16) | (sectionType.n << 24))
   }
 
   final def setNumElements(num: Int): Unit = {

--- a/memory/src/main/scala/filodb.memory/format/UnsafeUtils.scala
+++ b/memory/src/main/scala/filodb.memory/format/UnsafeUtils.scala
@@ -55,6 +55,12 @@ object UnsafeUtils {
     }
   }
 
+  def printBytes(buf: DirectBuffer, numBytes: Int = 16): Unit = {
+    //scalastyle:off
+    println((0 until numBytes).map(buf.getByte).map(i => f"$i%02x").mkString(" "))
+    //scalastyle:on
+  }
+
   /**
    * Generic methods to read and write data to any offset from a base object location.  Be careful, this
    * can easily crash the system!

--- a/memory/src/main/scala/filodb.memory/format/WireFormat.scala
+++ b/memory/src/main/scala/filodb.memory/format/WireFormat.scala
@@ -34,6 +34,7 @@ object WireFormat {
 
   val SUBTYPE_H_SIMPLE = 0x10         // Histograms, stored as is (Long/u64 values)
   val SUBTYPE_H_2DDELTA = 0x11        // Histograms, 2D-Delta encoded
+  val SUBTYPE_H_SECTDELTA = 0x12      // Histograms, Section-Delta encoded
 
   def vectorSubType(headerBytes: Int): Int = (headerBytes & 0x00ff00) >> 8
 

--- a/memory/src/main/scala/filodb.memory/format/WireFormat.scala
+++ b/memory/src/main/scala/filodb.memory/format/WireFormat.scala
@@ -32,7 +32,8 @@ object WireFormat {
   val SUBTYPE_INT = 0x07             // Int gets special type because Longs and Doubles may be encoded as Int
   val SUBTYPE_INT_NOMASK = 0x08
 
-  val SUBTYPE_H_SIMPLE = 0x10         // Histograms, stored as is
+  val SUBTYPE_H_SIMPLE = 0x10         // Histograms, stored as is (Long/u64 values)
+  val SUBTYPE_H_2DDELTA = 0x11        // Histograms, 2D-Delta encoded
 
   def vectorSubType(headerBytes: Int): Int = (headerBytes & 0x00ff00) >> 8
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -165,6 +165,21 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
   final def copy: MutableHistogram = MutableHistogram(buckets, values.clone)
 
   /**
+   * Copies the values of this histogram from another histogram.  Other histogram must have same bucket scheme.
+   */
+  final def populateFrom(other: HistogramWithBuckets): Unit = {
+    require(other.buckets == buckets)
+    other match {
+      case m: MutableHistogram =>
+        System.arraycopy(m.values, 0, values, 0, values.size)
+      case l: LongHistogram    =>
+        for { n <- 0 until values.size optimized } {
+          values(n) = l.values(n).toDouble
+        }
+    }
+  }
+
+  /**
    * Adds the values from another Histogram.
    * If the other histogram has the same bucket scheme, then the values are just added per bucket.
    * If the scheme is different, then an approximation is used so that the resulting histogram has

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
@@ -161,7 +161,7 @@ object HistogramIngestBench extends App with CompressorAnalyzer {
       val res = NibblePack.unpackToSink(ddSlice, ddsink, bucketDef.numBuckets)
       require(res == NibblePack.Ok)
       lastPos = increasingHistPos(i)
-      ddsink.finish
+      ddsink.reset()
     }
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
@@ -81,7 +81,7 @@ object HistogramCompressor extends App with CompressorAnalyzer {
   val inputBuffer = new ExpandableArrayBuffer(4096)
 
   val maxBytes = 60 * 300   // Maximum allowable histogram writebuffer size
-  val appender = HistogramVector.appending(memFactory, maxBytes)
+  val appender = HistogramVector.appendingSect(memFactory, maxBytes)
 
   histograms.foreach { h =>
     val buf = h.serialize()

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
@@ -8,6 +8,7 @@ import scalaxy.loops._
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._
 
+//scalastyle:off
 trait CompressorAnalyzer {
   def inputFile: String
   def numSamples: Int
@@ -65,7 +66,6 @@ trait CompressorAnalyzer {
   }
 }
 
-//scalastyle:off
 // Input is a file with one line per histogram, bucket values are comma separated
 // This app is designed to measure histogram compression ratios based on real world histogram data
 object HistogramCompressor extends App with CompressorAnalyzer {

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
@@ -3,45 +3,71 @@ package filodb.memory.format.vectors
 import scala.io.Source
 
 import org.agrona.ExpandableArrayBuffer
+import scalaxy.loops._
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._
 
+trait CompressorAnalyzer {
+  def inputFile: String
+  def numSamples: Int
+
+  val bucketDef = HistogramBuckets.binaryBuckets64
+
+  // TODO: switch to PageAlignedMemManager so the memory can be constantly recycled
+  val memFactory = new NativeMemoryManager(500 * 1024 * 1024)
+
+  var binHistBytesSum = 0
+  var binHistBytesMax = 0
+  var numRecords = 0
+  var numChunks = 0
+
+  var encodedTotal = 0
+  var writeBufferTotal = 0
+  var samplesEncoded = 0
+
+  lazy val histograms = Source.fromFile(inputFile).getLines
+                         .take(numSamples)
+                         .map { line =>
+                           val buckets = line.split(",").map(_.trim.toLong)
+                           LongHistogram(bucketDef, buckets)
+                         }
+
+  def analyze(): Unit = {
+    // Dump out overall aggregates
+    val avgEncoded = encodedTotal.toDouble / numChunks
+    val avgWriteBuf = writeBufferTotal.toDouble / numChunks
+    val histPerChunk = samplesEncoded.toDouble / numChunks
+    println(s"Total number of chunks: $numChunks")
+    println(s"Samples encoded: $samplesEncoded")
+    println(s"Histograms per chunk: $histPerChunk")
+
+    val normAvgEncoded = avgEncoded * 300 / histPerChunk
+    val normAvgWriteBuf = avgWriteBuf * 300 / histPerChunk
+    println(s"Average encoded chunk size: $avgEncoded (normalized to 300 histograms: $normAvgEncoded)")
+    println(s"Average write buffer size:  $avgWriteBuf (normalized to 300 histograms: $normAvgWriteBuf)")
+    println(s"Compression ratio: ${avgWriteBuf / avgEncoded}")
+    println(s"Average binHistogram size: ${binHistBytesSum / numRecords.toDouble}")
+    println(s"Max binHistogram size: $binHistBytesMax bytes")
+  }
+}
+
 //scalastyle:off
 // Input is a file with one line per histogram, bucket values are comma separated
 // This app is designed to measure histogram compression ratios based on real world histogram data
-object HistogramCompressor extends App {
+object HistogramCompressor extends App with CompressorAnalyzer {
   if (args.length < 1) {
     println("Usage: sbt memory/run <histogram-file> <numsamples>")
     println("Tests chunk compression, not runtime or performance, against real-world increasing bucket histogram files")
     sys.exit(0)
   }
   val inputFile = args(0)
-  var numChunks = 0
   val numSamples = if (args.length > 1) args(1).toInt else 6000
 
-  // TODO: switch to PageAlignedMemManager so the memory can be constantly recycled
-  val memFactory = new NativeMemoryManager(500 * 1024 * 1024)
   val inputBuffer = new ExpandableArrayBuffer(4096)
 
   val maxBytes = 60 * 300   // Maximum allowable histogram writebuffer size
   val appender = HistogramVector.appending(memFactory, maxBytes)
-  val bucketDef = HistogramBuckets.binaryBuckets64
-
-  var binHistBytesSum = 0
-  var binHistBytesMax = 0
-  var numRecords = 0
-
-  var encodedTotal = 0
-  var writeBufferTotal = 0
-  var samplesEncoded = 0
-
-  val histograms = Source.fromFile(inputFile).getLines
-                         .take(numSamples)
-                         .map { line =>
-                           val buckets = line.split(",").map(_.trim.toLong)
-                           LongHistogram(bucketDef, buckets)
-                         }
 
   histograms.foreach { h =>
     val buf = h.serialize()
@@ -72,21 +98,47 @@ object HistogramCompressor extends App {
     }
   }
 
-  // Encode final chunk?  Or just forget it, because it will mess up size statistics?
+  analyze()
+}
 
-  // Dump out overall aggregates
-  val avgEncoded = encodedTotal.toDouble / numChunks
-  val avgWriteBuf = writeBufferTotal.toDouble / numChunks
-  val histPerChunk = samplesEncoded.toDouble / numChunks
-  println(s"Total number of chunks: $numChunks")
-  println(s"Samples encoded: $samplesEncoded")
-  println(s"Histograms per chunk: $histPerChunk")
+// Like HistogramCompressor but uses individual Long writebuffers like Prometheus (time series per bucket)
+object PromCompressor extends App with CompressorAnalyzer {
+  if (args.length < 1) {
+    println("Usage: sbt memory/run <histogram-file> <numsamples>")
+    println("Tests chunk compression, not runtime or performance, against real-world increasing bucket histogram files")
+    sys.exit(0)
+  }
+  val inputFile = args(0)
+  val numSamples = if (args.length > 1) args(1).toInt else 6000
 
-  val normAvgEncoded = avgEncoded * 300 / histPerChunk
-  val normAvgWriteBuf = avgWriteBuf * 300 / histPerChunk
-  println(s"Average encoded chunk size: $avgEncoded (normalized to 300 histograms: $normAvgEncoded)")
-  println(s"Average write buffer size:  $avgWriteBuf (normalized to 300 histograms: $normAvgWriteBuf)")
-  println(s"Compression ratio: ${avgWriteBuf / avgEncoded}")
-  println(s"Average binHistogram size: ${binHistBytesSum / numRecords.toDouble}")
-  println(s"Max binHistogram size: $binHistBytesMax bytes")
+  val appenders = (0 until bucketDef.numBuckets).map { _ =>
+    LongBinaryVector.appendingVectorNoNA(memFactory, 300)
+  }.toArray
+
+  histograms.foreach { h =>
+    numRecords += 1
+    for { b <- 0 until bucketDef.numBuckets optimized } {
+      appenders(b).addData(h.values(b)) match {
+        case Ack =>    // data added, no problem
+        case VectorTooSmall(_, _) =>   // not enough space.   Encode, aggregate, and add to a new appender
+          // Optimize and get optimized size, dump out, aggregate
+          val writeBufSize = appenders.map(_.numBytes).sum
+          val optimized = appenders.map(_.optimize(memFactory))
+          val encodedSize = optimized.map(BinaryVector.totalBytes).sum
+          println(s" WriteBuffer size: ${writeBufSize}\t\tEncoded size: $encodedSize")
+          encodedTotal += encodedSize
+          writeBufferTotal += writeBufSize
+          numChunks += 1
+          samplesEncoded += 300
+
+          appenders.foreach(_.reset())
+          // Add back the input that did not fit into appender again
+          appenders(b).addData(h.values(b))
+        case other =>
+          println(s"Warning: response $other from appender.addData")
+      }
+    }
+  }
+
+  analyze()
 }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -348,7 +348,8 @@ class Appendable2DDeltaHistVector(factory: MemFactory,
     // TODO: if value dropped, instead of writing diff, start new section and mark as a reset/correction
     // TODO2: write both orig value AND diff, unless this is the first one?
     } else {
-      val repackedLen = repackSink.finish()
+      val repackedLen = repackSink.writePos
+      repackSink.reset()
       appendBlob(encodingBuf.byteArray, encodingBuf.addressOffset, repackedLen)
     }
   }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -89,6 +89,8 @@ object BinaryHistogram extends StrictLogging {
     case b: MutableDirectBuffer         => b
   }
 
+  val empty2DSink = NibblePack.DeltaDiffPackSink(Array[Long](), histBuf)
+
   val HistFormat_Null = 0x00.toByte
   val HistFormat_Geometric_Delta = 0x03.toByte
   val HistFormat_Geometric1_Delta = 0x04.toByte
@@ -184,12 +186,26 @@ object HistogramVector {
     new AppendableHistogramVector(factory, Ptr.U8(addr), maxBytes)
   }
 
+  def appending2D(factory: MemFactory, maxBytes: Int): AppendableHistogramVector = {
+    val addr = factory.allocateOffheap(maxBytes)
+    new Appendable2DDeltaHistVector(factory, Ptr.U8(addr), maxBytes)
+  }
+
   def apply(buffer: ByteBuffer): HistogramReader = apply(UnsafeUtils.addressFromDirectBuffer(buffer))
 
   import WireFormat._
 
   def apply(p: BinaryVectorPtr): HistogramReader = BinaryVector.vectorType(p) match {
     case x if x == WireFormat(VECTORTYPE_HISTOGRAM, SUBTYPE_H_SIMPLE) => new RowHistogramReader(Ptr.U8(p))
+  }
+
+  // Thread local buffer used as temp buffer for histogram vector encoding ONLY
+  private val tlEncodingBuf = new ThreadLocal[MutableDirectBuffer]()
+  private[memory] def encodingBuf: MutableDirectBuffer = tlEncodingBuf.get match {
+    case UnsafeUtils.ZeroPointer => val buf = new ExpandableArrayBuffer(4096)
+                                    tlEncodingBuf.set(buf)
+                                    buf
+    case b: MutableDirectBuffer         => b
   }
 }
 
@@ -198,6 +214,7 @@ object HistogramVector {
  * This is a Section-based vector - sections of up to 64 histograms are stored at a time.
  * It stores histograms up to a maximum allowed size (since histograms are variable length)
  * Note that the bucket schema is not set until getting the first item.
+ * This one stores the compressed histograms as-is, with no other transformation.
  *
  * Read/Write/Lock semantics: everything is gated by the number of elements.
  * When it is 0, nothing is initialized so the reader guards against that.
@@ -209,9 +226,10 @@ class AppendableHistogramVector(factory: MemFactory,
   import HistogramVector._
   import BinaryHistogram._
 
+  protected def vectSubType: Int = WireFormat.SUBTYPE_H_SIMPLE
+
   // Initialize header
-  BinaryVector.writeMajorAndSubType(addr, WireFormat.VECTORTYPE_HISTOGRAM,
-                                          WireFormat.SUBTYPE_H_SIMPLE)
+  BinaryVector.writeMajorAndSubType(addr, WireFormat.VECTORTYPE_HISTOGRAM, vectSubType)
   reset()
 
   final def addr: BinaryVectorPtr = vectPtr.addr
@@ -260,7 +278,7 @@ class AppendableHistogramVector(factory: MemFactory,
       if (!matchBucketDef(h, vectPtr)) return BucketSchemaMismatch
     }
 
-    val res = appendBlob(buf.byteArray, buf.addressOffset + h.valuesIndex, h.valuesNumBytes)
+    val res = appendHist(buf, h, numItems)
     if (res == Ack) {
       // set new number of bytes first. Remember to exclude initial 4 byte length prefix
       setNumBytes(maxBytes - bytesLeft - 4)
@@ -268,6 +286,11 @@ class AppendableHistogramVector(factory: MemFactory,
       incrNumHistograms(vectPtr)
     }
     res
+  }
+
+  // Inner method to add the histogram to this vector
+  protected def appendHist(buf: DirectBuffer, h: BinHistogram, numItems: Int): AddResponse = {
+    appendBlob(buf.byteArray, buf.addressOffset + h.valuesIndex, h.valuesNumBytes)
   }
 
   final def addNA(): AddResponse = Ack  // TODO: Add a 0 to every appender
@@ -288,6 +311,47 @@ class AppendableHistogramVector(factory: MemFactory,
 
   // We don't optimize -- for now.  Histograms are already stored compressed.
   // In future, play with other optimization strategies, such as delta encoding.
+}
+
+/**
+ * An appender for Prom-style histograms that increase over time.
+ * It stores deltas between successive histograms to save space, but the histograms are assumed to be always
+ * increasing.  If they do not increase, then that is considered a "reset" and recorded as such for
+ * counter correction during queries.
+ */
+class Appendable2DDeltaHistVector(factory: MemFactory,
+                                  vectPtr: Ptr.U8,
+                                  maxBytes: Int) extends AppendableHistogramVector(factory, vectPtr, maxBytes) {
+  import BinaryHistogram._
+  import HistogramVector._
+
+  override def vectSubType: Int = WireFormat.SUBTYPE_H_2DDELTA
+  private var repackSink = BinaryHistogram.empty2DSink
+
+  // TODO: handle corrections correctly. :D
+  override def appendHist(buf: DirectBuffer, h: BinHistogram, numItems: Int): AddResponse = {
+    // Must initialize sink correctly at beg once the actual # buckets are known
+    // Also, we need to write repacked diff histogram to a temporary buffer, as appendBlob needs to know the size
+    // before writing.
+    if (repackSink == BinaryHistogram.empty2DSink)
+      repackSink = NibblePack.DeltaDiffPackSink(new Array[Long](h.numBuckets), encodingBuf)
+
+    // Recompress hist based on delta from last hist, write to temp storage.  Note that no matter what
+    // we HAVE to feed each incoming hist through the sink, to properly seed the last hist values.
+    repackSink.writePos = 0
+    NibblePack.unpackToSink(h.valuesByteSlice, repackSink, h.numBuckets)
+
+    // See if we are at beginning of section.  If so, write the original histogram.  If not, repack and write diff
+    if (numItems == 0 || needNewSection(h.valuesNumBytes)) {
+      repackSink.reset()
+      appendBlob(buf.byteArray, buf.addressOffset + h.valuesIndex, h.valuesNumBytes)
+    // TODO: if value dropped, instead of writing diff, start new section and mark as a reset/correction
+    // TODO2: write both orig value AND diff, unless this is the first one?
+    } else {
+      val repackedLen = repackSink.finish()
+      appendBlob(encodingBuf.byteArray, encodingBuf.addressOffset, repackedLen)
+    }
+  }
 }
 
 trait HistogramReader extends VectorDataReader {

--- a/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
@@ -149,13 +149,18 @@ class NibblePackTest extends FunSpec with Matchers with PropertyChecks {
     unpackAndCompare(writeBuf, 0, finalWritten0, inputs.head)
 
     // Verify delta on subsequent ones yields diff
+    var initPos = finalWritten0
+    sink.writePos shouldEqual initPos
+
     bufsAndSize.drop(1).zip(diffs).foreach { case ((origCompressedBuf, origSize), diff) =>
       val bufSlice = new UnsafeBuffer(origCompressedBuf, 0, origSize)
       val res = NibblePack.unpackToSink(bufSlice, sink, inputs.head.size)
       res shouldEqual NibblePack.Ok
 
       val finalWritten = sink.finish
-      unpackAndCompare(writeBuf, 0, finalWritten, diff)
+      unpackAndCompare(writeBuf, initPos, finalWritten - initPos, diff)
+      initPos = finalWritten
+      sink.writePos shouldEqual finalWritten
     }
   }
 

--- a/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
@@ -1,6 +1,6 @@
 package filodb.memory.format
 
-import org.agrona.ExpandableArrayBuffer
+import org.agrona.{DirectBuffer, ExpandableArrayBuffer}
 import org.agrona.concurrent.UnsafeBuffer
 
 import org.scalatest._
@@ -104,6 +104,59 @@ class NibblePackTest extends FunSpec with Matchers with PropertyChecks {
 
     res shouldEqual NibblePack.Ok
     out shouldEqual inputs
+  }
+
+  def unpackAndCompare(inbuf: DirectBuffer, orig: Array[Long]): Unit = {
+    val sink2 = NibblePack.DeltaSink(new Array[Long](orig.size))
+    val res = NibblePack.unpackToSink(inbuf, sink2, orig.size)
+    res shouldEqual NibblePack.Ok
+    sink2.outArray shouldEqual orig
+  }
+
+  def unpackAndCompare(buf: DirectBuffer, index: Int, numBytes: Int, orig: Array[Long]): Unit = {
+    val slice = new UnsafeBuffer(buf, index, numBytes)
+    unpackAndCompare(slice, orig)
+  }
+
+  it("should repack increasing deltas to diffs using DeltaDiffPackSink") {
+    val inputs = Seq(Array(0L, 1000, 1001, 1002, 1003, 2005, 2010, 3034, 4045, 5056, 6067, 7078),
+                     Array(3L, 1004, 1006, 1008, 1009, 2010, 2020, 3056, 4070, 5090, 6101, 7150),
+                     Array(7L, 1010, 1016, 1018, 1019, 2020, 2030, 3078, 4101, 5112, 6134, 7195))
+    val diffs = inputs.sliding(2).map { case twoInputs =>
+      twoInputs.last.clone.zipWithIndex.map { case (num, i) => num - twoInputs.head(i) }
+    }.toSeq
+
+    val writeBuf = new ExpandableArrayBuffer()
+
+    // Compress each individual input into its own buffer
+    val bufsAndSize = inputs.map { in =>
+      val buf = new ExpandableArrayBuffer()
+      val bytesWritten = NibblePack.packDelta(in, buf, 0)
+      (buf, bytesWritten)
+    }
+
+    // Now, use DeltaDiffPackSink to recompress to deltas from initial inputs
+    val sink = NibblePack.DeltaDiffPackSink(new Array[Long](inputs.head.size), writeBuf)
+
+    // Verify delta on first one (empty diffs) yields back the original
+    val (firstCompBuf, firstBufSize) = bufsAndSize.head
+    val bufSlice0 = new UnsafeBuffer(firstCompBuf, 0, firstBufSize)
+    val res0 = NibblePack.unpackToSink(bufSlice0, sink, inputs.head.size)
+    res0 shouldEqual NibblePack.Ok
+
+    val finalWritten0 = sink.finish
+    finalWritten0 shouldEqual firstBufSize
+    unpackAndCompare(writeBuf, 0, finalWritten0, inputs.head)
+
+    // Verify delta on subsequent ones yields diff
+    bufsAndSize.drop(1).zip(diffs).foreach { case ((origCompressedBuf, origSize), diff) =>
+      val bufSlice = new UnsafeBuffer(origCompressedBuf, 0, origSize)
+      val res = NibblePack.unpackToSink(bufSlice, sink, inputs.head.size)
+      res shouldEqual NibblePack.Ok
+
+      val finalWritten = sink.finish
+      unpackAndCompare(writeBuf, 0, finalWritten, diff)
+    }
   }
 
   import org.scalacheck._

--- a/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
@@ -146,7 +146,7 @@ class NibblePackTest extends FunSpec with Matchers with PropertyChecks {
     val res0 = NibblePack.unpackToSink(bufSlice0, sink, inputs.head.size)
     res0 shouldEqual NibblePack.Ok
 
-    val finalWritten0 = sink.finish
+    val finalWritten0 = sink.writePos
     finalWritten0 shouldEqual firstBufSize
     unpackAndCompare(writeBuf, 0, finalWritten0, inputs.head)
 
@@ -155,11 +155,12 @@ class NibblePackTest extends FunSpec with Matchers with PropertyChecks {
     sink.writePos shouldEqual initPos
 
     bufsAndSize.drop(1).zip(diffs).foreach { case ((origCompressedBuf, origSize), diff) =>
+      sink.reset()
       val bufSlice = new UnsafeBuffer(origCompressedBuf, 0, origSize)
       val res = NibblePack.unpackToSink(bufSlice, sink, inputs.head.size)
       res shouldEqual NibblePack.Ok
 
-      val finalWritten = sink.finish
+      val finalWritten = sink.writePos
       unpackAndCompare(writeBuf, initPos, finalWritten - initPos, diff)
       initPos = finalWritten
       sink.writePos shouldEqual finalWritten

--- a/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
@@ -63,8 +63,10 @@ class NibblePackTest extends FunSpec with Matchers with PropertyChecks {
                        0x0000007654300000L, 0L, 0L)
 
     val inbuf = new UnsafeBuffer(compressed)
-    val outarray = new Array[Long](8)
-    val res = NibblePack.unpack8(inbuf, outarray)
+    var outarray: Array[Long] = null
+    val res = NibblePack.unpack8(inbuf, new NibblePack.Sink {
+      def process(data: Array[Long]): Unit = { outarray = data }
+    })
     res shouldEqual NibblePack.Ok
 
     inbuf.capacity shouldEqual 0

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -16,6 +16,10 @@ object HistogramTest {
     MutableHistogram(bucketScheme, buckets)
   }
 
+  val incrHistBuckets = rawHistBuckets.scanLeft(Array.fill(8)(0.0)) { case (acc, h) =>
+                          acc.zip(h).map { case (a, b) => a + b }
+                        }.drop(1)
+
   val customHistograms = rawHistBuckets.map { buckets =>
     LongHistogram(customScheme, buckets.take(customScheme.numBuckets).map(_.toLong))
   }

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -21,11 +21,11 @@ class HistogramVectorTest extends NativeVectorTest {
 
   val buffer = new UnsafeBuffer(new Array[Byte](4096))
 
-  def verifyHistogram(h: Histogram, itemNo: Int): Unit = {
+  def verifyHistogram(h: Histogram, itemNo: Int, rawBuckets: Seq[Array[Double]] = rawHistBuckets): Unit = {
     h.numBuckets shouldEqual bucketScheme.numBuckets
     for { i <- 0 until bucketScheme.numBuckets } {
       h.bucketTop(i) shouldEqual bucketScheme.bucketTop(i)
-      h.bucketValue(i) shouldEqual rawHistBuckets(itemNo)(i)
+      h.bucketValue(i) shouldEqual rawBuckets(itemNo)(i)
     }
   }
 
@@ -98,6 +98,32 @@ class HistogramVectorTest extends NativeVectorTest {
 
     appender.reset()
     appender.length shouldEqual 0
+  }
+
+  it("should append, optimize, and query SectDelta histograms") {
+    val appender = HistogramVector.appendingSect(memFactory, 1024)
+    incrHistBuckets.foreach { rawBuckets =>
+      BinaryHistogram.writeDelta(bucketScheme, rawBuckets.map(_.toLong), buffer)
+      appender.addData(buffer) shouldEqual Ack
+    }
+
+    appender.length shouldEqual incrHistBuckets.length
+
+    val reader = appender.reader.asInstanceOf[SectDeltaHistogramReader]
+    reader.length shouldEqual rawHistBuckets.length
+    println(reader.dumpAllSections)  //  XXX
+
+    (0 until incrHistBuckets.length).foreach { i =>
+      verifyHistogram(reader(i), i, incrHistBuckets)
+    }
+
+    val optimized = appender.optimize(memFactory)
+    val optReader = HistogramVector(BinaryVector.asBuffer(optimized))
+    optReader.length(optimized) shouldEqual incrHistBuckets.length
+    (0 until incrHistBuckets.length).foreach { i =>
+      val h = optReader(i)
+      verifyHistogram(h, i, incrHistBuckets)
+    }
   }
 
   it("should reject BinaryHistograms of schema different from first schema ingested") {

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -16,6 +16,7 @@ object FiloBuild extends Build {
   lazy val memory = project
     .in(file("memory"))
     .settings(commonSettings: _*)
+    .settings(assemblySettings: _*)
     .settings(name := "filodb-memory")
     .settings(scalacOptions += "-language:postfixOps")
     .settings(libraryDependencies ++= memoryDeps)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

Two new encoding schemes for Prom-style increasing counter based fixed bucket histograms:
- "2DDelta", using delta compression along both axes
- "SectDelta", a delta scheme relative to start of each section, much faster for reading

Some explanation of scheme in README as well, plus tests, benchmarks, and compression utilities.