### PR TITLE
feat(core): MultiSchema prep: Allow PartitionSet to be used with multiple schema/Dataset definitions

### DIFF
--- a/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
@@ -35,7 +35,7 @@ class PartitionSetSpec extends MemFactoryCleanupTest with ScalaFutures {
   private val ingestBlockHolder = new BlockMemFactory(blockStore, None, dataset2.blockMetaSize, true)
 
   val builder = new RecordBuilder(memFactory, dataset2.ingestionSchema)
-  val partSet = PartitionSet.empty(dataset2.ingestionSchema, dataset2.comparator)
+  val partSet = PartitionSet.empty()
 
   before {
     partSet.clear()
@@ -78,34 +78,34 @@ class PartitionSetSpec extends MemFactoryCleanupTest with ScalaFutures {
     partSet += part
     partSet.size shouldEqual 1
 
-    val got = partSet.getOrAddWithIngestBR(null, ingestRecordAddrs(0), { throw new RuntimeException("error")} )
+    val got = partSet.getOrAddWithIngestBR(null, ingestRecordAddrs(0), dataset2, { throw new RuntimeException("error")} )
     got shouldEqual part
     partSet.size shouldEqual 1
   }
 
   it("should add new TSPartition if one doesnt exist with getOrAddWithIngestBR") {
     partSet.isEmpty shouldEqual true
-    partSet.getWithPartKeyBR(null, partKeyAddrs(0)) shouldEqual None
-    partSet.getWithIngestBR(null, ingestRecordAddrs(0)) shouldEqual null
+    partSet.getWithPartKeyBR(null, partKeyAddrs(0), dataset2) shouldEqual None
+    partSet.getWithIngestBR(null, ingestRecordAddrs(0), dataset2) shouldEqual null
 
     val part = makePart(0, dataset2, partKeyAddrs(0), bufferPool)
-    val got = partSet.getOrAddWithIngestBR(null, ingestRecordAddrs(0), part)
+    val got = partSet.getOrAddWithIngestBR(null, ingestRecordAddrs(0), dataset2, part)
 
     partSet.size shouldEqual 1
     partSet.isEmpty shouldEqual false
     got shouldEqual part
-    partSet.getWithPartKeyBR(null, partKeyAddrs(0)) shouldEqual Some(part)
-    partSet.getWithIngestBR(null, ingestRecordAddrs(0)) shouldEqual part
+    partSet.getWithPartKeyBR(null, partKeyAddrs(0), dataset2) shouldEqual Some(part)
+    partSet.getWithIngestBR(null, ingestRecordAddrs(0), dataset2) shouldEqual part
   }
 
   it("should not add new TSPartition if function returns null") {
     partSet.isEmpty shouldEqual true
-    partSet.getWithPartKeyBR(null, partKeyAddrs(0)) shouldEqual None
+    partSet.getWithPartKeyBR(null, partKeyAddrs(0), dataset2) shouldEqual None
 
-    val got = partSet.getOrAddWithIngestBR(null, ingestRecordAddrs(0), null)
+    val got = partSet.getOrAddWithIngestBR(null, ingestRecordAddrs(0), dataset2, null)
     got shouldEqual null
     partSet.isEmpty shouldEqual true
-    partSet.getWithPartKeyBR(null, partKeyAddrs(0)) shouldEqual None
+    partSet.getWithPartKeyBR(null, partKeyAddrs(0), dataset2) shouldEqual None
   }
 
   it("should remove TSPartitions correctly") {

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -306,11 +306,11 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
       val expectedPartKey = dataset1.partKeySchema.asByteArray(UnsafeUtils.ZeroPointer, off)
       readPartKey.bytes.slice(readPartKey.offset, readPartKey.offset + readPartKey.length) shouldEqual expectedPartKey
       if (i%2 == 0) {
-        tsShard.partSet.getWithPartKeyBR(UnsafeUtils.ZeroPointer, off).get.partID shouldEqual i
+        tsShard.partSet.getWithPartKeyBR(UnsafeUtils.ZeroPointer, off, dataset).get.partID shouldEqual i
         tsShard.partitions.containsKey(i) shouldEqual true // since partition is ingesting
       }
       else {
-        tsShard.partSet.getWithPartKeyBR(UnsafeUtils.ZeroPointer, off) shouldEqual None
+        tsShard.partSet.getWithPartKeyBR(UnsafeUtils.ZeroPointer, off, dataset) shouldEqual None
         tsShard.partitions.containsKey(i) shouldEqual false // since partition is not ingesting
       }
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The current PartitionSet only supports one schema/Dataset as the ingestion schema and comparator are passed in as constructor params.

**New behavior :**

Remove the ingestionSchema and comparator from the constructor.  Instead pass in Dataset where needed.  This allows PartitionSet to be used with any number of potential schemas.
