### PR TITLE
feat(coord): Fix tests and some dataset config/initialization bugs/races

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -55,6 +55,9 @@
       bootstrap.servers = "localhost:9092"
       group.id = "filo-db-timeseries-ingestion"
 
+      # For tests - do not shut down and release memory after ingestion stops (with status IngestionStopped)
+      shutdown-ingest-after-stopped = true
+
       # Values controlling in-memory store chunking, flushing, etc.
       store {
         # Interval it takes to flush ALL time series in a shard.  This time is further divided by groups-per-shard

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -46,6 +46,16 @@ final class FilodbSettings(val conf: Config) {
 
   val datasets = config.as[Seq[String]]("dataset-configs")
 
+  /**
+   * Returns IngestionConfig/dataset configuration from parsing dataset-configs file paths.
+   * If those are empty, then parse the "streams" config key for inline configs.
+   */
+  val streamConfigs: Seq[Config] =
+    if (datasets.nonEmpty) {
+      datasets.map { d => ConfigFactory.parseFile(new java.io.File(d)) }
+    } else {
+      config.as[Seq[Config]]("streams")
+    }
 }
 
 /** Consistent naming: allows other actors to accurately filter

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -54,7 +54,7 @@ final class FilodbSettings(val conf: Config) {
     if (datasets.nonEmpty) {
       datasets.map { d => ConfigFactory.parseFile(new java.io.File(d)) }
     } else {
-      config.as[Seq[Config]]("streams")
+      config.as[Seq[Config]]("inline-dataset-configs")
     }
 }
 

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -106,7 +106,6 @@ private[filodb] final class IngestionActor(dataset: Dataset,
       logger.error(s"$state is invalid for this ingester '${dataset.ref}'.")
       return
     }
-    logger.debug(s"resync: Got new state $state from $origin...")
 
     if (state.version != 0 && state.version <= shardStateVersion) {
       logger.info(s"Ignoring old ShardIngestionState version: ${state.version} <= $shardStateVersion " +

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -106,6 +106,7 @@ private[filodb] final class IngestionActor(dataset: Dataset,
       logger.error(s"$state is invalid for this ingester '${dataset.ref}'.")
       return
     }
+    logger.debug(s"resync: Got new state $state from $origin...")
 
     if (state.version != 0 && state.version <= shardStateVersion) {
       logger.info(s"Ignoring old ShardIngestionState version: ${state.version} <= $shardStateVersion " +

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -225,8 +225,7 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
     // Restore previously set up datasets and shards.  This happens in a very specific order so that
     // shard and dataset state can be recovered correctly.  First all the datasets are set up.
     // Then shard state is recovered, and finally cluster membership events are replayed.
-    settings.datasets.foreach { d =>
-      val config = ConfigFactory.parseFile(new java.io.File(d))
+    settings.streamConfigs.foreach { config =>
       val dataset = Dataset.fromConfig(config)
       val ingestion = IngestionConfig(config, NodeClusterActor.noOpSource.streamFactoryClass).get
       initializeDataset(dataset, ingestion, None)

--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -146,7 +146,6 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
 
         logger.info(s"Creating QueryActor for dataset $ref")
         val queryRef = context.actorOf(QueryActor.props(memStore, dataset, shardMaps.get(ref)), s"$Query-$ref")
-        nca.tell(SubscribeShardUpdates(ref), self)
         queryActors(ref) = queryRef
 
         // TODO: Send status update to cluster actor
@@ -200,6 +199,7 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
       logger.debug(s"Received ShardSnapshot $mapper")
       shardMaps.put(ds, mapper)
       // NOTE: QueryActor has AtomicRef so no need to forward message to it
+    case s: ShardSubscriptions        =>
   }
 
   def receive: Receive = queryHandlers orElse ingestHandlers orElse datasetHandlers orElse coordinatorReceive

--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -8,7 +8,6 @@ import scala.concurrent.duration._
 import akka.actor.{ActorRef, OneForOneStrategy, PoisonPill, Props, Terminated}
 import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.event.LoggingReceive
-import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 
 import filodb.coordinator.client.MiscCommands
@@ -41,13 +40,13 @@ object NodeCoordinatorActor {
 
   def props(metaStore: MetaStore,
             memStore: MemStore,
-            config: Config): Props =
-    Props(classOf[NodeCoordinatorActor], metaStore, memStore, config)
+            settings: FilodbSettings): Props =
+    Props(classOf[NodeCoordinatorActor], metaStore, memStore, settings)
 }
 
 private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
                                                  memStore: MemStore,
-                                                 config: Config) extends NamingAwareBaseActor {
+                                                 settings: FilodbSettings) extends NamingAwareBaseActor {
   import context.dispatcher
 
   import NodeClusterActor._
@@ -55,7 +54,6 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
   import client.DatasetCommands._
   import client.IngestionCommands._
 
-  val settings = new FilodbSettings(config)
   val ingesters = new HashMap[DatasetRef, ActorRef]
   val queryActors = new HashMap[DatasetRef, ActorRef]
   var clusterActor: Option[ActorRef] = None
@@ -63,7 +61,7 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
   var statusActor: Option[ActorRef] = None
   var datasetsInitialized = false
 
-  private val statusAckTimeout = config.as[FiniteDuration]("tasks.timeouts.status-ack-timeout")
+  private val statusAckTimeout = settings.config.as[FiniteDuration]("tasks.timeouts.status-ack-timeout")
 
   // By default, stop children IngestionActors when something goes wrong.
   // restart query actors though
@@ -211,8 +209,8 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
     }
 
     if (!datasetsInitialized) {
-      settings.datasets.foreach { d =>
-        val config = ConfigFactory.parseFile(new java.io.File(d))
+      logger.debug(s"Initializing stream configs: ${settings.streamConfigs}")
+      settings.streamConfigs.foreach { config =>
         val dataset = Dataset.fromConfig(config)
         val ingestion = IngestionConfig(config, NodeClusterActor.noOpSource.streamFactoryClass).get
         initializeDataset(dataset, ingestion)

--- a/coordinator/src/main/scala/filodb.coordinator/NodeGuardian.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeGuardian.scala
@@ -75,7 +75,7 @@ final class NodeGuardian(val settings: FilodbSettings,
     */
   private def createCoordinator(requester: ActorRef): Unit = {
     val actor = context.child(CoordinatorName) getOrElse {
-      val props = NodeCoordinatorActor.props(metaStore, memStore, settings.config)
+      val props = NodeCoordinatorActor.props(metaStore, memStore, settings)
       context.actorOf(props, CoordinatorName) }
 
     requester ! CoordinatorIdentity(actor)

--- a/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
@@ -151,6 +151,7 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
   def addMember(address: Address, coordinator: ActorRef): Unit = {
     logger.info(s"Initiated addMember for coordinator $coordinator")
     _coordinators(address) = coordinator
+    subscribeAll(coordinator)
 
     for ((dataset, resources, mapper) <- datasetShardMaps) {
       val assignable = strategy.shardAssignments(coordinator, dataset, resources, mapper)

--- a/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
@@ -151,7 +151,6 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
   def addMember(address: Address, coordinator: ActorRef): Unit = {
     logger.info(s"Initiated addMember for coordinator $coordinator")
     _coordinators(address) = coordinator
-    subscribeAll(coordinator)
 
     for ((dataset, resources, mapper) <- datasetShardMaps) {
       val assignable = strategy.shardAssignments(coordinator, dataset, resources, mapper)
@@ -579,6 +578,7 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
 
         // Also send a complete ingestion state command to all ingestion actors. Without this,
         // they won't start or stop ingestion.
+        // Note that all coordinators also get latest snapshot through this.
 
         // TODO: Need to provide a globally consistent version, incremented when anything
         //       changes, for any dataset.

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -262,7 +262,7 @@ class ShardMapper(val numShards: Int) extends Serializable {
    */
   def prettyPrint: String = {
     val sortedCoords = allNodes.toSeq.sorted
-    "Status legend: U=Unassigned N=Assigned A=Active E=Error R=Recovery S=Stopped D=Down\n----- Status Map-----\n" +
+    "Status legend: .=Unassigned N=Assigned A=Active E=Error R=Recovery S=Stopped D=Down\n----- Status Map-----\n" +
     statusMap.toSeq.grouped(16).zipWithIndex.map { case (statGroup, i) =>
       f"  ${i * 16}%4d-${Math.min(i * 16 + 15, numShards)}%4d   " +
       statGroup.grouped(8).map(_.map(statusToLetter).mkString("")).mkString("  ")

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -12,15 +12,46 @@ import org.scalatest.time.{Millis, Seconds, Span}
 
 import filodb.core._
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{ColumnInfo, ResultSchema}
+import filodb.core.query.ColumnInfo
 
 object ClusterRecoverySpecConfig extends MultiNodeConfig {
   // register the named roles (nodes) of the test
   val first = role("first")
   val second = role("second")
 
+  // Combined dataset/stream definition, store config
+  // 2 shards, 2 nodes == 1 shard per node
+  val ourConf = s"""
+  filodb {
+    memstore.groups-per-shard = 4
+    streams = [
+      {
+        dataset = "gdelt"
+        definition {
+          partition-columns = ["Actor2Code:string", "Actor2Name:string"]
+          data-columns = ["GLOBALEVENTID:long", "SQLDATE:long", "MonthYear:int",
+                          "Year:int", "NumArticles:int", "AvgTone:double"]
+          row-key-columns = [ "GLOBALEVENTID" ]
+          downsamplers = []
+        }
+        ${GdeltTestData.datasetOptionConfig}
+        num-shards = 2
+        min-num-nodes = 2
+        sourcefactory = "${classOf[sources.CsvStreamFactory].getName}"
+        sourceconfig {
+          header = true
+          batch-size = 10
+          noflush = true
+          resource = "/GDELT-sample-test.csv"
+          shutdown-ingest-after-stopped = false
+          ${TestData.sourceConfStr}
+        }
+      }
+    ]
+  }"""
+
   // this configuration will be used for all nodes
-  val globalConfig = ConfigFactory.parseString("""filodb.memstore.groups-per-shard = 4""".stripMargin)
+  val globalConfig = ConfigFactory.parseString(ourConf)
                        .withFallback(ConfigFactory.parseResources("application_test.conf"))
                        .withFallback(ConfigFactory.load("filodb-defaults.conf"))
   commonConfig(globalConfig)
@@ -28,6 +59,8 @@ object ClusterRecoverySpecConfig extends MultiNodeConfig {
 
 /**
  * A cluster recovery (auto restart of previous ingestion streams, checkpoints) test.
+ * Also a good integration test for cluster and coordinator startup, etc.
+ * NOTE: since we moved to static configs every startup is a "recovery".
  */
 abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig) {
   import akka.testkit._
@@ -36,7 +69,6 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
   import filodb.query._
   import GdeltTestData._
   import NodeClusterActor._
-  import sources.CsvStreamFactory
 
   override def initialParticipants: Int = roles.size
 
@@ -50,24 +82,8 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
   private lazy val coordinatorActor = cluster.coordinatorActor
   private lazy val metaStore = cluster.metaStore
 
-  // 2 shards, 2 nodes == 1 shard per node
-  val sourceConfig = ConfigFactory.parseString(s"""header = true
-                                                   batch-size = 10
-                                                   noflush = true
-                                                   resource = "/GDELT-sample-test.csv"
-                                                   """).withFallback(TestData.sourceConf)
-  val shards = 2
-  private val setup = SetupDataset(dataset6,
-                                   DatasetResourceSpec(shards, shards),
-                                   IngestionSource(classOf[CsvStreamFactory].getName, sourceConfig),
-                                   TestData.storeConf)
-
   implicit val patience =   // make sure futureValue has long enough time
     PatienceConfig(timeout = Span(120, Seconds), interval = Span(500, Millis))
-
-  // FIXME need to fix this test
-//  metaStore.newDataset(dataset6).futureValue shouldEqual Success
-//  metaStore.writeIngestionConfig(setup.config).futureValue shouldEqual Success
 
   var clusterActor: ActorRef = _
   var mapper: ShardMapper = _
@@ -81,7 +97,7 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
 
   // Temporarily ignore this test, it always seems to fail in Travis.  Seems like in Travis the shards are
   // never assigned.
-  ignore("should start actors, join cluster, automatically start prev ingestion") {
+  it("should start actors, join cluster, automatically start prev ingestion") {
     // Start NodeCoordinator on all nodes so the ClusterActor will register them
     coordinatorActor
     cluster join address1
@@ -118,6 +134,7 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
         case CurrentShardSnapshot(ref, newMap) if ref == dataset6.ref => mapper = newMap
       }
     }
+    cluster.memStore.commitIndexForTesting(dataset6.ref)
     enterBarrier("ingestion-stopped")
 
     // val query = LogicalPlanQuery(dataset6.ref,
@@ -131,8 +148,8 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
     coordinatorActor ! q2
     expectMsgPF(10.seconds.dilated) {
       case QueryResult(_, schema, vectors) =>
-        schema shouldEqual ResultSchema(Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn),
-                                            ColumnInfo("AvgTone", ColumnType.DoubleColumn)), 1)
+        schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn),
+                                       ColumnInfo("AvgTone", ColumnType.DoubleColumn))
         // query is counting each partition....
         vectors should have length (59 * 2)
         // vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(575.24)

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -24,7 +24,7 @@ object ClusterRecoverySpecConfig extends MultiNodeConfig {
   val ourConf = s"""
   filodb {
     memstore.groups-per-shard = 4
-    streams = [
+    inline-dataset-configs = [
       {
         dataset = "gdelt"
         definition {

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -130,7 +130,6 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.expectMsg(DatasetCreated)
 
       startIngestion(MachineMetricsData.dataset1, numShards)
-      Thread.sleep(1000) // wait for Lucene index flush to happen correctly.  Wish there was a listener for this
       dataset1.ref
     }
 

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -69,7 +69,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
   var coordinatorActor: ActorRef = _
   var probe: TestProbe = _
   var shardMap = new ShardMapper(1)
-  val nodeCoordProps = NodeCoordinatorActor.props(metaStore, memStore, config)
+  val nodeCoordProps = NodeCoordinatorActor.props(metaStore, memStore, cluster.settings)
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/coordinator/src/test/scala/filodb.coordinator/SupervisorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/SupervisorSpec.scala
@@ -12,7 +12,6 @@ class SupervisorSpec extends AkkaSpec {
 
   private val filoCluster = FilodbCluster(system)
   private val settings = new FilodbSettings(system.settings.config)
-  import settings._
 
   /* Set all as lazy to test same startup as users. */
   // private lazy val threadPool = FutureUtils.getBoundedTPE(QueueLength, PoolName, PoolSize, MaxPoolSize)
@@ -23,7 +22,7 @@ class SupervisorSpec extends AkkaSpec {
   private lazy val metaStore: MetaStore = factory.metaStore
   private lazy val memStore = factory.memStore
   private lazy val assignmentStrategy = DefaultShardAssignmentStrategy
-  private lazy val coordinatorProps = NodeCoordinatorActor.props(metaStore, memStore, config)
+  private lazy val coordinatorProps = NodeCoordinatorActor.props(metaStore, memStore, settings)
   private lazy val guardianProps = NodeGuardian.props(settings, metaStore, memStore, assignmentStrategy)
   private lazy val cluster = Cluster(system)
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -5,14 +5,14 @@ filodb {
   # As an alternative to dataset-configs, one can inline list each dataset/stream ingestion config
   # here, which might be more convenient in some cases than listing file paths (eg tests, reuse of shared configs).
   # This is only used if dataset-configs is empty.
-  # streams = [
+  # inline-dataset-configs = [
   #   {
   #     dataset = "prometheus"
   #     definition { ... }
   #     sourceconfig { ... }
   #   },
   # ]
-  streams = []
+  inline-dataset-configs = []
 
   tasks {
     # Frequency with which new shard maps are published

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1,7 +1,18 @@
 filodb {
-
   # list of paths to dataset + ingestion config files
   dataset-configs = [ ]
+
+  # As an alternative to dataset-configs, one can inline list each dataset/stream ingestion config
+  # here, which might be more convenient in some cases than listing file paths (eg tests, reuse of shared configs).
+  # This is only used if dataset-configs is empty.
+  # streams = [
+  #   {
+  #     dataset = "prometheus"
+  #     definition { ... }
+  #     sourceconfig { ... }
+  #   },
+  # ]
+  streams = []
 
   tasks {
     # Frequency with which new shard maps are published

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -190,6 +190,11 @@ trait MemStore extends ChunkSource {
   def activeShards(dataset: DatasetRef): Seq[Int]
 
   /**
+   * Commits the index immediately so that queries can pick up the latest changes.  Used for testing.
+   */
+  def commitIndexForTesting(dataset: DatasetRef): Unit
+
+  /**
    * WARNING: truncates all the data in the memstore for the given dataset, and also the data
    *          in any underlying ChunkSink too.
    * @return Success, or some ErrorResponse

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -53,6 +53,17 @@ object TestData {
 
   val storeConf = StoreConfig(sourceConf.getConfig("store"))
   val nativeMem = new NativeMemoryManager(10 * 1024 * 1024)
+
+  val optionsString = """
+  options {
+    copyTags = {}
+    ignoreShardKeyColumnSuffixes = {}
+    ignoreTagsOnPartitionKeyHash = ["le"]
+    metricColumn = "__name__"
+    valueColumn = "value"
+    shardKeyColumns = ["__name__", "_ns"]
+  }
+  """
 }
 
 object NamesTestData {

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -36,7 +36,7 @@ object TestData {
                   }.toListL.map { rawChunkSets => RawPartData(partKeyBytes, rawChunkSets) }
   }
 
-  val sourceConf = ConfigFactory.parseString("""
+  val sourceConfStr = """
     store {
       max-chunks-size = 100
       demand-paged-chunk-retention-period = 10 hours
@@ -48,7 +48,8 @@ object TestData {
       part-index-flush-max-delay = 10 seconds
       part-index-flush-min-delay = 2 seconds
     }
-  """)
+  """
+  val sourceConf = ConfigFactory.parseString(sourceConfStr)
 
   val storeConf = StoreConfig(sourceConf.getConfig("store"))
   val nativeMem = new NativeMemoryManager(10 * 1024 * 1024)
@@ -188,6 +189,17 @@ object GdeltTestData {
   val datasetOptions = DatasetOptions.DefaultOptions.copy(
     shardKeyColumns = Seq( "__name__","_ns"))
   val dataset6 = Dataset("gdelt", schema.slice(4, 6), schema.patch(4, Nil, 2), "GLOBALEVENTID", datasetOptions)
+
+  val datasetOptionConfig = """
+    options {
+      shardKeyColumns = ["__name__","_ns"]
+      ignoreShardKeyColumnSuffixes = {}
+      valueColumn = "AvgTone"
+      metricColumn = "__name__"
+      ignoreTagsOnPartitionKeyHash = []
+      copyTags = {}
+    }
+  """
 }
 
 // A simulation of machine metrics data

--- a/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
@@ -16,7 +16,7 @@ object PrometheusApiRouteSpec extends ActorSpecConfig {
   override lazy val configString = s"""
   filodb {
     memstore.groups-per-shard = 4
-    streams = [
+    inline-dataset-configs = [
       {
         dataset = "prometheus"
         definition {

--- a/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
@@ -4,26 +4,48 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.TestProbe
-import com.typesafe.config.ConfigFactory
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import org.scalatest.FunSpec
 import scala.concurrent.duration._
 
 import filodb.coordinator._
-import filodb.core.{AsyncTest, TestData}
-import filodb.prometheus.FormatConversion
+import filodb.core.{AsyncTest, DatasetRef, TestData}
 import filodb.prometheus.query.PrometheusModel.ExplainPlanResponse
 
-object PrometheusApiRouteSpec extends ActorSpecConfig
+object PrometheusApiRouteSpec extends ActorSpecConfig {
+  override lazy val configString = s"""
+  filodb {
+    memstore.groups-per-shard = 4
+    streams = [
+      {
+        dataset = "prometheus"
+        definition {
+          partition-columns = ["tags:map"]
+          data-columns = ["timestamp:ts", "value:double"]
+          row-key-columns = [ "timestamp" ]
+          downsamplers = []
+        }
+        ${TestData.optionsString}
+        num-shards = 4
+        min-num-nodes = 1
+        sourcefactory = "${classOf[NoOpStreamFactory].getName}"
+        sourceconfig {
+          shutdown-ingest-after-stopped = false
+          ${TestData.sourceConfStr}
+        }
+      }
+    ]
+  }"""
+}
 
 class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncTest {
 
   import FailFastCirceSupport._
-  import NodeClusterActor._
   import io.circe.generic.auto._
 
   // Use our own ActorSystem with our test config so we can init cluster properly
-  override def createActorSystem(): ActorSystem = ClusterApiRouteSpec.getNewSystem
+  // Dataset will be created and ingestion started
+  override def createActorSystem(): ActorSystem = PrometheusApiRouteSpec.getNewSystem
 
   val cluster = FilodbCluster(system)
   val probe = TestProbe()
@@ -31,25 +53,18 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   cluster.coordinatorActor
   cluster.join()
   val clusterProxy = cluster.clusterSingleton(ClusterRole.Server, None)
-  val filoServerConfig = ConfigFactory.load("application_test.conf")
-  val config = GlobalConfig.systemConfig
 
-  val settings = new HttpSettings(config)
+  val settings = new HttpSettings(PrometheusApiRouteSpec.config)
   val prometheusAPIRoute = (new PrometheusApiRoute(cluster.coordinatorActor, settings)).route
 
-  private def setupDataset(): Unit = {
-    val command = SetupDataset(FormatConversion.dataset, DatasetResourceSpec(4, 1), noOpSource, TestData.storeConf)
-    probe.send(cluster.coordinatorActor, command)
-    val mapper = new ShardMapper(4)
-    mapper.updateFromEvent(IngestionStarted(FormatConversion.dataset.ref, 0, cluster.coordinatorActor))
-    mapper.updateFromEvent(IngestionStarted(FormatConversion.dataset.ref, 1, cluster.coordinatorActor))
-    mapper.updateFromEvent(IngestionStarted(FormatConversion.dataset.ref, 2, cluster.coordinatorActor))
-    mapper.updateFromEvent(IngestionStarted(FormatConversion.dataset.ref, 3, cluster.coordinatorActor))
-    probe.send(cluster.coordinatorActor, CurrentShardSnapshot(FormatConversion.dataset.ref, mapper))
+  // Wait for cluster actor to start up and register datasets
+  val ref = DatasetRef("prometheus")
+  probe.send(clusterProxy, NodeClusterActor.GetShardMap(ref))
+  probe.expectMsgPF(10.seconds) {
+    case CurrentShardSnapshot(ref, mapper) => info(s"Got mapper for $ref => ${mapper.prettyPrint}")
   }
 
   it("should get explainPlan for query") {
-    setupDataset()
     val query = "heap_usage{_ns=\"App-0\"}"
 
     Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
@@ -70,7 +85,6 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   }
 
   it("should take spread override value from config for app") {
-    setupDataset()
     val query = "heap_usage{_ns=\"App-0\"}"
 
     Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
@@ -86,7 +100,6 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   }
 
   it("should get explainPlan for query based on spread as query parameter") {
-    setupDataset()
     val query = "heap_usage{_ns=\"App-1\"}"
 
     Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
@@ -102,7 +115,6 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   }
 
     it("should take default spread value if there is no override") {
-      setupDataset()
       val query = "heap_usage{_ns=\"App-1\"}"
 
       Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

* Most multi-JVM tests and a few coordinator tests are disabled as they are deemed "flaky".
* A race condition exists where during NCA setup, the subscription to the ClusterActor for shard map updates happens after shard assignment, so the QueryActor does not get a good initial shard map and is not able to process queries for a while
* Tests use a flaky method of having to send a special message to NCA to set up a dataset, instead of initializing like the app actually does
* NCA constructor code is fed the wrong "Config" from the Guardian so that often during initialization no datasets are set up

**New behavior :**

* `IngestionStreamSpec`, `NodeCoordinatorActorSpec`, and the multi-JVM `ClusterRecoverySpec` are all green
* NCA no longer asks for subscription to shard updates explicitly. It is now fed shard map updates from the `ShardIngestionState` messages it is already getting all the time from the clusterActor.  This fixes the data race above.
* QueryActor no longer dies if there are no assigned shard keys
* NCA constructor is now passed a `FilodbSettings`, guaranteeing that the dataset config is consistent with what the ClusterActor is given
* A new `streams` config allows dataset/stream config to be inlined into the main config instead of as separate files (`dataset-configs`).  This is used for tests
* `shutdown-ingest-after-stopped` ingestion config allows tests to disable the shutdown sequence after IngestionStopped status is reached.  This may also be used for debugging.
