### PR TITLE
Remove stream subscription task before canceling it, and also rely on…

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -117,7 +117,7 @@ private[filodb] final class IngestionActor(dataset: Dataset,
 
     // Start with the full set of all shards being ingested, and remove shards from this set
     // which must continue being ingested.
-    val shardsToStop = HashSet() ++ streams.keySet
+    val shardsToStop = HashSet() ++ streamSubscriptions.keySet
 
     for (shard <- 0 until state.map.numShards) {
       if (state.map.coordForShard(shard) == context.parent) {
@@ -336,7 +336,7 @@ private[filodb] final class IngestionActor(dataset: Dataset,
     origin ! IngestionStatus(memStore.numRowsIngested(dataset.ref))
 
   private def stopIngestion(shard: Int): Unit = {
-    val shardIngestion = streamSubscriptions.get(shard)
+    val shardIngestion = streamSubscriptions.remove(shard)
     shardIngestion.foreach { s =>
       s.onComplete {
         case Success(_) =>


### PR DESCRIPTION
… same mapping when resync'ng. This doesn't fix all the race conditions, but it does permit resync to fix things.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Shards which report as being active can sometimes be stuck. This is because of a race condition in which the ingestion task is canceled but still remains in the mapping.

**New behavior :**
Remove the task from the mapping before it's canceled. The resync task checks the same mapping now, avoiding any races between the two maps.
