### PR TITLE
fix(conf,cassandra): Enable counter drop detection by default; fix C* metastore init

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,13 +345,13 @@ that part of the cluster could be with the old config and the rest could have ne
 
 * Partition key = `tags:map`
 * Row key = `timestamp`
-* Columns: `timestamp:ts,value:double:counter=true`
+* Columns: `timestamp:ts,value:double:detectDrops=true`
 
 The above is the classic Prometheus-compatible schema.  It supports indexing on any tag.  Thus standard Prometheus queries that filter by a tag such as `hostname` or `datacenter` for example would work fine.  Note that the Prometheus metric name is encoded as a key `__name__`, which is the Prometheus standard when exporting tags.
 
 Note that in the Prometheus data model, more complex metrics such as histograms are represented as individual time series.  This has some simplicity benefits, but does use up more time series and incur extra I/O overhead when transmitting raw data records.
 
-NOTE: `counter=true` allows for proper and efficient rate calculation on Prometheus counters.
+NOTE: `detectDrops=true` allows for proper and efficient rate calculation on Prometheus counters.
  
 ### Traditional, Multi-Column Schema
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Verify that tables were created in `filodb` and `filodb-admin` keyspaces.
 The script below brings up the FiloDB Dev Standalone server, and then sets up the prometheus dataset (NOTE: if you previously started FiloDB and have not cleared the metadata, then the -s is not needed as FiloDB will recover previous ingestion configs from Cassandra)
 
 ```
-./filodb-dev-start.sh -s
+./filodb-dev-start.sh
 ```
 
 Note that the above script starts the server with configuration at `conf/timeseries-filodb-server.conf`. This config

--- a/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
@@ -24,6 +24,7 @@ class CassandraMetaStore(config: Config, filoSessionProvider: Option[FiloSession
   val defaultKeySpace = config.getString("keyspace")
 
   def initialize(): Future[Response] = {
+    checkpointTable.createKeyspace(checkpointTable.keyspace)
     checkpointTable.initialize()
   }
 

--- a/conf/timeseries-128shards-source.conf
+++ b/conf/timeseries-128shards-source.conf
@@ -2,7 +2,7 @@
 
     definition {
       partition-columns = ["tags:map"]
-      data-columns = ["timestamp:ts", "value:double"]
+      data-columns = ["timestamp:ts", "value:double:counter=true"]
       row-key-columns = [ "timestamp" ]
       downsamplers = [ ]
     }

--- a/conf/timeseries-128shards-source.conf
+++ b/conf/timeseries-128shards-source.conf
@@ -2,7 +2,7 @@
 
     definition {
       partition-columns = ["tags:map"]
-      data-columns = ["timestamp:ts", "value:double:counter=true"]
+      data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
       row-key-columns = [ "timestamp" ]
       downsamplers = [ ]
     }

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -8,7 +8,7 @@
       # defines the unique identifier for partition
       partition-columns = ["tags:map"]
       # Schema of all of the values stored against the partition key. This includes the row-keys as well
-      data-columns = ["timestamp:ts", "value:double"]
+      data-columns = ["timestamp:ts", "value:double:counter=true"]
       # Clustering key for each row. Together with partition key, they form the primary key.
       row-key-columns = [ "timestamp" ]
       # List of downsamplers for the data columns

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -8,7 +8,7 @@
       # defines the unique identifier for partition
       partition-columns = ["tags:map"]
       # Schema of all of the values stored against the partition key. This includes the row-keys as well
-      data-columns = ["timestamp:ts", "value:double:counter=true"]
+      data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
       # Clustering key for each row. Together with partition key, they form the primary key.
       row-key-columns = [ "timestamp" ]
       # List of downsamplers for the data columns

--- a/conf/timeseries-standalonetest-source.conf
+++ b/conf/timeseries-standalonetest-source.conf
@@ -2,7 +2,7 @@
 
     definition {
       partition-columns = ["tags:map"]
-      data-columns = ["timestamp:ts", "value:double"]
+      data-columns = ["timestamp:ts", "value:double:counter=true"]
       row-key-columns = [ "timestamp" ]
       downsamplers = [ ]
     }

--- a/conf/timeseries-standalonetest-source.conf
+++ b/conf/timeseries-standalonetest-source.conf
@@ -2,7 +2,7 @@
 
     definition {
       partition-columns = ["tags:map"]
-      data-columns = ["timestamp:ts", "value:double:counter=true"]
+      data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
       row-key-columns = [ "timestamp" ]
       downsamplers = [ ]
     }

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -223,7 +223,7 @@ object MemStore {
         case IntColumn       => bv.IntBinaryVector.appendingVectorNoNA(memFactory, maxElements)
         case LongColumn      => bv.LongBinaryVector.appendingVectorNoNA(memFactory, maxElements)
         case DoubleColumn    => bv.DoubleVector.appendingVectorNoNA(memFactory, maxElements,
-                                  counter = col.params.as[Option[Boolean]]("counter").getOrElse(false))
+                                  detectDrops = col.params.as[Option[Boolean]]("detectDrops").getOrElse(false))
         case TimestampColumn => bv.LongBinaryVector.timestampVector(memFactory, maxElements)
         case StringColumn    => bv.UTF8Vector.appendingVector(memFactory, maxElements, config.maxBlobBufferSize)
         case HistogramColumn => bv.HistogramVector.appending(memFactory, config.maxBlobBufferSize)

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -5,7 +5,7 @@ filodb {
     hosts = ["localhost"]
     port = 9042
     keyspace = "unittest"
-    admin-keyspace = "unittest"
+    admin-keyspace = "unittest_admin"
     keyspace-replication-options = "{'class': 'SimpleStrategy', 'replication_factor': '1'}"
     lz4-chunk-compress = false
     sstable-compression = "LZ4Compressor"

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -404,7 +404,7 @@ object CustomMetricsData {
 object MetricsTestData {
   val timeseriesDataset = Dataset.make("timeseries",
                                   Seq("tags:map"),
-                                  Seq("timestamp:ts", "value:double:counter=true"),
+                                  Seq("timestamp:ts", "value:double:detectDrops=true"),
                                   Seq("timestamp"),
                                   Seq.empty,
                                   DatasetOptions(Seq("__name__", "job"), "__name__", "value")).get

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -42,7 +42,7 @@ definition {
   # defines the unique identifier for partition
   partition-columns = ["tags:map"]
   # Schema of all of the values stored against the partition key. This includes the row-keys as well
-  data-columns = ["timestamp:ts", "value:double:counter=true"]
+  data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
   # Clustering key for each row. Together with partition key, they form the primary key.
   row-key-columns = [ "timestamp" ]
   # List of downsamplers for the data columns

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -42,7 +42,7 @@ definition {
   # defines the unique identifier for partition
   partition-columns = ["tags:map"]
   # Schema of all of the values stored against the partition key. This includes the row-keys as well
-  data-columns = ["timestamp:ts", "value:double"]
+  data-columns = ["timestamp:ts", "value:double:counter=true"]
   # Clustering key for each row. Together with partition key, they form the primary key.
   row-key-columns = [ "timestamp" ]
   # List of downsamplers for the data columns

--- a/filodb-dev-start.sh
+++ b/filodb-dev-start.sh
@@ -3,7 +3,7 @@ set -e
 # set -x
 
 function showHelp {
-        echo "`basename $0` [-h] [-c arg] [-l arg] [-p] [-s]"
+        echo "`basename $0` [-h] [-c arg] [-l arg] [-p]"
         echo "   -h help"
         echo "   -c takes server config path as argument"
         echo "   -l takes log file suffix as argument"
@@ -12,7 +12,6 @@ function showHelp {
 
 CONFIG=conf/timeseries-filodb-server.conf
 LOG_SUFFIX=1
-SETUP_DATASET=NO
 AKKA_PORT_ARG=""
 
 while getopts "hc:l:ps" opt; do
@@ -25,8 +24,6 @@ while getopts "hc:l:ps" opt; do
     l)  LOG_SUFFIX=$OPTARG
         ;;
     p)  PORTS_ARG="-Dakka.remote.netty.tcp.port=0 -Dfilodb.http.bind-port=0"
-        ;;
-    s)  SETUP_DATASET=YES
         ;;
     esac
 done

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -28,15 +28,15 @@ object DoubleVector {
    * Creates a DoubleAppendingVector - does not grow and does not have bit mask. All values are marked
    * as available.
    * @param maxElements the max number of elements the vector will hold.  Not expandable
-   * @param counter if true, then use a DoubleCounterAppender instead
+   * @param detectDrops if true, then use a DoubleCounterAppender instead to detect drops
    */
-  def appendingVectorNoNA(memFactory: MemFactory, maxElements: Int, counter: Boolean = false):
+  def appendingVectorNoNA(memFactory: MemFactory, maxElements: Int, detectDrops: Boolean = false):
   BinaryAppendableVector[Double] = {
     val bytesRequired = 8 + 8 * maxElements
     val addr = memFactory.allocateOffheap(bytesRequired)
     val dispose = () => memFactory.freeMemory(addr)
-    if (counter) new DoubleCounterAppender(addr, bytesRequired, dispose)
-    else         new DoubleAppendingVector(addr, bytesRequired, dispose)
+    if (detectDrops) new DoubleCounterAppender(addr, bytesRequired, dispose)
+    else             new DoubleAppendingVector(addr, bytesRequired, dispose)
   }
 
   /**

--- a/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
@@ -213,7 +213,7 @@ class DoubleVectorTest extends NativeVectorTest {
       reader.detectDropAndCorrection(frozen, corr2) shouldEqual DoubleCorrection(1201.2, 100.0 + 1201.2)
     }
 
-    it("should return correctedValue with correction adjustment even if vector has no resets") {
+    it("should return correctedValue with correction adjustment even if vector has no drops") {
       reader.correctedValue(frozen, 1, NoCorrection) shouldEqual 2001.1
 
       val corr1 = DoubleCorrection(999.9, 100.0)
@@ -227,8 +227,8 @@ class DoubleVectorTest extends NativeVectorTest {
       reader.updateCorrection(frozen, 0, corr1) shouldEqual DoubleCorrection(7678, 50.0)
     }
 
-    it("should detect resets with DoubleCounterAppender and carry flag to optimized version") {
-      val cb = DoubleVector.appendingVectorNoNA(memFactory, 10, counter=true)
+    it("should detect drops with DoubleCounterAppender and carry flag to optimized version") {
+      val cb = DoubleVector.appendingVectorNoNA(memFactory, 10, detectDrops=true)
       cb.addData(101)
       cb.addData(102.5)
 
@@ -257,7 +257,7 @@ class DoubleVectorTest extends NativeVectorTest {
 
     it("should read out corrected values properly") {
       val orig = Seq(101, 102.5, 9, 13.3, 21.1)
-      val cb = DoubleVector.appendingVectorNoNA(memFactory, 10, counter=true)
+      val cb = DoubleVector.appendingVectorNoNA(memFactory, 10, detectDrops=true)
       orig.foreach(cb.addData)
       cb.length shouldEqual orig.length
       val sc = cb.optimize(memFactory)
@@ -278,7 +278,7 @@ class DoubleVectorTest extends NativeVectorTest {
 
     it("should read out length and values correctly for corrected vectors") {
       val orig = Seq(4419.00, 4511.00, 4614.00, 4724.00, 4909.00, 948.00, 1000.00, 1095.00, 1102.00, 1201.00)
-      val cb = DoubleVector.appendingVectorNoNA(memFactory, 10, counter=true)
+      val cb = DoubleVector.appendingVectorNoNA(memFactory, 10, detectDrops=true)
       orig.foreach(cb.addData)
       cb.length shouldEqual orig.length
       val sc = cb.optimize(memFactory)

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -275,9 +275,11 @@ object RangeFunction {
   def doubleChunkedFunction(func: Option[RangeFunctionId],
                             funcParams: Seq[Any] = Nil): RangeFunctionGenerator = func match {
     case None                 => () => new LastSampleChunkedFunctionD
-    case Some(Rate)           => () => new ChunkedRateFunction
-    case Some(Increase)       => () => new ChunkedIncreaseFunction
-    case Some(Delta)          => () => new ChunkedDeltaFunction
+    // NOTE: temporarily commented out to allow data with drop detection to collect for multiple days before
+    // chunk optimizations kick in
+    // case Some(Rate)           => () => new ChunkedRateFunction
+    // case Some(Increase)       => () => new ChunkedIncreaseFunction
+    // case Some(Delta)          => () => new ChunkedDeltaFunction
     case Some(CountOverTime)  => () => new CountOverTimeChunkedFunctionD()
     case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionD
     case Some(AvgOverTime)    => () => new AvgOverTimeChunkedFunctionD


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Counter drop detection is not enabled; thus any drops will not be detected properly.
CLI --init command does not work from clean C* setup

**New behavior :**

`counter=true` added to dataset config everywhere so counter drop detection is enabled.
Bug fixed so that MetaStore for C* will initialize missing key spaces correctly.
Also, the obsolete -s option to `filodb-dev-start` was removed.
