### PR TITLE
fix(query): Correctly extract max column for LastSample + histogram_max_quantile

### DIFF
--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -77,6 +77,11 @@ class HistogramTest extends NativeVectorTest {
       val values = Array[Double](10, 15, 17, 20, 25, 25, 25, 25)
       val h2 = MaxHistogram(MutableHistogram(bucketScheme, values), 10)
       h2.quantile(0.95) shouldEqual 9.5 +- 0.1   // more accurate due to max!
+
+      val values3 = Array[Double](1, 1, 1, 1, 1, 4, 7, 7, 9, 9) ++ Array.fill(54)(12.0)
+      val h3 = MaxHistogram(MutableHistogram(HistogramBuckets.binaryBuckets64, values3), 1617.0)
+      h3.quantile(0.99) shouldEqual 1593.2 +- 0.1
+      h3.quantile(0.90) shouldEqual 1379.4 +- 0.1
     }
 
     it("should serialize to and from BinaryHistograms and compare correctly") {

--- a/query/src/main/scala/filodb/query/exec/TransientRow.scala
+++ b/query/src/main/scala/filodb/query/exec/TransientRow.scala
@@ -84,7 +84,7 @@ class TransientHistRow(var timestamp: Long = 0L,
   def getBlobOffset(columnNo: Int): Long = throw new IllegalArgumentException()
   def getBlobNumBytes(columnNo: Int): Int = throw new IllegalArgumentException()
 
-  override def toString: String = s"TransientRow(t=$timestamp, v=$value)"
+  override def toString: String = s"TransientHistRow(t=$timestamp, v=$value)"
 }
 
 // 0: Timestamp, 1: Histogram, 2: Max/Double
@@ -93,6 +93,8 @@ final class TransientHistMaxRow(var max: Double = 0.0) extends TransientHistRow(
     if (columnNo == 2) max = valu else throw new IllegalArgumentException()
   override def getDouble(columnNo: Int): Double =
     if (columnNo == 2) max else throw new IllegalArgumentException()
+
+  override def toString: String = s"TransientHistMaxRow(t=$timestamp, h=$value, max=$max)"
 }
 
 final class AvgAggTransientRow extends MutableRowReader {

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -294,6 +294,7 @@ object RangeFunction {
   def histChunkedFunction(func: Option[RangeFunctionId],
                           funcParams: Seq[Any] = Nil,
                           maxCol: Option[Int] = None): RangeFunctionGenerator = func match {
+    case None if maxCol.isDefined => () => new LastSampleChunkedFunctionHMax(maxCol.get)
     case None                 => () => new LastSampleChunkedFunctionH
     case Some(SumOverTime) if maxCol.isDefined => () => new SumAndMaxOverTimeFuncHD(maxCol.get)
     case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionH
@@ -391,6 +392,39 @@ extends LastSampleChunkedFunction[TransientHistRow] {
   final def updateValue(ts: Long, valVector: BinaryVectorPtr, valReader: VectorDataReader, endRowNum: Int): Unit = {
     timestamp = ts
     value = valReader.asHistReader(endRowNum)
+  }
+}
+
+class LastSampleChunkedFunctionHMax(maxColID: Int,
+                                    var timestamp: Long = -1L,
+                                    var value: bv.HistogramWithBuckets = bv.Histogram.empty,
+                                    var max: Double = Double.NaN) extends ChunkedRangeFunction[TransientHistMaxRow] {
+  override final def reset(): Unit = { timestamp = -1L; value = bv.Histogram.empty; max = Double.NaN }
+  final def apply(endTimestamp: Long, sampleToEmit: TransientHistMaxRow): Unit = {
+    sampleToEmit.setValues(endTimestamp, value)
+    sampleToEmit.setDouble(2, max)
+  }
+
+  // Add each chunk and update timestamp and value such that latest sample wins
+  final def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
+                      valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
+                      startTime: Long, endTime: Long, info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
+    // Just in case timestamp vectors are a bit longer than others.
+    val endRowNum = Math.min(tsReader.ceilingIndex(tsVector, endTime), info.numRows - 1)
+
+    // update timestamp only if
+    //   1) endRowNum >= 0 (timestamp within chunk)
+    //   2) timestamp is within stale window; AND
+    //   3) timestamp is greater than current timestamp (for multiple chunk scenarios)
+    if (endRowNum >= 0) {
+      val ts = tsReader(tsVector, endRowNum)
+      if ((endTime - ts) <= queryConfig.staleSampleAfterMs && ts > timestamp) {
+        val maxVect = info.vectorPtr(maxColID)
+        timestamp = ts
+        value = valueReader.asHistReader(endRowNum)
+        max = bv.DoubleVector(maxVect)(maxVect, endRowNum)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Fixes a bug where histogram_max_quantile on raw data was not reporting correct max.
the max column value was not being passed onto the TransientRow properly because the LastSample function ignored it.  Created a new histogram-with-max based last sample function.