### PR TITLE
fix(query): histogram_max_quantile: fix NaN bug for proper aggregations

### DIFF
--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -58,6 +58,7 @@ filodb {
     sample-limit = 1000000
     min-step = 1 ms
     faster-rate = true
+    fastreduce-max-windows = 50
   }
 
   spread-default = 1

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -431,7 +431,7 @@ object HistMaxSumAggregator extends RowAggregator {
       case h if newHist.numBuckets > 0  => acc.h.add(newHist.asInstanceOf[bv.HistogramWithBuckets])
       case h                            =>
     }
-    acc.m = if (acc.m == Double.NaN) aggRes.getDouble(2) else Math.max(acc.m, aggRes.getDouble(2))
+    acc.m = if (acc.m.isNaN) aggRes.getDouble(2) else Math.max(acc.m, aggRes.getDouble(2))
     acc
   }
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

`histogram_max_quantile(...., sum(....))` would return no results for certain time ranges.
This was due to a bug in aggregation where NaN was not compared correctly, leading to NaN results which would get filtered out.

**New behavior :**

Comparison is fixed and new tests added.

