### PR TITLE
feat(core, *): PartitionSchema and DataSchemas: multi-schema part I

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ A single partition key schema is used for a running FiloDB cluster, though multi
 
 THIS IS IMPORTANT TO READ AND UNDERSTAND.
 
+Each "dataset" ingests one stream or Kafka topic of raw time series data, and is also the unit of isolation.  Each dataset contains its own offheap memory, and can have independent data retention and ingestion properties.
+
 Datasets are setup and loaded into the server via configuration files referred to by application.conf loaded by the server.
 See `conf/timeseries-dev-source.conf` for an example. It is important to note that some aspects of the dataset,
 like its column definition are immutable. This is primarily because the data columns are used to populate persistent

--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ The **partition key** differentiates time series and also controls distribution 
 
 The data points use a configurable schema consisting of multiple columns.  Each column definition consists of `name:columntype`, with optional parameters. For examples, see the examples below, or see the introductory walk-through above where two datasets are created.
 
+A single partition key schema is used for a running FiloDB cluster, though multiple data schemas may be supported.  These schemas are defined in the config file - see the `partition-schema` and `schemas` sections of `filodb-defaults.conf`.  The CLI command `validateSchemas` may be run to verify schemas defined in config files, as follows:
+
+    ./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf --command validateSchemas
+
 ### Dataset Configuration
 
 THIS IS IMPORTANT TO READ AND UNDERSTAND.
@@ -344,7 +348,6 @@ that part of the cluster could be with the old config and the rest could have ne
 ### Prometheus FiloDB Schema for Operational Metrics
 
 * Partition key = `tags:map`
-* Row key = `timestamp`
 * Columns: `timestamp:ts,value:double:detectDrops=true`
 
 The above is the classic Prometheus-compatible schema.  It supports indexing on any tag.  Thus standard Prometheus queries that filter by a tag such as `hostname` or `datacenter` for example would work fine.  Note that the Prometheus metric name is encoded as a key `__name__`, which is the Prometheus standard when exporting tags.
@@ -358,7 +361,6 @@ NOTE: `detectDrops=true` allows for proper and efficient rate calculation on Pro
 Let's say that one had a metrics client, such as CodaHale metrics, which pre-aggregates percentiles and sends them along with the metric.  If we used the Prometheus schema, each percentile would wind up in its own time series.  This is fine, but incurs significant overhead as the partition key has to then be sent with each percentile over the wire.  Instead we can have a schema which includes all the percentiles together when sending the data:
 
 * Partition key = `metricName:string,tags:map`
-* Row key = `timestamp`
 * Columns: `timestamp:ts,min:double,max:double,p50:double,p90:double,p95:double,p99:double,p999:double`
 
 ### Data Modelling and Performance Considerations

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -9,12 +9,13 @@ import scala.util.Try
 import com.opencsv.CSVWriter
 import com.quantifind.sumac.{ArgMain, FieldArgs}
 import monix.reactive.Observable
+import org.scalactic._
 
 import filodb.coordinator._
 import filodb.coordinator.client._
 import filodb.coordinator.client.QueryCommands.{SpreadChange, SpreadProvider, StaticSpreadProvider}
 import filodb.core._
-import filodb.core.metadata.Column
+import filodb.core.metadata.{Column, Schemas}
 import filodb.memory.format.RowReader
 import filodb.prometheus.ast.{InMemoryParam, TimeRangeParams, TimeStepParams, WriteBuffersParam}
 import filodb.prometheus.parse.Parser
@@ -144,6 +145,8 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
           val (remote, ref) = getClientAndRef(args)
           dumpShardStatus(remote, ref)
 
+        case Some("validateSchemas") => validateSchemas()
+
         case Some("timeseriesMetadata") =>
           require(args.host.nonEmpty && args.dataset.nonEmpty && args.matcher.nonEmpty, "--host, --dataset and --matcher must be defined")
           val remote = Client.standaloneClient(system, args.host.get, args.port)
@@ -199,6 +202,22 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
         }
       case _ =>
         println(s"Unable to obtain status for dataset $ref, has it been setup yet?")
+    }
+  }
+
+  def validateSchemas(): Unit = {
+    Schemas.fromConfig(config) match {
+      case Good(Schemas(partSchema, data, _)) =>
+        println("Schema validated.\nPartition schema:")
+        partSchema.columns.foreach(c => println(s"\t$c"))
+        data.foreach { case (schemaName, sch) =>
+          println(s"Schema $schemaName:")
+          sch.columns.foreach(c => println(s"\t$c"))
+        }
+      case Bad(errors) =>
+        println(s"Schema validation errors:")
+        errors.foreach { case (name, err) => println(s"$name\t$err")}
+        exitCode = 1
     }
   }
 

--- a/conf/timeseries-128shards-source.conf
+++ b/conf/timeseries-128shards-source.conf
@@ -1,20 +1,5 @@
     dataset = "prometheus"
-
-    definition {
-      partition-columns = ["tags:map"]
-      data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
-      row-key-columns = [ "timestamp" ]
-      downsamplers = [ ]
-    }
-
-    options {
-      shardKeyColumns = [ "__name__", "_ns" ]
-      ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
-      valueColumn = "value"
-      metricColumn = "__name__"
-      ignoreTagsOnPartitionKeyHash = [ "le" ]
-      copyTags = { }
-    }
+    schema = "prometheus"
 
     num-shards = 128
     min-num-nodes = 2

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -1,40 +1,7 @@
     dataset = "prometheus"
 
-    # Schema used for defining the BinaryRecord used in ingestion and persistence.
-    #
-    # Should not change once dataset has been set up on the server and data has been ingested into kafka
-    # or written to cassandra
-    definition {
-      # defines the unique identifier for partition
-      partition-columns = ["tags:map"]
-      # Schema of all of the values stored against the partition key. This includes the row-keys as well
-      data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
-      # Clustering key for each row. Together with partition key, they form the primary key.
-      row-key-columns = [ "timestamp" ]
-      # List of downsamplers for the data columns
-      downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
-    }
-
-    # Dataset Options
-    #
-    # Should not change once dataset has been set up on the server and data has been ingested into kafka
-    # or written to cassandra
-    options {
-      # These column values are used to identify the shard group for the partition
-      shardKeyColumns = [ "__name__", "_ns" ]
-      # suffixes from map values are stripped before hashing
-      ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
-      # default data column name to be used referencing the value column
-      valueColumn = "value"
-      # column name to use when referencing the name column
-      metricColumn = "__name__"
-      # these columns are ignored in calculation of full partition key hash
-      ignoreTagsOnPartitionKeyHash = [ "le" ]
-
-      # These key-names will be replaced in the key map during ingestion/query.
-      # Temporary workaround. Will be deprecated.
-      copyTags = { }
-    }
+    # Name of schema used for this dataset stream.  See filodb.schemas in filodb-defaults or any other server conf
+    schema = "prometheus"
 
     # Should not change once dataset has been set up on the server and data has been persisted to cassandra
     num-shards = 4

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -6,7 +6,6 @@
     # Should not change once dataset has been set up on the server and data has been persisted to cassandra
     num-shards = 4
 
-
     min-num-nodes = 2
     # Length of chunks to be written, roughly
     sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"

--- a/conf/timeseries-ds-1m-dev-source.conf
+++ b/conf/timeseries-ds-1m-dev-source.conf
@@ -1,20 +1,5 @@
     dataset = "prometheus_ds_1m"
-
-    definition {
-      partition-columns = ["tags:map"]
-      data-columns = [ "timestamp:ts", "min:double", "max:double", "sum:double", "count:double", "avg:double" ]
-      row-key-columns = [ "timestamp" ]
-      downsamplers = [ ]
-    }
-
-    options {
-      shardKeyColumns = [ "__name__", "_ns" ]
-      ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
-      valueColumn = "avg"
-      metricColumn = "__name__"
-      ignoreTagsOnPartitionKeyHash = [ "le" ]
-      copyTags = { }
-    }
+    schema = "prom-ds-gauge"
 
     num-shards = 4
     min-num-nodes = 2

--- a/conf/timeseries-standalonetest-source.conf
+++ b/conf/timeseries-standalonetest-source.conf
@@ -1,20 +1,5 @@
     dataset = "prometheus"
-
-    definition {
-      partition-columns = ["tags:map"]
-      data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
-      row-key-columns = [ "timestamp" ]
-      downsamplers = [ ]
-    }
-
-    options {
-      shardKeyColumns = [ "__name__", "_ns" ]
-      ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
-      valueColumn = "value"
-      metricColumn = "__name__"
-      ignoreTagsOnPartitionKeyHash = [ "le" ]
-      copyTags = { }
-    }
+    schema = "prometheus"
 
     num-shards = 4
     min-num-nodes = 2

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -6,12 +6,14 @@ import scala.concurrent.duration.FiniteDuration
 import akka.actor.{ActorPath, Address, RootActorPath}
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
+import org.scalactic._
+
+import filodb.core.metadata.{Dataset, Schemas}
 
 /** Settings for the FiloCluster Akka Extension which gets
   * config from `GlobalConfig`. Uses Ficus.
   */
 final class FilodbSettings(val conf: Config) {
-
   def this() = this(ConfigFactory.empty)
 
   ConfigFactory.invalidateCaches()
@@ -44,18 +46,32 @@ final class FilodbSettings(val conf: Config) {
   /** The timeout to use to resolve an actor ref for new nodes. */
   val ResolveActorTimeout = config.as[FiniteDuration]("tasks.timeouts.resolve-actor")
 
-  val datasets = config.as[Seq[String]]("dataset-configs")
+  val datasetConfPaths = config.as[Seq[String]]("dataset-configs")
 
   /**
    * Returns IngestionConfig/dataset configuration from parsing dataset-configs file paths.
    * If those are empty, then parse the "streams" config key for inline configs.
    */
   val streamConfigs: Seq[Config] =
-    if (datasets.nonEmpty) {
-      datasets.map { d => ConfigFactory.parseFile(new java.io.File(d)) }
+    if (datasetConfPaths.nonEmpty) {
+      datasetConfPaths.map { d => ConfigFactory.parseFile(new java.io.File(d)) }
     } else {
       config.as[Seq[Config]]("inline-dataset-configs")
     }
+
+  val schemas = Schemas.fromConfig(config) match {
+    case Good(sch) => sch
+    case Bad(errs)  => throw new RuntimeException("Errors parsing schemas:\n" +
+                         errs.map { case (ds, err) => s"Schema $ds\t$err" }.mkString("\n"))
+  }
+
+  // Creates a Dataset from a stream config. NOTE: this is a temporary thing to keep old code using Dataset
+  // compatible and minimize changes.  The Dataset name is taken from the dataset/stream config, but the schema
+  // underneath points to one of the schemas above and schema may have a different name.  The approach below
+  // allows one schema (with one schema name) to be shared amongst datasets using different names.
+  def datasetFromStream(streamConf: Config): Dataset =
+    Dataset(streamConf.getString("dataset"),
+            schemas.schemas(streamConf.getString("schema")))
 }
 
 /** Consistent naming: allows other actors to accurately filter

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -226,7 +226,7 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
     // shard and dataset state can be recovered correctly.  First all the datasets are set up.
     // Then shard state is recovered, and finally cluster membership events are replayed.
     settings.streamConfigs.foreach { config =>
-      val dataset = Dataset.fromConfig(config)
+      val dataset = settings.datasetFromStream(config)
       val ingestion = IngestionConfig(config, NodeClusterActor.noOpSource.streamFactoryClass).get
       initializeDataset(dataset, ingestion, None)
     }

--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -157,7 +157,7 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
   def datasetHandlers: Receive = LoggingReceive {
     case CreateDataset(datasetObj, db) =>
       // used only for unit testing now
-      createDataset(sender(), datasetObj.copy(database = db))
+      createDataset(sender(), datasetObj)
 
     case TruncateDataset(ref) =>
       truncateDataset(sender(), ref)
@@ -211,7 +211,7 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
     if (!datasetsInitialized) {
       logger.debug(s"Initializing stream configs: ${settings.streamConfigs}")
       settings.streamConfigs.foreach { config =>
-        val dataset = Dataset.fromConfig(config)
+        val dataset = settings.datasetFromStream(config)
         val ingestion = IngestionConfig(config, NodeClusterActor.noOpSource.streamFactoryClass).get
         initializeDataset(dataset, ingestion)
       }

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine/Utils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine/Utils.scala
@@ -12,7 +12,7 @@ import monix.reactive.Observable
 import org.scalactic._
 
 import filodb.coordinator.ShardMapper
-import filodb.core.{ErrorResponse, Types}
+import filodb.core.ErrorResponse
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.Dataset
 import filodb.core.query.{ColumnFilter, Filter}
@@ -28,18 +28,6 @@ final case class ChildErrorResponse(source: ActorRef, resp: ErrorResponse) exten
 object Utils extends StrictLogging {
   import filodb.coordinator.client.QueryCommands._
   import TrySugar._
-  import filodb.coordinator.client.QueryCommands._
-
-  /**
-   * Convert column name strings into columnIDs.  NOTE: column names should not include row key columns
-   * as those are automatically prepended.
-   */
-  def getColumnIDs(dataset: Dataset, colStrs: Seq[String]): Seq[Types.ColumnId] Or ErrorResponse =
-    dataset.colIDs(colStrs: _*).badMap(missing => UndefinedColumns(missing.toSet))
-           .map { ids =>   // avoid duplication if first ids are already row keys
-             if (ids.take(dataset.rowKeyIDs.length) == dataset.rowKeyIDs) { ids }
-             else { dataset.rowKeyIDs ++ ids }
-           }
 
   /**
    * Validates a PartitionQuery, returning a set of PartitionScanMethods with shard numbers.

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -24,17 +24,23 @@ object ClusterRecoverySpecConfig extends MultiNodeConfig {
   val ourConf = s"""
   filodb {
     memstore.groups-per-shard = 4
+    partition-schema {
+      columns = ["Actor2Code:string", "Actor2Name:string"]
+      predefined-keys = []
+      ${GdeltTestData.datasetOptionConfig}
+    }
+    schemas {
+      gdelt {
+        columns = ["GLOBALEVENTID:long", "SQLDATE:long", "MonthYear:int",
+                        "Year:int", "NumArticles:int", "AvgTone:double"]
+        value-column = "AvgTone"
+        downsamplers = []
+      }
+    }
     inline-dataset-configs = [
       {
         dataset = "gdelt"
-        definition {
-          partition-columns = ["Actor2Code:string", "Actor2Name:string"]
-          data-columns = ["GLOBALEVENTID:long", "SQLDATE:long", "MonthYear:int",
-                          "Year:int", "NumArticles:int", "AvgTone:double"]
-          row-key-columns = [ "GLOBALEVENTID" ]
-          downsamplers = []
-        }
-        ${GdeltTestData.datasetOptionConfig}
+        schema = "gdelt"
         num-shards = 2
         min-num-nodes = 2
         sourcefactory = "${classOf[sources.CsvStreamFactory].getName}"

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -126,10 +126,12 @@ class QueryEngineSpec extends FunSpec with Matchers {
     }
   }
 
+  import com.softwaremill.quicklens._
+
   it("should rename Prom __name__ filters if dataset has different metric column") {
     // Custom QueryEngine with different dataset with different metric name
-    val dataset2 = dataset.copy(options = dataset.options.copy(
-                     metricColumn = "kpi", shardKeyColumns = Seq("kpi", "job")))
+    val datasetOpts = dataset.options.copy(metricColumn = "kpi", shardKeyColumns = Seq("kpi", "job"))
+    val dataset2 = dataset.modify(_.schema.partition.options).setTo(datasetOpts)
     val engine2 = new QueryEngine(dataset2, mapperRef)
 
     // materialized exec plan

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -14,6 +14,42 @@ filodb {
   # ]
   inline-dataset-configs = []
 
+  # Definition of cluster-wide partition key scheme.  The partition key defines each unique time series,
+  # such as labels or tags, and is used for sharding time series across the cluster.
+  # The below definition is standard for Prometheus schema
+  partition-schema {
+    # Typical column types used: map, string.  Also possible: ts,long,double
+    columns = ["tags:map"]
+
+    # Predefined keys allow space to be saved for over the wire tags with the given keys
+    predefined-keys = ["_ns", "app", "__name__", "instance", "dc"]
+
+    options {
+      copyTags = {}
+      ignoreShardKeyColumnSuffixes = {}
+      ignoreTagsOnPartitionKeyHash = ["le"]
+      metricColumn = "__name__"
+      valueColumn = "value"   # TODO: remove this when it's not needed anymore
+      shardKeyColumns = ["__name__", "_ns"]
+    }
+  }
+
+  # Definitions of possible data schemas to be used in all datasets
+  # Each one must have a unique name and column schema
+  schemas {
+    prometheus {
+      # Each column def is of name:type format.  Type may be ts,long,double,string,int
+      # The first column must be ts or long
+      columns = ["timestamp:ts", "value:double:detectDrops=true"]
+
+      # Default column to query using PromQL
+      value-column = "value"
+
+      # Downsampling configuration.  See doc/downsampling.md
+      downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
+    }
+  }
+
   tasks {
     # Frequency with which new shard maps are published
     shardmap-publish-frequency = 5s

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -47,6 +47,13 @@ filodb {
       # Downsampling configuration.  See doc/downsampling.md
       downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
     }
+
+    # Used for downsampled gauge data
+    prom-ds-gauge {
+      columns = [ "timestamp:ts", "min:double", "max:double", "sum:double", "count:double", "average:double" ]
+      value-column = "average"
+      downsamplers = []
+    }
   }
 
   tasks {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -22,19 +22,20 @@ filodb {
     columns = ["tags:map"]
 
     # Predefined keys allow space to be saved for over the wire tags with the given keys
-    predefined-keys = ["_ns", "app", "__name__", "instance", "dc"]
+    predefined-keys = ["_ns", "app", "__name__", "instance", "dc", "le"]
 
     options {
       copyTags = {}
-      ignoreShardKeyColumnSuffixes = {}
+      ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
       ignoreTagsOnPartitionKeyHash = ["le"]
       metricColumn = "__name__"
-      shardKeyColumns = ["__name__", "_ns"]
+      shardKeyColumns = [ "__name__", "_ns" ]
     }
   }
 
   # Definitions of possible data schemas to be used in all datasets
-  # Each one must have a unique name and column schema
+  # Each one must have a unique name and column schema.
+  # FiloDB will refuse to start if the schema definitions have errors.  Use the validateSchemas CLI command to check.
   schemas {
     prometheus {
       # Each column def is of name:type format.  Type may be ts,long,double,string,int
@@ -50,8 +51,8 @@ filodb {
 
     # Used for downsampled gauge data
     prom-ds-gauge {
-      columns = [ "timestamp:ts", "min:double", "max:double", "sum:double", "count:double", "average:double" ]
-      value-column = "average"
+      columns = [ "timestamp:ts", "min:double", "max:double", "sum:double", "count:double", "avg:double" ]
+      value-column = "avg"
       downsamplers = []
     }
   }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -29,7 +29,6 @@ filodb {
       ignoreShardKeyColumnSuffixes = {}
       ignoreTagsOnPartitionKeyHash = ["le"]
       metricColumn = "__name__"
-      valueColumn = "value"   # TODO: remove this when it's not needed anymore
       shardKeyColumns = ["__name__", "_ns"]
     }
   }

--- a/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
+++ b/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
@@ -25,9 +25,11 @@ class ShardDownsampler(dataset: Dataset,
                        resolutions: Seq[Int],
                        publisher: DownsamplePublisher,
                        stats: TimeSeriesShardStats) extends StrictLogging {
+  private val downsamplers = dataset.schema.data.downsamplers
+
   if (enabled) {
     logger.info(s"Downsampling enabled for dataset=${dataset.ref} shard=$shardNum with " +
-      s"following downsamplers: ${dataset.downsamplers.map(_.encoded)} at resolutions: $resolutions")
+      s"following downsamplers: ${downsamplers.map(_.encoded)} at resolutions: $resolutions")
   } else {
     logger.info(s"Downsampling disabled for dataset=${dataset.ref} shard=$shardNum")
   }
@@ -58,7 +60,7 @@ class ShardDownsampler(dataset: Dataset,
     */
   private[downsample] def downsampleIngestSchema(): RecordSchema = {
     // The name of the column in downsample record does not matter at the ingestion side. Type does matter.
-    val downsampleCols = dataset.downsamplers.map { d => ColumnInfo(s"${d.name.entryName}", d.colType) }
+    val downsampleCols = downsamplers.map { d => ColumnInfo(s"${d.name.entryName}", d.colType) }
     new RecordSchema(downsampleCols ++ dataset.partKeySchema.columns,
       Some(downsampleCols.size), dataset.ingestionSchema.predefinedKeys)
   }
@@ -94,7 +96,7 @@ class ShardDownsampler(dataset: Dataset,
             val endRowNum = Math.min(tsReader.ceilingIndex(vecPtr, pEnd), chunkset.numRows - 1)
             builder.startNewRecord()
             // for each downsampler, add downsample column value
-            dataset.downsamplers.foreach {
+            downsamplers.foreach {
               case d: TimeChunkDownsampler =>
                 builder.addLong(d.downsampleChunk(part, chunkset, startRowNum, endRowNum))
               case d: DoubleChunkDownsampler =>

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -268,6 +268,7 @@ object Dataset {
   case class UnknownRowKeyColumn(keyColumn: String) extends BadSchema
   case class IllegalMapColumn(reason: String) extends BadSchema
   case class NoTimestampRowKey(colName: String, colType: String) extends BadSchema
+  case class HashConflict(detail: String) extends BadSchema
 
   case class BadSchemaError(badSchema: BadSchema) extends Exception(badSchema.toString)
 

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -35,9 +35,9 @@ import filodb.memory.format.{RowReader, TypedIterator, ZeroCopyUTF8String => ZCU
  * something which makes a value unique within a partition and describes a range of data in a chunk.
  */
 final case class Dataset(name: String, schema: Schema) {
-  def options: DatasetOptions = schema.partition.options
-  def dataColumns: Seq[Column] = schema.data.columns
-  def partitionColumns: Seq[Column] = schema.partition.columns
+  val options         = schema.partition.options
+  val dataColumns     = schema.data.columns
+  val partitionColumns = schema.partition.columns
 
   val ref = DatasetRef(name, None)
   val rowKeyColumns   = schema.data.columns take 1

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -66,6 +66,7 @@ final case class PartitionSchema(columns: Seq[Column],
 
 object DataSchema {
   import Dataset._
+  import java.nio.charset.StandardCharsets.UTF_8
 
   def validateValueColumn(dataColumns: Seq[Column], valueColName: String): ColumnId Or BadSchema = {
     val index = dataColumns.indexWhere(_.name == valueColName)
@@ -80,7 +81,7 @@ object DataSchema {
     var hash = 7
     for { col <- columns } {
       // Use XXHash to get high quality hash for column name.  String.hashCode is _horrible_
-      hash = 31 * hash + (BinaryRegion.hash32(col.name.getBytes) * col.columnType.hashCode)
+      hash = 31 * hash + (BinaryRegion.hash32(col.name.getBytes(UTF_8)) * col.columnType.hashCode)
     }
     hash & 0x0ffff
   }

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -47,9 +47,11 @@ final case class DataSchema private(name: String,
 final case class PartitionSchema(columns: Seq[Column],
                                  predefinedKeys: Seq[String],
                                  options: DatasetOptions) {
+  import PartitionSchema._
+
   val binSchema = new RecordSchema(columns.map(c => ColumnInfo(c.name, c.columnType)), Some(0), predefinedKeys)
 
-  private val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, binSchema, 10240)
+  private val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, binSchema, DefaultContainerSize)
 
   /**
    * Creates a PartitionKey (BinaryRecord v2) from individual parts.  Horribly slow, use for testing only.
@@ -127,6 +129,8 @@ object DataSchema {
 
 object PartitionSchema {
   import Dataset._
+
+  val DefaultContainerSize = 10240
 
   /**
    * Creates and validates a new PartitionSchema

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -1,0 +1,182 @@
+package filodb.core.metadata
+
+import com.typesafe.config.Config
+import net.ceedubs.ficus.Ficus._
+import org.scalactic._
+
+import filodb.core.binaryrecord2.{RecordBuilder, RecordComparator, RecordSchema}
+import filodb.core.downsample.ChunkDownsampler
+import filodb.core.query.ColumnInfo
+import filodb.core.store.ChunkSetInfo
+import filodb.core.Types._
+import filodb.memory.{BinaryRegion, MemFactory}
+import filodb.memory.format.BinaryVector
+
+/**
+ * A DataSchema describes the data columns within a time series - the actual data that would vary from sample to
+ * sample and is encoded.  It has a unique hash code for each unique DataSchema.
+ * One Dataset in FiloDB can comprise multiple DataSchemas.
+ * One DataSchema should be used for each type of metric or data, such as gauge, histogram, etc.
+ * The "timestamp" or rowkey is the first column and must be either a LongColumn or TimestampColumn.
+ * DataSchemas are intended to be built from config through Schemas.
+ */
+final case class DataSchema private(name: String,
+                                    columns: Seq[Column],
+                                    downsamplers: Seq[ChunkDownsampler],
+                                    hash: Int,
+                                    valueColumn: ColumnId) {
+  val timestampColumn  = columns.head
+  val timestampColID   = 0
+
+  // Used to create a `VectorDataReader` of correct type for a given data column ID;  type PtrToDataReader
+  val readers          = columns.map(col => BinaryVector.defaultPtrToReader(col.columnType.clazz)).toArray
+
+  // The number of bytes of chunkset metadata including vector pointers in memory
+  val chunkSetInfoSize = ChunkSetInfo.chunkSetInfoSize(columns.length)
+  val blockMetaSize    = chunkSetInfoSize + 4
+}
+
+/**
+ * A PartitionSchema is the schema describing the unique "key" of each time series, such as labels.
+ * The columns inside PartitionSchema are used for distribution and sharding, as well as filtering and searching
+ * for time series during querying.
+ * There should only be ONE PartitionSchema across the entire Database.
+ */
+final case class PartitionSchema(columns: Seq[Column],
+                                 predefinedKeys: Seq[String],
+                                 options: DatasetOptions) {
+  val binSchema = new RecordSchema(columns.map(c => ColumnInfo(c.name, c.columnType)), Some(0), predefinedKeys)
+
+  private val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, binSchema, 10240)
+
+  /**
+   * Creates a PartitionKey (BinaryRecord v2) from individual parts.  Horribly slow, use for testing only.
+   */
+  def partKey(parts: Any*): Array[Byte] = {
+    val offset = partKeyBuilder.addFromObjects(parts: _*)
+    val bytes = binSchema.asByteArray(partKeyBuilder.allContainers.head.base, offset)
+    partKeyBuilder.reset()
+    bytes
+  }
+}
+
+object DataSchema {
+  import Dataset._
+
+  def validateValueColumn(dataColumns: Seq[Column], valueColName: String): ColumnId Or BadSchema = {
+    val index = dataColumns.indexWhere(_.name == valueColName)
+    if (index < 0) Bad(BadColumnName(valueColName, s"$valueColName not a valid data column"))
+    else           Good(index)
+  }
+
+  /**
+   * Generates a unique 16-bit hash from the column names and types.  Sensitive to order.
+   */
+  def genHash(columns: Seq[Column]): Int = {
+    var hash = 7
+    for { col <- columns } {
+      // Use XXHash to get high quality hash for column name.  String.hashCode is _horrible_
+      hash = 31 * hash + (BinaryRegion.hash32(col.name.getBytes) * col.columnType.hashCode)
+    }
+    hash & 0x0ffff
+  }
+
+  /**
+   * Creates and validates a new DataSchema
+   * @param name The name of the schema
+   * @param dataColNameTypes list of data columns in name:type[:params] form
+   * @return Good(Dataset) or Bad(BadSchema)
+   */
+  def make(name: String,
+           dataColNameTypes: Seq[String],
+           downsamplerNames: Seq[String] = Seq.empty,
+           valueColumn: String): DataSchema Or BadSchema = {
+
+    for { dataColumns  <- Column.makeColumnsFromNameTypeList(dataColNameTypes)
+          downsamplers <- validateDownsamplers(downsamplerNames)
+          valueColID   <- validateValueColumn(dataColumns, valueColumn)
+          _ <- validateTimeSeries(dataColumns, Seq(0)) }
+    yield {
+      DataSchema(name, dataColumns, downsamplers, genHash(dataColumns), valueColID)
+    }
+  }
+
+  /**
+   * Parses a DataSchema from config object, like this:
+   * {{{
+   *   {
+   *     prometheus {
+   *       columns = ["timestamp:ts", "value:double:detectDrops=true"]
+   *       value-column = "value"
+   *       downsamplers = []
+   *     }
+   *   }
+   * }}}
+   *
+   * From the example above, pass in "prometheus" as the schemaName.
+   * It is advisable to parse the outer config of all schemas using `.as[Map[String, Config]]`
+   */
+  def fromConfig(schemaName: String, conf: Config): DataSchema Or BadSchema =
+    make(schemaName,
+         conf.as[Seq[String]]("columns"),
+         conf.as[Seq[String]]("downsamplers"),
+         conf.getString("value-column"))
+}
+
+object PartitionSchema {
+  import Dataset._
+
+  /**
+   * Creates and validates a new PartitionSchema
+   * @param partColNameTypes list of partition columns in name:type[:params] form
+   * @param options
+   * @param predefinedKeys
+   * @return Good(Dataset) or Bad(BadSchema)
+   */
+  def make(partColNameTypes: Seq[String],
+           options: DatasetOptions,
+           predefinedKeys: Seq[String] = Seq.empty): PartitionSchema Or BadSchema = {
+
+    for { partColumns  <- Column.makeColumnsFromNameTypeList(partColNameTypes, PartColStartIndex)
+         _             <- validateMapColumn(partColumns, Nil) }
+    yield {
+      PartitionSchema(partColumns, predefinedKeys, options)
+    }
+  }
+
+  /**
+   * Parses a PartitionSchema from config.  Format:
+   * {{{
+   *   columns = ["tags:map"]
+   *   predefined-keys = ["_ns", "app", "__name__", "instance", "dc"]
+   *   options {
+   *     ...  # See DatasetOptions parsing format
+   *   }
+   * }}}
+   */
+  def fromConfig(partConfig: Config): PartitionSchema Or BadSchema =
+    make(partConfig.as[Seq[String]]("columns"),
+         DatasetOptions.fromConfig(partConfig.getConfig("options")),
+         partConfig.as[Option[Seq[String]]]("predefined-keys").getOrElse(Nil))
+}
+
+/**
+ * A Schema combines a PartitionSchema with a DataSchema, forming all the columns of a single ingestion record.
+ */
+final case class Schema(partition: PartitionSchema, data: DataSchema) {
+  val allColumns = data.columns ++ partition.columns
+  val ingestionSchema = new RecordSchema(allColumns.map(c => ColumnInfo(c.name, c.columnType)),
+                                         Some(data.columns.length),
+                                         partition.predefinedKeys)
+
+  val comparator      = new RecordComparator(ingestionSchema)
+  val partKeySchema   = comparator.partitionKeySchema
+}
+
+/**
+ * Singleton with code to load all schemas from config, verify no conflicts, and ensure there is only
+ * one PartitionSchema.
+ */
+object Schemas {
+  // function to initialize all the data schemas and partition schemas
+}

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -604,9 +604,8 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     val timeseriesDataset = Dataset.make("timeseries",
       Seq("tags:map"),
       Seq("timestamp:ts", "value:double"),
-      Seq("timestamp"),
       Seq.empty,
-      DatasetOptions(Seq("__name__", "job"), "__name__", "value", Map("dummy" -> Seq("_bucket")))).get
+      DatasetOptions(Seq("__name__", "job"), "__name__", Map("dummy" -> Seq("_bucket")))).get
     val metricName4 = RecordBuilder.trimShardColumn(timeseriesDataset, "__name__", "heap_usage_bucket")
     metricName4 shouldEqual "heap_usage_bucket"
 

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -199,13 +199,13 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
     // avg
     val expectedAvgs2 = expectedSums2.zip(expectedCounts2).map { case (sum,count) => sum/count }
     downsampledData2.map(_._6) shouldEqual expectedAvgs2
-
   }
 
+  import com.softwaremill.quicklens._
+
   val histDSDownsamplers = Seq("tTime(0)", "tTime(1)", "tTime(2)", "hSum(3)")
-  val histDSDataset = MMD.histDataset.copy(schema = MMD.histDataset.schema.copy(
-                        data = MMD.histDataset.schema.data.copy(
-                          downsamplers = Dataset.validateDownsamplers(histDSDownsamplers).get)))
+  val histDSDataset = modify(MMD.histDataset)(_.schema.data.downsamplers)
+                        .setTo(Dataset.validateDownsamplers(histDSDownsamplers).get)
 
   // Create downsampleOps for histogram dataset.  Samples every 10s, downsample freq 60s/1min
   val downsampleOpsH = new ShardDownsampler(histDSDataset, 0, true, Seq(60000), NoOpDownsamplePublisher,

--- a/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
@@ -1,183 +1,20 @@
 package filodb.core.metadata
 
-import com.typesafe.config.ConfigFactory
 import org.scalatest.{FunSpec, Matchers}
 
 import filodb.core._
 import filodb.core.query.ColumnInfo
 
+// DEPRECATED: remove soon
 class DatasetSpec extends FunSpec with Matchers {
   import Column.ColumnType._
   import Dataset._
   import NamesTestData._
 
-  describe("Dataset creation") {
-    it("should load/write dataset from/to config") {
-      val config = ConfigFactory.parseString(
-        """
-          |    dataset = "prometheus"
-          |
-          |    definition {
-          |      partition-columns = ["tags:map"]
-          |      data-columns = ["timestamp:ts", "value:double"]
-          |      row-key-columns = [ "timestamp" ]
-          |      downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)"]
-          |    }
-          |
-          |    options {
-          |      shardKeyColumns = [ "__name__", "_ns" ]
-          |      ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
-          |      valueColumn = "value"
-          |      metricColumn = "__name__"
-          |      ignoreTagsOnPartitionKeyHash = [ "le" ]
-          |      copyTags = { }
-          |    }
-        """.stripMargin)
-      val dataset = Dataset.fromConfig(config)
-
-      val config2 = dataset.toConfig
-      val dataset2 = Dataset.fromConfig(config2)
-
-      dataset shouldEqual dataset2
-    }
-  }
-
   describe("Dataset validation") {
-    it("should return NotNameColonType if column specifiers not name:type format") {
-      val resp1 = Dataset.make("dataset", Seq("part:string"), dataColSpecs :+ "column2", Seq("age"))
-      resp1.isBad shouldEqual true
-      resp1.swap.get shouldEqual ColumnErrors(Seq(NotNameColonType("column2")))
-
-      intercept[BadSchemaError] {
-        Dataset("dataset", Seq("part:string"), dataColSpecs :+ "column2:a:b", "age", DatasetOptions.DefaultOptions)
-      }
-    }
-
-    it("should return BadColumnParams if name:type:params portion not valid key=value pairs") {
-      val resp1 = Dataset.make("dataset", Seq("part:string"), dataColSpecs :+ "column2:a:b", Seq("age"))
-      resp1.isBad shouldEqual true
-      resp1.swap.get shouldBe a[ColumnErrors]
-      val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
-      errors should have length 1
-      errors.head shouldBe a[BadColumnParams]
-    }
-
-    it("should return BadColumnParams if required param config not specified") {
-      val resp1 = Dataset.make("dataset", Seq("part:string"), dataColSpecs :+ "h:hist:foo=bar", Seq("age"))
-      resp1.isBad shouldEqual true
-      resp1.swap.get shouldBe a[ColumnErrors]
-      val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
-      errors should have length 1
-      errors.head shouldBe a[BadColumnParams]
-
-      val resp2 = Dataset.make("dataset", Seq("part:string"), dataColSpecs :+ "h:hist:counter=bar", Seq("age"))
-      resp2.isBad shouldEqual true
-      resp2.swap.get shouldBe a[ColumnErrors]
-      val errors2 = resp2.swap.get.asInstanceOf[ColumnErrors].errs
-      errors2 should have length 1
-      errors2.head shouldBe a[BadColumnParams]
-    }
-
-    it("should return BadColumnName if illegal chars in column name") {
-      val resp1 = Dataset.make("dataset", Seq("part:string"), Seq("col, umn1:string"), Seq("age"))
-      resp1.isBad shouldEqual true
-      val errors = resp1.swap.get match {
-        case ColumnErrors(errs) => errs
-        case x => throw new RuntimeException(s"Did not expect $x")
-      }
-      errors should have length (1)
-      errors.head shouldBe a[BadColumnName]
-    }
-
-    it("should return BadColumnType if unsupported type specified in column spec") {
-      val resp1 = Dataset.make("dataset", Seq("part:linkedlist"), dataColSpecs, Seq("age"))
-      resp1.isBad shouldEqual true
-      val errors = resp1.swap.get match {
-        case ColumnErrors(errs) => errs
-        case x => throw new RuntimeException(s"Did not expect $x")
-      }
-      errors should have length (1)
-      errors.head shouldEqual BadColumnType("linkedlist")
-    }
-
-    it("should return multiple column spec errors") {
-      val resp1 = Dataset.make("dataset", Seq("part:string"),
-                               Seq("first:str", "age:long", "la(st):int"), Seq("age"))
-      resp1.isBad shouldEqual true
-      val errors = resp1.swap.get match {
-        case ColumnErrors(errs) => errs
-        case x => throw new RuntimeException(s"Did not expect $x")
-      }
-      errors should have length (2)
-      errors.head shouldEqual BadColumnType("str")
-    }
-
-    it("should return UnknownRowKeyColumn if row key column(s) not in data columns") {
-      val resp1 = Dataset.make("dataset", Seq("part:string"), dataColSpecs, Seq("column2"))
-      resp1.isBad shouldEqual true
-      resp1.swap.get shouldEqual UnknownRowKeyColumn("column2")
-
-      val resp2 = Dataset.make("dataset", Seq("part:string"), dataColSpecs, Seq("age", "column9"))
-      resp2.isBad shouldEqual true
-      resp2.swap.get shouldEqual UnknownRowKeyColumn("column9")
-    }
-
-    it("should allow MapColumns only in last position of partition key") {
-      val mapCol = "tags:map"
-
-      // OK: only partition column is map
-      val ds1 = Dataset("dataset", Seq(mapCol), dataColSpecs, "age", DatasetOptions.DefaultOptions)
-      ds1.partitionColumns.map(_.name) should equal (Seq("tags"))
-
-      // OK: last partition column is map
-      val ds2 = Dataset("dataset", Seq("first:string", mapCol), dataColSpecs drop 1, "age", DatasetOptions.DefaultOptions)
-      ds2.partitionColumns.map(_.name) should equal (Seq("first", "tags"))
-
-      // Not OK: first partition column is map
-      val resp3 = Dataset.make("dataset", Seq(mapCol, "first:string"), dataColSpecs drop 1, Seq("age"))
-      resp3.isBad shouldEqual true
-      resp3.swap.get shouldBe an[IllegalMapColumn]
-
-      // Not OK: map in data columns, not partition column
-      intercept[BadSchemaError] {
-        Dataset("dataset", Seq("seg:int"), dataColSpecs :+ mapCol, Seq("age")) }
-    }
-
-    it("should return NoTimestampRowKey if non timestamp used for row key") {
-      val ds1 = Dataset.make("dataset", Seq("part:string"), dataColSpecs, Seq("first"))
-      ds1.isBad shouldEqual true
-      ds1.swap.get shouldBe a[NoTimestampRowKey]
-    }
-
-    it("should return a valid Dataset when a good specification passed") {
-      val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, "age", DatasetOptions.DefaultOptions)
-      ds.rowKeyIDs shouldEqual Seq(2)
-      ds.dataColumns should have length (3)
-      ds.dataColumns.map(_.id) shouldEqual Seq(0, 1, 2)
-      ds.dataColumns.map(_.columnType) shouldEqual Seq(StringColumn, StringColumn, LongColumn)
-      ds.partitionColumns should have length (1)
-      ds.partitionColumns.map(_.columnType) shouldEqual Seq(StringColumn)
-      ds.partitionColumns.map(_.id) shouldEqual Seq(PartColStartIndex)
-      Dataset.isPartitionID(ds.partitionColumns.head.id) shouldEqual true
-      ds.timestampColumn.name shouldEqual "age"
-      ds.rowKeyRouting shouldEqual Array(2)
-    }
-
-    it("should return valid Dataset when multiple row key columns specified") {
-      val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, Seq("age", "first"))
-      ds.rowKeyIDs shouldEqual Seq(2, 0)
-      ds.dataColumns should have length (3)
-      ds.dataColumns.map(_.id) shouldEqual Seq(0, 1, 2)
-      ds.dataColumns.map(_.columnType) shouldEqual Seq(StringColumn, StringColumn, LongColumn)
-      ds.partitionColumns should have length (1)
-      ds.partitionColumns.map(_.columnType) shouldEqual Seq(StringColumn)
-      ds.timestampColumn.name shouldEqual "age"
-      ds.rowKeyRouting shouldEqual Array(2, 0)
-    }
-
     it("should return IDs for column names or seq of missing names") {
-      val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, "age", DatasetOptions.DefaultOptions)
-      ds.colIDs("first", "age").get shouldEqual Seq(0, 2)
+      val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, DatasetOptions.DefaultOptions)
+      ds.colIDs("first", "age").get shouldEqual Seq(1, 0)
 
       ds.colIDs("part").get shouldEqual Seq(Dataset.PartColStartIndex)
 
@@ -187,11 +24,11 @@ class DatasetSpec extends FunSpec with Matchers {
     }
 
     it("should return ColumnInfos for colIDs") {
-      val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, "age", DatasetOptions.DefaultOptions)
-      val infos = ds.infosFromIDs(Seq(0, 2))
+      val ds = Dataset("dataset", Seq("part:string"), dataColSpecs, DatasetOptions.DefaultOptions)
+      val infos = ds.infosFromIDs(Seq(1, 0))
       infos shouldEqual Seq(ColumnInfo("first", StringColumn), ColumnInfo("age", LongColumn))
 
-      val infos2 = ds.infosFromIDs(Seq(PartColStartIndex, 1))
+      val infos2 = ds.infosFromIDs(Seq(PartColStartIndex, 2))
       infos2 shouldEqual Seq(ColumnInfo("part", StringColumn), ColumnInfo("last", StringColumn))
     }
 

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -236,13 +236,13 @@ class SchemasSpec extends FunSpec with Matchers {
       schemas.part.predefinedKeys shouldEqual Seq("_ns", "app", "__name__", "instance", "dc")
       Dataset.isPartitionID(schemas.part.columns.head.id) shouldEqual true
 
-      val promRef = DatasetRef("prom")
-      val histRef = DatasetRef("hist")
-      schemas.data.keySet shouldEqual Set(promRef, histRef)
-      schemas.schemas.keySet shouldEqual Set(promRef, histRef)
-      schemas.data(promRef).columns.map(_.columnType) shouldEqual Seq(TimestampColumn, DoubleColumn)
-      schemas.data(promRef).columns.map(_.id) shouldEqual Seq(0, 1)
-      schemas.data(promRef).timestampColumn.name shouldEqual "timestamp"
+      schemas.data.keySet shouldEqual Set("prom", "hist")
+      schemas.schemas.keySet shouldEqual Set("prom", "hist")
+      schemas.data("prom").columns.map(_.columnType) shouldEqual Seq(TimestampColumn, DoubleColumn)
+      schemas.data("prom").columns.map(_.id) shouldEqual Seq(0, 1)
+      schemas.data("prom").timestampColumn.name shouldEqual "timestamp"
+      schemas.data("hist").columns.map(_.columnType) shouldEqual
+        Seq(TimestampColumn, LongColumn, LongColumn, HistogramColumn)
       // println(schemas.data.values.map(_.hash))
     }
   }

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -1,0 +1,129 @@
+package filodb.core.metadata
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{FunSpec, Matchers}
+
+import filodb.core._
+
+class SchemasSpec extends FunSpec with Matchers {
+  import Column.ColumnType._
+  import Dataset._
+  import NamesTestData._
+
+  describe("DataSchema") {
+    it("should return NotNameColonType if column specifiers not name:type format") {
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "column2", Nil, "first")
+      resp1.isBad shouldEqual true
+      resp1.swap.get shouldEqual ColumnErrors(Seq(NotNameColonType("column2")))
+    }
+
+    it("should return BadColumnParams if name:type:params portion not valid key=value pairs") {
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "column2:a:b", Nil, "first")
+      resp1.isBad shouldEqual true
+      resp1.swap.get shouldBe a[ColumnErrors]
+      val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
+      errors should have length 1
+      errors.head shouldBe a[BadColumnParams]
+    }
+
+    it("should return BadColumnParams if required param config not specified") {
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "h:hist:foo=bar", Nil, "first")
+      resp1.isBad shouldEqual true
+      resp1.swap.get shouldBe a[ColumnErrors]
+      val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
+      errors should have length 1
+      errors.head shouldBe a[BadColumnParams]
+
+      val resp2 = DataSchema.make("dataset", dataColSpecs :+ "h:hist:counter=bar", Nil, "first")
+      resp2.isBad shouldEqual true
+      resp2.swap.get shouldBe a[ColumnErrors]
+      val errors2 = resp2.swap.get.asInstanceOf[ColumnErrors].errs
+      errors2 should have length 1
+      errors2.head shouldBe a[BadColumnParams]
+    }
+
+    it("should return BadColumnName if illegal chars in column name") {
+      val resp1 = DataSchema.make("dataset", Seq("col, umn1:string"), Nil, "first")
+      resp1.isBad shouldEqual true
+      val errors = resp1.swap.get match {
+        case ColumnErrors(errs) => errs
+        case x => throw new RuntimeException(s"Did not expect $x")
+      }
+      errors should have length (1)
+      errors.head shouldBe a[BadColumnName]
+    }
+
+    it("should return BadColumnType if unsupported type specified in column spec") {
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "part:linkedlist", Nil, "first")
+      resp1.isBad shouldEqual true
+      val errors = resp1.swap.get match {
+        case ColumnErrors(errs) => errs
+        case x => throw new RuntimeException(s"Did not expect $x")
+      }
+      errors should have length (1)
+      errors.head shouldEqual BadColumnType("linkedlist")
+    }
+
+    it("should return BadColumnName if value column not one of other columns") {
+      val conf2 = ConfigFactory.parseString("""
+                    {
+                      columns = ["first:string", "last:string", "age:long"]
+                      value-column = "first2"
+                      downsamplers = []
+                    }""")
+      val resp = DataSchema.fromConfig("dataset", conf2)
+      resp.isBad shouldEqual true
+      resp.swap.get shouldBe a[BadColumnName]
+    }
+
+    it("should return multiple column spec errors") {
+      val resp1 = DataSchema.make("dataset", Seq("first:str", "age:long", "la(st):int"), Nil, "first")
+      resp1.isBad shouldEqual true
+      val errors = resp1.swap.get match {
+        case ColumnErrors(errs) => errs
+        case x => throw new RuntimeException(s"Did not expect $x")
+      }
+      errors should have length (2)
+      errors.head shouldEqual BadColumnType("str")
+    }
+
+    it("should return NoTimestampRowKey if non timestamp used for row key / first column") {
+      val ds1 = DataSchema.make("dataset", dataColSpecs, Nil, "first")
+      ds1.isBad shouldEqual true
+      ds1.swap.get shouldBe a[NoTimestampRowKey]
+    }
+
+    it("should return a valid Dataset when a good specification passed") {
+      val conf2 = ConfigFactory.parseString("""
+                    {
+                      columns = ["timestamp:ts", "code:long", "event:string"]
+                      value-column = "event"
+                      downsamplers = []
+                    }""")
+      val schema = DataSchema.fromConfig("dataset", conf2).get
+      schema.columns should have length (3)
+      schema.columns.map(_.id) shouldEqual Seq(0, 1, 2)
+      schema.columns.map(_.columnType) shouldEqual Seq(TimestampColumn, LongColumn, StringColumn)
+      schema.timestampColumn.name shouldEqual "timestamp"
+    }
+  }
+
+  describe("PartitionSchema") {
+    it("should allow MapColumns only in last position of partition key") {
+      val mapCol = "tags:map"
+
+      // OK: only partition column is map
+      val ds1 = PartitionSchema.make(Seq(mapCol), DatasetOptions.DefaultOptions).get
+      ds1.columns.map(_.name) should equal (Seq("tags"))
+
+      // OK: last partition column is map
+      val ds2 = PartitionSchema.make(Seq("first:string", mapCol), DatasetOptions.DefaultOptions).get
+      ds2.columns.map(_.name) should equal (Seq("first", "tags"))
+
+      // Not OK: first partition column is map
+      val resp3 = PartitionSchema.make(Seq(mapCol, "first:string"), DatasetOptions.DefaultOptions)
+      resp3.isBad shouldEqual true
+      resp3.swap.get shouldBe an[IllegalMapColumn]
+    }
+  }
+}

--- a/core/src/test/scala/filodb.core/query/KeyFilterSpec.scala
+++ b/core/src/test/scala/filodb.core/query/KeyFilterSpec.scala
@@ -12,15 +12,15 @@ class KeyFilterSpec extends FunSpec with Matchers {
   import Filter._
 
   it("should parse values for regular KeyTypes") {
-    KeyFilter.parseSingleValue(dataset.dataColumns.head, "abc") should equal ("abc".utf8)
-    KeyFilter.parseSingleValue(dataset.dataColumns.head, "abc".utf8) should equal ("abc".utf8)
+    KeyFilter.parseSingleValue(dataset.dataColumns(1), "abc") should equal ("abc".utf8)
+    KeyFilter.parseSingleValue(dataset.dataColumns(1), "abc".utf8) should equal ("abc".utf8)
     KeyFilter.parseSingleValue(dataset.partitionColumns.head, -15) should equal (-15)
 
-    KeyFilter.parseValues(dataset.dataColumns.head, Set("abc", "def")) should equal (Set("abc".utf8, "def".utf8))
+    KeyFilter.parseValues(dataset.dataColumns(1), Set("abc", "def")) should equal (Set("abc".utf8, "def".utf8))
   }
 
   it("should validate equalsFunc for string and other types") {
-    val eqFunc1 = Equals(KeyFilter.parseSingleValue(dataset.dataColumns.head, "abc")).filterFunc
+    val eqFunc1 = Equals(KeyFilter.parseSingleValue(dataset.dataColumns(1), "abc")).filterFunc
     eqFunc1("abc".utf8) should equal (true)
     eqFunc1("abc") should equal (false)
     eqFunc1(15) should equal (false)
@@ -30,7 +30,7 @@ class KeyFilterSpec extends FunSpec with Matchers {
   }
 
   it("should validate inFunc for string and other types") {
-    val inFunc1 = In(KeyFilter.parseValues(dataset.dataColumns.head, Set("abc", "def")).toSet).filterFunc
+    val inFunc1 = In(KeyFilter.parseValues(dataset.dataColumns(1), Set("abc", "def")).toSet).filterFunc
     inFunc1("abc".utf8) should equal (true)
     inFunc1("aaa".utf8) should equal (false)
     inFunc1(15) should equal (false)

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -27,21 +27,17 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
   val policy = new FixedMaxPartitionsEvictionPolicy(100)   // Since 99 GDELT rows, this will never evict
   val memStore = new TimeSeriesMemStore(config, colStore, metaStore, Some(policy))
 
-  val datasetDb2 = dataset.copy(database = Some("unittest2"))
-
   // First create the tables in C*
   override def beforeAll(): Unit = {
     super.beforeAll()
     metaStore.initialize().futureValue
     colStore.initialize(dataset.ref).futureValue
     colStore.initialize(GdeltTestData.dataset2.ref).futureValue
-    colStore.initialize(datasetDb2.ref).futureValue
   }
 
   before {
     colStore.truncate(dataset.ref).futureValue
     colStore.truncate(GdeltTestData.dataset2.ref).futureValue
-    colStore.truncate(datasetDb2.ref).futureValue
     memStore.reset()
     metaStore.clearAllData()
   }
@@ -104,21 +100,6 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     // check that can read from same partition again
     val rowIt2 = memStore.scanRows(dataset, Seq(2), FilteredPartitionScan(paramSet.head))
     rowIt2.map(_.getLong(0)).toSeq should equal (Seq(24L, 28L, 25L, 40L, 39L, 29L))
-  }
-
-  it should "read back rows written in another database" ignore {
-    whenReady(colStore.write(datasetDb2, chunkSetStream())) { response =>
-      response should equal (Success)
-    }
-
-    val paramSet = colStore.getScanSplits(dataset.ref, 1)
-    paramSet should have length (1)
-
-    val rowIt = memStore.scanRows(datasetDb2, Seq(0, 1, 2), FilteredPartitionScan(paramSet.head))
-    rowIt.map(_.getLong(2)).toSeq should equal (Seq(24L, 28L, 25L, 40L, 39L, 29L))
-
-    // Check that original keyspace/database has no data
-    memStore.scanRows(dataset, Seq(0), partScan).toSeq should have length (0)
   }
 
   it should "read back rows written with multi-column row keys" ignore {

--- a/core/src/test/scala/filodb.core/store/MetaStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/MetaStoreSpec.scala
@@ -19,35 +19,35 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     metaStore.initialize().futureValue
   }
 
-  val dataset = Dataset("foo", Seq("part:string"), Seq("timestamp:long", "value:double"), "timestamp",
+  val dataset = Dataset("foo", Seq("part:string"), Seq("timestamp:long", "value:double"),
     DatasetOptions.DefaultOptions)
 
   before { metaStore.clearAllData().futureValue }
 
   describe("checkpoint api") {
     it("should allow reading and writing checkpoints for shard") {
-      val ds = dataset.copy(name = "gdelt-" + UUID.randomUUID()) // Add uuid so tests can be rerun
+      val ref = DatasetRef("gdelt-" + UUID.randomUUID()) // Add uuid so tests can be rerun
 
       // when there is no data for a shard, then return Long.MinValue as the checkpoint
-      metaStore.readEarliestCheckpoint(ds.ref, 2).futureValue shouldEqual Long.MinValue
-      metaStore.readCheckpoints(ds.ref, 2).futureValue.isEmpty shouldBe true
+      metaStore.readEarliestCheckpoint(ref, 2).futureValue shouldEqual Long.MinValue
+      metaStore.readCheckpoints(ref, 2).futureValue.isEmpty shouldBe true
 
       // should be able to insert checkpoints for new groups
-      metaStore.writeCheckpoint(ds.ref, 2, 1, 10).futureValue shouldEqual Success
-      metaStore.writeCheckpoint(ds.ref, 2, 2, 9).futureValue shouldEqual Success
-      metaStore.writeCheckpoint(ds.ref, 2, 3, 13).futureValue shouldEqual Success
-      metaStore.writeCheckpoint(ds.ref, 2, 4, 5).futureValue shouldEqual Success
-      metaStore.readEarliestCheckpoint(ds.ref, 2).futureValue shouldEqual 5
+      metaStore.writeCheckpoint(ref, 2, 1, 10).futureValue shouldEqual Success
+      metaStore.writeCheckpoint(ref, 2, 2, 9).futureValue shouldEqual Success
+      metaStore.writeCheckpoint(ref, 2, 3, 13).futureValue shouldEqual Success
+      metaStore.writeCheckpoint(ref, 2, 4, 5).futureValue shouldEqual Success
+      metaStore.readEarliestCheckpoint(ref, 2).futureValue shouldEqual 5
 
       // should be able to update checkpoints for existing groups
-      metaStore.writeCheckpoint(ds.ref, 2, 1, 12).futureValue shouldEqual Success
-      metaStore.writeCheckpoint(ds.ref, 2, 2, 15).futureValue shouldEqual Success
-      metaStore.writeCheckpoint(ds.ref, 2, 3, 17).futureValue shouldEqual Success
-      metaStore.writeCheckpoint(ds.ref, 2, 4, 7).futureValue shouldEqual Success
-      metaStore.readEarliestCheckpoint(ds.ref, 2).futureValue shouldEqual 7
+      metaStore.writeCheckpoint(ref, 2, 1, 12).futureValue shouldEqual Success
+      metaStore.writeCheckpoint(ref, 2, 2, 15).futureValue shouldEqual Success
+      metaStore.writeCheckpoint(ref, 2, 3, 17).futureValue shouldEqual Success
+      metaStore.writeCheckpoint(ref, 2, 4, 7).futureValue shouldEqual Success
+      metaStore.readEarliestCheckpoint(ref, 2).futureValue shouldEqual 7
 
       // should be able to retrieve raw offsets as well
-      val offsets = metaStore.readCheckpoints(ds.ref, 2).futureValue
+      val offsets = metaStore.readCheckpoints(ref, 2).futureValue
       offsets.size shouldEqual 4
       offsets(1) shouldEqual 12
       offsets(2) shouldEqual 15
@@ -56,7 +56,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
 
       // should be able to clear the table
       metaStore.clearAllData().futureValue
-      metaStore.readCheckpoints(ds.ref, 2).futureValue.isEmpty shouldBe true
+      metaStore.readCheckpoints(ref, 2).futureValue.isEmpty shouldBe true
     }
   }
 

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -33,43 +33,7 @@ NOTE: for the latest and most up to date, see [timeseries-dev-source.conf](../co
 
 ```yaml
 dataset = "example"
-
-# Schema used for defining the BinaryRecord used in ingestion and persistence.
-#
-# Should not change once dataset has been set up on the server and data has been ingested into kafka
-# or written to cassandra
-definition {
-  # defines the unique identifier for partition
-  partition-columns = ["tags:map"]
-  # Schema of all of the values stored against the partition key. This includes the row-keys as well
-  data-columns = ["timestamp:ts", "value:double:detectDrops=true"]
-  # Clustering key for each row. Together with partition key, they form the primary key.
-  row-key-columns = [ "timestamp" ]
-  # List of downsamplers for the data columns
-  downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)"]
-}
-
-# Dataset Options
-#
-# Should not change once dataset has been set up on the server and data has been ingested into kafka
-# or written to cassandra
-options {
-  # These column values are used to identify the shard group for the partition
-  shardKeyColumns = [ "__name__", "_ns" ]
-  # suffixes from map values are stripped before hashing
-  ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
-  # default data column name to be used referencing the value column
-  valueColumn = "value"
-  # column name to use when referencing the name column
-  metricColumn = "__name__"
-  # these columns are ignored in calculation of full partition key hash
-  ignoreTagsOnPartitionKeyHash = [ "le" ]
-
-  # These key-names will be replaced in the key map during ingestion/query.
-  # Temporary workaround. Will be deprecated.
-  copyTags = { }
-}
-
+schema = "prometheus"
 
 # e.g. one shard per kafka partition
 num-shards = 100

--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -25,7 +25,7 @@ import org.jboss.netty.handler.ssl.util.SelfSignedCertificate
 import org.jctools.queues.MpscGrowableArrayQueue
 import org.rogach.scallop._
 
-import filodb.coordinator.{FilodbSettings, GlobalConfig, ShardMapper, StoreFactory}
+import filodb.coordinator.{FilodbSettings, ShardMapper, StoreFactory}
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.Dataset
 import filodb.gateway.conversion._
@@ -57,8 +57,9 @@ import filodb.timeseries.TestTimeseriesProducer
  */
 object GatewayServer extends StrictLogging {
   // Get global configuration using universal FiloDB/Akka-based config
-  val config = GlobalConfig.systemConfig
-  val storeFactory = StoreFactory(new FilodbSettings(config), Scheduler.io())
+  val settings = new FilodbSettings()
+  val config = settings.allConfig
+  val storeFactory = StoreFactory(settings, Scheduler.io())
 
   // ==== Metrics ====
   val numInfluxMessages = Kamon.counter("num-influx-messages")
@@ -88,7 +89,7 @@ object GatewayServer extends StrictLogging {
     val sourceConfig = ConfigFactory.parseFile(new java.io.File(userOpts.sourceConfigPath()))
     val numShards = sourceConfig.getInt("num-shards")
 
-    val dataset = Dataset.fromConfig(sourceConfig)
+    val dataset = settings.datasetFromStream(sourceConfig)
 
     // NOTE: the spread MUST match the default spread used in the HTTP module for consistency between querying
     //       and ingestion sharding

--- a/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
@@ -19,13 +19,7 @@ object PrometheusApiRouteSpec extends ActorSpecConfig {
     inline-dataset-configs = [
       {
         dataset = "prometheus"
-        definition {
-          partition-columns = ["tags:map"]
-          data-columns = ["timestamp:ts", "value:double"]
-          row-key-columns = [ "timestamp" ]
-          downsamplers = []
-        }
-        ${TestData.optionsString}
+        schema = "prometheus"
         num-shards = 4
         min-num-nodes = 1
         sourcefactory = "${classOf[NoOpStreamFactory].getName}"

--- a/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
@@ -14,8 +14,7 @@ import filodb.core.store.ChunkSet
 import filodb.memory.format.{vectors => bv, TupleRowReader, UnsafeUtils}
 
 object IntSumReadBenchmark {
-  val dataset = Dataset("dataset", Seq("part:int"), Seq("int:int", "rownum:long"), "rownum",
-    DatasetOptions.DefaultOptions)
+  val dataset = Dataset("dataset", Seq("part:int"), Seq("int:int", "rownum:long"), DatasetOptions.DefaultOptions)
   val rowIt = Iterator.from(0).map { row => (Some(scala.util.Random.nextInt), Some(row.toLong), Some(0)) }
   val partKey = NamesTestData.defaultPartKey
   val rowColumns = Seq("int", "rownum", "part")

--- a/kafka/src/main/scala/filodb/kafka/TestConsumer.scala
+++ b/kafka/src/main/scala/filodb/kafka/TestConsumer.scala
@@ -8,7 +8,6 @@ import monix.execution.Scheduler
 
 import filodb.coordinator.{FilodbSettings, IngestionStreamFactory, StoreFactory}
 import filodb.core.memstore.SomeData
-import filodb.core.metadata.Dataset
 import filodb.core.store.IngestionConfig
 
 /**
@@ -39,7 +38,7 @@ object TestConsumer extends App {
   import monix.execution.Scheduler.Implicits.global
 
   val ingestConf = IngestionConfig(sourceConf, classOf[KafkaIngestionStreamFactory].getClass.getName).get
-  val dataset = Dataset.fromConfig(sourceConf)
+  val dataset = settings.datasetFromStream(sourceConf)
 
   val ctor = Class.forName(ingestConf.streamFactoryClass).getConstructors.head
   val streamFactory = ctor.newInstance().asInstanceOf[IngestionStreamFactory]

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -275,6 +275,7 @@ object FiloBuild extends Build {
 
   lazy val gatewayDeps = commonDeps ++ Seq(
     scalaxyDep,
+    logbackDep,
     "io.monix" %% "monix-kafka-1x" % monixKafkaVersion,
     "org.rogach" %% "scallop" % "3.1.1"
   )

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -194,6 +194,7 @@ object FiloBuild extends Build {
     "io.kamon" %% "kamon-akka-remote-2.5" % "1.1.0",
     logbackDep % Test,
     scalaTest  % Test,
+    "com.softwaremill.quicklens" %% "quicklens" % "1.4.12" % Test,
     scalaCheck % "test"
   )
 

--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -9,10 +9,10 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
  */
 object FormatConversion {
   // An official Prometheus-format Dataset object with a single timestamp and value
-  val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
-                  .copy(options = DatasetOptions(Seq("__name__", "_ns"),
-                    "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
-                    Map("exporter" -> "_ns", "job" -> "_ns")))
+  val options = DatasetOptions(Seq("__name__", "_ns"),
+                    "__name__", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
+                    Map("exporter" -> "_ns", "job" -> "_ns"))
+  val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"), options)
 
   /**
    * Extracts a java ArrayList of labels from the TimeSeries

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -41,15 +41,13 @@ final case class SelectRawPartitionsExec(id: String,
   require(colIds.nonEmpty)
 
   protected[filodb] def schemaOfDoExecute(dataset: Dataset): ResultSchema = {
-    val numRowKeyCols = colIds.zip(dataset.rowKeyIDs).takeWhile { case (a, b) => a == b }.length
-
     // Add the max column to the schema together with Histograms for max computation -- just in case it's needed
     // But make sure the max column isn't already included
     histMaxColumn(dataset, colIds).filter { mId => !(colIds contains mId) }
                                   .map { maxColId =>
-      ResultSchema(dataset.infosFromIDs(colIds :+ maxColId), numRowKeyCols, colIDs = (colIds :+ maxColId))
+      ResultSchema(dataset.infosFromIDs(colIds :+ maxColId), 1, colIDs = (colIds :+ maxColId))
     }.getOrElse {
-      ResultSchema(dataset.infosFromIDs(colIds), numRowKeyCols, colIDs = colIds)
+      ResultSchema(dataset.infosFromIDs(colIds), 1, colIDs = colIds)
     }
   }
 
@@ -58,8 +56,6 @@ final case class SelectRawPartitionsExec(id: String,
                           queryConfig: QueryConfig)
                          (implicit sched: Scheduler,
                           timeout: FiniteDuration): Observable[RangeVector] = {
-    require(colIds.indexOfSlice(dataset.rowKeyIDs) == 0)
-
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     source.rangeVectors(dataset, colIds, partMethod, chunkMethod)
   }


### PR DESCRIPTION
NOTE: Strongly suggest going through the code in commit order, rather than browsing all code at once

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The `Dataset` class rules the world.  It blends ingestion stream and definition for partition keys and data schema, and is used virtually everywhere.

**New behavior :**

This is the start of multi-schema changes for FiloDB.  
It defines multiple new schema definition classes which are intended to eventually replace `Dataset`:
* `PartitionSchema` contains the schema for the partition key, and is to be shared across all datasets in a FiloDB cluster
* `DataSchema` defines the columns for a single data type.   Multiple DataSchemas will be supported at once, in the future.
* There are no more "Row key columns".  The first DataSchema column is the "row key", and it must be a `TimestampColumn` or `LongColumn`. 

The `Dataset` class implementation now points at a `Schema` which is just a `PartitionSchema` plus a `DataSchema`.  All usage of Dataset remains essentially the same as today.

PartitionSchemas and DataSchemas are now defined in the root/application server config.  Each source/dataset config points back at the schema it supports.  

**BREAKING CHANGES**

Noncompatible change to config files.
