### PR TITLE
bug(core): Revert synchronous run of populateRawChunks

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import scala.concurrent.duration._
 
 import com.typesafe.scalalogging.StrictLogging
+import monix.eval.Task
 import org.jctools.maps.NonBlockingHashMapLong
 
 import filodb.core.store._
@@ -60,7 +61,7 @@ extends RawToPartitionMaker with StrictLogging {
   /**
    * Stores raw chunks into offheap memory and populates chunks into partition
    */
-  def populateRawChunks(rawPartition: RawPartData): ReadablePartition = {
+  def populateRawChunks(rawPartition: RawPartData): Task[ReadablePartition] = Task {
     // Find the right partition given the partition key
     tsShard.getPartition(rawPartition.partitionKey).map { tsPart =>
       tsShard.shardStats.partitionsPagedFromColStore.increment()

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -7,7 +7,8 @@ import debox.Buffer
 import kamon.Kamon
 import kamon.trace.Span
 import monix.eval.Task
-import monix.reactive.Observable
+import monix.execution.Scheduler
+import monix.reactive.{Observable, OverflowStrategy}
 
 import filodb.core.Types
 import filodb.core.downsample.{DownsampleConfig, DownsamplePublisher}
@@ -34,6 +35,10 @@ class OnDemandPagingShard(dataset: Dataset,
 TimeSeriesShard(dataset, storeConfig, shardNum, bufferMemoryManager, rawStore, metastore, evictionPolicy,
                 downsampleConfig, downsamplePublisher)(ec) {
   import TimeSeriesShard._
+
+  private val singleThreadPool = Scheduler.singleThread(s"make-partition-${dataset.ref}-$shardNum")
+  // TODO: make this configurable
+  private val strategy = OverflowStrategy.BackPressure(1000)
 
   private def startODPSpan(): Span = Kamon.buildSpan(s"odp-cassandra-latency")
     .withTag("dataset", dataset.name)
@@ -97,7 +102,10 @@ TimeSeriesShard(dataset, storeConfig, shardNum, bufferMemoryManager, rawStore, m
           if (partKeyBytesToPage.nonEmpty) {
             val span = startODPSpan()
             rawStore.readRawPartitions(dataset, allDataCols, multiPart, computeBoundingMethod(pagingMethods))
-              .map { rawPart => partitionMaker.populateRawChunks(rawPart) }
+              // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
+              // In the future optimize this if needed.
+              .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
+              .asyncBoundary(strategy) // This is needed so future computations happen in a different thread
               .doOnTerminate(ex => span.finish())
           } else { Observable.empty }
         }
@@ -109,7 +117,8 @@ TimeSeriesShard(dataset, storeConfig, shardNum, bufferMemoryManager, rawStore, m
             Observable.fromIterable(partKeyBytesToPage.zip(pagingMethods))
               .mapAsync(storeConfig.demandPagingParallelism) { case (partBytes, method) =>
                 rawStore.readRawPartitions(dataset, allDataCols, SinglePartitionScan(partBytes, shardNum), method)
-                  .map { rawPart => partitionMaker.populateRawChunks(rawPart) }
+                  .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
+                  .asyncBoundary(strategy) // This is needed so future computations happen in a different thread
                   .defaultIfEmpty(getPartition(partBytes).get)
                   .headL
               }

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -3,7 +3,9 @@ package filodb.core.store
 import java.nio.ByteBuffer
 
 import kamon.Kamon
-import monix.reactive.Observable
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.{Observable, OverflowStrategy}
 
 import filodb.core._
 import filodb.core.memstore.TimeSeriesShard
@@ -120,7 +122,7 @@ final case class PartKeyTimeBucketSegment(segmentId: Int, segment: ByteBuffer)
  * Responsible for uploading RawPartDatas to offheap memory and creating a queryable ReadablePartition
  */
 trait RawToPartitionMaker {
-  def populateRawChunks(rawPartition: RawPartData): ReadablePartition
+  def populateRawChunks(rawPartition: RawPartData): Task[ReadablePartition]
 }
 
 /**
@@ -133,6 +135,10 @@ trait DefaultChunkSource extends ChunkSource {
    */
   def partMaker(dataset: Dataset, shard: Int): RawToPartitionMaker
 
+  val singleThreadPool = Scheduler.singleThread("make-partition")
+  // TODO: make this configurable
+  private val strategy = OverflowStrategy.BackPressure(1000)
+
   // Default implementation takes every RawPartData and turns it into a regular TSPartition
   def scanPartitions(dataset: Dataset,
                      columnIDs: Seq[Types.ColumnId],
@@ -141,7 +147,10 @@ trait DefaultChunkSource extends ChunkSource {
     readRawPartitions(dataset, columnIDs, partMethod, chunkMethod)
       // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
       // In the future optimize this if needed.
-      .map { rawPart => partMaker(dataset, partMethod.shard).populateRawChunks(rawPart) }
+      .mapAsync { rawPart =>
+          partMaker(dataset, partMethod.shard).populateRawChunks(rawPart).executeOn(singleThreadPool)
+       }
+      .asyncBoundary(strategy)
   }
 }
 

--- a/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
@@ -51,7 +51,7 @@ class DemandPagedChunkStoreSpec extends FunSpec with AsyncTest {
     for { partNo <- 0 to 9 } {
       val chunkStream = filterByPartAndMakeStream(rawData, partNo)
       val rawPartition = TestData.toRawPartData(chunkStream).runAsync.futureValue
-      val tsPartition = onDemandPartMaker.populateRawChunks(rawPartition)
+      val tsPartition = onDemandPartMaker.populateRawChunks(rawPartition).runAsync.futureValue
 
       tsPartition.appendingChunkLen shouldEqual 2   // 2 samples ingested into write buffers
       tsPartition.numChunks shouldEqual 10          // write buffers + 9 chunks above
@@ -69,6 +69,6 @@ class DemandPagedChunkStoreSpec extends FunSpec with AsyncTest {
     val data2 = linearMultiSeries(start - 2.hours.toMillis, timeStep=100000).take(20)
     val stream2 = filterByPartAndMakeStream(data2, 0)
     val rawPart2 = TestData.toRawPartData(stream2).runAsync.futureValue
-    val tsPart2 = onDemandPartMaker.populateRawChunks(rawPart2)
+    val tsPart2 = onDemandPartMaker.populateRawChunks(rawPart2).runAsync.futureValue
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Revert previous change to run populateRawChunks in query thread.
This caused problems since BlockManager was not thread safe.