### PR TITLE
feat(query, core): QueryResult need not always be serializable

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -2,7 +2,7 @@ package filodb.prometheus.query
 
 import remote.RemoteStorage._
 
-import filodb.core.query.{ColumnFilter, Filter, SerializableRangeVector}
+import filodb.core.query.{ColumnFilter, Filter, RangeVector}
 import filodb.query.{IntervalSelector, LogicalPlan, QueryResultType, RawSeries}
 import filodb.query.exec.ExecPlan
 
@@ -67,7 +67,7 @@ object PrometheusModel {
   /**
     * Used to send out raw data
     */
-  def toPromTimeSeries(srv: SerializableRangeVector): TimeSeries = {
+  def toPromTimeSeries(srv: RangeVector): TimeSeries = {
     val b = TimeSeries.newBuilder()
     srv.key.labelValues.foreach {lv =>
       b.addLabels(LabelPair.newBuilder().setName(lv._1.toString).setValue(lv._2.toString))
@@ -99,7 +99,7 @@ object PrometheusModel {
   /**
     * Used to send out HTTP response
     */
-  def toPromResult(srv: SerializableRangeVector, verbose: Boolean): Result = {
+  def toPromResult(srv: RangeVector, verbose: Boolean): Result = {
     val tags = srv.key.labelValues.map { case (k, v) => (k.toString, v.toString)} ++
                 (if (verbose) Map("_shards_" -> srv.key.sourceShards.mkString(","),
                                   "_partIds_" -> srv.key.partIds.mkString(","))

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -3,7 +3,7 @@ package filodb.query
 import enumeratum.{Enum, EnumEntry}
 
 import filodb.core.{DatasetRef, ErrorResponse, NodeCommand, NodeResponse}
-import filodb.core.query.{ResultSchema, SerializableRangeVector}
+import filodb.core.query.{RangeVector, ResultSchema}
 
 trait QueryCommand extends NodeCommand with java.io.Serializable {
   def submitTime: Long
@@ -35,11 +35,11 @@ object QueryResultType extends Enum[QueryResultType] {
 
 final case class QueryResult(id: String,
                              resultSchema: ResultSchema,
-                             result: Seq[SerializableRangeVector]) extends QueryResponse {
+                             result: Seq[RangeVector]) extends QueryResponse {
   def resultType: QueryResultType = {
     result match {
-      case Seq(one) => if (one.numRows == 1) QueryResultType.Scalar else QueryResultType.RangeVectors
-      case many: Seq[SerializableRangeVector] => if (many.forall(_.numRows == 1)) QueryResultType.InstantVector
+      case Seq(one) => if (one.numRows.contains(1)) QueryResultType.Scalar else QueryResultType.RangeVectors
+      case many: Seq[RangeVector] => if (many.forall(_.numRows.contains(1))) QueryResultType.InstantVector
                                                  else QueryResultType.RangeVectors
     }
   }

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -125,7 +125,7 @@ trait ExecPlan extends QueryCommand {
       finalRes._1
         .map {
           case srv: SerializableRangeVector =>
-            numResultSamples += srv.numRows
+            numResultSamples += srv.numRowsInt
             // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
             if (enforceLimit && numResultSamples > limit)
               throw new BadQueryException(s"This query results in more than $limit samples. " +
@@ -134,7 +134,7 @@ trait ExecPlan extends QueryCommand {
           case rv: RangeVector =>
             // materialize, and limit rows per RV
             val srv = SerializableRangeVector(rv, builder, recSchema, printTree(false))
-            numResultSamples += srv.numRows
+            numResultSamples += srv.numRowsInt
             // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
             if (enforceLimit && numResultSamples > limit)
               throw new BadQueryException(s"This query results in more than $limit samples. " +
@@ -222,7 +222,7 @@ trait ExecPlan extends QueryCommand {
     }
   }
 
-  protected def rowIterAccumulator(srvsList: List[Seq[SerializableRangeVector]]): Iterator[RowReader] = {
+  protected def rowIterAccumulator(srvsList: List[Seq[RangeVector]]): Iterator[RowReader] = {
 
     new Iterator[RowReader] {
       val listSize = srvsList.size

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.FiniteDuration
 import monix.execution.Scheduler
 import monix.reactive.Observable
 
-import filodb.core.{query, DatasetRef}
+import filodb.core.DatasetRef
 import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.memstore.{MemStore, PartKeyRowReader}
 import filodb.core.metadata.Column.ColumnType

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -61,7 +61,7 @@ final case class SetOperatorExec(id: String,
       val lhsRvs = resp.filter(_._2 < lhs.size).flatMap(_._1)
       val rhsRvs = resp.filter(_._2 >= lhs.size).flatMap(_._1)
 
-      val results: List[SerializableRangeVector] = binaryOp  match {
+      val results: List[RangeVector] = binaryOp  match {
         case LAND => setOpAnd(lhsRvs, rhsRvs)
         case LOR => setOpOr(lhsRvs, rhsRvs)
         case LUnless => setOpUnless(lhsRvs, rhsRvs)
@@ -78,10 +78,10 @@ final case class SetOperatorExec(id: String,
     else rvk.labelValues.filterNot(lv => ignoringLabels.contains(lv._1))
   }
 
-  private def setOpAnd(lhsRvs: List[SerializableRangeVector]
-                       , rhsRvs: List[SerializableRangeVector]): List[SerializableRangeVector] = {
+  private def setOpAnd(lhsRvs: List[RangeVector]
+                       , rhsRvs: List[RangeVector]): List[RangeVector] = {
     val rhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
-    var result = new ListBuffer[SerializableRangeVector]()
+    var result = new ListBuffer[RangeVector]()
     rhsRvs.foreach { rv =>
       val jk = joinKeys(rv.key)
       if (!jk.isEmpty)
@@ -99,10 +99,10 @@ final case class SetOperatorExec(id: String,
     result.toList
   }
 
-  private def setOpOr(lhsRvs: List[SerializableRangeVector]
-                      , rhsRvs: List[SerializableRangeVector]): List[SerializableRangeVector] = {
+  private def setOpOr(lhsRvs: List[RangeVector]
+                      , rhsRvs: List[RangeVector]): List[RangeVector] = {
     val lhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
-    var result = new ListBuffer[SerializableRangeVector]()
+    var result = new ListBuffer[RangeVector]()
     // Add everything from left hand side range vector
     lhsRvs.foreach { rv =>
       val jk = joinKeys(rv.key)
@@ -119,10 +119,10 @@ final case class SetOperatorExec(id: String,
     result.toList
   }
 
-  private def setOpUnless(lhsRvs: List[SerializableRangeVector]
-                          , rhsRvs: List[SerializableRangeVector]): List[SerializableRangeVector] = {
+  private def setOpUnless(lhsRvs: List[RangeVector]
+                          , rhsRvs: List[RangeVector]): List[RangeVector] = {
     val rhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
-    var result = new ListBuffer[SerializableRangeVector]()
+    var result = new ListBuffer[RangeVector]()
     rhsRvs.foreach { rv =>
       val jk = joinKeys(rv.key)
       rhsKeysSet += jk

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -11,11 +11,11 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 
+import filodb.core.{query, TestData}
 import filodb.core.MetricsTestData._
-import filodb.core.TestData
 import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
-import filodb.core.query.{ColumnFilter, Filter}
+import filodb.core.query.{ColumnFilter, Filter, SerializableRangeVector}
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.query._
@@ -85,7 +85,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
-        rv.schema.toStringPairs(record.recordBase, record.recordOffset)
+        rv.asInstanceOf[query.SerializableRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset)
       }
     }
     result shouldEqual jobQueryResult1
@@ -118,7 +118,8 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
     val result = resp match {
       case QueryResult(id, _, response) => {
         response.size shouldEqual 1
-        response(0).rows.map (row => response(0).schema.toStringPairs(row.getBlobBase(0),
+        response(0).rows.map (row => response(0).asInstanceOf[SerializableRangeVector]
+          .schema.toStringPairs(row.getBlobBase(0),
           row.getBlobOffset(0)).toMap).toList
       }
     }
@@ -137,7 +138,8 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
     val result = resp match {
       case QueryResult(id, _, response) => {
         response.size shouldEqual 1
-        response(0).rows.map (row => response(0).schema.toStringPairs(row.getBlobBase(0),
+        response(0).rows.map (row => response(0).asInstanceOf[query.SerializableRangeVector]
+          .schema.toStringPairs(row.getBlobBase(0),
           row.getBlobOffset(0)).toMap).toList
       }
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

QueryResult uses SerializableRangeVectors only.

**New behavior :**

Since QueryResult can be a result of an ExecPlan that is executed within the current JVM, we should not be forced into converting results into a SerializableRangeVector.

Hence the interface changes

