### PR TITLE
bug(core): Queries have been executing in ingestSched

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -5,7 +5,6 @@ import java.nio.ByteBuffer
 import scala.concurrent.duration._
 
 import com.typesafe.scalalogging.StrictLogging
-import monix.eval.Task
 import org.jctools.maps.NonBlockingHashMapLong
 
 import filodb.core.store._
@@ -61,7 +60,7 @@ extends RawToPartitionMaker with StrictLogging {
   /**
    * Stores raw chunks into offheap memory and populates chunks into partition
    */
-  def populateRawChunks(rawPartition: RawPartData): Task[ReadablePartition] = Task {
+  def populateRawChunks(rawPartition: RawPartData): ReadablePartition = {
     // Find the right partition given the partition key
     tsShard.getPartition(rawPartition.partitionKey).map { tsPart =>
       tsShard.shardStats.partitionsPagedFromColStore.increment()

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -131,7 +131,7 @@ extends MemStore with StrictLogging {
                                                                 diskTimeToLiveSeconds, flushTimeBucket))
                     case a: Any => throw new IllegalStateException(s"Unexpected DataOrCommand $a")
                   }.collect { case Some(flushGroup) => flushGroup }
-                  .mapAsync(numParallelFlushes) { f => shard.createFlushTask(f).executeOn(flushSched) }
+                  .mapAsync(numParallelFlushes) { f => shard.createFlushTask(f).executeOn(flushSched).asyncBoundary }
                   .foreach({ x => })(shard.ingestSched)
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -132,6 +132,7 @@ extends MemStore with StrictLogging {
                     case a: Any => throw new IllegalStateException(s"Unexpected DataOrCommand $a")
                   }.collect { case Some(flushGroup) => flushGroup }
                   .mapAsync(numParallelFlushes) { f => shard.createFlushTask(f).executeOn(flushSched).asyncBoundary }
+                           // asyncBoundary so subsequent computations in pipeline happen in default threadpool
                   .foreach({ x => })(shard.ingestSched)
   }
 

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -146,7 +146,7 @@ trait DefaultChunkSource extends ChunkSource {
       // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
       // In the future optimize this if needed.
       .mapAsync { rawPart => partMaker(dataset, partMethod.shard).populateRawChunks(rawPart)
-                               .executeOn(singleThreadPool) }
+                               .executeOn(singleThreadPool).asyncBoundary }
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -145,8 +145,10 @@ trait DefaultChunkSource extends ChunkSource {
     readRawPartitions(dataset, columnIDs, partMethod, chunkMethod)
       // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
       // In the future optimize this if needed.
-      .mapAsync { rawPart => partMaker(dataset, partMethod.shard).populateRawChunks(rawPart)
-                               .executeOn(singleThreadPool).asyncBoundary }
+      .mapAsync { rawPart =>
+        partMaker(dataset, partMethod.shard).populateRawChunks(rawPart).executeOn(singleThreadPool).asyncBoundary
+        // asyncBoundary so subsequent computations in pipeline happen in default threadpool
+      }
   }
 }
 

--- a/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
@@ -51,7 +51,7 @@ class DemandPagedChunkStoreSpec extends FunSpec with AsyncTest {
     for { partNo <- 0 to 9 } {
       val chunkStream = filterByPartAndMakeStream(rawData, partNo)
       val rawPartition = TestData.toRawPartData(chunkStream).runAsync.futureValue
-      val tsPartition = onDemandPartMaker.populateRawChunks(rawPartition).runAsync.futureValue
+      val tsPartition = onDemandPartMaker.populateRawChunks(rawPartition)
 
       tsPartition.appendingChunkLen shouldEqual 2   // 2 samples ingested into write buffers
       tsPartition.numChunks shouldEqual 10          // write buffers + 9 chunks above
@@ -69,6 +69,6 @@ class DemandPagedChunkStoreSpec extends FunSpec with AsyncTest {
     val data2 = linearMultiSeries(start - 2.hours.toMillis, timeStep=100000).take(20)
     val stream2 = filterByPartAndMakeStream(data2, 0)
     val rawPart2 = TestData.toRawPartData(stream2).runAsync.futureValue
-    val tsPart2 = onDemandPartMaker.populateRawChunks(rawPart2).runAsync.futureValue
+    val tsPart2 = onDemandPartMaker.populateRawChunks(rawPart2)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Looks like executeOn causes subsequent map/foreach lambdas to run on the specified executor than the default one assigned for the whole pipeline. Call to `asyncBoundary` is needed to fix this.