### PR TITLE
misc(prometheus): Add scala-parser-combinators dependencies directly to prometheus module

### DIFF
--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -269,7 +269,8 @@ object FiloBuild extends Build {
     logbackDep % "test,it")
 
   lazy val promDeps = Seq(
-    "com.google.protobuf" % "protobuf-java" % "2.5.0"
+    "com.google.protobuf" % "protobuf-java" % "2.5.0",
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
   )
 
   lazy val gatewayDeps = commonDeps ++ Seq(


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Though the prometheus module has a direct dependency on org.scala-lang.modules:scala-parser-combinators_2.11:1.1.1 , corresponding jar is getting pulled in via kamon-akka-remote.


**New behavior :**
Prometheus module will have direct dependency on org.scala-lang.modules:scala-parser-combinators_2.11:1.1.1
