### PR TITLE
bug(coord): Monix-io threadpool used in ingestion

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/GlobalConfig.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/GlobalConfig.scala
@@ -2,7 +2,6 @@ package filodb.coordinator
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
-import monix.execution.{Scheduler => MonixScheduler, UncaughtExceptionReporter}
 
 /**
   * Loads the overall configuration in a specific order:
@@ -13,9 +12,6 @@ import monix.execution.{Scheduler => MonixScheduler, UncaughtExceptionReporter}
   * - all other reference.conf's
   */
 object GlobalConfig extends StrictLogging {
-
-  val ioPool = MonixScheduler.io(
-    reporter = UncaughtExceptionReporter(logger.error("Uncaught Exception in GlobalConfig.ioPool", _)))
 
   val systemConfig: Config = {
     ConfigFactory.invalidateCaches()

--- a/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
+++ b/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
@@ -8,7 +8,7 @@ import monix.reactive.Observable
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
-import filodb.coordinator.{GlobalConfig, IngestionStream, IngestionStreamFactory}
+import filodb.coordinator.{IngestionStream, IngestionStreamFactory}
 import filodb.core.binaryrecord2.RecordContainer
 import filodb.core.memstore.SomeData
 import filodb.core.metadata.Dataset
@@ -49,7 +49,7 @@ class KafkaIngestionStream(config: Config,
   override def get: Observable[SomeData] =
     consumer.map { record =>
       SomeData(record.value.asInstanceOf[RecordContainer], record.offset)
-    }.executeOn(GlobalConfig.ioPool)
+    }
 
   override def teardown(): Unit = {
     logger.info(s"Shutting down stream $tp")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Ingestion operations were happening on monix-io scheduler

**New behavior :**

Remove monix-io scheduler
