### PR TITLE
bug(core): Release searchers after each acquire

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
@@ -46,7 +46,7 @@ class MemstoreCassandraSinkSpec extends AllTablesTest {
     memStore.store.sinkStats.chunksetsWritten should be >= 3
     memStore.store.sinkStats.chunksetsWritten should be <= 4
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     // Verify data still in MemStore... all of it
     val splits = memStore.getScanSplits(dataset1.ref, 1)
     val agg1 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(splits.head))

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -163,7 +163,7 @@ final class QueryActor(memStore: MemStore,
     case q: ExecPlan              =>  execPhysicalPlan2(q, sender())
 
     case GetIndexNames(ref, limit, _) =>
-      sender() ! memStore.indexNames(ref).take(limit).map(_._1).toBuffer
+      sender() ! memStore.indexNames(ref, limit).map(_._1).toBuffer
     case g: GetIndexValues         => processIndexValues(g, sender())
 
     case ThrowException(dataset) =>

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -134,7 +134,7 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
         case CurrentShardSnapshot(ref, newMap) if ref == dataset6.ref => mapper = newMap
       }
     }
-    cluster.memStore.commitIndexForTesting(dataset6.ref)
+    cluster.memStore.refreshIndexForTesting(dataset6.ref)
     enterBarrier("ingestion-stopped")
 
     // val query = LogicalPlanQuery(dataset6.ref,

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -145,7 +145,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, IngestRows(ref, 0, records(dataset1, multiSeriesData().take(20))))
       probe.expectMsg(Ack(0L))
 
-      memStore.commitIndexForTesting(dataset1.ref)
+      memStore.refreshIndexForTesting(dataset1.ref)
 
       // Query existing partition: Series 1
       val q1 = LogicalPlan2Query(ref, RawSeries(AllChunksSelector, filters("series" -> "Series 1"), Seq("min")), qOpt)
@@ -191,7 +191,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                  Aggregate(AggregationOperator.Avg,
                    PeriodicSeries(
                      RawSeries(AllChunksSelector, multiFilter, Seq("min")), 120000L, 10000L, 130000L)), qOpt)
-      memStore.commitIndexForTesting(dataset1.ref)
+      memStore.refreshIndexForTesting(dataset1.ref)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
         case QueryResult(_, schema, vectors) =>
@@ -232,7 +232,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, IngestRows(ref, 0, records(dataset1, linearMultiSeries().take(40))))
       probe.expectMsg(Ack(0L))
 
-      memStore.commitIndexForTesting(dataset1.ref)
+      memStore.refreshIndexForTesting(dataset1.ref)
 
       val numQueries = 6
 
@@ -262,7 +262,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, IngestRows(ref, 1, records(dataset1, linearMultiSeries(130000L).take(20))))
       probe.expectMsg(Ack(0L))
 
-      memStore.commitIndexForTesting(dataset1.ref)
+      memStore.refreshIndexForTesting(dataset1.ref)
 
       // Should return results from both shards
       // shard 1 - timestamps 110000 -< 130000;  shard 2 - timestamps 130000 <- 1400000
@@ -291,7 +291,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, IngestRows(ref, 1, records(dataset1, linearMultiSeries(130000L).take(20))))
       probe.expectMsg(Ack(0L))
 
-      memStore.commitIndexForTesting(dataset1.ref)
+      memStore.refreshIndexForTesting(dataset1.ref)
 
       val queryOpt = QueryOptions(shardOverrides = Some(Seq(0, 1)))
       val series2 = (2 to 4).map(n => s"Series $n")
@@ -317,7 +317,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, IngestRows(ref, 0, records(dataset1, linearMultiSeries().take(30))))
       probe.expectMsg(Ack(0L))
 
-      memStore.commitIndexForTesting(dataset1.ref)
+      memStore.refreshIndexForTesting(dataset1.ref)
 
       probe.send(coordinatorActor, GetIndexNames(ref))
       probe.expectMsg(Seq("series"))
@@ -331,7 +331,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, IngestRows(ref, 0, records(dataset1, linearMultiSeries().take(30))))
       probe.expectMsg(Ack(0L))
 
-      memStore.commitIndexForTesting(dataset1.ref)
+      memStore.refreshIndexForTesting(dataset1.ref)
 
       probe.send(coordinatorActor, GetIndexNames(ref))
       probe.expectMsg(Seq("series"))
@@ -362,7 +362,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     probe.send(coordinatorActor, StatusActor.GetCurrentEvents)
     probe.expectMsg(Map(ref -> Seq(IngestionStarted(ref, 0, coordinatorActor))))
 
-    memStore.commitIndexForTesting(dataset6.ref)
+    memStore.refreshIndexForTesting(dataset6.ref)
     // Also the original aggregator is sum(sum_over_time(....)) which is not quite represented by below plan
     // Below plan is really sum each time bucket
     val q2 = LogicalPlan2Query(ref,

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -139,7 +139,7 @@ trait MemStore extends ChunkSource {
    * all shards on this node
    * @return an index name and shard number
    */
-  def indexNames(dataset: DatasetRef): Iterator[(String, Int)]
+  def indexNames(dataset: DatasetRef, limit: Int): Seq[(String, Int)]
 
   /**
    * Returns values for a given index name (and # of series for each) for a dataset and shard,
@@ -193,7 +193,7 @@ trait MemStore extends ChunkSource {
   /**
    * Commits the index immediately so that queries can pick up the latest changes.  Used for testing.
    */
-  def commitIndexForTesting(dataset: DatasetRef): Unit
+  def refreshIndexForTesting(dataset: DatasetRef): Unit
 
   /**
    * WARNING: truncates all the data in the memstore for the given dataset, and also the data

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -158,8 +158,18 @@ class PartKeyLuceneIndex(dataset: Dataset,
   def partIdsEndedBefore(endedBefore: Long): EWAHCompressedBitmap = {
     val collector = new PartIdCollector()
     val deleteQuery = LongPoint.newRangeQuery(PartKeyLuceneIndex.END_TIME, 0, endedBefore)
-    searcherManager.acquire().search(deleteQuery, collector)
+
+    withNewSearcher(s => s.search(deleteQuery, collector))
     collector.result
+  }
+
+  private def withNewSearcher(func: IndexSearcher => Unit): Unit = {
+    val s = searcherManager.acquire()
+    try {
+      func(s)
+    } finally {
+      searcherManager.release(s)
+    }
   }
 
   /**
@@ -202,46 +212,54 @@ class PartKeyLuceneIndex(dataset: Dataset,
     */
   def indexValues(fieldName: String, topK: Int = 100): Seq[TermInfo] = {
     // FIXME this API returns duplicate values because same value can be present in multiple lucene segments
-    val searcher = searcherManager.acquire()
-    val indexReader = searcher.getIndexReader
-    val segments = indexReader.leaves()
+
     val freqOrder = Ordering.by[TermInfo, Int](_.freq)
     val topkResults = new PriorityQueue[TermInfo](topK, freqOrder)
-    var termsRead = 0
-    segments.asScala.foreach { segment =>
-      val terms = segment.reader().terms(fieldName)
 
-      //scalastyle:off
-      if (terms != null) {
-        val termsEnum = terms.iterator()
-        var nextVal: BytesRef = termsEnum.next()
-        while (nextVal != null && termsRead < MAX_TERMS_TO_ITERATE) {
-          //scalastyle:on
-          val valu = BytesRef.deepCopyOf(nextVal) // copy is needed since lucene uses a mutable cursor underneath
-          val ret = new UTF8Str(valu.bytes, bytesRefToUnsafeOffset(valu.offset), valu.length)
-          val freq = termsEnum.docFreq()
-          if (topkResults.size < topK) {
-            topkResults.add(TermInfo(ret, freq))
+    withNewSearcher { searcher =>
+      val indexReader = searcher.getIndexReader
+      val segments = indexReader.leaves()
+      var termsRead = 0
+      segments.asScala.foreach { segment =>
+        val terms = segment.reader().terms(fieldName)
+
+        //scalastyle:off
+        if (terms != null) {
+          val termsEnum = terms.iterator()
+          var nextVal: BytesRef = termsEnum.next()
+          while (nextVal != null && termsRead < MAX_TERMS_TO_ITERATE) {
+            //scalastyle:on
+            val valu = BytesRef.deepCopyOf(nextVal) // copy is needed since lucene uses a mutable cursor underneath
+            val ret = new UTF8Str(valu.bytes, bytesRefToUnsafeOffset(valu.offset), valu.length)
+            val freq = termsEnum.docFreq()
+            if (topkResults.size < topK) {
+              topkResults.add(TermInfo(ret, freq))
+            }
+            else if (topkResults.peek.freq < freq) {
+              topkResults.remove()
+              topkResults.add(TermInfo(ret, freq))
+            }
+            nextVal = termsEnum.next()
+            termsRead += 1
           }
-          else if (topkResults.peek.freq < freq) {
-            topkResults.remove()
-            topkResults.add(TermInfo(ret, freq))
-          }
-          nextVal = termsEnum.next()
-          termsRead += 1
         }
       }
     }
     topkResults.toArray(new Array[TermInfo](0)).sortBy(-_.freq).toSeq
   }
 
-  def indexNames: scala.Iterator[String] = {
-    val searcher = searcherManager.acquire()
-    val indexReader = searcher.getIndexReader
-    val segments = indexReader.leaves()
-    segments.asScala.iterator.flatMap { segment =>
-      segment.reader().getFieldInfos.asScala.toIterator.map(_.name)
-    }.filterNot { n => ignoreIndexNames.contains(n) }
+  def indexNames(limit: Int): Seq[String] = {
+
+    var ret: Seq[String] = Nil
+    withNewSearcher { searcher =>
+      val indexReader = searcher.getIndexReader
+      val segments = indexReader.leaves()
+      val iter = segments.asScala.iterator.flatMap { segment =>
+        segment.reader().getFieldInfos.asScala.toIterator.map(_.name)
+      }.filterNot { n => ignoreIndexNames.contains(n) }
+      ret = iter.take(limit).toSeq
+    }
+    ret
   }
 
   private def addIndexEntry(labelName: String, value: BytesRef, partIndex: Int): Unit = {
@@ -319,7 +337,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
     */
   def partKeyFromPartId(partId: Int): Option[BytesRef] = {
     val collector = new SinglePartKeyCollector()
-    searcherManager.acquire().search(new TermQuery(new Term(PART_ID, partId.toString)), collector)
+    withNewSearcher(s => s.search(new TermQuery(new Term(PART_ID, partId.toString)), collector) )
     Option(collector.singleResult)
   }
 
@@ -328,7 +346,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
     */
   def startTimeFromPartId(partId: Int): Long = {
     val collector = new NumericDocValueCollector(PartKeyLuceneIndex.START_TIME)
-    searcherManager.acquire().search(new TermQuery(new Term(PART_ID, partId.toString)), collector)
+    withNewSearcher(s => s.search(new TermQuery(new Term(PART_ID, partId.toString)), collector))
     collector.singleResult
   }
 
@@ -347,7 +365,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
     }
     // dont use BooleanQuery which will hit the 1024 term limit. Instead use TermInSetQuery which is
     // more efficient within Lucene
-    searcherManager.acquire().search(new TermInSetQuery(PART_ID, terms), collector)
+    withNewSearcher(s => s.search(new TermInSetQuery(PART_ID, terms), collector))
     span.finish()
     collector.startTimes
   }
@@ -357,7 +375,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
     */
   def endTimeFromPartId(partId: Int): Long = {
     val collector = new NumericDocValueCollector(PartKeyLuceneIndex.END_TIME)
-    searcherManager.acquire().search(new TermQuery(new Term(PART_ID, partId.toString)), collector)
+    withNewSearcher(s => s.search(new TermQuery(new Term(PART_ID, partId.toString)), collector))
     collector.singleResult
   }
 
@@ -371,13 +389,13 @@ class PartKeyLuceneIndex(dataset: Dataset,
                               fromEndTime: Long = 0,
                               toEndTime: Long = Long.MaxValue): EWAHCompressedBitmap = {
     val coll = new TopKPartIdsCollector(topk)
-    searcherManager.acquire().search(LongPoint.newRangeQuery(END_TIME, fromEndTime, toEndTime), coll)
+    withNewSearcher(s => s.search(LongPoint.newRangeQuery(END_TIME, fromEndTime, toEndTime), coll))
     coll.topKPartIDsBitmap()
   }
 
   def foreachPartKeyStillIngesting(func: (Int, BytesRef) => Unit): Int = {
     val coll = new ActionCollector(func)
-    searcherManager.acquire().search(LongPoint.newExactQuery(END_TIME, Long.MaxValue), coll)
+    withNewSearcher(s => s.search(LongPoint.newExactQuery(END_TIME, Long.MaxValue), coll))
     coll.numHits
   }
 
@@ -403,7 +421,7 @@ class PartKeyLuceneIndex(dataset: Dataset,
     * Refresh readers with updates to index. May be expensive - use carefully.
     * @return
     */
-  def commitBlocking(): Unit = {
+  def refreshReadersBlocking(): Unit = {
     searcherManager.maybeRefreshBlocking()
     logger.info("Refreshed index searchers to make reads consistent")
   }
@@ -469,9 +487,8 @@ class PartKeyLuceneIndex(dataset: Dataset,
     booleanQuery.add(LongPoint.newRangeQuery(END_TIME, startTime, Long.MaxValue), Occur.FILTER)
     val query = booleanQuery.build()
     logger.debug(s"Querying dataset=${dataset.ref} shard=$shardNum partKeyIndex with: $query")
-    val searcher = searcherManager.acquire()
     val collector = new PartIdCollector() // passing zero for unlimited results
-    searcher.search(query, collector)
+    withNewSearcher(s => s.search(query, collector))
     partKeySpan.finish()
     collector.result
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -73,9 +73,9 @@ extends MemStore with StrictLogging {
   /**
     * WARNING: use only for testing. Not performant
     */
-  def commitIndexForTesting(dataset: DatasetRef): Unit =
+  def refreshIndexForTesting(dataset: DatasetRef): Unit =
     datasets.get(dataset).foreach(_.values().asScala.foreach { s =>
-      s.commitPartKeyIndexBlocking()
+      s.refreshPartKeyIndexBlocking()
     })
 
   /**
@@ -180,13 +180,13 @@ extends MemStore with StrictLogging {
     }
   }
 
-  def indexNames(dataset: DatasetRef): Iterator[(String, Int)] =
+  def indexNames(dataset: DatasetRef, limit: Int): Seq[(String, Int)] =
     datasets.get(dataset).map { shards =>
-      shards.entrySet.iterator.asScala.flatMap { entry =>
+      shards.entrySet.asScala.flatMap { entry =>
         val shardNum = entry.getKey.toInt
-        entry.getValue.indexNames.map { s => (s, shardNum) }
-      }
-    }.getOrElse(Iterator.empty)
+        entry.getValue.indexNames(limit).map { s => (s, shardNum) }
+      }.toSeq
+    }.getOrElse(Nil)
 
   def labelValues(dataset: DatasetRef, shard: Int, labelName: String, topK: Int = 100): Seq[TermInfo] =
     getShard(dataset, shard).map(_.labelValues(labelName, topK)).getOrElse(Nil)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -476,7 +476,7 @@ class TimeSeriesShard(val dataset: Dataset,
 
   def completeIndexRecovery(): Unit = {
     assertThreadName(IngestSchedName)
-    commitPartKeyIndexBlocking()
+    refreshPartKeyIndexBlocking()
     startFlushingIndex() // start flushing index now that we have recovered
     logger.info(s"Bootstrapped index for dataset=${dataset.ref} shard=$shardNum")
   }
@@ -555,7 +555,7 @@ class TimeSeriesShard(val dataset: Dataset,
       s" numPartsInIndex=${partIdMap.size} numIngestingParts=${partitions.size}")
   }
 
-  def indexNames: Iterator[String] = partKeyIndex.indexNames
+  def indexNames(limit: Int): Seq[String] = partKeyIndex.indexNames(limit)
 
   def labelValues(labelName: String, topK: Int): Seq[TermInfo] = partKeyIndex.indexValues(labelName, topK)
 
@@ -650,9 +650,9 @@ class TimeSeriesShard(val dataset: Dataset,
   }
 
   /**
-    * WARNING: use only for testing. Not performant
+    * WARNING: Not performant. Use only in tests, or during initial bootstrap.
     */
-  def commitPartKeyIndexBlocking(): Unit = partKeyIndex.commitBlocking()
+  def refreshPartKeyIndexBlocking(): Unit = partKeyIndex.refreshReadersBlocking()
 
   def closePartKeyIndex(): Unit = partKeyIndex.closeIndex()
 

--- a/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
@@ -42,7 +42,7 @@ class DemandPagedChunkStoreSpec extends FunSpec with AsyncTest {
     val initData = records(dataset1, linearMultiSeries(start).take(20))
     memStore.ingest(dataset1.ref, 0, initData)
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
 
     val rawData = linearMultiSeries(start, timeStep=100000).drop(100).take(900)  // makes 9 chunks per partition?

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -27,7 +27,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   before {
     keyIndex.reset()
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
   }
 
   after {
@@ -50,7 +50,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
     }
     val end = System.currentTimeMillis()
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     // Should get empty iterator when passing no filters
     val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
@@ -90,7 +90,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
         keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, time)()
         if (i%2 == 0) keyIndex.upsertPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, time, time + 300)()
     }
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     keyIndex.indexNumEntries shouldEqual 10
 
@@ -112,7 +112,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       .zipWithIndex.foreach { case (addr, i) =>
       keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, start + i)()
     }
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     val startTimes = keyIndex.startTimeFromPartIds((0 until numPartIds).iterator)
     for { i <- 0 until numPartIds} {
@@ -129,7 +129,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       .zipWithIndex.foreach { case (addr, i) =>
       keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, start + i, start + i + 100)()
     }
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     val pIds = keyIndex.partIdsEndedBefore(start + 200)
     for { i <- 0 until numPartIds} {
@@ -137,7 +137,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     keyIndex.removePartKeys(pIds)
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     for { i <- 0 until numPartIds} {
       keyIndex.partKeyFromPartId(i).isDefined shouldEqual (if (i <= 100) false else true)
@@ -152,11 +152,11 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       .zipWithIndex.foreach { case (addr, i) =>
       val time = System.currentTimeMillis()
       keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, time)()
-      keyIndex.commitBlocking() // updates need to be able to read startTime from index, so commit
+      keyIndex.refreshReadersBlocking() // updates need to be able to read startTime from index, so commit
       keyIndex.updatePartKeyWithEndTime(partKeyOnHeap(dataset6, ZeroPointer, addr), i, time + 10000)()
     }
     val end = System.currentTimeMillis()
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     // Should get empty iterator when passing no filters
     val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
@@ -194,7 +194,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
     }
 
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     val filter2 = ColumnFilter("Actor2Name", Equals(UTF8Wrapper("REGIME".utf8)))
     val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), 0, Long.MaxValue)
@@ -212,9 +212,9 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
     }
 
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
-    keyIndex.indexNames.toList shouldEqual Seq("Actor2Code", "Actor2Name")
+    keyIndex.indexNames(10).toList shouldEqual Seq("Actor2Code", "Actor2Name")
     keyIndex.indexValues("not_found").toSeq should equal (Nil)
 
     val infos = Seq("AFR", "CHN", "COP", "CVL", "EGYEDU").map(_.utf8).map(TermInfo(_, 1))
@@ -233,7 +233,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
     }
 
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
       ColumnFilter("Actor2Name", Equals("REGIME".utf8)))
@@ -251,7 +251,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
     partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
       index2.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
     }
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)), ColumnFilter("Year", Equals(1979)))
     val partNums1 = index2.partIdsFromFilters(filters1, 0, Long.MaxValue)
@@ -264,7 +264,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       .zipWithIndex.foreach { case (addr, i) =>
       val partKeyBytes = partKeyOnHeap(dataset6, ZeroPointer, addr)
       keyIndex.addPartKey(partKeyBytes, i, System.currentTimeMillis())()
-      keyIndex.commitBlocking()
+      keyIndex.refreshReadersBlocking()
       keyIndex.partKeyFromPartId(i).get.bytes shouldEqual partKeyBytes
 //      keyIndex.partIdFromPartKey(new BytesRef(partKeyBytes)) shouldEqual i
     }
@@ -276,12 +276,12 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
       .zipWithIndex.map { case (addr, i) =>
         val start = Math.abs(Random.nextLong())
         keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, start)()
-        keyIndex.commitBlocking() // updates need to be able to read startTime from index, so commit
+        keyIndex.refreshReadersBlocking() // updates need to be able to read startTime from index, so commit
         val end = start + Random.nextInt()
         keyIndex.updatePartKeyWithEndTime(partKeyOnHeap(dataset6, ZeroPointer, addr), i, end)()
         (end, start, i)
       }
-    keyIndex.commitBlocking()
+    keyIndex.refreshReadersBlocking()
 
     for {
       from <- 0 until 99 // for various from values

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -48,7 +48,7 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
   override def beforeAll(): Unit = {
     memStore.setup(timeseriesDataset, 0, TestData.storeConf)
     memStore.ingest(timeseriesDataset.ref, 0, SomeData(container, 0))
-    memStore.commitIndexForTesting(timeseriesDataset.ref)
+    memStore.refreshIndexForTesting(timeseriesDataset.ref)
   }
 
   it ("should read the metadata") {

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -56,9 +56,9 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data = records(dataset1, rawData)   // 2 records per series x 10 series
     memStore.ingest(dataset1.ref, 0, data)
 
-    memStore.asInstanceOf[TimeSeriesMemStore].commitIndexForTesting(dataset1.ref)
+    memStore.asInstanceOf[TimeSeriesMemStore].refreshIndexForTesting(dataset1.ref)
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
-    memStore.indexNames(dataset1.ref).toSeq should equal (Seq(("series", 0)))
+    memStore.indexNames(dataset1.ref, 10).toSeq should equal (Seq(("series", 0)))
     memStore.latestOffset(dataset1.ref, 0) shouldEqual 0
 
     val minSet = rawData.map(_(1).asInstanceOf[Double]).toSet
@@ -83,7 +83,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
       memStore.ingest(dataset1.ref, 0, data)
     }
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     val split = memStore.getScanSplits(dataset1.ref, 1).head
     val agg1 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(split)).map(_.getDouble(0)).sum
     agg1 shouldEqual (1 to 20).map(_.toDouble).sum
@@ -94,7 +94,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data = records(dataset2, withMap(linearMultiSeries().take(20)))   // 2 records per series x 10 series
     memStore.ingest(dataset2.ref, 0, data)
 
-    memStore.asInstanceOf[TimeSeriesMemStore].commitIndexForTesting(dataset2.ref)
+    memStore.asInstanceOf[TimeSeriesMemStore].refreshIndexForTesting(dataset2.ref)
     val split = memStore.getScanSplits(dataset2.ref, 1).head
     val filter = ColumnFilter("n", Filter.Equals("2".utf8))
     val agg1 = memStore.scanRows(dataset2, Seq(1), FilteredPartitionScan(split, Seq(filter))).map(_.getDouble(0)).sum
@@ -105,7 +105,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.setup(histDataset, 0, TestData.storeConf)
     val data = linearHistSeries().take(40)
     memStore.ingest(histDataset.ref, 0, records(histDataset, data))
-    memStore.commitIndexForTesting(histDataset.ref)
+    memStore.refreshIndexForTesting(histDataset.ref)
 
     memStore.numRowsIngested(histDataset.ref, 0) shouldEqual 40L
     // Below will catch any partition match errors.  Should only be 10 tsParts.
@@ -155,7 +155,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.setup(dataset1, 0, TestData.storeConf)
     val data = records(dataset1, linearMultiSeries().take(20))   // 2 records per series x 10 series
     memStore.ingest(dataset1.ref, 0, data)
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
 
     val filter =  ColumnFilter("series", Filter.Equals("Series 1".utf8))
     val split = memStore.getScanSplits(dataset1.ref, 1).head
@@ -170,7 +170,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.ingest(dataset2.ref, 0, data)
     val data2 = records(dataset2, withMap(linearMultiSeries(200000L, 6), 6).take(20))   // 5 series only
     memStore.ingest(dataset2.ref, 1, data2)
-    memStore.commitIndexForTesting(dataset2.ref)
+    memStore.refreshIndexForTesting(dataset2.ref)
 
     memStore.activeShards(dataset1.ref) should equal (Seq(0, 1))
     memStore.numRowsIngested(dataset1.ref, 0) should equal (20L)
@@ -178,7 +178,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val splits = memStore.getScanSplits(dataset2.ref, 1)
     splits should have length (2)
 
-    memStore.indexNames(dataset2.ref).toSet should equal (
+    memStore.indexNames(dataset2.ref, 10).toSet should equal (
       Set(("n", 0), ("series", 0), ("n", 1), ("series", 1)))
 
     val filter = ColumnFilter("n", Filter.Equals("2".utf8))
@@ -206,7 +206,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     fut1.futureValue
     fut2.futureValue
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     val splits = memStore.getScanSplits(dataset1.ref, 1)
     val agg1 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(splits.head))
                        .map(_.getDouble(0)).sum
@@ -245,7 +245,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     // Two flushes and 3 chunksets have been flushed
     chunksetsWritten shouldEqual initChunksWritten + 4
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     // Try reading - should be able to read optimized chunks too
     val splits = memStore.getScanSplits(dataset1.ref, 1)
     val agg1 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(splits.head))
@@ -299,7 +299,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     timeBucketRb.optimalContainerBytes(true).foreach { bytes =>
       tsShard.extractTimeBucket(new IndexData(1, 0, RecordContainer(bytes)), partIdMap)
     }
-    tsShard.commitPartKeyIndexBlocking()
+    tsShard.refreshPartKeyIndexBlocking()
     partIdMap.size shouldEqual partKeys.size
     partKeys.zipWithIndex.foreach { case (off, i) =>
       val readPartKey = tsShard.partKeyIndex.partKeyFromPartId(i).get
@@ -353,7 +353,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     // no flushes
     chunksetsWritten shouldEqual initChunksWritten
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     // Should have less than 50 records ingested
     // Try reading - should be able to read optimized chunks too
     val splits = memStore.getScanSplits(dataset1.ref, 1)
@@ -367,9 +367,9 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data = records(dataset1, multiSeriesData().take(20))   // 2 records per series x 10 series
     memStore.ingest(dataset1.ref, 0, data)
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
-    memStore.indexNames(dataset1.ref).toSeq should equal (Seq(("series", 0)))
+    memStore.indexNames(dataset1.ref, 10).toSeq should equal (Seq(("series", 0)))
 
     memStore.truncate(dataset1.ref)
 
@@ -390,7 +390,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
       shard.updatePartEndTimeInIndex(part, part.timestampOfLatestSample)
       endTime = part.timestampOfLatestSample
     }
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     endTime
   }
 
@@ -401,7 +401,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data = records(dataset1, linearMultiSeries().take(10))
     memStore.ingest(dataset1.ref, 0, data)
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
 
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
     memStore.labelValues(dataset1.ref, 0, "series").toSeq should have length (10)
@@ -419,7 +419,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.getShardE(dataset1.ref, 0).evictionWatermark shouldEqual endTime + 1
     memStore.getShardE(dataset1.ref, 0).addPartitionsDisabled() shouldEqual false
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     val split = memStore.getScanSplits(dataset1.ref, 1).head
     val parts = memStore.scanPartitions(dataset1, Seq(0, 1), FilteredPartitionScan(split))
                         .toListL.runAsync
@@ -437,7 +437,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data = records(dataset1, linearMultiSeries().take(10))
     memStore.ingest(dataset1.ref, 0, data)
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
 
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
     memStore.labelValues(dataset1.ref, 0, "series").toSeq should have length (10)
@@ -473,7 +473,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data = records(dataset1, linearMultiSeries().take(10))
     memStore.ingest(dataset1.ref, 0, data)
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
 
     val shard0 = memStore.getShard(dataset1.ref, 0).get
     val shard0Partitions = shard0.partitions
@@ -517,7 +517,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data = records(dataset1, linearMultiSeries().take(10))
     memStore.ingest(dataset1.ref, 0, data)
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
 
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 10
     memStore.labelValues(dataset1.ref, 0, "series").toSeq should have length (10)
@@ -531,7 +531,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 21   // due to the way the eviction policy works
     memStore.getShardE(dataset1.ref, 0).evictionWatermark shouldEqual 0
 
-    memStore.commitIndexForTesting(dataset1.ref)
+    memStore.refreshIndexForTesting(dataset1.ref)
     // Check partitions are now 0 to 20, 21/22 did not get added
     val split = memStore.getScanSplits(dataset1.ref, 1).head
     val parts = memStore.scanPartitions(dataset1, Seq(0, 1), FilteredPartitionScan(split))
@@ -554,7 +554,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
       // Ingest normal multi series data with 10 partitions.  Should have 10 partitions.
       val data = records(dataset1, linearMultiSeries(numSeries = numSeries).take(numSeries))
       store2.ingest(dataset1.ref, 0, data)
-      store2.commitIndexForTesting(dataset1.ref)
+      store2.refreshIndexForTesting(dataset1.ref)
 
       store2.numPartitions(dataset1.ref, 0) shouldEqual numSeries
       shard.bufferPool.poolSize shouldEqual 100    // Two allocations of 200 each = 400; used up 300; 400-300=100

--- a/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
@@ -53,7 +53,7 @@ class HistogramQueryBenchmark {
   memStore.setup(histDataset, 0, ingestConf)
   val hShard = memStore.getShardE(histDataset.ref, 0)
   histSchemaBuilder.allContainers.foreach { c => hShard.ingest(c, 0) }
-  memStore.commitIndexForTesting(histDataset.ref) // commit lucene index
+  memStore.refreshIndexForTesting(histDataset.ref) // commit lucene index
 
   // Prometheus hist data: 10 series * 66 = 660 series * 180 samples
   println("Ingesting containers of prometheus schema data....")
@@ -65,7 +65,7 @@ class HistogramQueryBenchmark {
   memStore.setup(promDataset, 0, ingestConf)
   val pShard = memStore.getShardE(promDataset.ref, 0)
   promBuilder.allContainers.foreach { c => pShard.ingest(c, 0) }
-  memStore.commitIndexForTesting(promDataset.ref) // commit lucene index
+  memStore.refreshIndexForTesting(promDataset.ref) // commit lucene index
 
   val system = ActorSystem("test", ConfigFactory.load("filodb-defaults.conf"))
   private val cluster = FilodbCluster(system)

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -38,7 +38,7 @@ class PartKeyIndexBenchmark {
     }
   }
   partKeyBuilder.allContainers.foreach(_.consumeRecords(consumer))
-  partKeyIndex.commitBlocking()
+  partKeyIndex.refreshReadersBlocking()
 
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -114,7 +114,7 @@ class QueryAndIngestBenchmark extends StrictLogging {
   // Initial ingest just to populate index
   Await.result(ingestSamples(30), 30.seconds)
   Thread sleep 2000
-  memstore.commitIndexForTesting(dataset.ref) // commit lucene index
+  memstore.refreshIndexForTesting(dataset.ref) // commit lucene index
   println(s"Initial ingestion ended, indexes set up")
 
   /**

--- a/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
@@ -95,7 +95,7 @@ class QueryHiCardInMemoryBenchmark extends StrictLogging {
   Await.result(producingFut, 200.seconds)
   Thread sleep 2000
   val store = cluster.memStore.asInstanceOf[TimeSeriesMemStore]
-  store.commitIndexForTesting(dataset.ref) // commit lucene index
+  store.refreshIndexForTesting(dataset.ref) // commit lucene index
   println(s"Ingestion ended")
 
   // Stuff for directly executing queries ourselves

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -97,7 +97,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
                     }.countL.runAsync
   Await.result(producingFut, 30.seconds)
   Thread sleep 2000
-  cluster.memStore.asInstanceOf[TimeSeriesMemStore].commitIndexForTesting(dataset.ref) // commit lucene index
+  cluster.memStore.asInstanceOf[TimeSeriesMemStore].refreshIndexForTesting(dataset.ref) // commit lucene index
   println(s"Ingestion ended")
 
   // Stuff for directly executing queries ourselves

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -113,7 +113,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
                     }.countL.runAsync
   Await.result(producingFut, 30.seconds)
   Thread sleep 2000
-  memStore.commitIndexForTesting(dataset.ref) // commit lucene index
+  memStore.refreshIndexForTesting(dataset.ref) // commit lucene index
   println(s"Ingestion ended.")
 
   // For each invocation, reclaim all blocks to make sure ODP is really happening

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -58,7 +58,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
   override def beforeAll(): Unit = {
     memStore.setup(timeseriesDataset, 0, TestData.storeConf)
     memStore.ingest(timeseriesDataset.ref, 0, SomeData(container, 0))
-    memStore.commitIndexForTesting(timeseriesDataset.ref)
+    memStore.refreshIndexForTesting(timeseriesDataset.ref)
   }
 
   override def afterAll(): Unit = {

--- a/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
@@ -78,10 +78,10 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
     memStore.ingest(MMD.histDataset.ref, 0, MMD.records(MMD.histDataset, histData))
     memStore.setup(MMD.histMaxDS, 0, TestData.storeConf)
     memStore.ingest(MMD.histMaxDS.ref, 0, MMD.records(MMD.histMaxDS, histMaxData))
-    memStore.commitIndexForTesting(timeseriesDataset.ref)
-    memStore.commitIndexForTesting(MMD.dataset1.ref)
-    memStore.commitIndexForTesting(MMD.histDataset.ref)
-    memStore.commitIndexForTesting(MMD.histMaxDS.ref)
+    memStore.refreshIndexForTesting(timeseriesDataset.ref)
+    memStore.refreshIndexForTesting(MMD.dataset1.ref)
+    memStore.refreshIndexForTesting(MMD.histDataset.ref)
+    memStore.refreshIndexForTesting(MMD.histMaxDS.ref)
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

After each `acquire` of searcher, we need to call `release` so that searcher releases the segments and they are deleted after merge. Prior to this change, release calls were not being made.

Currently, we are seeing a constant growth of disk space because old segments are never deleted. Expecting that this change will fix it.

Also renamed commit operation to refresh. Those two are technically different in Lucene. We are actually not doing commit at the bottom of the call stack.
