### PR TITLE
regression(memory): Rely on global logger instance again.

### DIFF
--- a/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
@@ -139,7 +139,7 @@ object ChunkMap extends StrictLogging {
  * @param memFactory a THREAD-SAFE factory for allocating offheap space
  * @param capacity initial capacity of the map; must be more than 0
  */
-class ChunkMap(val memFactory: MemFactory, var capacity: Int) extends StrictLogging {
+class ChunkMap(val memFactory: MemFactory, var capacity: Int) {
   require(capacity > 0)
 
   private var lockState: Int = 0
@@ -283,9 +283,9 @@ class ChunkMap(val memFactory: MemFactory, var capacity: Int) extends StrictLogg
         val locks2 = new ConcurrentHashMap[Thread, String](execPlanTracker)
         locks2.entrySet().retainAll(locks1.entrySet())
         val lockState = UnsafeUtils.getIntVolatile(this, lockStateOffset)
-        logger.error(s"Following execPlan locks have not been released for a while: " +
+        _logger.error(s"Following execPlan locks have not been released for a while: " +
           s"$locks2 $locks1 $execPlanTracker $lockState")
-        logger.error(s"Shutting down process since it may be in an unstable/corrupt state.")
+        _logger.error(s"Shutting down process since it may be in an unstable/corrupt state.")
         Runtime.getRuntime.halt(1)
       }
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Looking at a heap dump I noticed way too many logger instances, referenced by TimeSeriesPartition instances.

**New behavior :**
ChunkMap relies only on a global logger instance again.
