### PR TITLE
feat(various): Assert Thread Name of various operations

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
@@ -14,12 +14,12 @@ import filodb.core.store.NullColumnStore
  * and a Cassandra MetaStore
  *
  * @param config a Typesafe Config, not at the root but at the "filodb." level
- * @param sched a Monix Scheduler, recommended to be the standard I/O pool, for scheduling asynchronous I/O
+ * @param ioPool a Monix Scheduler, recommended to be the standard I/O pool, for scheduling asynchronous I/O
  */
-class CassandraTSStoreFactory(config: Config, sched: Scheduler) extends StoreFactory {
-  val colStore = new CassandraColumnStore(config, sched)(sched)
-  val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(sched)
-  val memStore = new TimeSeriesMemStore(config, colStore, metaStore)(sched)
+class CassandraTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFactory {
+  val colStore = new CassandraColumnStore(config, ioPool)(ioPool)
+  val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(ioPool)
+  val memStore = new TimeSeriesMemStore(config, colStore, metaStore)(ioPool)
 }
 
 /**
@@ -29,10 +29,10 @@ class CassandraTSStoreFactory(config: Config, sched: Scheduler) extends StoreFac
   * on-demand-paging.
   *
   * @param config a Typesafe Config, not at the root but at the "filodb." level
-  * @param sched a Monix Scheduler, recommended to be the standard I/O pool, for scheduling asynchronous I/O
+  * @param ioPool a Monix Scheduler, recommended to be the standard I/O pool, for scheduling asynchronous I/O
   */
-class NonPersistentTSStoreFactory(config: Config, sched: Scheduler) extends StoreFactory {
-  val colStore = new NullColumnStore()(sched)
-  val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(sched)
-  val memStore = new TimeSeriesMemStore(config, colStore, metaStore)(sched)
+class NonPersistentTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFactory {
+  val colStore = new NullColumnStore()(ioPool)
+  val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(ioPool)
+  val memStore = new TimeSeriesMemStore(config, colStore, metaStore)(ioPool)
 }

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -22,6 +22,11 @@ filodb {
       _spread_ = 0
     }
   ]
+
+  scheduler {
+    enable-assertions = true
+  }
+
 }
 
 kamon {

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -6,11 +6,11 @@ import scala.collection.immutable
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
+import akka.Done
 import akka.actor._
 import akka.cluster._
 import akka.cluster.ClusterEvent._
 import akka.util.Timeout
-import akka.Done
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
@@ -18,6 +18,7 @@ import monix.execution.{Scheduler, UncaughtExceptionReporter}
 import monix.execution.misc.NonFatal
 
 import filodb.core.GlobalScheduler
+import filodb.core.memstore.FiloSchedulers
 import filodb.core.store.MetaStore
 
 /** The base Coordinator Extension implementation providing standard ActorSystem startup.
@@ -62,7 +63,7 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
 
   implicit lazy val ec = GlobalScheduler.globalImplicitScheduler
 
-  lazy val ioPool = Scheduler.io(name = IOPoolName,
+  lazy val ioPool = Scheduler.io(name = FiloSchedulers.IOSchedName,
                                  reporter = UncaughtExceptionReporter(
                                    logger.error("Uncaught Exception in FilodbCluster.ioPool", _)))
 

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -36,8 +36,6 @@ final class FilodbSettings(val conf: Config) {
 
   val ShardMapPublishFrequency = config.as[FiniteDuration]("tasks.shardmap-publish-frequency")
 
-  val IOPoolName = "filodb.io"
-
   lazy val DatasetDefinitions = config.as[Option[Map[String, Config]]]("dataset-definitions")
                                       .getOrElse(Map.empty[String, Config])
 

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -7,6 +7,8 @@ import akka.actor.{ActorPath, Address, RootActorPath}
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 
+import filodb.core.GlobalConfig
+
 /** Settings for the FiloCluster Akka Extension which gets
   * config from `GlobalConfig`. Uses Ficus.
   */

--- a/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeClusterActor.scala
@@ -235,6 +235,7 @@ private[filodb] class NodeClusterActor(settings: FilodbSettings,
   }
 
   override def postStop(): Unit = {
+    shardManager.logAllMappers("PostStop of NodeClusterActor")
     super.postStop()
     cluster.unsubscribe(self)
     pubTask foreach (_.cancel)

--- a/coordinator/src/main/scala/filodb.coordinator/NodeConfiguration.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeConfiguration.scala
@@ -1,0 +1,16 @@
+package filodb.coordinator
+
+import com.typesafe.config.Config
+
+import filodb.core.GlobalConfig
+
+
+/** Mixin used for nodes and tests. */
+trait NodeConfiguration {
+
+  /** The global Filo configuration. */
+  val systemConfig: Config = GlobalConfig.systemConfig
+
+}
+
+

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -13,7 +13,7 @@ import scala.util.control.NonFatal
 
 import filodb.coordinator.queryengine2.QueryEngine
 import filodb.core._
-import filodb.core.memstore.{MemStore, TermInfo}
+import filodb.core.memstore.{FiloSchedulers, MemStore, TermInfo}
 import filodb.core.metadata.Dataset
 import filodb.core.query.ColumnFilter
 import filodb.query._
@@ -96,7 +96,7 @@ final class QueryActor(memStore: MemStore,
       .start()
     q.execute(memStore, dataset, queryConfig)(queryScheduler, queryConfig.askTimeout)
      .foreach { res =>
-       require(Thread.currentThread().getName.startsWith(QuerySchedName))
+       FiloSchedulers.assertThreadName(QuerySchedName)
        replyTo ! res
        res match {
          case QueryResult(_, _, vectors) => resultVectors.record(vectors.length)

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -54,6 +54,7 @@ final class QueryActor(memStore: MemStore,
                        shardMapFunc: => ShardMapper) extends BaseActor {
   import QueryActor._
   import client.QueryCommands._
+  import filodb.core.memstore.FiloSchedulers._
 
   val config = context.system.settings.config
 
@@ -79,7 +80,7 @@ final class QueryActor(memStore: MemStore,
   val queryEngine2 = new QueryEngine(dataset, shardMapFunc)
   val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
   val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor") * sys.runtime.availableProcessors)
-  implicit val scheduler = Scheduler.fixedPool(s"query-${dataset.ref}", numSchedThreads.toInt)
+  val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName-${dataset.ref}", numSchedThreads.toInt)
 
   private val tags = Map("dataset" -> dataset.ref.toString)
   private val lpRequests = Kamon.counter("queryactor-logicalPlan-requests").refine(tags)
@@ -93,9 +94,9 @@ final class QueryActor(memStore: MemStore,
     val span = Kamon.buildSpan(s"execplan2-${q.getClass.getSimpleName}")
       .withTag("query-id", q.id)
       .start()
-    implicit val _ = queryConfig.askTimeout
-    q.execute(memStore, dataset, queryConfig)
+    q.execute(memStore, dataset, queryConfig)(queryScheduler, queryConfig.askTimeout)
      .foreach { res =>
+       require(Thread.currentThread().getName.startsWith(QuerySchedName))
        replyTo ! res
        res match {
          case QueryResult(_, _, vectors) => resultVectors.record(vectors.length)
@@ -104,12 +105,12 @@ final class QueryActor(memStore: MemStore,
            logger.debug(s"queryId ${q.id} Normal QueryError returned from query execution: $e")
        }
        span.finish()
-     }.recover { case ex =>
+     }(queryScheduler).recover { case ex =>
        // Unhandled exception in query, should be rare
        logger.error(s"queryId ${q.id} Unhandled Query Error: ", ex)
        replyTo ! QueryError(q.id, ex)
        span.finish()
-     }
+     }(queryScheduler)
   }
 
   private def getSpreadProvider(queryOptions: QueryOptions): SpreadProvider = {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -30,6 +30,10 @@ filodb {
     }
   }
 
+  scheduler {
+    enable-assertions = false
+  }
+
   profiler {
     # Uncomment to enable profiling, using the filodb.standalone.SimpleProfiler class.
     #sample-rate = 10ms

--- a/core/src/main/scala/filodb.core/GlobalConfig.scala
+++ b/core/src/main/scala/filodb.core/GlobalConfig.scala
@@ -1,4 +1,4 @@
-package filodb.coordinator
+package filodb.core
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
@@ -29,13 +29,3 @@ object GlobalConfig extends StrictLogging {
                  .resolve()
   }
 }
-
-/** Mixin used for nodes and tests. */
-trait NodeConfiguration {
-
-  /** The global Filo configuration. */
-  val systemConfig: Config = GlobalConfig.systemConfig
-
-}
-
-

--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -62,6 +62,7 @@ extends RawToPartitionMaker with StrictLogging {
    * Stores raw chunks into offheap memory and populates chunks into partition
    */
   def populateRawChunks(rawPartition: RawPartData): Task[ReadablePartition] = Task {
+    FiloSchedulers.assertThreadName(FiloSchedulers.PopulateChunksSched)
     // Find the right partition given the partition key
     tsShard.getPartition(rawPartition.partitionKey).map { tsPart =>
       tsShard.shardStats.partitionsPagedFromColStore.increment()

--- a/core/src/main/scala/filodb.core/memstore/FiloSchedulers.scala
+++ b/core/src/main/scala/filodb.core/memstore/FiloSchedulers.scala
@@ -1,0 +1,14 @@
+package filodb.core.memstore
+
+object FiloSchedulers {
+  val IngestSchedName = "ingestion-shard"
+  val FlushSchedName = "flush-sched"
+  val IOSchedName = "filodb.io"
+  val QuerySchedName = "query-sched"
+  val PopulateChunksSched = "populate-odp-chunks"
+
+  def assertThreadName(name: String): Unit = {
+    require(Thread.currentThread().getName.startsWith(name),
+      s"Current thread expected to startWith $name but was ${Thread.currentThread().getName}")
+  }
+}

--- a/core/src/main/scala/filodb.core/memstore/FiloSchedulers.scala
+++ b/core/src/main/scala/filodb.core/memstore/FiloSchedulers.scala
@@ -1,5 +1,7 @@
 package filodb.core.memstore
 
+import filodb.core.GlobalConfig
+
 object FiloSchedulers {
   val IngestSchedName = "ingestion-shard"
   val FlushSchedName = "flush-sched"
@@ -8,7 +10,10 @@ object FiloSchedulers {
   val PopulateChunksSched = "populate-odp-chunks"
 
   def assertThreadName(name: String): Unit = {
-    require(Thread.currentThread().getName.startsWith(name),
-      s"Current thread expected to startWith $name but was ${Thread.currentThread().getName}")
+
+    if (GlobalConfig.systemConfig.getBoolean("filodb.scheduler.enable-assertions")) {
+      require(Thread.currentThread().getName.startsWith(name),
+        s"Current thread expected to startWith $name but was ${Thread.currentThread().getName}")
+    }
   }
 }

--- a/core/src/main/scala/filodb.core/memstore/FiloSchedulers.scala
+++ b/core/src/main/scala/filodb.core/memstore/FiloSchedulers.scala
@@ -9,9 +9,10 @@ object FiloSchedulers {
   val QuerySchedName = "query-sched"
   val PopulateChunksSched = "populate-odp-chunks"
 
-  def assertThreadName(name: String): Unit = {
+  val assertEnabled = GlobalConfig.systemConfig.getBoolean("filodb.scheduler.enable-assertions")
 
-    if (GlobalConfig.systemConfig.getBoolean("filodb.scheduler.enable-assertions")) {
+  def assertThreadName(name: String): Unit = {
+    if (assertEnabled) {
       require(Thread.currentThread().getName.startsWith(name),
         s"Current thread expected to startWith $name but was ${Thread.currentThread().getName}")
     }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -12,7 +12,6 @@ import monix.reactive.{Observable, OverflowStrategy}
 
 import filodb.core.Types
 import filodb.core.downsample.{DownsampleConfig, DownsamplePublisher}
-import filodb.core.memstore.FiloSchedulers.IngestSchedName
 import filodb.core.metadata.Dataset
 import filodb.core.store._
 import filodb.memory.BinaryRegionLarge

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -11,7 +11,6 @@ import org.jctools.maps.NonBlockingHashMapLong
 
 import filodb.core.{DatasetRef, Response, Types}
 import filodb.core.downsample.{DownsampleConfig, DownsamplePublisher}
-import filodb.core.memstore.FiloSchedulers.IngestSchedName
 import filodb.core.metadata.Dataset
 import filodb.core.query.ColumnFilter
 import filodb.core.store._
@@ -21,7 +20,7 @@ import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 
 class TimeSeriesMemStore(config: Config, val store: ColumnStore, val metastore: MetaStore,
                          evictionPolicy: Option[PartitionEvictionPolicy] = None)
-                        (implicit val ec: ExecutionContext)
+                        (implicit val ioPool: ExecutionContext)
 extends MemStore with StrictLogging {
   import collection.JavaConverters._
   import FiloSchedulers._

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -2,7 +2,7 @@ package filodb.core.memstore
 
 import java.util.concurrent.locks.StampedLock
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 import scala.util.{Random, Try}
 
@@ -190,6 +190,7 @@ class TimeSeriesShard(val dataset: Dataset,
   import collection.JavaConverters._
 
   import TimeSeriesShard._
+  import FiloSchedulers._
 
   val shardStats = new TimeSeriesShardStats(dataset.ref, shardNum)
 
@@ -236,7 +237,7 @@ class TimeSeriesShard(val dataset: Dataset,
 
   // Create a single-threaded scheduler just for ingestion.  Name the thread for ease of debugging
   // NOTE: to control intermixing of different Observables/Tasks in this thread, customize ExecutionModel param
-  val ingestSched = Scheduler.singleThread(s"ingestion-shard-${dataset.ref}-$shardNum",
+  val ingestSched = Scheduler.singleThread(s"$IngestSchedName-${dataset.ref}-$shardNum",
     reporter = UncaughtExceptionReporter(logger.error("Uncaught Exception in TimeSeriesShard.ingestSched", _)))
 
   private val blockMemorySize = storeConfig.shardMemSize
@@ -391,6 +392,7 @@ class TimeSeriesShard(val dataset: Dataset,
   class IngestConsumer(var numActuallyIngested: Int = 0, var ingestOffset: Long = -1L) extends BinaryRegionConsumer {
     // Receives a new ingestion BinaryRecord
     final def onNext(recBase: Any, recOffset: Long): Unit = {
+      assertThreadName(IngestSchedName)
       val group = partKeyGroup(ingestSchema, recBase, recOffset, numGroups)
       if (ingestOffset < groupWatermark(group)) {
         shardStats.rowsSkipped.increment
@@ -421,6 +423,7 @@ class TimeSeriesShard(val dataset: Dataset,
     * Adds new partitions if needed.
     */
   def ingest(container: RecordContainer, offset: Long): Long = {
+    assertThreadName(IngestSchedName)
     ingestConsumer.numActuallyIngested = 0
     ingestConsumer.ingestOffset = offset
     binRecordReader.recordBase = container.base
@@ -437,34 +440,42 @@ class TimeSeriesShard(val dataset: Dataset,
   def ingest(data: SomeData): Long = ingest(data.records, data.offset)
 
   def recoverIndex(): Future[Unit] = {
-    val tracer = Kamon.buildSpan("memstore-recover-index-latency")
-      .withTag("dataset", dataset.name)
-      .withTag("shard", shardNum).start()
+    val p = Promise[Unit]()
+    Future {
+      assertThreadName(IngestSchedName)
+      val tracer = Kamon.buildSpan("memstore-recover-index-latency")
+        .withTag("dataset", dataset.name)
+        .withTag("shard", shardNum).start()
 
-    /* We need this map to track partKey->partId because lucene index cannot be looked up
+      /* We need this map to track partKey->partId because lucene index cannot be looked up
        using partKey efficiently, and more importantly, it is eventually consistent.
         The map and contents will be garbage collected after we are done with recovery */
-    val partIdMap = debox.Map.empty[BytesRef, Int]
+      val partIdMap = debox.Map.empty[BytesRef, Int]
 
-    val earliestTimeBucket = Math.max(0, currentIndexTimeBucket - numTimeBucketsToRetain)
-    logger.info(s"Recovering timebuckets $earliestTimeBucket to ${currentIndexTimeBucket - 1} " +
-      s"for dataset=${dataset.ref} shard=$shardNum ")
-    // go through the buckets in reverse order to first one wins and we need not rewrite
-    // entries in lucene
-    // no need to go into currentIndexTimeBucket since it is not present in cass
-    val timeBuckets = for { tb <- currentIndexTimeBucket-1 to earliestTimeBucket by -1 } yield {
-      colStore.getPartKeyTimeBucket(dataset, shardNum, tb).map { b =>
-        new IndexData(tb, b.segmentId, RecordContainer(b.segment.array()))
+      val earliestTimeBucket = Math.max(0, currentIndexTimeBucket - numTimeBucketsToRetain)
+      logger.info(s"Recovering timebuckets $earliestTimeBucket to ${currentIndexTimeBucket - 1} " +
+        s"for dataset=${dataset.ref} shard=$shardNum ")
+      // go through the buckets in reverse order to first one wins and we need not rewrite
+      // entries in lucene
+      // no need to go into currentIndexTimeBucket since it is not present in cass
+      val timeBuckets = for {tb <- currentIndexTimeBucket - 1 to earliestTimeBucket by -1} yield {
+        colStore.getPartKeyTimeBucket(dataset, shardNum, tb).map { b =>
+          new IndexData(tb, b.segmentId, RecordContainer(b.segment.array()))
+        }
       }
-    }
-    val fut = Observable.flatten(timeBuckets: _*)
-      .foreach(tb => extractTimeBucket(tb, partIdMap))(ingestSched)
-      .map(_ => completeIndexRecovery())
-    fut.onComplete(_ => tracer.finish())
-    fut
+      Observable.flatten(timeBuckets: _*)
+        .foreach(tb => extractTimeBucket(tb, partIdMap))(ingestSched)
+        .map(_ => completeIndexRecovery())(ingestSched)
+        .onComplete { _ =>
+          tracer.finish()
+          p.success(())
+        }(ingestSched)
+    }(ingestSched)
+    p.future
   }
 
   def completeIndexRecovery(): Unit = {
+    assertThreadName(IngestSchedName)
     commitPartKeyIndexBlocking()
     startFlushingIndex() // start flushing index now that we have recovered
     logger.info(s"Bootstrapped index for dataset=${dataset.ref} shard=$shardNum")
@@ -472,6 +483,7 @@ class TimeSeriesShard(val dataset: Dataset,
 
   // scalastyle:off method.length
   private[memstore] def extractTimeBucket(segment: IndexData, partIdMap: debox.Map[BytesRef, Int]): Unit = {
+    assertThreadName(IngestSchedName)
     var numRecordsProcessed = 0
     segment.records.iterate(indexTimeBucketSchema).foreach { row =>
       // read binary record and extract the indexable data fields
@@ -673,6 +685,7 @@ class TimeSeriesShard(val dataset: Dataset,
     * NEEDS TO RUN ON INGESTION THREAD since it removes entries from the partition data structures.
     */
   def prepareIndexTimeBucketForFlush(group: Int): Option[FlushIndexTimeBuckets] = {
+    assertThreadName(IngestSchedName)
     if (group == indexTimeBucketFlushGroup) {
       logger.debug(s"Switching timebucket=$currentIndexTimeBucket in dataset=${dataset.ref}" +
         s"shard=$shardNum out for flush. ")
@@ -687,6 +700,7 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   private def purgeExpiredPartitions(): Unit = ingestSched.executeTrampolined { () =>
+    assertThreadName(IngestSchedName)
     val partsToPurge = partKeyIndex.partIdsEndedBefore(
       System.currentTimeMillis() - storeConfig.demandPagedRetentionPeriod.toMillis)
     var numDeleted = 0
@@ -706,12 +720,14 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   def createFlushTask(flushGroup: FlushGroup): Task[Response] = {
+    assertThreadName(IngestSchedName)
     // clone the bitmap so that reads on the flush thread do not conflict with writes on ingestion thread
     val partitionIt = InMemPartitionIterator(partitionGroups(flushGroup.groupNum).clone().intIterator)
     doFlushSteps(flushGroup, partitionIt)
   }
 
   private def updateGauges(): Unit = {
+    assertThreadName(IngestSchedName)
     shardStats.bufferPoolSize.set(bufferPool.poolSize)
     shardStats.indexEntries.set(partKeyIndex.indexNumEntries)
     shardStats.indexBytes.set(partKeyIndex.indexRamBytes)
@@ -725,6 +741,7 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   private def addPartKeyToTimebucketRb(timebucketNum: Int, indexRb: RecordBuilder, p: TimeSeriesPartition) = {
+    assertThreadName(IOSchedName)
     var startTime = partKeyIndex.startTimeFromPartId(p.partID)
     if (startTime == -1) startTime = p.earliestTime // can remotely happen since lucene reads are eventually consistent
     if (startTime == Long.MaxValue) startTime = 0 // if for any reason we cant find the startTime, use 0
@@ -747,6 +764,8 @@ class TimeSeriesShard(val dataset: Dataset,
   // scalastyle:off method.length
   private def doFlushSteps(flushGroup: FlushGroup,
                            partitionIt: Iterator[TimeSeriesPartition]): Task[Response] = {
+    assertThreadName(IngestSchedName)
+
     val tracer = Kamon.buildSpan("chunk-flush-task-latency-after-retries")
       .withTag("dataset", dataset.name)
       .withTag("shard", shardNum).start()
@@ -760,6 +779,9 @@ class TimeSeriesShard(val dataset: Dataset,
     val downsampleRecords = shardDownsampler.newEmptyDownsampleRecords
 
     val chunkSetIter = partitionIt.flatMap { p =>
+
+      assertThreadName(IngestSchedName)
+
       /* Step 2: Make chunks to be flushed for each partition */
       val chunks = p.makeFlushChunks(blockHolder)
 
@@ -785,7 +807,10 @@ class TimeSeriesShard(val dataset: Dataset,
      * We recover future since we want to proceed to publish downsample data even if chunk flush failed.
      * This is done after writeChunksFuture because chunkSetIter is lazy. */
     val pubDownsampleFuture = writeChunksFuture.recover {case _ => Success}
-      .flatMap(_=>shardDownsampler.publishToDownsampleDataset(downsampleRecords))
+      .flatMap { _ =>
+        assertThreadName(IOSchedName)
+        shardDownsampler.publishToDownsampleDataset(downsampleRecords)
+      }
 
     /* Step 5.2: We flush index time buckets in the one designated group for each shard
      * We recover future since we want to proceed to write time buckets even if chunk flush failed.
@@ -806,6 +831,7 @@ class TimeSeriesShard(val dataset: Dataset,
       DataDropped
     }
     result.onComplete { resp =>
+      assertThreadName(IngestSchedName)
       try {
         blockFactoryPool.release(blockHolder)
         flushDoneTasks(flushGroup, resp)
@@ -820,6 +846,7 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   protected def flushDoneTasks(flushGroup: FlushGroup, resTry: Try[Response]): Unit = {
+    assertThreadName(IngestSchedName)
     resTry.foreach { resp =>
       logger.info(s"Flush of dataset=${dataset.ref} shard=$shardNum group=${flushGroup.groupNum} " +
         s"timebucket=${flushGroup.flushTimeBuckets.map(_.timeBucket)} " +
@@ -833,6 +860,7 @@ class TimeSeriesShard(val dataset: Dataset,
 
   // scalastyle:off method.length
   private def writeTimeBuckets(flushGroup: FlushGroup): Future[Response] = {
+    assertThreadName(IOSchedName)
     flushGroup.flushTimeBuckets.map { cmd =>
       val rbTrace = Kamon.buildSpan("memstore-index-timebucket-populate-timebucket")
         .withTag("dataset", dataset.name)
@@ -907,6 +935,8 @@ class TimeSeriesShard(val dataset: Dataset,
                           chunkSetIt: Iterator[ChunkSet],
                           partitionIt: Iterator[TimeSeriesPartition],
                           blockHolder: BlockMemFactory): Future[Response] = {
+    assertThreadName(IngestSchedName)
+
     val chunkSetStream = Observable.fromIterator(chunkSetIt)
     logger.debug(s"Created flush ChunkSets stream for group ${flushGroup.groupNum} in " +
       s"dataset=${dataset.ref} shard=$shardNum")
@@ -926,6 +956,7 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   private def writeHighestTimebucket(shardNum: Int, timebucket: Int): Future[Response] = {
+    assertThreadName(IOSchedName)
     metastore.writeHighestIndexTimeBucket(dataset.ref, shardNum, timebucket).recover { case e =>
       logger.error(s"Critical! Highest Time Bucket persistence skipped after retries failed in " +
         s"dataset=${dataset.ref} shard=$shardNum", e)
@@ -940,6 +971,7 @@ class TimeSeriesShard(val dataset: Dataset,
   private def updateIndexWithEndTime(p: TimeSeriesPartition,
                                      partFlushChunks: Iterator[ChunkSet],
                                      timeBucket: Int) = {
+    assertThreadName(IngestSchedName)
     // Below is coded to work concurrently with logic in getOrAddPartitionAndIngest
     // where we try to activate an inactive time series
     activelyIngesting.synchronized {
@@ -954,8 +986,9 @@ class TimeSeriesShard(val dataset: Dataset,
     }
   }
 
-  private def commitCheckpoint(ref: DatasetRef, shardNum: Int, flushGroup: FlushGroup): Future[Response] =
-  // negative checkpoints are refused by Kafka, and also offsets should be positive
+  private def commitCheckpoint(ref: DatasetRef, shardNum: Int, flushGroup: FlushGroup): Future[Response] = {
+    assertThreadName(IOSchedName)
+    // negative checkpoints are refused by Kafka, and also offsets should be positive
     if (flushGroup.flushWatermark > 0) {
       val fut = metastore.writeCheckpoint(ref, shardNum, flushGroup.groupNum, flushGroup.flushWatermark).map { r =>
         shardStats.flushesSuccessful.increment
@@ -978,12 +1011,14 @@ class TimeSeriesShard(val dataset: Dataset,
     } else {
       Future.successful(NotApplied)
     }
+  }
 
   private[memstore] val addPartitionsDisabled = AtomicBoolean(false)
 
   // scalastyle:off null
   private[filodb] def getOrAddPartitionForIngestion(recordBase: Any, recordOff: Long,
                                                     group: Int, ingestOffset: Long) = {
+    assertThreadName(IngestSchedName)
     var part = partSet.getWithIngestBR(recordBase, recordOff)
     if (part == null) {
       part = addPartitionForIngestion(recordBase, recordOff, group)
@@ -997,6 +1032,7 @@ class TimeSeriesShard(val dataset: Dataset,
     * @return partId >=0 if one is found, CREATE_NEW_PARTID (-1) if not found.
     */
   private def lookupPreviouslyAssignedPartId(partKeyBase: Array[Byte], partKeyOffset: Long): Int = {
+    assertThreadName(IngestSchedName)
     shardStats.evictedPartKeyBloomFilterQueries.increment()
 
     val mightContain = evictedPartKeys.synchronized {
@@ -1047,6 +1083,7 @@ class TimeSeriesShard(val dataset: Dataset,
     * This method also updates lucene index and time bucket bitmaps properly.
     */
   private def addPartitionForIngestion(recordBase: Any, recordOff: Long, group: Int) = {
+    assertThreadName(IngestSchedName)
     val partKeyOffset = recordComp.buildPartKeyFromIngest(recordBase, recordOff, partKeyBuilder)
     val previousPartId = lookupPreviouslyAssignedPartId(partKeyArray, partKeyOffset)
     val newPart = createNewPartition(partKeyArray, partKeyOffset, group, previousPartId)
@@ -1085,10 +1122,13 @@ class TimeSeriesShard(val dataset: Dataset,
     * @param recordOff the offset of the ingestion BinaryRecord
     * @param group the group number, from abs(record.partitionHash % numGroups)
     */
-  def getOrAddPartitionAndIngest(recordBase: Any, recordOff: Long, group: Int, ingestOffset: Long): Unit =
+  def getOrAddPartitionAndIngest(recordBase: Any, recordOff: Long, group: Int, ingestOffset: Long): Unit = {
+    assertThreadName(IngestSchedName)
     try {
       val part: FiloPartition = getOrAddPartitionForIngestion(recordBase, recordOff, group, ingestOffset)
-      if (part == OutOfMemPartition) { disableAddPartitions() }
+      if (part == OutOfMemPartition) {
+        disableAddPartitions()
+      }
       else {
         val tsp = part.asInstanceOf[TimeSeriesPartition]
         tsp.ingest(binRecordReader, overflowBlockFactory)
@@ -1109,9 +1149,11 @@ class TimeSeriesShard(val dataset: Dataset,
       }
     } catch {
       case e: OutOfOffheapMemoryException => disableAddPartitions()
-      case e: Exception                   => logger.error(s"Unexpected ingestion err in dataset=${dataset.ref} " +
-                                             s"shard=$shardNum", e); disableAddPartitions()
+      case e: Exception => logger.error(s"Unexpected ingestion err in dataset=${dataset.ref} " +
+        s"shard=$shardNum", e);
+        disableAddPartitions()
     }
+  }
 
   private def shouldTrace(partKeyAddr: Long): Boolean = {
     tracedPartFilters.nonEmpty && {
@@ -1128,9 +1170,12 @@ class TimeSeriesShard(val dataset: Dataset,
     */
   protected def createNewPartition(partKeyBase: Array[Byte], partKeyOffset: Long,
                                    group: Int, usePartId: Int,
-                                   initMapSize: Int = initInfoMapSize): TimeSeriesPartition =
-  // Check and evict, if after eviction we still don't have enough memory, then don't proceed
-    if (addPartitionsDisabled() || !ensureFreeSpace()) { OutOfMemPartition }
+                                   initMapSize: Int = initInfoMapSize): TimeSeriesPartition = {
+    assertThreadName(IngestSchedName)
+    // Check and evict, if after eviction we still don't have enough memory, then don't proceed
+    if (addPartitionsDisabled() || !ensureFreeSpace()) {
+      OutOfMemPartition
+    }
     else {
       // PartitionKey is copied to offheap bufferMemory and stays there until it is freed
       // NOTE: allocateAndCopy and allocNew below could fail if there isn't enough memory.  It is CRUCIAL
@@ -1150,18 +1195,23 @@ class TimeSeriesShard(val dataset: Dataset,
       partitionGroups(group).set(partId)
       newPart
     }
+  }
 
   private def disableAddPartitions(): Unit = {
+    assertThreadName(IngestSchedName)
     if (addPartitionsDisabled.compareAndSet(false, true))
       logger.warn(s"dataset=${dataset.ref} shard=$shardNum: Out of buffer memory and not able to evict enough; " +
         s"adding partitions disabled")
     shardStats.dataDropped.increment
   }
 
-  private def checkEnableAddPartitions(): Unit = if (addPartitionsDisabled()) {
-    if (ensureFreeSpace()) {
-      logger.info(s"dataset=${dataset.ref} shard=$shardNum: Enough free space to add partitions again!  Yay!")
-      addPartitionsDisabled := false
+  private def checkEnableAddPartitions(): Unit = {
+    assertThreadName(IngestSchedName)
+    if (addPartitionsDisabled()) {
+      if (ensureFreeSpace()) {
+        logger.info(s"dataset=${dataset.ref} shard=$shardNum: Enough free space to add partitions again!  Yay!")
+        addPartitionsDisabled := false
+      }
     }
   }
 
@@ -1170,6 +1220,7 @@ class TimeSeriesShard(val dataset: Dataset,
    * partition ID wouldn't work with bitmaps.
    */
   private def createPartitionID(): Int = {
+    assertThreadName(IngestSchedName)
     val id = nextPartitionID
 
     // It's unlikely that partition IDs will wrap around, and it's unlikely that collisions
@@ -1196,6 +1247,7 @@ class TimeSeriesShard(val dataset: Dataset,
    */
   // scalastyle:off method.length
   private[filodb] def ensureFreeSpace(): Boolean = {
+    assertThreadName(IngestSchedName)
     var lastPruned = EmptyBitmap
     while (evictionPolicy.shouldEvict(partSet.size, bufferMemoryManager)) {
       // Eliminate partitions evicted from last cycle so we don't have an endless loop
@@ -1270,6 +1322,7 @@ class TimeSeriesShard(val dataset: Dataset,
   // Permanently removes the given partition ID from our in-memory data structures
   // Also frees partition key if necessary
   private def removePartition(partitionObj: TimeSeriesPartition): Unit = {
+    assertThreadName(IngestSchedName)
     val stamp = partSetLock.writeLock()
     try {
       partSet.remove(partitionObj)
@@ -1368,7 +1421,9 @@ class TimeSeriesShard(val dataset: Dataset,
     */
   def reset(): Unit = {
     logger.info(s"Clearing all MemStore state for dataset=${dataset.ref} shard=$shardNum")
-    partitions.values.asScala.foreach(removePartition)
+    ingestSched.executeTrampolined { () =>
+      partitions.values.asScala.foreach(removePartition)
+    }
     partKeyIndex.reset()
     // TODO unable to reset/clear bloom filter
     ingested = 0L

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -186,7 +186,7 @@ class TimeSeriesShard(val dataset: Dataset,
                       evictionPolicy: PartitionEvictionPolicy,
                       downsampleConfig: DownsampleConfig,
                       downsamplePublisher: DownsamplePublisher)
-                     (implicit val ec: ExecutionContext) extends StrictLogging {
+                     (implicit val ioPool: ExecutionContext) extends StrictLogging {
   import collection.JavaConverters._
 
   import TimeSeriesShard._

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -8,7 +8,7 @@ import monix.execution.Scheduler
 import monix.reactive.{Observable, OverflowStrategy}
 
 import filodb.core._
-import filodb.core.memstore.TimeSeriesShard
+import filodb.core.memstore.{FiloSchedulers, TimeSeriesShard}
 import filodb.core.metadata.Dataset
 import filodb.core.query._
 
@@ -135,7 +135,7 @@ trait DefaultChunkSource extends ChunkSource {
    */
   def partMaker(dataset: Dataset, shard: Int): RawToPartitionMaker
 
-  val singleThreadPool = Scheduler.singleThread("make-partition")
+  val singleThreadPool = Scheduler.singleThread(FiloSchedulers.PopulateChunksSched)
   // TODO: make this configurable
   private val strategy = OverflowStrategy.BackPressure(1000)
 

--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -25,7 +25,8 @@ import org.jboss.netty.handler.ssl.util.SelfSignedCertificate
 import org.jctools.queues.MpscGrowableArrayQueue
 import org.rogach.scallop._
 
-import filodb.coordinator.{FilodbSettings, GlobalConfig, ShardMapper, StoreFactory}
+import filodb.coordinator.{FilodbSettings, ShardMapper, StoreFactory}
+import filodb.core.GlobalConfig
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.Dataset
 import filodb.gateway.conversion._

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -11,7 +11,8 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import monix.reactive.Observable
 
-import filodb.coordinator.{GlobalConfig, ShardMapper}
+import filodb.coordinator.ShardMapper
+import filodb.core.GlobalConfig
 import filodb.core.metadata.{Column, Dataset}
 import filodb.gateway.GatewayServer
 import filodb.gateway.conversion.{InputRecord, MetricTagInputRecord, PrometheusInputRecord}

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -13,6 +13,7 @@ import monix.eval.Task
 import monix.reactive.Observable
 import org.openjdk.jmh.annotations.{Level => JMHLevel, _}
 
+import filodb.core.GlobalConfig
 import filodb.core.binaryrecord2.RecordContainer
 import filodb.core.memstore.{SomeData, TimeSeriesMemStore}
 import filodb.core.store.StoreConfig

--- a/kafka/src/main/scala/filodb/kafka/KafkaSettings.scala
+++ b/kafka/src/main/scala/filodb/kafka/KafkaSettings.scala
@@ -15,7 +15,7 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.LongDeserializer
 
-import filodb.coordinator.GlobalConfig
+import filodb.core.GlobalConfig
 
 class SourceConfig(conf: Config, shard: Int)
   extends KafkaSettings(conf, ConsumerConfig.configNames.asScala.toSet) {

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -10,6 +10,8 @@ import monix.reactive.Observable
 import scalaxy.loops._
 
 import filodb.core.binaryrecord2.RecordBuilder
+import filodb.core.memstore.FiloSchedulers
+import filodb.core.memstore.FiloSchedulers.QuerySchedName
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
 import filodb.core.query._
@@ -660,6 +662,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
     // Important TODO / TechDebt: We need to replace Iterators with cursors to better control
     // the chunk iteration, lock acquisition and release. This is much needed for safe memory access.
     try {
+      FiloSchedulers.assertThreadName(QuerySchedName)
       ChunkMap.validateNoSharedLocks(s"TopkQuery-$k-$bottomK")
       // We limit the results wherever it is materialized first. So it is done here.
       aggRangeVector.rows.take(limit).foreach { row =>

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -10,6 +10,7 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.DatasetRef
+import filodb.core.memstore.FiloSchedulers.QuerySchedName
 import filodb.core.metadata.Dataset
 import filodb.core.query.{RangeVector, ResultSchema, SerializableRangeVector}
 import filodb.core.store.ChunkSource
@@ -108,6 +109,7 @@ trait ExecPlan extends QueryCommand {
     // Lucene index lookup, and On-Demand Paging orchestration work could suck up nontrivial time and
     // we don't want these to happen in a single thread.
     Task {
+      require(Thread.currentThread().getName.startsWith(QuerySchedName))
       qLogger.debug(s"queryId: ${id} Setting up ExecPlan ${getClass.getSimpleName} with $args")
       val res = doExecute(source, dataset, queryConfig)
       val schema = schemaOfDoExecute(dataset)

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -10,6 +10,7 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.DatasetRef
+import filodb.core.memstore.FiloSchedulers
 import filodb.core.memstore.FiloSchedulers.QuerySchedName
 import filodb.core.metadata.Dataset
 import filodb.core.query.{RangeVector, ResultSchema, SerializableRangeVector}
@@ -109,7 +110,7 @@ trait ExecPlan extends QueryCommand {
     // Lucene index lookup, and On-Demand Paging orchestration work could suck up nontrivial time and
     // we don't want these to happen in a single thread.
     Task {
-      require(Thread.currentThread().getName.startsWith(QuerySchedName))
+      FiloSchedulers.assertThreadName(QuerySchedName)
       qLogger.debug(s"queryId: ${id} Setting up ExecPlan ${getClass.getSimpleName} with $args")
       val res = doExecute(source, dataset, queryConfig)
       val schema = schemaOfDoExecute(dataset)

--- a/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 
 import filodb.coordinator._
 import filodb.coordinator.client.LocalClient
-import filodb.core.Success
+import filodb.core.{GlobalConfig, Success}
 import filodb.timeseries.TestTimeseriesProducer
 
 object ClusterSingletonFailoverMultiNodeConfig extends MultiNodeConfig {

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 
 import filodb.coordinator._
 import filodb.coordinator.client.Client
-import filodb.core.Success
+import filodb.core.{GlobalConfig, Success}
 import filodb.timeseries.TestTimeseriesProducer
 
 object IngestionAndRecoveryMultiNodeConfig extends MultiNodeConfig {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently there is a lot of confusion and un-clarity and risk of bugs because what operation executed on which thread pool does not stand out so much so that it is almost impossible for a new developer to confidently change code without risking introducing new issues with concurrency.

**New behavior :**

This is an interim solution for introducing cleanliness, clarity and maintainability by clearly conveying to reader/developer which thread pool code is executed in.

Using this assertion, also fixed a bug where index recovery was being executed on akka actor thread instead of ingestion thread.

Also bringing clarity in threadpool by making implicitly passed scheduler arguments explicit.
Also renamed `ec` and `sched` threadpools to `ioPool` in many places. Former names are too ambiguous and unclear and can lead to bugs.

