### PR TITLE
feat(core): Log and meter events when kafka recovery drops data

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -145,12 +145,12 @@ extends MemStore with StrictLogging {
                     endOffset: Long,
                     checkpoints: Map[Int, Long],
                     reportingInterval: Long): Observable[Long] = {
-    var startOffsetValidated = false
     val shard = getShardE(dataset, shardNum)
     shard.setGroupWatermarks(checkpoints)
     if (endOffset < startOffset) Observable.empty
     else {
       var targetOffset = startOffset + reportingInterval
+      var startOffsetValidated = false
       stream.map { r =>
         if (!startOffsetValidated) {
           if (r.offset > startOffset) {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -156,7 +156,8 @@ extends MemStore with StrictLogging {
           if (r.offset > startOffset) {
             val offsetsNotRecovered = r.offset - startOffset
             logger.error(s"Could not recover dataset=$dataset shard=$shardNum from check pointed offset possibly " +
-                         s"because of retention issues. offsetsNotRecovered=$offsetsNotRecovered")
+                         s"because of retention issues. recoveryStartOffset=$startOffset " +
+                         s"firstRecordOffset=${r.offset} offsetsNotRecovered=$offsetsNotRecovered")
             shard.shardStats.offsetsNotRecovered.increment(offsetsNotRecovered)
           }
           startOffsetValidated = true

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -39,6 +39,7 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val rowsIngested = Kamon.counter("memstore-rows-ingested").refine(tags)
   val partitionsCreated = Kamon.counter("memstore-partitions-created").refine(tags)
   val dataDropped = Kamon.counter("memstore-data-dropped").refine(tags)
+  val offsetsNotRecovered = Kamon.counter("memstore-offsets-no-recovered").refine(tags)
   val outOfOrderDropped = Kamon.counter("memstore-out-of-order-samples").refine(tags)
   val rowsSkipped  = Kamon.counter("recovery-row-skipped").refine(tags)
   val rowsPerContainer = Kamon.histogram("num-samples-per-container")

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -39,7 +39,7 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val rowsIngested = Kamon.counter("memstore-rows-ingested").refine(tags)
   val partitionsCreated = Kamon.counter("memstore-partitions-created").refine(tags)
   val dataDropped = Kamon.counter("memstore-data-dropped").refine(tags)
-  val offsetsNotRecovered = Kamon.counter("memstore-offsets-no-recovered").refine(tags)
+  val offsetsNotRecovered = Kamon.counter("memstore-offsets-not-recovered").refine(tags)
   val outOfOrderDropped = Kamon.counter("memstore-out-of-order-samples").refine(tags)
   val rowsSkipped  = Kamon.counter("recovery-row-skipped").refine(tags)
   val rowsPerContainer = Kamon.histogram("num-samples-per-container")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

System does not log or meter events when kafka offset to recover from is not available.

**New behavior :**

Log and meter events when kafka offset to recover from is not available. Indicates potential data loss.

