### PR TITLE
bug(core): Temporarily disable chunk consumption thread assertion 

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -780,7 +780,10 @@ class TimeSeriesShard(val dataset: Dataset,
 
     val chunkSetIter = partitionIt.flatMap { p =>
 
-      assertThreadName(IngestSchedName)
+      // TODO re-enable following assertion. Am noticing that monix uses TrampolineExecutionContext
+      // causing the iterator to be consumed synchronously in some cases. It doesnt
+      // seem to be consistent environment to environment.
+      // assertThreadName(IOSchedName)
 
       /* Step 2: Make chunks to be flushed for each partition */
       val chunks = p.makeFlushChunks(blockHolder)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

monix uses TrampolineExecutionContext causing the iterator to be consumed synchronously in some cases. It doesn't seem to be consistent environment to environment.

Disable the assertion temporarily

