### PR TITLE
feat(query): Ability to respond to gauge related PromQL queries from downsampled data

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -65,6 +65,7 @@ object QueryCommands {
                                 parallelism: Int = 16,
                                 queryTimeoutSecs: Int = 30,
                                 sampleLimit: Int = 1000000,
+                                downsampleMode: Boolean = false,
                                 shardOverrides: Option[Seq[Int]] = None)
 
   object QueryOptions {

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -65,7 +65,6 @@ object QueryCommands {
                                 parallelism: Int = 16,
                                 queryTimeoutSecs: Int = 30,
                                 sampleLimit: Int = 1000000,
-                                downsampleMode: Boolean = false,
                                 shardOverrides: Option[Seq[Int]] = None)
 
   object QueryOptions {

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -249,8 +249,9 @@ class QueryEngine(dataset: Dataset,
 
   private def materializePeriodicSeries(queryId: String,
                                         submitTime: Long,
-                                       options: QueryOptions,
-                                       lp: PeriodicSeries, spreadProvider : SpreadProvider): PlanResult = {
+                                        options: QueryOptions,
+                                        lp: PeriodicSeries,
+                                        spreadProvider : SpreadProvider): PlanResult = {
     val rawSeries = walkLogicalPlanTree(lp.rawSeries, queryId, submitTime, options, spreadProvider)
     rawSeries.plans.foreach(_.addRangeVectorTransformer(PeriodicSamplesMapper(lp.start, lp.step, lp.end,
       None, None, Nil)))
@@ -260,7 +261,8 @@ class QueryEngine(dataset: Dataset,
   private def materializeRawSeries(queryId: String,
                                    submitTime: Long,
                                    options: QueryOptions,
-                                   lp: RawSeries, spreadProvider : SpreadProvider): PlanResult = {
+                                   lp: RawSeries,
+                                   spreadProvider: SpreadProvider): PlanResult = {
     val colIDs = getColumnIDs(dataset, lp.columns)
     val renamedFilters = renameMetricFilter(lp.filters)
     val spreadChanges = spreadProvider.spreadFunc(renamedFilters)
@@ -277,9 +279,10 @@ class QueryEngine(dataset: Dataset,
   }
 
   private def materializeLabelValues(queryId: String,
-                                      submitTime: Long,
-                                      options: QueryOptions,
-                                      lp: LabelValues, spreadProvider : SpreadProvider): PlanResult = {
+                                     submitTime: Long,
+                                     options: QueryOptions,
+                                     lp: LabelValues,
+                                     spreadProvider: SpreadProvider): PlanResult = {
     val filters = lp.labelConstraints.map { case (k, v) =>
       new ColumnFilter(k, Filter.Equals(v))
     }.toSeq
@@ -368,8 +371,7 @@ class QueryEngine(dataset: Dataset,
     * as those are automatically prepended.
     */
   private def getColumnIDs(dataset: Dataset, cols: Seq[String]): Seq[Types.ColumnId] = {
-    val realCols = if (cols.isEmpty) Seq(dataset.options.valueColumn) else cols
-    val ids = dataset.colIDs(realCols: _*)
+    val ids = dataset.colIDs(cols: _*)
       .recover(missing => throw new BadQueryException(s"Undefined columns $missing"))
       .get
     // avoid duplication if first ids are already row keys

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -159,13 +159,18 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
                           ignoreShardKeyColumnSuffixes: Map[String, Seq[String]] = Map.empty,
                           ignoreTagsOnPartitionKeyHash: Seq[String] = Nil,
                           // For each key, copy the tag to the value if the value is absent
-                          copyTags: Map[String, String] = Map.empty) {
+                          copyTags: Map[String, String] = Map.empty,
+                          minColumn: Option[String] = None,
+                          maxColumn: Option[String] = None,
+                          sumColumn: Option[String] = None,
+                          countColumn: Option[String] = None,
+                          avgColumn: Option[String] = None) {
   override def toString: String = {
     toConfig.root.render(ConfigRenderOptions.concise)
   }
 
   def toConfig: Config = {
-    val map: Map[String, Any] = Map(
+    val map: scala.collection.mutable.Map[String, Any] = scala.collection.mutable.Map(
       "shardKeyColumns" -> shardKeyColumns.asJava,
       "metricColumn" -> metricColumn,
       "valueColumn" -> valueColumn,
@@ -173,6 +178,13 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
         ignoreShardKeyColumnSuffixes.mapValues(_.asJava).asJava,
       "ignoreTagsOnPartitionKeyHash" -> ignoreTagsOnPartitionKeyHash.asJava,
       "copyTags" -> copyTags.asJava)
+
+    minColumn.foreach(map += "min-column" -> _)
+    maxColumn.foreach(map += "max-column" -> _)
+    sumColumn.foreach(map += "sum-column" -> _)
+    countColumn.foreach(map += "count-column" -> _)
+    avgColumn.foreach(map += "avg-column" -> _)
+
     ConfigFactory.parseMap(map.asJava)
   }
 
@@ -206,7 +218,12 @@ object DatasetOptions {
                    ignoreShardKeyColumnSuffixes =
                      config.as[Map[String, Seq[String]]]("ignoreShardKeyColumnSuffixes"),
                    ignoreTagsOnPartitionKeyHash = config.as[Seq[String]]("ignoreTagsOnPartitionKeyHash"),
-                   copyTags = config.as[Map[String, String]]("copyTags"))
+                   copyTags = config.as[Map[String, String]]("copyTags"),
+                   minColumn = config.as[Option[String]]("min-column"),
+                   maxColumn = config.as[Option[String]]("max-column"),
+                   sumColumn = config.as[Option[String]]("sum-column"),
+                   countColumn = config.as[Option[String]]("count-column"),
+                   avgColumn = config.as[Option[String]]("avg-column"))
 }
 
 /**

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -108,6 +108,13 @@ final case class Dataset(name: String,
             .combined.badMap(_.toSeq)
 
   /**
+    * Throws exception on invalid column name
+    */
+  def dataColId(colName: String): Int = {
+    dataColumns.find(_.name == colName).map(_.id).get
+  }
+
+  /**
    * Given a list of column names representing say CSV columns, returns a routing from each data column
    * in this dataset to the column number in that input column name list.  To be used for RoutingRowReader
    * over the input RowReader to return data columns corresponding to dataset definition.

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -166,12 +166,7 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
                           ignoreShardKeyColumnSuffixes: Map[String, Seq[String]] = Map.empty,
                           ignoreTagsOnPartitionKeyHash: Seq[String] = Nil,
                           // For each key, copy the tag to the value if the value is absent
-                          copyTags: Map[String, String] = Map.empty,
-                          minColumn: Option[String] = None,
-                          maxColumn: Option[String] = None,
-                          sumColumn: Option[String] = None,
-                          countColumn: Option[String] = None,
-                          avgColumn: Option[String] = None) {
+                          copyTags: Map[String, String] = Map.empty) {
   override def toString: String = {
     toConfig.root.render(ConfigRenderOptions.concise)
   }
@@ -186,11 +181,6 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
       "ignoreTagsOnPartitionKeyHash" -> ignoreTagsOnPartitionKeyHash.asJava,
       "copyTags" -> copyTags.asJava)
 
-    minColumn.foreach(map += "min-column" -> _)
-    maxColumn.foreach(map += "max-column" -> _)
-    sumColumn.foreach(map += "sum-column" -> _)
-    countColumn.foreach(map += "count-column" -> _)
-    avgColumn.foreach(map += "avg-column" -> _)
 
     ConfigFactory.parseMap(map.asJava)
   }
@@ -225,12 +215,7 @@ object DatasetOptions {
                    ignoreShardKeyColumnSuffixes =
                      config.as[Map[String, Seq[String]]]("ignoreShardKeyColumnSuffixes"),
                    ignoreTagsOnPartitionKeyHash = config.as[Seq[String]]("ignoreTagsOnPartitionKeyHash"),
-                   copyTags = config.as[Map[String, String]]("copyTags"),
-                   minColumn = config.as[Option[String]]("min-column"),
-                   maxColumn = config.as[Option[String]]("max-column"),
-                   sumColumn = config.as[Option[String]]("sum-column"),
-                   countColumn = config.as[Option[String]]("count-column"),
-                   avgColumn = config.as[Option[String]]("avg-column"))
+                   copyTags = config.as[Map[String, String]]("copyTags"))
 }
 
 /**

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -222,7 +222,7 @@ object Dataset {
     val dataCols = defn.as[Seq[String]]("data-columns")
     val downsamplers = defn.as[Seq[String]]("downsamplers")
     val rowKeyColumns = defn.as[Seq[String]]("row-key-columns")
-    val hasDownsampledData = config.as[Option[Boolean]]("has-downsampled-data").getOrElse(false)
+    val hasDownsampledData = defn.as[Option[Boolean]]("has-downsampled-data").getOrElse(false)
 
     Dataset.make(dataset, partitionCols, dataCols, rowKeyColumns, downsamplers,
                  hasDownsampledData, DatasetOptions.fromConfig(options)).get

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -407,6 +407,7 @@ object CustomMetricsData {
                         columns,
                         Seq("timestamp"),
                         Seq.empty,
+                        true,
                         options = DatasetOptions(Seq("metric", "_ns"), "metric", "count")).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, metricdataset.partKeySchema, 2048)
   val defaultPartKey = partKeyBuilder.addFromObjects("metric1", "app1")
@@ -418,6 +419,7 @@ object CustomMetricsData {
                         columns,
                         Seq("timestamp"),
                         Seq.empty,
+                        true,
                         options = DatasetOptions(Seq("__name__"), "__name__", "count")).get
   val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, metricdataset2.partKeySchema, 2048)
   val defaultPartKey2 = partKeyBuilder2.addFromObjects(Map(ZeroCopyUTF8String("abc") -> ZeroCopyUTF8String("cba")))

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -343,8 +343,10 @@ object MachineMetricsData {
     }
   }
 
-  val histMaxDS = Dataset("histmax", Seq("tags:map"),
-                          Seq("timestamp:ts", "count:long", "sum:long", "max:double", "h:hist:counter=false"))
+  val histMaxDS = Dataset.make("histmax", Seq("tags:map"),
+                          Seq("timestamp:ts", "count:long", "sum:long", "max:double", "h:hist:counter=false"),
+                          Seq("timestamp"),
+                          options = DatasetOptions.DefaultOptions.copy(maxColumn = Some("max"))).get
 
   // Pass in the output of linearHistSeries here.
   // Adds in the max column before h/hist

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -409,8 +409,7 @@ object CustomMetricsData {
                         columns,
                         Seq("timestamp"),
                         Seq.empty,
-                        true,
-                        options = DatasetOptions(Seq("metric", "_ns"), "metric", "count")).get
+                        options = DatasetOptions(Seq("metric", "_ns"), "metric", "count", true)).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, metricdataset.partKeySchema, 2048)
   val defaultPartKey = partKeyBuilder.addFromObjects("metric1", "app1")
 
@@ -421,8 +420,7 @@ object CustomMetricsData {
                         columns,
                         Seq("timestamp"),
                         Seq.empty,
-                        true,
-                        options = DatasetOptions(Seq("__name__"), "__name__", "count")).get
+                        options = DatasetOptions(Seq("__name__"), "__name__", "count", true)).get
   val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, metricdataset2.partKeySchema, 2048)
   val defaultPartKey2 = partKeyBuilder2.addFromObjects(Map(ZeroCopyUTF8String("abc") -> ZeroCopyUTF8String("cba")))
 
@@ -441,8 +439,7 @@ object MetricsTestData {
     Seq("timestamp:ts", "min:double", "max:double", "sum:double", "count:double", "avg:double"),
     Seq("timestamp"),
     Seq.empty,
-    true,
-    options = DatasetOptions(Seq("__name__"), "__name__", "average")
+    options = DatasetOptions(Seq("__name__"), "__name__", "average", true)
   ).get
 
   val builder = new RecordBuilder(MemFactory.onHeapFactory, timeseriesDataset.ingestionSchema)

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -346,7 +346,7 @@ object MachineMetricsData {
   val histMaxDS = Dataset.make("histmax", Seq("tags:map"),
                           Seq("timestamp:ts", "count:long", "sum:long", "max:double", "h:hist:counter=false"),
                           Seq("timestamp"),
-                          options = DatasetOptions.DefaultOptions.copy(maxColumn = Some("max"))).get
+                          options = DatasetOptions.DefaultOptions).get
 
   // Pass in the output of linearHistSeries here.
   // Adds in the max column before h/hist
@@ -441,12 +441,7 @@ object MetricsTestData {
     Seq("timestamp"),
     Seq.empty,
     true,
-    options = DatasetOptions(Seq("__name__"), "__name__", "average",
-                            maxColumn = Some("max"),
-                            minColumn = Some("min"),
-                            sumColumn = Some("sum"),
-                            countColumn = Some("count"),
-                            avgColumn = Some("avg"))
+    options = DatasetOptions(Seq("__name__"), "__name__", "average")
   ).get
 
   val builder = new RecordBuilder(MemFactory.onHeapFactory, timeseriesDataset.ingestionSchema)

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -7,17 +7,16 @@ import monix.eval.Task
 import monix.reactive.Observable
 import org.joda.time.DateTime
 
+import filodb.core.Types.{PartitionKey, UTF8Map}
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{SomeData, TimeSeriesPartitionSpec, WriteBufferPool}
-import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.{Dataset, DatasetOptions}
+import filodb.core.metadata.Column.ColumnType
 import filodb.core.query.RawDataRangeVector
 import filodb.core.store._
-import filodb.core.Types.{PartitionKey, UTF8Map}
-import filodb.memory.format._
-import filodb.memory.format.ZeroCopyUTF8String._
-import filodb.memory.format.{vectors => bv}
 import filodb.memory._
+import filodb.memory.format.{vectors => bv, _}
+import filodb.memory.format.ZeroCopyUTF8String._
 
 object TestData {
   def toChunkSetStream(ds: Dataset,
@@ -433,6 +432,14 @@ object MetricsTestData {
                                   Seq("timestamp"),
                                   Seq.empty,
                                   options = DatasetOptions(Seq("__name__", "job"), "__name__", "value")).get
+
+  val downsampleDataset = Dataset.make("tsdbdata",
+    Seq("tags:map"),
+    Seq("timestamp:ts", "min:double", "max:double", "sum:double", "count:double", "avg:double"),
+    Seq("timestamp"),
+    Seq.empty,
+    true,
+    options = DatasetOptions(Seq("__name__"), "__name__", "average")).get
 
   val builder = new RecordBuilder(MemFactory.onHeapFactory, timeseriesDataset.ingestionSchema)
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -439,7 +439,13 @@ object MetricsTestData {
     Seq("timestamp"),
     Seq.empty,
     true,
-    options = DatasetOptions(Seq("__name__"), "__name__", "average")).get
+    options = DatasetOptions(Seq("__name__"), "__name__", "average",
+                            maxColumn = Some("max"),
+                            minColumn = Some("min"),
+                            sumColumn = Some("sum"),
+                            countColumn = Some("count"),
+                            avgColumn = Some("avg"))
+  ).get
 
   val builder = new RecordBuilder(MemFactory.onHeapFactory, timeseriesDataset.ingestionSchema)
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -407,7 +407,7 @@ object CustomMetricsData {
                         columns,
                         Seq("timestamp"),
                         Seq.empty,
-                        DatasetOptions(Seq("metric", "_ns"), "metric", "count")).get
+                        options = DatasetOptions(Seq("metric", "_ns"), "metric", "count")).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, metricdataset.partKeySchema, 2048)
   val defaultPartKey = partKeyBuilder.addFromObjects("metric1", "app1")
 
@@ -418,7 +418,7 @@ object CustomMetricsData {
                         columns,
                         Seq("timestamp"),
                         Seq.empty,
-                        DatasetOptions(Seq("__name__"), "__name__", "count")).get
+                        options = DatasetOptions(Seq("__name__"), "__name__", "count")).get
   val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, metricdataset2.partKeySchema, 2048)
   val defaultPartKey2 = partKeyBuilder2.addFromObjects(Map(ZeroCopyUTF8String("abc") -> ZeroCopyUTF8String("cba")))
 
@@ -430,7 +430,7 @@ object MetricsTestData {
                                   Seq("timestamp:ts", "value:double:detectDrops=true"),
                                   Seq("timestamp"),
                                   Seq.empty,
-                                  DatasetOptions(Seq("__name__", "job"), "__name__", "value")).get
+                                  options = DatasetOptions(Seq("__name__", "job"), "__name__", "value")).get
 
   val builder = new RecordBuilder(MemFactory.onHeapFactory, timeseriesDataset.ingestionSchema)
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -51,7 +51,7 @@ object TestData {
   val sourceConf = ConfigFactory.parseString(sourceConfStr)
 
   val storeConf = StoreConfig(sourceConf.getConfig("store"))
-  val nativeMem = new NativeMemoryManager(20 * 1024 * 1024)
+  val nativeMem = new NativeMemoryManager(40 * 1024 * 1024)
 
   val optionsString = """
   options {

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -51,7 +51,7 @@ object TestData {
   val sourceConf = ConfigFactory.parseString(sourceConfStr)
 
   val storeConf = StoreConfig(sourceConf.getConfig("store"))
-  val nativeMem = new NativeMemoryManager(10 * 1024 * 1024)
+  val nativeMem = new NativeMemoryManager(20 * 1024 * 1024)
 
   val optionsString = """
   options {

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -606,7 +606,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       Seq("timestamp:ts", "value:double"),
       Seq("timestamp"),
       Seq.empty,
-      DatasetOptions(Seq("__name__", "job"), "__name__", "value", Map("dummy" -> Seq("_bucket")))).get
+      options = DatasetOptions(Seq("__name__", "job"), "__name__", "value", Map("dummy" -> Seq("_bucket")))).get
     val metricName4 = RecordBuilder.trimShardColumn(timeseriesDataset, "__name__", "heap_usage_bucket")
     metricName4 shouldEqual "heap_usage_bucket"
 

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -606,7 +606,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       Seq("timestamp:ts", "value:double"),
       Seq("timestamp"),
       Seq.empty,
-      options = DatasetOptions(Seq("__name__", "job"), "__name__", "value", Map("dummy" -> Seq("_bucket")))).get
+      options = DatasetOptions(Seq("__name__", "job"), "__name__", "value", false, Map("dummy" -> Seq("_bucket")))).get
     val metricName4 = RecordBuilder.trimShardColumn(timeseriesDataset, "__name__", "heap_usage_bucket")
     metricName4 shouldEqual "heap_usage_bucket"
 

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -22,6 +22,7 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
     Seq("timestamp:ts", "value:double"),
     Seq("timestamp"),
     Seq("tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)"),
+    true,
     DatasetOptions(Seq("__name__", "job"), "__name__", "value")).get
 
   val customDataset = Dataset.make("custom2",
@@ -29,6 +30,7 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
     Seq("timestamp:ts", "count:double", "min:double", "max:double", "total:double", "avg:double", "h:hist:counter=false"),
     Seq("timestamp"),
     Seq("tTime(0)", "dSum(1)", "dMin(2)", "dMax(3)", "dSum(4)", "dAvgAc(5@1)", "hSum(6)"),
+    true,
     DatasetOptions(Seq("name", "namespace"), "name", "total")).get
 
   private val blockStore = MMD.blockStore
@@ -70,7 +72,7 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
   it ("should formulate downsample ingest schema correctly for custom1 schema") {
     val dsSchema = downsampleOps.downsampleIngestSchema()
     dsSchema.columns.map(_.name) shouldEqual
-      Seq("tTime", "dMin", "dMax", "dSum", "dCount","dAvg", "someStr", "tags")
+      Seq("tTime", "dMin", "dMax", "dSum", "dCount", "dAvg", "someStr", "tags")
     dsSchema.columns.map(_.colType) shouldEqual
       Seq(TimestampColumn, DoubleColumn, DoubleColumn, DoubleColumn, DoubleColumn, DoubleColumn,
         StringColumn, MapColumn)

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -22,16 +22,14 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
     Seq("timestamp:ts", "value:double"),
     Seq("timestamp"),
     Seq("tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)"),
-    true,
-    DatasetOptions(Seq("__name__", "job"), "__name__", "value")).get
+    DatasetOptions(Seq("__name__", "job"), "__name__", "value", true)).get
 
   val customDataset = Dataset.make("custom2",
     Seq("name:string", "namespace:string", "instance:string"),
     Seq("timestamp:ts", "count:double", "min:double", "max:double", "total:double", "avg:double", "h:hist:counter=false"),
     Seq("timestamp"),
     Seq("tTime(0)", "dSum(1)", "dMin(2)", "dMax(3)", "dSum(4)", "dAvgAc(5@1)", "hSum(6)"),
-    true,
-    DatasetOptions(Seq("name", "namespace"), "name", "total")).get
+    DatasetOptions(Seq("name", "namespace"), "name", "total", true)).get
 
   private val blockStore = MMD.blockStore
   protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, promDataset.blockMetaSize, true)

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -274,6 +274,7 @@ object FiloBuild extends Build {
 
   lazy val gatewayDeps = commonDeps ++ Seq(
     scalaxyDep,
+    logbackDep,
     "io.monix" %% "monix-kafka-1x" % monixKafkaVersion,
     "org.rogach" %% "scallop" % "3.1.1"
   )

--- a/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/FormatConversion.scala
@@ -11,7 +11,7 @@ object FormatConversion {
   // An official Prometheus-format Dataset object with a single timestamp and value
   val dataset = Dataset("prometheus", Seq("tags:map"), Seq("timestamp:ts", "value:double"))
                   .copy(options = DatasetOptions(Seq("__name__", "_ns"),
-                    "__name__", "value", Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
+                    "__name__", "value", false, Map("__name__" -> Seq("_bucket", "_count", "_sum")), Seq("le"),
                     Map("exporter" -> "_ns", "job" -> "_ns")))
 
   /**

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -38,7 +38,6 @@ case class RawSeries(rangeSelector: RangeSelector,
                      filters: Seq[ColumnFilter],
                      columns: Seq[String]) extends RawSeriesPlan
 
-
 case class LabelValues(labelNames: Seq[String],
                        labelConstraints: Map[String, String],
                        lookbackTimeInMillis: Long) extends MetadataQueryPlan

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -61,7 +61,8 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
   protected[exec] def args: String =
     s"aggrOp=$aggrOp, aggrParams=$aggrParams, without=$without, by=$by"
 
-  def apply(source: Observable[RangeVector],
+  def apply(dataset: Dataset,
+            source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {
@@ -99,7 +100,8 @@ final case class AggregatePresenter(aggrOp: AggregationOperator,
 
   protected[exec] def args: String = s"aggrOp=$aggrOp, aggrParams=$aggrParams"
 
-  def apply(source: Observable[RangeVector],
+  def apply(dataset: Dataset,
+            source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -124,7 +124,6 @@ trait ExecPlan extends QueryCommand {
       finalRes._1
         .map {
           case srv: SerializableRangeVector =>
-            qLogger.debug(s"queryId: ${id} SRVs already materialized from iterators")
             numResultSamples += srv.numRows
             // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
             if (enforceLimit && numResultSamples > limit)
@@ -133,7 +132,6 @@ trait ExecPlan extends QueryCommand {
             srv
           case rv: RangeVector =>
             // materialize, and limit rows per RV
-            qLogger.debug(s"queryId: ${id} Materializing SRVs from iterators")
             val srv = SerializableRangeVector(rv, builder, recSchema, printTree(false))
             numResultSamples += srv.numRows
             // fail the query instead of limiting range vectors and returning incomplete/inaccurate results

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -4,6 +4,7 @@ import monix.reactive.Observable
 import org.agrona.MutableDirectBuffer
 import scalaxy.loops._
 
+import filodb.core.metadata.Dataset
 import filodb.core.query._
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String}
 import filodb.memory.format.vectors.Histogram
@@ -45,7 +46,7 @@ case class HistogramQuantileMapper(funcParams: Seq[Any]) extends RangeVectorTran
     * but should be the rate of increase for that bucket counter. The histogram_quantile function should always
     * be preceded by a rate function or a sum-of-rate function.
     */
-  override def apply(source: Observable[RangeVector],
+  override def apply(dataset: Dataset, source: Observable[RangeVector],
                      queryConfig: QueryConfig, limit: Int,
                      sourceSchema: ResultSchema): Observable[RangeVector] = {
     val res = source.toListL.map { rvs =>

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -9,10 +9,38 @@ import filodb.core.metadata.Dataset
 import filodb.core.query._
 import filodb.core.store.{ChunkSetInfo, WindowedChunkIterator}
 import filodb.memory.format.{vectors => bv, _}
-import filodb.query.{BadQueryException, Query, QueryConfig, RangeFunctionId}
-import filodb.query.exec.rangefn.{ChunkedRangeFunction, RangeFunction, Window}
+import filodb.query._
 import filodb.query.Query.qLogger
+import filodb.query.RangeFunctionId._
+import filodb.query.exec.rangefn._
 import filodb.query.util.IndexedArrayQueue
+
+
+final case object PeriodicSamplesMapper {
+  def downsampleColFromRangeFunction(f: Option[RangeFunctionId]): String = {
+    f match {
+      case None                   => "avg"
+      case Some(Rate)             => "counter"
+      case Some(Delta)            => "counter"
+      case Some(Irate)            => "counter"
+      case Some(Increase)         => "counter"
+      case Some(Resets)           => "counter"
+      case Some(CountOverTime)    => "count"
+      case Some(Delta)            => "avg"
+      case Some(Idelta)           => "avg"
+      case Some(Deriv)            => "avg"
+      case Some(HoltWinters)      => "avg"
+      case Some(PredictLinear)    => "avg"
+      case Some(SumOverTime)      => "sum"
+      case Some(AvgOverTime)      => "avg"
+      case Some(StdDevOverTime)   => "avg"
+      case Some(StdVarOverTime)   => "avg"
+      case Some(QuantileOverTime) => "avg"
+      case Some(MinOverTime)      => "min"
+      case Some(MaxOverTime)      => "max"
+    }
+  }
+}
 
 /**
   * Transforms raw reported samples to samples with

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -11,7 +11,6 @@ import filodb.core.store.{ChunkSetInfo, WindowedChunkIterator}
 import filodb.memory.format.{vectors => bv, _}
 import filodb.query._
 import filodb.query.Query.qLogger
-import filodb.query.RangeFunctionId._
 import filodb.query.exec.rangefn._
 import filodb.query.util.IndexedArrayQueue
 

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -48,7 +48,7 @@ final case class PeriodicSamplesMapper(start: Long,
     val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
     val maxCol = if (valColType == ColumnType.HistogramColumn && sourceSchema.colIDs.length > 2)
                    sourceSchema.columns.zip(sourceSchema.colIDs).find(_._1.name == "max").map(_._2) else None
-    val rangeFuncGen = RangeFunction.generatorFor(dataset, functionId, valColType, queryConfig, funcParams)
+    val rangeFuncGen = RangeFunction.generatorFor(dataset, functionId, valColType, queryConfig, funcParams, maxCol)
 
     // Generate one range function to check if it is chunked
     val sampleRangeFunc = rangeFuncGen()

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -59,7 +59,7 @@ final case class PeriodicSamplesMapper(start: Long,
     sampleRangeFunc match {
       case c: ChunkedRangeFunction[_] if valColType == ColumnType.HistogramColumn =>
         source.map { rv =>
-          val maxCol = dataset.options.maxColumn.map(dataset.colIDs(_).get.head)
+          val maxCol = dataset.options.maxColumn.map(dataset.dataColId(_))
           val histRow = if (maxCol.isDefined) new TransientHistMaxRow() else new TransientHistRow()
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorH(rv.asInstanceOf[RawDataRangeVector], start, step, end,

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -15,33 +15,6 @@ import filodb.query.RangeFunctionId._
 import filodb.query.exec.rangefn._
 import filodb.query.util.IndexedArrayQueue
 
-
-final case object PeriodicSamplesMapper {
-  def downsampleColsFromRangeFunction(f: Option[RangeFunctionId]): Seq[String] = {
-    f match {
-      case None                   => Seq("sum", "count") // to calculate last average
-      case Some(Rate)             => Seq("value")
-      case Some(Irate)            => Seq("value")
-      case Some(Increase)         => Seq("value")
-      case Some(Resets)           => Seq("value")
-      case Some(CountOverTime)    => Seq("count")
-      case Some(Changes)          => Seq("avg")
-      case Some(Delta)            => Seq("avg")
-      case Some(Idelta)           => Seq("avg")
-      case Some(Deriv)            => Seq("avg")
-      case Some(HoltWinters)      => Seq("avg")
-      case Some(PredictLinear)    => Seq("avg")
-      case Some(SumOverTime)      => Seq("sum")
-      case Some(AvgOverTime)      => Seq("sum", "count")
-      case Some(StdDevOverTime)   => Seq("avg")
-      case Some(StdVarOverTime)   => Seq("avg")
-      case Some(QuantileOverTime) => Seq("avg")
-      case Some(MinOverTime)      => Seq("min")
-      case Some(MaxOverTime)      => Seq("max")
-    }
-  }
-}
-
 /**
   * Transforms raw reported samples to samples with
   * regular interval from start to end, with step as

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -20,12 +20,12 @@ final case object PeriodicSamplesMapper {
   def downsampleColFromRangeFunction(f: Option[RangeFunctionId]): String = {
     f match {
       case None                   => "avg"
-      case Some(Rate)             => "counter"
-      case Some(Delta)            => "counter"
-      case Some(Irate)            => "counter"
-      case Some(Increase)         => "counter"
-      case Some(Resets)           => "counter"
+      case Some(Rate)             => "value"
+      case Some(Irate)            => "value"
+      case Some(Increase)         => "value"
+      case Some(Resets)           => "value"
       case Some(CountOverTime)    => "count"
+      case Some(Changes)          => "avg"
       case Some(Delta)            => "avg"
       case Some(Idelta)           => "avg"
       case Some(Deriv)            => "avg"

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -56,10 +56,10 @@ final case class PeriodicSamplesMapper(start: Long,
     // so that it returns value present at time - staleSampleAfterMs
     val windowLength = window.getOrElse(if (functionId.isEmpty) queryConfig.staleSampleAfterMs + 1 else 0L)
 
+    val maxCol = dataset.dataColumns.find(_.name == "max").map(_.id)
     sampleRangeFunc match {
       case c: ChunkedRangeFunction[_] if valColType == ColumnType.HistogramColumn =>
         source.map { rv =>
-          val maxCol = dataset.options.maxColumn.map(dataset.dataColId(_))
           val histRow = if (maxCol.isDefined) new TransientHistMaxRow() else new TransientHistRow()
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorH(rv.asInstanceOf[RawDataRangeVector], start, step, end,

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -26,7 +26,8 @@ import filodb.query.exec.rangefn._
   * compute intensive and not I/O intensive.
   */
 trait RangeVectorTransformer extends java.io.Serializable {
-  def apply(source: Observable[RangeVector],
+  def apply(dataset: Dataset,
+            source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector]
@@ -60,7 +61,8 @@ final case class InstantVectorFunctionMapper(function: InstantFunctionId,
   protected[exec] def args: String =
     s"function=$function, funcParams=$funcParams"
 
-  def apply(source: Observable[RangeVector],
+  def apply(dataset: Dataset,
+            source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {
@@ -82,7 +84,7 @@ final case class InstantVectorFunctionMapper(function: InstantFunctionId,
         if (function == HistogramQuantile) {
           // Special mapper to pull all buckets together from different Prom-schema time series
           val mapper = HistogramQuantileMapper(funcParams)
-          mapper.apply(source, queryConfig, limit, sourceSchema)
+          mapper.apply(dataset, source, queryConfig, limit, sourceSchema)
         } else {
           val instantFunction = InstantFunction.double(function, funcParams)
           source.map { rv =>
@@ -158,7 +160,8 @@ final case class ScalarOperationMapper(operator: BinaryOperator,
 
   val operatorFunction = BinaryOperatorFunction.factoryMethod(operator)
 
-  def apply(source: Observable[RangeVector],
+  def apply(dataset: Dataset,
+            source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {
@@ -200,7 +203,8 @@ final case class MiscellaneousFunctionMapper(function: MiscellaneousFunctionId,
     }
   }
 
-  def apply(source: Observable[RangeVector],
+  def apply(dataset: Dataset,
+            source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -10,6 +10,7 @@ import filodb.core.metadata.{Column, Dataset}
 import filodb.core.query.{ColumnFilter, RangeVector, ResultSchema}
 import filodb.core.store._
 import filodb.query.{Query, QueryConfig}
+import filodb.query.exec.rangefn.RangeFunction
 
 object SelectRawPartitionsExec {
   import Column.ColumnType._
@@ -64,7 +65,7 @@ final case class SelectRawPartitionsExec(id: String,
       } else {
         // need to select column based on range function
         val colNames = rangeVectorTransformers.find(_.isInstanceOf[PeriodicSamplesMapper]).map { p =>
-          PeriodicSamplesMapper.downsampleColsFromRangeFunction(p.asInstanceOf[PeriodicSamplesMapper].functionId)
+          RangeFunction.downsampleColsFromRangeFunction(p.asInstanceOf[PeriodicSamplesMapper].functionId)
         }.getOrElse(Seq("avg"))
         colIds ++ dataset.colIDs(colNames: _*).get
       }

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -19,7 +19,7 @@ object SelectRawPartitionsExec {
   def histMaxColumn(dataset: Dataset, colIDs: Seq[Types.ColumnId]): Option[Int] = {
     colIDs.find { id => dataset.dataColumns(id).columnType == HistogramColumn }
           .flatMap { histColID =>
-            dataset.options.maxColumn.map(dataset.dataColId(_))
+            dataset.dataColumns.find(_.name == "max").map(_.id)
           }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -89,7 +89,8 @@ final case class StitchRvsExec(id: String,
   */
 final case class StitchRvsMapper() extends RangeVectorTransformer {
 
-  def apply(source: Observable[RangeVector],
+  def apply(dataset: Dataset,
+            source: Observable[RangeVector],
             queryConfig: QueryConfig,
             limit: Int,
             sourceSchema: ResultSchema): Observable[RangeVector] = {

--- a/query/src/main/scala/filodb/query/exec/TransientRow.scala
+++ b/query/src/main/scala/filodb/query/exec/TransientRow.scala
@@ -43,7 +43,8 @@ final class TransientRow(var timestamp: Long, var value: Double) extends Mutable
   def getBoolean(columnNo: Int): Boolean = throw new IllegalArgumentException()
   def getInt(columnNo: Int): Int = throw new IllegalArgumentException()
   def getLong(columnNo: Int): Long = if (columnNo == 0) timestamp else throw new IllegalArgumentException()
-  def getDouble(columnNo: Int): Double = if (columnNo == 1) value else throw new IllegalArgumentException()
+  def getDouble(columnNo: Int): Double = if (columnNo == 1) value
+                                         else throw new IllegalArgumentException(s"Invalid col $columnNo")
   def getFloat(columnNo: Int): Float = throw new IllegalArgumentException()
   def getString(columnNo: Int): String = throw new IllegalArgumentException()
   def getAny(columnNo: Int): Any = throw new IllegalArgumentException()

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -223,7 +223,8 @@ class SumAndMaxOverTimeFuncHD(maxColID: Int) extends ChunkedRangeFunction[Transi
 }
 
 /**
-  * Sums Histograms over time and also computes Max over time of a Max field.
+  * Computes Average Over Time using sum and count columns.
+  * Used in when calculating avg_over_time using downsampled data
   */
 class AvgWithSumAndCountOverTimeFuncD(countColId: Int) extends ChunkedRangeFunction[TransientRow] {
   private val sumFunc = new SumOverTimeChunkedFunctionD
@@ -259,7 +260,8 @@ class AvgWithSumAndCountOverTimeFuncD(countColId: Int) extends ChunkedRangeFunct
 }
 
 /**
-  * Sums Histograms over time and also computes Max over time of a Max field.
+  * Computes Average Over Time using sum and count columns.
+  * Used in when calculating avg_over_time using downsampled data
   */
 class AvgWithSumAndCountOverTimeFuncL(countColId: Int) extends ChunkedRangeFunction[TransientRow] {
   private val sumFunc = new SumOverTimeChunkedFunctionL

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -225,10 +225,9 @@ class SumAndMaxOverTimeFuncHD(maxColID: Int) extends ChunkedRangeFunction[Transi
 /**
   * Sums Histograms over time and also computes Max over time of a Max field.
   */
-class AvgWithSumAndCountOverTimeFuncD extends ChunkedRangeFunction[TransientRow] {
+class AvgWithSumAndCountOverTimeFuncD(countColId: Int) extends ChunkedRangeFunction[TransientRow] {
   private val sumFunc = new SumOverTimeChunkedFunctionD
   private val countFunc = new SumOverTimeChunkedFunctionD
-  private val countColId: Int = 4 // FIXME hard coded for now
 
   override final def reset(): Unit = {
     sumFunc.reset()
@@ -262,10 +261,9 @@ class AvgWithSumAndCountOverTimeFuncD extends ChunkedRangeFunction[TransientRow]
 /**
   * Sums Histograms over time and also computes Max over time of a Max field.
   */
-class AvgWithSumAndCountOverTimeFuncL extends ChunkedRangeFunction[TransientRow] {
+class AvgWithSumAndCountOverTimeFuncL(countColId: Int) extends ChunkedRangeFunction[TransientRow] {
   private val sumFunc = new SumOverTimeChunkedFunctionL
   private val countFunc = new CountOverTimeChunkedFunction
-  private val countColId: Int = 4 // FIXME hard coded for now
 
   override final def reset(): Unit = {
     sumFunc.reset()

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -228,7 +228,7 @@ class SumAndMaxOverTimeFuncHD(maxColID: Int) extends ChunkedRangeFunction[Transi
 class AvgWithSumAndCountOverTimeFuncD extends ChunkedRangeFunction[TransientRow] {
   private val sumFunc = new SumOverTimeChunkedFunctionD
   private val countFunc = new SumOverTimeChunkedFunctionD
-  private val countColId: Int = 1 // FIXME hard coded for now
+  private val countColId: Int = 4 // FIXME hard coded for now
 
   override final def reset(): Unit = {
     sumFunc.reset()
@@ -265,7 +265,7 @@ class AvgWithSumAndCountOverTimeFuncD extends ChunkedRangeFunction[TransientRow]
 class AvgWithSumAndCountOverTimeFuncL extends ChunkedRangeFunction[TransientRow] {
   private val sumFunc = new SumOverTimeChunkedFunctionL
   private val countFunc = new CountOverTimeChunkedFunction
-  private val countColId: Int = 1 // FIXME hard coded for now
+  private val countColId: Int = 4 // FIXME hard coded for now
 
   override final def reset(): Unit = {
     sumFunc.reset()

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -229,25 +229,25 @@ object RangeFunction {
 
   def downsampleColsFromRangeFunction(dataset: Dataset, f: Option[RangeFunctionId]): Seq[String] = {
     f match {
-      case None                   => Seq(dataset.options.avgColumn.get)
+      case None                   => Seq("avg")
       case Some(Rate)             => Seq(dataset.options.valueColumn)
       case Some(Irate)            => Seq(dataset.options.valueColumn)
       case Some(Increase)         => Seq(dataset.options.valueColumn)
       case Some(Resets)           => Seq(dataset.options.valueColumn)
-      case Some(CountOverTime)    => Seq(dataset.options.countColumn.get)
-      case Some(Changes)          => Seq(dataset.options.avgColumn.get)
-      case Some(Delta)            => Seq(dataset.options.avgColumn.get)
-      case Some(Idelta)           => Seq(dataset.options.avgColumn.get)
-      case Some(Deriv)            => Seq(dataset.options.avgColumn.get)
-      case Some(HoltWinters)      => Seq(dataset.options.avgColumn.get)
-      case Some(PredictLinear)    => Seq(dataset.options.avgColumn.get)
-      case Some(SumOverTime)      => Seq(dataset.options.sumColumn.get)
-      case Some(AvgOverTime)      => Seq(dataset.options.sumColumn.get, dataset.options.countColumn.get)
-      case Some(StdDevOverTime)   => Seq(dataset.options.avgColumn.get)
-      case Some(StdVarOverTime)   => Seq(dataset.options.avgColumn.get)
-      case Some(QuantileOverTime) => Seq(dataset.options.avgColumn.get)
-      case Some(MinOverTime)      => Seq(dataset.options.minColumn.get)
-      case Some(MaxOverTime)      => Seq(dataset.options.maxColumn.get)
+      case Some(CountOverTime)    => Seq("count")
+      case Some(Changes)          => Seq("avg")
+      case Some(Delta)            => Seq("avg")
+      case Some(Idelta)           => Seq("avg")
+      case Some(Deriv)            => Seq("avg")
+      case Some(HoltWinters)      => Seq("avg")
+      case Some(PredictLinear)    => Seq("avg")
+      case Some(SumOverTime)      => Seq("sum")
+      case Some(AvgOverTime)      => Seq("sum", "count")
+      case Some(StdDevOverTime)   => Seq("avg")
+      case Some(StdVarOverTime)   => Seq("avg")
+      case Some(QuantileOverTime) => Seq("avg")
+      case Some(MinOverTime)      => Seq("min")
+      case Some(MaxOverTime)      => Seq("max")
     }
   }
   /**
@@ -295,7 +295,7 @@ object RangeFunction {
                                          else new CountOverTimeChunkedFunction()
       case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionL
       case Some(AvgOverTime)    => () => if (dataset.hasDownsampledData) {
-                                           val cntCol = dataset.options.countColumn.map(dataset.dataColId(_)).get
+                                           val cntCol = dataset.dataColId("count")
                                            new AvgWithSumAndCountOverTimeFuncL(cntCol)
                                          }
                                          else new AvgOverTimeChunkedFunctionL
@@ -323,7 +323,7 @@ object RangeFunction {
                                          else new CountOverTimeChunkedFunctionD()
       case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionD
       case Some(AvgOverTime)    => () => if (dataset.hasDownsampledData) {
-                                            val cntCol = dataset.options.countColumn.map(dataset.dataColId(_)).get
+                                            val cntCol = dataset.dataColId("count")
                                             new AvgWithSumAndCountOverTimeFuncD(cntCol)
                                          }
                                          else new AvgOverTimeChunkedFunctionD
@@ -338,7 +338,7 @@ object RangeFunction {
   def histChunkedFunction(dataset: Dataset,
                           func: Option[RangeFunctionId],
                           funcParams: Seq[Any] = Nil): RangeFunctionGenerator = {
-    val maxCol = dataset.options.maxColumn.map(dataset.dataColId(_))
+    val maxCol = dataset.dataColumns.find(_.name == "max").map(_.id)
     func match {
       case None if maxCol.isDefined => () => new LastSampleChunkedFunctionHMax(maxCol.get)
       case None                 => () => new LastSampleChunkedFunctionH

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -1,6 +1,7 @@
 package filodb.query.exec.rangefn
 
 import filodb.core.metadata.Column.ColumnType
+import filodb.core.metadata.Dataset
 import filodb.core.store.ChunkSetInfo
 import filodb.memory.format.{vectors => bv, _}
 import filodb.memory.format.BinaryVector.BinaryVectorPtr
@@ -252,85 +253,99 @@ object RangeFunction {
   /**
    * Returns a (probably new) instance of RangeFunction given the func ID and column type
    */
-  def apply(func: Option[RangeFunctionId],
+  def apply(dataset: Dataset,
+            func: Option[RangeFunctionId],
             columnType: ColumnType,
             config: QueryConfig,
             funcParams: Seq[Any] = Nil,
             useDownsampledColumns: Boolean = false,
             maxCol: Option[Int] = None,
             useChunked: Boolean): BaseRangeFunction =
-    generatorFor(func, columnType, config, useDownsampledColumns, funcParams, maxCol, useChunked)()
+    generatorFor(dataset, func, columnType, config, funcParams, useChunked)()
 
   /**
    * Given a function type and column type, returns a RangeFunctionGenerator
    */
-  def generatorFor(func: Option[RangeFunctionId],
+  def generatorFor(dataset: Dataset,
+                   func: Option[RangeFunctionId],
                    columnType: ColumnType,
                    config: QueryConfig,
-                   useDownsampledColumns: Boolean,
                    funcParams: Seq[Any] = Nil,
-                   maxCol: Option[Int] = None,
-                   useChunked: Boolean = true): RangeFunctionGenerator =
+                   useChunked: Boolean = true): RangeFunctionGenerator = {
     if (useChunked) columnType match {
-      case ColumnType.DoubleColumn => doubleChunkedFunction(func, useDownsampledColumns, config, funcParams)
-      case ColumnType.LongColumn   => longChunkedFunction(func, useDownsampledColumns, funcParams)
-      case ColumnType.TimestampColumn => longChunkedFunction(func, useDownsampledColumns, funcParams)
-      case ColumnType.HistogramColumn => histChunkedFunction(func, funcParams, maxCol)
-      case other: ColumnType       => throw new IllegalArgumentException(s"Column type $other not supported")
+      case ColumnType.DoubleColumn => doubleChunkedFunction(dataset, func, config, funcParams)
+      case ColumnType.LongColumn => longChunkedFunction(dataset, func, funcParams)
+      case ColumnType.TimestampColumn => longChunkedFunction(dataset, func, funcParams)
+      case ColumnType.HistogramColumn => histChunkedFunction(dataset, func, funcParams)
+      case other: ColumnType => throw new IllegalArgumentException(s"Column type $other not supported")
     } else {
       iteratingFunction(func, funcParams)
     }
+  }
 
   /**
    * Returns a function to generate a ChunkedRangeFunction for Long columns
    */
-  def longChunkedFunction(func: Option[RangeFunctionId],
-                          useDownsampledColumns: Boolean,
-                          funcParams: Seq[Any] = Nil): RangeFunctionGenerator = func match {
-    case None                 => () => new LastSampleChunkedFunctionL
-    case Some(CountOverTime)  => () => if (useDownsampledColumns) new SumOverTimeChunkedFunctionL
-                                       else new CountOverTimeChunkedFunction()
-    case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionL
-    case Some(AvgOverTime)    => () => if (useDownsampledColumns) new AvgWithSumAndCountOverTimeFuncL
-                                       else new AvgOverTimeChunkedFunctionL
-    case Some(MinOverTime)    => () => new MinOverTimeChunkedFunctionL
-    case Some(MaxOverTime)    => () => new MaxOverTimeChunkedFunctionL
-    case Some(StdDevOverTime) => () => new StdDevOverTimeChunkedFunctionL
-    case Some(StdVarOverTime) => () => new StdVarOverTimeChunkedFunctionL
-    case _                    => iteratingFunction(func, funcParams)
+  def longChunkedFunction(dataset: Dataset,
+                          func: Option[RangeFunctionId],
+                          funcParams: Seq[Any] = Nil): RangeFunctionGenerator = {
+    func match {
+      case None                 => () => new LastSampleChunkedFunctionL
+      case Some(CountOverTime)  => () => if (dataset.hasDownsampledData) new SumOverTimeChunkedFunctionL
+                                         else new CountOverTimeChunkedFunction()
+      case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionL
+      case Some(AvgOverTime)    => () => if (dataset.hasDownsampledData) {
+                                           val cntCol = dataset.options.countColumn.map(dataset.colIDs(_).get.head).get
+                                           new AvgWithSumAndCountOverTimeFuncL(cntCol)
+                                         }
+                                         else new AvgOverTimeChunkedFunctionL
+      case Some(MinOverTime)    => () => new MinOverTimeChunkedFunctionL
+      case Some(MaxOverTime)    => () => new MaxOverTimeChunkedFunctionL
+      case Some(StdDevOverTime) => () => new StdDevOverTimeChunkedFunctionL
+      case Some(StdVarOverTime) => () => new StdVarOverTimeChunkedFunctionL
+      case _                    => iteratingFunction(func, funcParams)
+    }
   }
 
   /**
    * Returns a function to generate a ChunkedRangeFunction for Double columns
    */
-  def doubleChunkedFunction(func: Option[RangeFunctionId],
-                            useDownsampledColumns: Boolean,
+  def doubleChunkedFunction(dataset: Dataset,
+                            func: Option[RangeFunctionId],
                             config: QueryConfig,
-                            funcParams: Seq[Any] = Nil): RangeFunctionGenerator = func match {
-    case None                 => () => new LastSampleChunkedFunctionD
-    case Some(Rate)     if config.has("faster-rate") => () => new ChunkedRateFunction
-    case Some(Increase) if config.has("faster-rate") => () => new ChunkedIncreaseFunction
-    case Some(Delta)    if config.has("faster-rate") => () => new ChunkedDeltaFunction
-    case Some(CountOverTime)  => () => if (useDownsampledColumns) new SumOverTimeChunkedFunctionD
-                                       else new CountOverTimeChunkedFunctionD()
-    case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionD
-    case Some(AvgOverTime)    => () => if (useDownsampledColumns) new AvgWithSumAndCountOverTimeFuncD
-                                       else new AvgOverTimeChunkedFunctionD
-    case Some(MinOverTime)    => () => new MinOverTimeChunkedFunctionD
-    case Some(MaxOverTime)    => () => new MaxOverTimeChunkedFunctionD
-    case Some(StdDevOverTime) => () => new StdDevOverTimeChunkedFunctionD
-    case Some(StdVarOverTime) => () => new StdVarOverTimeChunkedFunctionD
-    case _                    => iteratingFunction(func, funcParams)
+                            funcParams: Seq[Any] = Nil): RangeFunctionGenerator = {
+    func match {
+      case None                 => () => new LastSampleChunkedFunctionD
+      case Some(Rate)     if config.has("faster-rate") => () => new ChunkedRateFunction
+      case Some(Increase) if config.has("faster-rate") => () => new ChunkedIncreaseFunction
+      case Some(Delta)    if config.has("faster-rate") => () => new ChunkedDeltaFunction
+      case Some(CountOverTime)  => () => if (dataset.hasDownsampledData) new SumOverTimeChunkedFunctionD
+                                         else new CountOverTimeChunkedFunctionD()
+      case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionD
+      case Some(AvgOverTime)    => () => if (dataset.hasDownsampledData) {
+                                            val cntCol = dataset.options.countColumn.map(dataset.colIDs(_).get.head).get
+                                            new AvgWithSumAndCountOverTimeFuncD(cntCol)
+                                         }
+                                         else new AvgOverTimeChunkedFunctionD
+      case Some(MinOverTime)    => () => new MinOverTimeChunkedFunctionD
+      case Some(MaxOverTime)    => () => new MaxOverTimeChunkedFunctionD
+      case Some(StdDevOverTime) => () => new StdDevOverTimeChunkedFunctionD
+      case Some(StdVarOverTime) => () => new StdVarOverTimeChunkedFunctionD
+      case _                    => iteratingFunction(func, funcParams)
+    }
   }
 
-  def histChunkedFunction(func: Option[RangeFunctionId],
-                          funcParams: Seq[Any] = Nil,
-                          maxCol: Option[Int] = None): RangeFunctionGenerator = func match {
-    case None if maxCol.isDefined => () => new LastSampleChunkedFunctionHMax(maxCol.get)
-    case None                 => () => new LastSampleChunkedFunctionH
-    case Some(SumOverTime) if maxCol.isDefined => () => new SumAndMaxOverTimeFuncHD(maxCol.get)
-    case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionH
-    case _                    => ???
+  def histChunkedFunction(dataset: Dataset,
+                          func: Option[RangeFunctionId],
+                          funcParams: Seq[Any] = Nil): RangeFunctionGenerator = {
+    val maxCol = dataset.options.maxColumn.map(dataset.colIDs(_).get.head)
+    func match {
+      case None if maxCol.isDefined => () => new LastSampleChunkedFunctionHMax(maxCol.get)
+      case None                 => () => new LastSampleChunkedFunctionH
+      case Some(SumOverTime) if maxCol.isDefined => () => new SumAndMaxOverTimeFuncHD(maxCol.get)
+      case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionH
+      case _                    => ???
+    }
   }
 
   /**

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -225,6 +225,30 @@ trait ChunkedLongRangeFunction extends TimeRangeFunction[TransientRow] {
 object RangeFunction {
   type RangeFunctionGenerator = () => BaseRangeFunction
 
+
+  def downsampleColsFromRangeFunction(f: Option[RangeFunctionId]): Seq[String] = {
+    f match {
+      case None                   => Seq("sum", "count") // to calculate last average
+      case Some(Rate)             => Seq("value")
+      case Some(Irate)            => Seq("value")
+      case Some(Increase)         => Seq("value")
+      case Some(Resets)           => Seq("value")
+      case Some(CountOverTime)    => Seq("count")
+      case Some(Changes)          => Seq("avg")
+      case Some(Delta)            => Seq("avg")
+      case Some(Idelta)           => Seq("avg")
+      case Some(Deriv)            => Seq("avg")
+      case Some(HoltWinters)      => Seq("avg")
+      case Some(PredictLinear)    => Seq("avg")
+      case Some(SumOverTime)      => Seq("sum")
+      case Some(AvgOverTime)      => Seq("sum", "count")
+      case Some(StdDevOverTime)   => Seq("avg")
+      case Some(StdVarOverTime)   => Seq("avg")
+      case Some(QuantileOverTime) => Seq("avg")
+      case Some(MinOverTime)      => Seq("min")
+      case Some(MaxOverTime)      => Seq("max")
+    }
+  }
   /**
    * Returns a (probably new) instance of RangeFunction given the func ID and column type
    */

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -11,6 +11,7 @@ import monix.reactive.Observable
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 
+import filodb.core.MetricsTestData
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String}
@@ -183,7 +184,8 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
 
     val agg = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
     val aggMR = AggregateMapReduce(AggregationOperator.Sum, Nil, Nil, Seq("instance", "job"))
-    val mapped = aggMR(Observable.fromIterable(sampleNodeCpu), queryConfig, 1000, tvSchema)
+    val mapped = aggMR(MetricsTestData.timeseriesDataset, Observable.fromIterable(sampleNodeCpu),
+                      queryConfig, 1000, tvSchema)
 
     val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key)
     val samplesRhs = resultObs4.toListL.runAsync.futureValue
@@ -262,7 +264,8 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
 
     val agg = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
     val aggMR = AggregateMapReduce(AggregationOperator.Sum, Nil, Nil, Seq("instance", "job"))
-    val mapped = aggMR(Observable.fromIterable(sampleNodeCpu), queryConfig, 1000, tvSchema)
+    val mapped = aggMR(MetricsTestData.timeseriesDataset, Observable.fromIterable(sampleNodeCpu),
+                 queryConfig, 1000, tvSchema)
 
     val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key)
     val samplesRhs = resultObs4.toListL.runAsync.futureValue

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -217,7 +217,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LAND,
       Nil, Nil)
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -254,7 +255,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LAND,
       Seq("instance", "job"), Nil)
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -291,7 +293,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LAND,
       Seq("instance"), Nil)
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -327,7 +330,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LAND,
       Nil, Seq("group"))
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -362,7 +366,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LAND,
       Nil, Seq("group", "job"))
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -469,7 +474,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LOR,
       Nil, Nil)
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -529,7 +535,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LOR,
       Nil, Nil)
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs1 = QueryResult("someId", null, sampleHttpRequests.map(rv => SerializableRangeVector(rv, schema)))
@@ -600,7 +607,8 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       BinaryOperator.LOR,
       Nil, Nil)
 
-    val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
+    val canaryPlusOne = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
     // scalastyle:off
     val lhs1 = QueryResult("someId", null, sampleHttpRequests.map(rv => SerializableRangeVector(rv, schema)))

--- a/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
+import filodb.core.MetricsTestData
 import filodb.memory.format.ZeroCopyUTF8String
 import filodb.query.QueryConfig
 
@@ -17,8 +18,8 @@ class HistogramQuantileMapperSpec extends FunSpec with Matchers with ScalaFuture
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
   val queryConfig = new QueryConfig(config.getConfig("query"))
-  import ZeroCopyUTF8String._
   import HistogramQuantileMapper._
+  import ZeroCopyUTF8String._
 
   private def genHistBuckets(histKey: Map[ZeroCopyUTF8String, ZeroCopyUTF8String]): Array[CustomRangeVectorKey] = {
     val numBuckets = 8
@@ -56,7 +57,8 @@ class HistogramQuantileMapperSpec extends FunSpec with Matchers with ScalaFuture
                       expectedResult: Seq[(Map[ZeroCopyUTF8String, ZeroCopyUTF8String], Seq[(Int, Double)])]): Unit = {
     val hqMapper = HistogramQuantileMapper(Seq(q))
 
-    val result = hqMapper.apply(Observable.fromIterable(histRvs),
+    val result = hqMapper.apply(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(histRvs),
       queryConfig, 10, new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
         ColumnInfo("value", ColumnType.DoubleColumn)), 1))
       .toListL.runAsync.futureValue

--- a/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
@@ -30,7 +30,8 @@ class PeriodicSamplesMapperSpec extends FunSpec with Matchers with ScalaFutures 
   it("should return value present at time - staleSampleAfterMs") {
 
     val periodicSamplesVectorFnMapper = exec.PeriodicSamplesMapper(100000L, 100000, 600000L, None, None)
-    val resultObs = periodicSamplesVectorFnMapper(Observable.fromIterable(Seq(rv)), queryConfig, 1000, resultSchema)
+    val resultObs = periodicSamplesVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(Seq(rv)), queryConfig, 1000, resultSchema)
 
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map
     (r => (r.getLong(0), r.getDouble(1))).filter(!_._2.isNaN))

--- a/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
@@ -93,7 +93,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
                        ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher,
-      timeseriesDataset.ref, 0, filters, AllChunkScan, Seq(0, 1))
+      timeseriesDataset.ref, 0, filters, AllChunkScan, Nil)
 
     val resp = execPlan.execute(memStore, timeseriesDataset, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
@@ -113,7 +113,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val endTime   = now - (numRawSamples-10) * reportingInterval
 
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, timeseriesDataset.ref, 0,
-      filters, TimeRangeChunkScan(startTime, endTime), Seq(0, 1))
+      filters, TimeRangeChunkScan(startTime, endTime), Nil)
 
     val resp = execPlan.execute(memStore, timeseriesDataset, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
@@ -130,7 +130,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
 
     // read from an interval of 100000ms, resulting in 11 samples
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, MMD.dataset1.ref, 0,
-      filters, TimeRangeChunkScan(100000L, 150000L), Seq(0, 4))
+      filters, TimeRangeChunkScan(100000L, 150000L), Seq(4))
 
     val resp = execPlan.execute(memStore, MMD.dataset1, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
@@ -144,7 +144,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
 
     val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)))
     val execPlan = SelectRawPartitionsExec("id1", now, numRawSamples, dummyDispatcher, MMD.histDataset.ref, 0,
-      filters, TimeRangeChunkScan(100000L, 150000L), Seq(0, 3))
+      filters, TimeRangeChunkScan(100000L, 150000L), Seq(3))
 
     val resp = execPlan.execute(memStore, MMD.histDataset, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
@@ -160,7 +160,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, timeseriesDataset.ref, 0,
-      filters, AllChunkScan, Seq(0, 1))
+      filters, AllChunkScan, Nil)
     val start = now - numRawSamples * reportingInterval - 100 // reduce by 100 to not coincide with reporting intervals
     val step = 20000
     val end = now - (numRawSamples-100) * reportingInterval
@@ -191,7 +191,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     import ZeroCopyUTF8String._
     val filters = Seq(ColumnFilter("series", Filter.Equals("Series 1".utf8)))
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, MMD.dataset1.ref, 0,
-      filters, AllChunkScan, Seq(0, 4))
+      filters, AllChunkScan, Seq(4))
 
     // Raw data like 101000, 111000, ....
     val start = 105000L
@@ -211,7 +211,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     import ZeroCopyUTF8String._
     val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)))
     val execPlan = SelectRawPartitionsExec("id1", now, numRawSamples, dummyDispatcher, MMD.histDataset.ref, 0,
-      filters, AllChunkScan, Seq(0, 3))
+      filters, AllChunkScan, Seq(3))
 
     val start = 105000L
     val step = 20000L
@@ -233,7 +233,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
   it("should sum Histogram records with max correctly") {
     val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)))
     val execPlan = SelectRawPartitionsExec("hMax", now, numRawSamples, dummyDispatcher, MMD.histMaxDS.ref, 0,
-      filters, AllChunkScan, Seq(0, 4))
+      filters, AllChunkScan, Seq(4))
 
     val start = 105000L
     val step = 20000L
@@ -275,7 +275,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
   it("should extract Histogram with max using Last/None function correctly") {
     val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)))
     val execPlan = SelectRawPartitionsExec("hMax", now, numRawSamples, dummyDispatcher, MMD.histMaxDS.ref, 0,
-      filters, AllChunkScan, Seq(0, 4))
+      filters, AllChunkScan, Seq(4))
 
     val start = 105000L
     val step = 20000L
@@ -305,7 +305,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher, timeseriesDataset.ref, 0,
-      filters, AllChunkScan, Seq(0, 1))
+      filters, AllChunkScan, Nil)
     val resultSchema = execPlan.schema(timeseriesDataset)
     resultSchema.isTimeSeries shouldEqual true
     resultSchema.numRowKeyColumns shouldEqual 1
@@ -317,14 +317,14 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
   it("should produce correct schema for histogram RVs with and without max column") {
     // Histogram dataset, no max column
     val noMaxPlan = SelectRawPartitionsExec("someQueryId", System.currentTimeMillis, 100, dummyDispatcher,
-                      MMD.histDataset.ref, 0, Nil, AllChunkScan, Seq(0, 3))
+                      MMD.histDataset.ref, 0, Nil, AllChunkScan, Seq(3))
     val expected1 = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn),
                                      ColumnInfo("h", HistogramColumn)), 1, colIDs = Seq(0, 3))
     noMaxPlan.schemaOfDoExecute(MMD.histDataset) shouldEqual expected1
 
     // Histogram dataset with max column - should add max to schema automatically
     val maxPlan = SelectRawPartitionsExec("someQueryId", System.currentTimeMillis, 100, dummyDispatcher,
-                      MMD.histMaxDS.ref, 0, Nil, AllChunkScan, Seq(0, 4))
+                      MMD.histMaxDS.ref, 0, Nil, AllChunkScan, Seq(4))
     val expected2 = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn),
                                      ColumnInfo("h", HistogramColumn),
                                      ColumnInfo("max", DoubleColumn)), 1, colIDs = Seq(0, 4, 3))
@@ -364,7 +364,7 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     // Query returns n ("numRawSamples") samples - Applying Limit (n-1) to fail the query execution
     // with ResponseTooLargeException
     val execPlan = SelectRawPartitionsExec("someQueryId", now, numRawSamples - 1, dummyDispatcher,
-      timeseriesDataset.ref, 0, filters, AllChunkScan, Seq(0, 1))
+      timeseriesDataset.ref, 0, filters, AllChunkScan, Nil)
 
     val resp = execPlan.execute(memStore, timeseriesDataset, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryError]

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -459,9 +459,8 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
     )
     val chunkedItCnt = new ChunkedWindowIteratorD(rvCnt, 50000L, 100000, 750000L, 100000,
       RangeFunction(MetricsTestData.downsampleDataset, Some(RangeFunctionId.CountOverTime),
-        ColumnType.DoubleColumn, queryConfig, useDownsampledColumns = true, useChunked = true).asChunkedD, queryConfig)
+        ColumnType.DoubleColumn, queryConfig, useChunked = true).asChunkedD, queryConfig)
     chunkedItCnt.map(r => (r.getLong(0), r.getDouble(1))).filter(!_._2.isNaN).toList shouldEqual countWindowResults
-
   }
 
   it("should calculate MinOverTime correctly even for windows with no values") {

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -22,9 +22,12 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
 
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
     new MemoryStats(Map("test"-> "test")), null, 16)
-  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, timeseriesDataset.blockMetaSize, true)
   val storeConf = TestData.storeConf.copy(maxChunksSize = 200)
+  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, timeseriesDataset.blockMetaSize, true)
   protected val tsBufferPool = new WriteBufferPool(TestData.nativeMem, timeseriesDataset, storeConf)
+
+  protected val ingestBlockHolder2 = new BlockMemFactory(blockStore, None, downsampleDataset.blockMetaSize, true)
+  protected val tsBufferPool2 = new WriteBufferPool(TestData.nativeMem, downsampleDataset, storeConf)
 
   override def afterAll(): Unit = {
     blockStore.releaseBlocks()
@@ -52,6 +55,19 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
     part.switchBuffers(ingestBlockHolder, encode = true)
     // part.encodeAndReleaseBuffers(ingestBlockHolder)
     RawDataRangeVector(null, part, AllChunkScan, Array(0, 1))
+  }
+
+  def timeValueRvDownsample(tuples: Seq[(Long, Double, Double, Double, Double, Double)],
+                            colIds: Array[Int]): RawDataRangeVector = {
+    val part = TimeSeriesPartitionSpec.makePart(0, downsampleDataset, bufferPool = tsBufferPool2)
+    val readers = tuples.map { case (ts, d1, d2, d3, d4, d5) =>
+      TupleRowReader((Some(ts), Some(d1), Some(d2), Some(d3), Some(d4), Some(d5)))
+    }
+    readers.foreach { row => part.ingest(row, ingestBlockHolder2) }
+    // Now flush and ingest the rest to ensure two separate chunks
+    part.switchBuffers(ingestBlockHolder2, encode = true)
+    // part.encodeAndReleaseBuffers(ingestBlockHolder)
+    RawDataRangeVector(null, part, AllChunkScan, colIds)
   }
 
   def timeValueRV(data: Seq[Double], startTS: Long = defaultStartTS): RawDataRangeVector = {

--- a/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
@@ -214,7 +214,8 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
     // ceil
     val expectedVal = sampleBase.map(_.rows.map(v => scala.math.floor(v.getDouble(1))))
     val binaryOpMapper = exec.ScalarOperationMapper(BinaryOperator.ADD, scalar, true)
-    val resultObs = binaryOpMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+    val resultObs = binaryOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     val result = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
     expectedVal.zip(result).foreach {
       case (ex, res) =>  {
@@ -229,7 +230,8 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
   private def applyBinaryOperationAndAssertResult(samples: Array[RangeVector], expectedVal: Array[Iterator[Double]],
                                                   binOp: BinaryOperator, scalar: Double, scalarOnLhs: Boolean): Unit = {
     val scalarOpMapper = exec.ScalarOperationMapper(binOp, scalar, scalarOnLhs)
-    val resultObs = scalarOpMapper(Observable.fromIterable(samples), queryConfig, 1000, resultSchema)
+    val resultObs = scalarOpMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(samples), queryConfig, 1000, resultSchema)
     val result = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
     expectedVal.zip(result).foreach {
       case (ex, res) =>  {

--- a/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
@@ -161,7 +161,8 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     // sort_desc
     the[UnsupportedOperationException] thrownBy {
       val miscellaneousVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.SortDesc)
-      miscellaneousVectorFnMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      miscellaneousVectorFnMapper(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "SortDesc not supported."
   }
 
@@ -169,58 +170,65 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     // clamp_max
     the[IllegalArgumentException] thrownBy {
       val instantVectorFnMapper1 = exec.InstantVectorFunctionMapper(InstantFunctionId.ClampMax)
-      instantVectorFnMapper1(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      instantVectorFnMapper1(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Cannot use ClampMax without providing a upper limit of max."
     the[IllegalArgumentException] thrownBy {
       val instantVectorFnMapper2 = exec.InstantVectorFunctionMapper(InstantFunctionId.ClampMax, Seq("hi"))
-      instantVectorFnMapper2(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      instantVectorFnMapper2(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Cannot use ClampMax without providing a upper limit of max as a Number."
 
     // clamp_min
     the[IllegalArgumentException] thrownBy {
       val instantVectorFnMapper3 = exec.InstantVectorFunctionMapper(InstantFunctionId.ClampMin)
-      instantVectorFnMapper3(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      instantVectorFnMapper3(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Cannot use ClampMin without providing a lower limit of min."
     the[IllegalArgumentException] thrownBy {
       val instantVectorFnMapper4 = exec.InstantVectorFunctionMapper(InstantFunctionId.ClampMin, Seq("hi"))
-      instantVectorFnMapper4(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      instantVectorFnMapper4(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Cannot use ClampMin without providing a lower limit of min as a Number."
 
     the[IllegalArgumentException] thrownBy {
       val instantVectorFnMapper5 = exec.InstantVectorFunctionMapper(InstantFunctionId.Sqrt, Seq(1))
-      instantVectorFnMapper5(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      instantVectorFnMapper5(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: No additional parameters required for the instant function."
 
     the[IllegalArgumentException] thrownBy {
       val instantVectorFnMapper5 = exec.InstantVectorFunctionMapper(InstantFunctionId.Round, Seq("hi"))
-      instantVectorFnMapper5(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      instantVectorFnMapper5(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: to_nearest optional parameter should be a Number."
 
     the[IllegalArgumentException] thrownBy {
       val instantVectorFnMapper5 = exec.InstantVectorFunctionMapper(InstantFunctionId.Round, Seq(1, 2))
-      instantVectorFnMapper5(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+      instantVectorFnMapper5(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Only one optional parameters allowed for Round."
 
     // histogram quantile
     the[IllegalArgumentException] thrownBy {
       val ivMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.HistogramQuantile)
-      ivMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
+      ivMapper(MetricsTestData.timeseriesDataset, Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
     } should have message "requirement failed: Quantile (between 0 and 1) required for histogram quantile"
 
     the[IllegalArgumentException] thrownBy {
       val ivMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.HistogramQuantile, Seq("b012"))
-      ivMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
+      ivMapper(MetricsTestData.timeseriesDataset, Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
     } should have message "requirement failed: histogram_quantile parameter must be a number"
 
     // histogram bucket
     the[IllegalArgumentException] thrownBy {
       val ivMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.HistogramBucket)
-      ivMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
+      ivMapper(MetricsTestData.timeseriesDataset, Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
     } should have message "requirement failed: Bucket/le required for histogram bucket"
 
     the[IllegalArgumentException] thrownBy {
       val ivMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.HistogramBucket, Seq("b012"))
-      ivMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
+      ivMapper(MetricsTestData.timeseriesDataset, Observable.fromIterable(sampleBase), queryConfig, 1000, histSchema)
     } should have message "requirement failed: histogram_bucket parameter must be a number"
   }
 
@@ -228,7 +236,8 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     // ceil
     val expectedVal = sampleBase.map(_.rows.map(v => scala.math.floor(v.getDouble(1))))
     val instantVectorFnMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.Ceil)
-    val resultObs = instantVectorFnMapper(Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
+    val resultObs = instantVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleBase), queryConfig, 1000, resultSchema)
     val result = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
     expectedVal.zip(result).foreach {
       case (ex, res) =>  {
@@ -291,7 +300,8 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
                                 instantFunctionId: InstantFunctionId, funcParams: Seq[Any] = Nil,
                                 schema: ResultSchema = resultSchema): Unit = {
     val instantVectorFnMapper = exec.InstantVectorFunctionMapper(instantFunctionId, funcParams)
-    val resultObs = instantVectorFnMapper(Observable.fromIterable(samples), queryConfig, 1000, schema)
+    val resultObs = instantVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(samples), queryConfig, 1000, schema)
     val result = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
     expectedVal.zip(result).foreach {
       case (ex, res) =>  {

--- a/query/src/test/scala/filodb/query/exec/rangefn/LabelReplaceSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/LabelReplaceSpec.scala
@@ -74,7 +74,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
 
     val funcParams = Seq("instance", "$1 new Label Value $2", "instance", "(.*):90(.*)")
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(sampleWithKey), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleWithKey), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -120,7 +121,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("instanceNew", "$1-$1", "instance", "(.*)\\d")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(sampleWithKey), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleWithKey), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -161,7 +163,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("instance", "$1", "instance", "(.*)9")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(sampleWithKey), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(sampleWithKey), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -184,13 +187,15 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     the[IllegalArgumentException] thrownBy {
       val miscellaneousFunctionMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace,
         funcParams)
-      miscellaneousFunctionMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+      miscellaneousFunctionMapper(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     } should have message "Invalid Regular Expression for label_replace"
 
     the[IllegalArgumentException] thrownBy {
       val miscellaneousFunctionMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace,
         Seq("instance", "$1"))
-      miscellaneousFunctionMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+      miscellaneousFunctionMapper(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: " +
       "Cannot use LabelReplace without function parameters: " +
       "instant-vector, dst_label string, replacement string, src_label string, regex string"
@@ -198,7 +203,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     the[IllegalArgumentException] thrownBy {
       val miscellaneousFunctionMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace,
         Seq("$instance", "$1", "instance", "(.*)9("))
-      miscellaneousFunctionMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+      miscellaneousFunctionMapper(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Invalid destination label name"
   }
 
@@ -212,7 +218,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("dst", "destination-value-$1", "src", "source-value-(.*)")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -238,7 +245,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("dst", "destination-value-$1", "src", "value-(.*)")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -264,7 +272,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("dst", "$1-value-$2 $3$67", "src", "(.*)-value-(.*)")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -290,7 +299,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("dst", "value-$1", "nonexistent-src", "source-value-(.*)")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -316,7 +326,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("dst", "value-$1", "nonexistent-src", ".*")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -342,7 +353,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("dst", "value-$1", "src", "dummy-regex")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -366,7 +378,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("dst", "", "dst", ".*")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -390,7 +403,8 @@ class LabelReplaceSpec extends FunSpec with Matchers with ScalaFutures {
     val funcParams = Seq("src", "", "", "")
 
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelReplace, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/LableJoinSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/LableJoinSpec.scala
@@ -101,7 +101,8 @@ class LableJoinSpec extends FunSpec with Matchers with ScalaFutures {
 
     val funcParams = Seq("dst", "-", "src", "src1", "src2")
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -132,7 +133,8 @@ class LableJoinSpec extends FunSpec with Matchers with ScalaFutures {
 
     val funcParams = Seq("dst", "-", "src", "src3", "src1")
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -162,7 +164,8 @@ class LableJoinSpec extends FunSpec with Matchers with ScalaFutures {
 
     val funcParams = Seq("dst", "", "emptysrc", "emptysrc1", "emptysrc2")
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -193,7 +196,8 @@ class LableJoinSpec extends FunSpec with Matchers with ScalaFutures {
 
     val funcParams = Seq("dst", "-", "src", "src1", "src2")
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -223,7 +227,8 @@ class LableJoinSpec extends FunSpec with Matchers with ScalaFutures {
 
     val funcParams = Seq("dst", "-")
     val labelVectorFnMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin, funcParams)
-    val resultObs = labelVectorFnMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+    val resultObs = labelVectorFnMapper(MetricsTestData.timeseriesDataset,
+      Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     val resultLabelValues = resultObs.toListL.runAsync.futureValue.map(_.key.labelValues)
     val resultRows = resultObs.toListL.runAsync.futureValue.map(_.rows.map(_.getDouble(1)))
 
@@ -248,19 +253,22 @@ class LableJoinSpec extends FunSpec with Matchers with ScalaFutures {
     the[IllegalArgumentException] thrownBy {
       val miscellaneousFunctionMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin,
         funcParams1)
-      miscellaneousFunctionMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+      miscellaneousFunctionMapper(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Invalid source label name in label_join()"
 
     the[IllegalArgumentException] thrownBy {
       val miscellaneousFunctionMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin,
         funcParams2)
-      miscellaneousFunctionMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+      miscellaneousFunctionMapper(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: Invalid destination label name in label_join()"
 
     the[IllegalArgumentException] thrownBy {
       val miscellaneousFunctionMapper = exec.MiscellaneousFunctionMapper(MiscellaneousFunctionId.LabelJoin,
         Seq("dst"))
-      miscellaneousFunctionMapper(Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
+      miscellaneousFunctionMapper(MetricsTestData.timeseriesDataset,
+        Observable.fromIterable(testSample), queryConfig, 1000, resultSchema)
     } should have message "requirement failed: expected at least 3 argument(s) in call to label_join"
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Ability to respond to gauge queries from downsampled data.

* Use the right downsampled column based on the time range function used
* Modify the time range function based on whether we are querying from downsampled data. For example, count_over_time when applied on downsampled data is sum_over_time on the count column.

TODO:
* Currently presence of average downsample column is assumed. But we can do better by using just sum and count. 

Above todos can come in the next iteration (or I will look into this right away time permitting).

