### PR TITLE
bug(memory): ChunkMap lock logger should be at higher level

### DIFF
--- a/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
@@ -123,12 +123,12 @@ object ChunkMap extends StrictLogging {
   def validateNoSharedLocks(execPlan: String): Unit = {
     val t = Thread.currentThread()
     if (execPlanTracker.containsKey(t)) {
-      logger.debug(s"Current thread ${t.getName} did not release lock for execPlan: ${execPlanTracker.get(t)}")
+      logger.error(s"Current thread ${t.getName} did not release lock for execPlan: ${execPlanTracker.get(t)}")
     }
 
     val numLocksReleased = ChunkMap.releaseAllSharedLocks()
     if (numLocksReleased > 0) {
-      logger.warn(s"Number of locks was non-zero: $numLocksReleased. " +
+      logger.error(s"Number of locks was non-zero: $numLocksReleased. " +
         s"This is indicative of a possible lock acquisition/release bug.")
     }
     execPlanTracker.put(t, execPlan)


### PR DESCRIPTION
**Pull Request checklist**

- x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Lock bugs logger should be higher than current debug level. Using error.