### PR TITLE
bug(coordinator) Stopping ingestion didn't actually run the handler.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -2,6 +2,7 @@ package filodb.core.memstore
 
 import scala.concurrent.Future
 
+import monix.eval.Task
 import monix.execution.{CancelableFuture, Scheduler}
 import monix.reactive.Observable
 import net.ceedubs.ficus.Ficus._
@@ -99,8 +100,8 @@ trait MemStore extends ChunkSource {
                    stream: Observable[SomeData],
                    flushSched: Scheduler,
                    flushStream: Observable[FlushCommand] = FlushStream.empty,
-                   diskTimeToLiveSeconds: Int = 259200): CancelableFuture[Unit]
-
+                   diskTimeToLiveSeconds: Int = 259200,
+                   cancelTask: Task[Unit] = Task {}): CancelableFuture[Unit]
 
   def recoverIndex(dataset: DatasetRef, shard: Int): Future[Unit]
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -119,13 +119,6 @@ extends MemStore with StrictLogging {
                      shardNum: Int,
                      combinedStream: Observable[DataOrCommand],
                      flushSched: Scheduler,
-                     diskTimeToLiveSeconds: Int): CancelableFuture[Unit] =
-    doIngestStream(dataset, shardNum, combinedStream, flushSched, diskTimeToLiveSeconds, Task(() => {}))
-
-  def doIngestStream(dataset: DatasetRef,
-                     shardNum: Int,
-                     combinedStream: Observable[DataOrCommand],
-                     flushSched: Scheduler,
                      diskTimeToLiveSeconds: Int,
                      cancelTask: Task[Unit]): CancelableFuture[Unit] = {
     val shard = getShardE(dataset, shardNum)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -106,7 +106,7 @@ extends MemStore with StrictLogging {
                    diskTimeToLiveSeconds: Int = 259200,
                    cancelTask: Task[Unit] = Task {}): CancelableFuture[Unit] = {
     val ingestCommands = Observable.merge(stream, flushStream)
-    doIngestStream(dataset, shard, ingestCommands, flushSched, diskTimeToLiveSeconds, cancelTask)
+    ingestStream(dataset, shard, ingestCommands, flushSched, diskTimeToLiveSeconds, cancelTask)
   }
 
   def recoverIndex(dataset: DatasetRef, shard: Int): Future[Unit] =
@@ -115,12 +115,12 @@ extends MemStore with StrictLogging {
   // NOTE: Each ingestion message is a SomeData which has a RecordContainer, which can hold hundreds or thousands
   // of records each.  For this reason the object allocation of a SomeData and RecordContainer is not that bad.
   // If it turns out the batch size is small, consider using object pooling.
-  def doIngestStream(dataset: DatasetRef,
-                     shardNum: Int,
-                     combinedStream: Observable[DataOrCommand],
-                     flushSched: Scheduler,
-                     diskTimeToLiveSeconds: Int,
-                     cancelTask: Task[Unit]): CancelableFuture[Unit] = {
+  def ingestStream(dataset: DatasetRef,
+                   shardNum: Int,
+                   combinedStream: Observable[DataOrCommand],
+                   flushSched: Scheduler,
+                   diskTimeToLiveSeconds: Int,
+                   cancelTask: Task[Unit]): CancelableFuture[Unit] = {
     val shard = getShardE(dataset, shardNum)
     combinedStream.map {
                     case d: SomeData =>       shard.ingest(d)

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -140,7 +140,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
+    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)
@@ -157,7 +157,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
+    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -141,7 +141,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400, Task {}).futureValue
+    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400, Task {}).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)
@@ -158,7 +158,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400, Task {}).futureValue
+    memStore.ingestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400, Task {}).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -1,6 +1,7 @@
 package filodb.core.store
 
 import com.typesafe.config.ConfigFactory
+import monix.eval.Task
 import monix.reactive.Observable
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
@@ -140,7 +141,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
+    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400, Task {}).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)
@@ -157,7 +158,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     memStore.setup(dataset2, 0, TestData.storeConf)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
-    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400).futureValue
+    memStore.doIngestStream(dataset2.ref, 0, stream ++ FlushStream.allGroups(4), s, 86400, Task {}).futureValue
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)
     paramSet should have length (1)

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -108,7 +108,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
                       }
                       // Just do a single flush at the end for all groups
                       val combinedStream: Observable[DataOrCommand] = shardStream ++ FlushStream.allGroups(4)
-                      Task.fromFuture(memStore.ingestStream(dataset.ref, shard, combinedStream, global, 3 * 86400))
+                      Task.fromFuture(memStore.doIngestStream(dataset.ref, shard, combinedStream, global, 3 * 86400))
                     }.countL.runAsync
   Await.result(producingFut, 30.seconds)
   Thread sleep 2000

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -108,7 +108,8 @@ class QueryOnDemandBenchmark extends StrictLogging {
                       }
                       // Just do a single flush at the end for all groups
                       val combinedStream: Observable[DataOrCommand] = shardStream ++ FlushStream.allGroups(4)
-                      Task.fromFuture(memStore.doIngestStream(dataset.ref, shard, combinedStream, global, 3 * 86400))
+                      Task.fromFuture(memStore.doIngestStream
+                        (dataset.ref, shard, combinedStream, global, 3 * 86400, Task {}))
                     }.countL.runAsync
   Await.result(producingFut, 30.seconds)
   Thread sleep 2000

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -108,7 +108,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
                       }
                       // Just do a single flush at the end for all groups
                       val combinedStream: Observable[DataOrCommand] = shardStream ++ FlushStream.allGroups(4)
-                      Task.fromFuture(memStore.doIngestStream
+                      Task.fromFuture(memStore.ingestStream
                         (dataset.ref, shard, combinedStream, global, 3 * 86400, Task {}))
                     }.countL.runAsync
   Await.result(producingFut, 30.seconds)


### PR DESCRIPTION
Stopping ingestion didn't actually run the handler. Define an explicit cancel task which is passed to the Observable, and complete the stop request via actor messages only.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
When ingestion is stopped, no handler is invoked, and no resources are cleaned up. This gives the appearance than ingestion is still active, when in fact it isn't. In some cases this leads to stuck shards.

**New behavior :**
An explicit cancel handler is used now, which actually gets invoked when the ingestion Observable is canceled. I verified that it's invoked by the test suite by deliberately breaking it, exiting the process.

Also, the remove and release of resources is invoked via an actor message, preventing any odd thread-safety or ordering issues.
