### PR TITLE
fix(query): Fix output schema of histogram_max_quantile function

### DIFF
--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -100,10 +100,9 @@ final case class InstantVectorFunctionMapper(function: InstantFunctionId,
     RangeVectorTransformer.valueColumnType(source) match {
       case ColumnType.HistogramColumn =>
         val instantFunction = InstantFunction.histogram(function, funcParams)
-        if (instantFunction.isHToDoubleFunc) {
+        if (instantFunction.isHToDoubleFunc || instantFunction.isHistDoubleToDoubleFunc) {
           // Hist to Double function, so output schema is double
-          source.copy(columns = Seq(source.columns.head,
-                                    source.columns(1).copy(colType = ColumnType.DoubleColumn)))
+          source.copy(columns = Seq(source.columns.head, ColumnInfo("value", ColumnType.DoubleColumn)))
         } else { source }
       case cType: ColumnType          =>
         source

--- a/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
@@ -245,6 +245,12 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     val expected = Seq(0.8, 1.6, 2.4, 3.2, 4.0, 5.6, 7.2, 9.6)
     applyFunctionAndAssertResult(Array(histRV), Array(expected.toIterator),
                                  InstantFunctionId.HistogramQuantile, Seq(0.4), histSchema)
+
+    // check output schema
+    val instantVectorFnMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.HistogramQuantile,
+                                                                 Seq(0.99))
+    val outSchema = instantVectorFnMapper.schema(MMD.histDataset, histSchema)
+    outSchema.columns.map(_.colType) shouldEqual resultSchema.columns.map(_.colType)
   }
 
   it("should compute histogram_max_quantile on Histogram RV") {
@@ -261,6 +267,13 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     }
     applyFunctionAndAssertResult(Array(histRV), Array(expected.toIterator),
                                  InstantFunctionId.HistogramMaxQuantile, Seq(0.9), histMaxSchema)
+  }
+
+  it("should return proper schema after applying histogram_max_quantile") {
+    val instantVectorFnMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.HistogramMaxQuantile,
+                                                                 Seq(0.99))
+    val outSchema = instantVectorFnMapper.schema(MMD.histMaxDS, histMaxSchema)
+    outSchema.columns.map(_.colType) shouldEqual resultSchema.columns.map(_.colType)
   }
 
   it("should compute histogram_bucket on Histogram RV") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

`histogram_max_quantile` errors out with a NotImplementedError due to mismatched output schema

**New behavior :**

The output schema now matches that returned by `histogram_quantile` from histogram columns.
