### PR TITLE
feat(core): PartitionKey/BR: +SchemID, Map format changes; RecordContainer timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+dist: trusty
 env:
   global:
    _JAVA_OPTIONS="-Dakka.test.timefactor=3 -XX:MaxMetaspaceSize=256m"

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -207,12 +207,13 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
 
   def validateSchemas(): Unit = {
     Schemas.fromConfig(config) match {
-      case Good(Schemas(partSchema, data, _)) =>
+      case Good(Schemas(partSchema, schemas)) =>
         println("Schema validated.\nPartition schema:")
         partSchema.columns.foreach(c => println(s"\t$c"))
-        data.foreach { case (schemaName, sch) =>
+        schemas.foreach { case (schemaName, sch) =>
           println(s"Schema $schemaName:")
-          sch.columns.foreach(c => println(s"\t$c"))
+          sch.data.columns.foreach(c => println(s"\t$c"))
+          println(s"\n\tDownsamplers: ${sch.data.downsamplers}\n\tDownsample schema: ${sch.data.downsampleSchema}")
         }
       case Bad(errors) =>
         println(s"Schema validation errors:")

--- a/coordinator/src/main/scala/filodb.coordinator/sources/CsvStream.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/sources/CsvStream.scala
@@ -106,8 +106,8 @@ private[filodb] class CsvStream(csvReader: CSVReader,
                         .grouped(settings.batchSize)
                         .zipWithIndex
                         .flatMap { case (readers, idx) =>
-                          val builder = new RecordBuilder(MemFactory.onHeapFactory, dataset.ingestionSchema)
-                          readers.foreach(builder.addFromReader)
+                          val builder = new RecordBuilder(MemFactory.onHeapFactory)
+                          readers.foreach(builder.addFromReader(_, dataset.schema))
                           // Most likely to have only one container.  Just assign same offset.
                           builder.allContainers.map { c => SomeData(c, idx) }
                         }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -47,6 +47,9 @@ filodb {
 
       # Downsampling configuration.  See doc/downsampling.md
       downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
+
+      # If downsamplers are defined, then the downsample schema must also be defined
+      downsample-schema = "prom-ds-gauge"
     }
 
     # Used for downsampled gauge data

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -82,7 +82,7 @@ final class RecordBuilder(memFactory: MemFactory,
    * @param schemaID the schemaID to use.  It may not be the same as the schema of the recSchema - for example
    *        for partition keys.  However for ingestion records it would be the same.
    */
-  final def startNewRecord(recSchema: RecordSchema, schemaID: Int): Unit = {
+  private[core] final def startNewRecord(recSchema: RecordSchema, schemaID: Int): Unit = {
     require(curRecEndOffset == curRecordOffset, s"Illegal state: $curRecEndOffset != $curRecordOffset")
 
     // Set schema, hashoffset, and write schema ID if needed
@@ -97,6 +97,13 @@ final class RecordBuilder(memFactory: MemFactory,
 
     fieldNo = 0
     recHash = HASH_INIT
+  }
+
+  // startNewRecord when one uses a RecordSchema for say query results, or where schemaID is not needed.
+  final def startNewRecord(schema: RecordSchema): Unit = {
+    // TODO: use types to eliminate this check?
+    require(schema.partitionFieldStart.isEmpty, s"Cannot use schema $schema with no schemaID")
+    startNewRecord(schema, 0)
   }
 
   // startNewRecord for an ingestion schema.  Use this if creating an ingestion record, ensures right ID is used.

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -54,6 +54,7 @@ final class RecordBuilder(memFactory: MemFactory,
   // Reset last container and all pointers
   def reset(): Unit = if (containers.nonEmpty) {
     resetContainerPointers()
+    containers.last.updateTimestamp()
     fieldNo = -1
     mapOffset = -1L
     recHash = -1
@@ -519,6 +520,7 @@ final class RecordBuilder(memFactory: MemFactory,
     curRecEndOffset = curRecordOffset
     container.updateLengthWithOffset(curRecordOffset)
     container.writeVersionWord()
+    container.updateTimestamp()
     maxOffset = newOff + containerSize
   }
 
@@ -546,8 +548,9 @@ object RecordBuilder {
 
   // Please do not change this.  It should only be changed with a change in BinaryRecord and/or RecordContainer
   // format, and only then REALLY carefully.
-  val Version = 0
-  val ContainerHeaderLen = 8
+  val Version = 1
+  val ContainerHeaderLen = 16
+  val EmptyNumBytes = ContainerHeaderLen - 4
 
   val stringPairComparator = new java.util.Comparator[(String, String)] {
     def compare(pair1: (String, String), pair2: (String, String)): Int = pair1._1 compare pair2._1

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
@@ -120,7 +120,7 @@ final class RecordComparator(ingestSchema: RecordSchema) {
    * @return the Long offset or native address of the new partition key BR
    */
   final def buildPartKeyFromIngest(ingestBase: Any, ingestOffset: Long, builder: RecordBuilder): Long = {
-    require(builder.schema == partitionKeySchema, s"${builder.schema} is not part key schema $partitionKeySchema")
+    builder.setSchema(partitionKeySchema)
 
     // Copy fixed area + hash over, then variable areas
     val ingestNumBytes = UnsafeUtils.getInt(ingestBase, ingestOffset)

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.agrona.DirectBuffer
 import org.agrona.concurrent.UnsafeBuffer
 
-import filodb.core.metadata.{Column, Dataset}
+import filodb.core.metadata.Column
 import filodb.core.metadata.Column.ColumnType.{LongColumn, TimestampColumn}
 import filodb.core.query.ColumnInfo
 import filodb.memory.{BinaryRegion, BinaryRegionLarge, UTF8StringMedium}
@@ -400,16 +400,6 @@ object RecordSchema {
   }
 
   final def schemaID(addr: BinaryRegion.NativePointer): Int = schemaID(UnsafeUtils.ZeroPointer, addr)
-
-  /**
-   * Create an "ingestion" RecordSchema with the data columns followed by the partition columns.
-   */
-  def ingestion(dataset: Dataset, predefinedKeys: Seq[String] = Nil): RecordSchema = {
-    val columns = dataset.dataColumns ++ dataset.partitionColumns
-    new RecordSchema(columns.map(c => ColumnInfo(c.name, c.columnType)),
-                     Some(dataset.dataColumns.length),
-                     predefinedKeys)
-  }
 
   def fromSerializableTuple(tuple: (Seq[ColumnInfo],
                                     Option[Int], Seq[String], Map[Int, RecordSchema])): RecordSchema =

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -304,6 +304,7 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
    * Allows us to compare two RecordSchemas against each other
    */
   override def equals(other: Any): Boolean = other match {
+    case UnsafeUtils.ZeroPointer => false
     case r: RecordSchema => columnTypes == r.columnTypes &&
                             partitionFieldStart == r.partitionFieldStart &&
                             predefinedKeys == r.predefinedKeys

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -398,6 +398,8 @@ object RecordSchema {
     UnsafeUtils.getShort(base, offset + 4) & 0x0ffff
   }
 
+  final def schemaID(addr: BinaryRegion.NativePointer): Int = schemaID(UnsafeUtils.ZeroPointer, addr)
+
   /**
    * Create an "ingestion" RecordSchema with the data columns followed by the partition columns.
    */

--- a/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
+++ b/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
@@ -6,10 +6,9 @@ import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 
 import filodb.core.{ErrorResponse, Response, Success}
-import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
+import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesShardStats}
-import filodb.core.metadata.Dataset
-import filodb.core.query.ColumnInfo
+import filodb.core.metadata.Schema
 import filodb.core.store.ChunkInfoIterator
 import filodb.memory.MemFactory
 
@@ -18,23 +17,25 @@ final case class DownsampleRecords(resolution: Int, builder: RecordBuilder)
 /**
   * This class takes the responsibility of carrying out the
   * downsampling algorithms and publish to another dataset given the chunksets.
+  * One ShardDownsampler exist for each source schema to target schema.
   */
-class ShardDownsampler(dataset: Dataset,
+class ShardDownsampler(datasetName: String,
                        shardNum: Int,
+                       sourceSchema: Schema,
+                       targetSchema: Schema,
                        enabled: Boolean,
                        resolutions: Seq[Int],
                        publisher: DownsamplePublisher,
                        stats: TimeSeriesShardStats) extends StrictLogging {
-  private val downsamplers = dataset.schema.data.downsamplers
+  private val downsamplers = sourceSchema.data.downsamplers
 
   if (enabled) {
-    logger.info(s"Downsampling enabled for dataset=${dataset.ref} shard=$shardNum with " +
+    logger.info(s"Downsampling enabled for dataset=$datasetName shard=$shardNum with " +
       s"following downsamplers: ${downsamplers.map(_.encoded)} at resolutions: $resolutions")
+    logger.info(s"From source schema $sourceSchema to target schema $targetSchema")
   } else {
-    logger.info(s"Downsampling disabled for dataset=${dataset.ref} shard=$shardNum")
+    logger.info(s"Downsampling disabled for dataset=$datasetName shard=$shardNum")
   }
-
-  private[downsample] val downsampleSchema = downsampleIngestSchema()
 
   /**
     * Allocates record builders to store downsample records for chunksets that
@@ -48,21 +49,11 @@ class ShardDownsampler(dataset: Dataset,
   def newEmptyDownsampleRecords: Seq[DownsampleRecords] = {
     if (enabled) {
       resolutions.map { res =>
-        DownsampleRecords(res, new RecordBuilder(MemFactory.onHeapFactory, downsampleSchema))
+        DownsampleRecords(res, new RecordBuilder(MemFactory.onHeapFactory))
       }
     } else {
       Seq.empty
     }
-  }
-
-  /**
-    * Formulates downsample schema using the downsampler configuration for dataset
-    */
-  private[downsample] def downsampleIngestSchema(): RecordSchema = {
-    // The name of the column in downsample record does not matter at the ingestion side. Type does matter.
-    val downsampleCols = downsamplers.map { d => ColumnInfo(s"${d.name.entryName}", d.colType) }
-    new RecordSchema(downsampleCols ++ dataset.partKeySchema.columns,
-      Some(downsampleCols.size), dataset.ingestionSchema.predefinedKeys)
   }
 
   /**
@@ -76,15 +67,14 @@ class ShardDownsampler(dataset: Dataset,
                                 records: Seq[DownsampleRecords]): Unit = {
     if (enabled) {
       val downsampleTrace = Kamon.buildSpan("memstore-downsample-records-trace")
-        .withTag("dataset", dataset.name)
+        .withTag("dataset", datasetName)
         .withTag("shard", shardNum).start()
-      val timestampCol = dataset.timestampColID
       while (chunksets.hasNext) {
         val chunkset = chunksets.nextInfo
         val startTime = chunkset.startTime
         val endTime = chunkset.endTime
-        val vecPtr = chunkset.vectorPtr(timestampCol)
-        val tsReader = part.chunkReader(timestampCol, vecPtr).asLongReader
+        val tsPtr = chunkset.vectorPtr(0)
+        val tsReader = part.chunkReader(0, tsPtr).asLongReader
         // for each downsample resolution
         records.foreach { case DownsampleRecords(resolution, builder) =>
           var pStart = ((startTime - 1) / resolution) * resolution + 1 // inclusive startTime for downsample period
@@ -92,9 +82,9 @@ class ShardDownsampler(dataset: Dataset,
           // for each downsample period
           while (pStart <= endTime) {
             // fix the boundary row numbers for the downsample period by looking up the timestamp column
-            val startRowNum = tsReader.binarySearch(vecPtr, pStart) & 0x7fffffff
-            val endRowNum = Math.min(tsReader.ceilingIndex(vecPtr, pEnd), chunkset.numRows - 1)
-            builder.startNewRecord()
+            val startRowNum = tsReader.binarySearch(tsPtr, pStart) & 0x7fffffff
+            val endRowNum = Math.min(tsReader.ceilingIndex(tsPtr, pEnd), chunkset.numRows - 1)
+            builder.startNewRecord(targetSchema)
             // for each downsampler, add downsample column value
             downsamplers.foreach {
               case d: TimeChunkDownsampler =>
@@ -105,7 +95,7 @@ class ShardDownsampler(dataset: Dataset,
                 builder.addBlob(h.downsampleChunk(part, chunkset, startRowNum, endRowNum).serialize())
             }
             // add partKey finally
-            builder.addPartKeyRecordFields(part.partKeyBase, part.partKeyOffset, dataset.partKeySchema)
+            builder.addPartKeyRecordFields(part.partKeyBase, part.partKeyOffset, sourceSchema.partKeySchema)
             builder.endRecord(true)
             stats.downsampleRecordsCreated.increment()
             pStart += resolution
@@ -126,7 +116,7 @@ class ShardDownsampler(dataset: Dataset,
       val responses = dsRecords.map { rec =>
         val containers = rec.builder.optimalContainerBytes(true)
         logger.debug(s"Publishing ${containers.size} downsample record containers " +
-          s"of dataset=${dataset.ref} shard=$shardNum for resolution ${rec.resolution}")
+          s"of dataset=$datasetName shard=$shardNum for resolution ${rec.resolution}")
         publisher.publish(shardNum, rec.resolution, containers)
       }
       Future.sequence(responses).map(_.find(_.isInstanceOf[ErrorResponse]).getOrElse(Success))

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -28,7 +28,7 @@ import filodb.core.metadata.Dataset
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.query.Filter._
 import filodb.core.store.StoreConfig
-import filodb.memory.{BinaryRegionLarge, UTF8StringMedium}
+import filodb.memory.{BinaryRegionLarge, UTF8StringMedium, UTF8StringShort}
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String => UTF8Str}
 
 object PartKeyLuceneIndex {
@@ -103,8 +103,8 @@ class PartKeyLuceneIndex(dataset: Dataset,
   private val mapConsumer = new MapItemConsumer {
     def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
       import filodb.core._
-      val key = utf8ToStrCache.getOrElseUpdate(new UTF8Str(keyBase, keyOffset + 2,
-                                                           UTF8StringMedium.numBytes(keyBase, keyOffset)),
+      val key = utf8ToStrCache.getOrElseUpdate(new UTF8Str(keyBase, keyOffset + 1,
+                                                           UTF8StringShort.numBytes(keyBase, keyOffset)),
                                                _.toString)
       val value = new BytesRef(valueBase.asInstanceOf[Array[Byte]],
                                unsafeOffsetToBytesRefOffset(valueOffset + 2), // add 2 to move past numBytes

--- a/core/src/main/scala/filodb.core/memstore/PartitionKeyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionKeyIndex.scala
@@ -10,8 +10,8 @@ import filodb.core.metadata.{Column, Dataset}
 import filodb.core.query.ColumnFilter
 import filodb.core.store.ChunkSetInfo.emptySkips
 import filodb.core.Types.PartitionKey
+import filodb.memory.{UTF8StringMedium, UTF8StringShort}
 import filodb.memory.format.{ZeroCopyUTF8String => UTF8Str}
-import filodb.memory.UTF8StringMedium
 
 trait Indexer {
   def fromPartKey(base: Any, offset: Long, partIndex: Int): Unit
@@ -35,7 +35,7 @@ class PartitionKeyIndex(dataset: Dataset) extends StrictLogging {
 
   class IndexingMapConsumer(partIndex: Int) extends MapItemConsumer {
     def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
-      val keyUtf8 = new UTF8Str(keyBase, keyOffset + 2, UTF8StringMedium.numBytes(keyBase, keyOffset))
+      val keyUtf8 = new UTF8Str(keyBase, keyOffset + 1, UTF8StringShort.numBytes(keyBase, keyOffset))
       val valUtf8 = new UTF8Str(valueBase, valueOffset + 2, UTF8StringMedium.numBytes(valueBase, valueOffset))
       addIndexEntry(keyUtf8, valUtf8, partIndex)
     }

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -301,7 +301,10 @@ object Dataset {
    * @param name The name of the dataset
    * @param partitionColNameTypes list of partition columns in name:type[:params] form
    * @param dataColNameTypes list of data columns in name:type[:params] form
-   * @param keyColumnNames   the key column names, no :type
+   * @param downsamplerNames a list of downsamplers to use on this schema
+   * @param options DatasetOptions
+   * @param valueColumn the default value column to pick if a column is not supplied
+   * @param dsSchema Option, name of downsample schema, required if downsamplerNames is not empty
    * @return Good(Dataset) or Bad(BadSchema)
    */
   def make(name: String,
@@ -309,11 +312,12 @@ object Dataset {
            dataColNameTypes: Seq[String],
            downsamplerNames: Seq[String] = Seq.empty,
            options: DatasetOptions = DatasetOptions.DefaultOptions,
-           valueColumn: Option[String] = None): Dataset Or BadSchema = {
+           valueColumn: Option[String] = None,
+           dsSchema: Option[String] = None): Dataset Or BadSchema = {
     // Default value column is the last data column name
     val valueCol = valueColumn.getOrElse(dataColNameTypes.last.split(":").head)
     for { partSchema <- PartitionSchema.make(partitionColNameTypes, options)
-          dataSchema <- DataSchema.make(name, dataColNameTypes, downsamplerNames, valueCol) }
+          dataSchema <- DataSchema.make(name, dataColNameTypes, downsamplerNames, valueCol, dsSchema) }
     yield { Dataset(name, Schema(partSchema, dataSchema, None)) }
   }
 }

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -66,7 +66,7 @@ final case class Dataset(name: String, schema: Schema) {
    * Creates a PartitionKey (BinaryRecord v2) from individual parts.  Horribly slow, use for testing only.
    */
   def partKey(parts: Any*): Array[Byte] = {
-    val offset = partKeyBuilder.addFromObjects(schema, parts: _*)
+    val offset = partKeyBuilder.partKeyFromObjects(schema, parts: _*)
     val bytes = partKeySchema.asByteArray(partKeyBuilder.allContainers.head.base, offset)
     partKeyBuilder.reset()
     bytes

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -167,6 +167,7 @@ final case class Schema(partition: PartitionSchema, data: DataSchema, downsample
 
   val comparator      = new RecordComparator(ingestionSchema)
   val partKeySchema   = comparator.partitionKeySchema
+  val options         = partition.options
 }
 
 final case class Schemas(part: PartitionSchema,

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -188,7 +188,7 @@ object SerializableRangeVector extends StrictLogging {
       val rows = rv.rows
       while (rows.hasNext) {
         numRows += 1
-        builder.addFromReader(rows.next)
+        builder.addFromReader(rows.next, schema, 0)
       }
     } finally {
       // clear exec plan
@@ -210,7 +210,7 @@ object SerializableRangeVector extends StrictLogging {
     */
   def apply(rv: RangeVector, cols: Seq[ColumnInfo]): SerializableRangeVector = {
     val schema = toSchema(cols)
-    apply(rv, toBuilder(schema), schema, "Test-Only-Plan")
+    apply(rv, newBuilder(), schema, "Test-Only-Plan")
   }
 
   // TODO: make this configurable....
@@ -223,8 +223,8 @@ object SerializableRangeVector extends StrictLogging {
   def toSchema(colSchema: Seq[ColumnInfo], brSchemas: Map[Int, RecordSchema] = Map.empty): RecordSchema =
     schemaCache.getOrElseUpdate(colSchema, { cols => new RecordSchema(cols, brSchema = brSchemas) })
 
-  def toBuilder(schema: RecordSchema): RecordBuilder =
-    new RecordBuilder(MemFactory.onHeapFactory, schema, MaxContainerSize)
+  def newBuilder(): RecordBuilder =
+    new RecordBuilder(MemFactory.onHeapFactory, MaxContainerSize)
 }
 
 final case class IteratorBackedRangeVector(key: RangeVectorKey,

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -8,7 +8,7 @@ import filodb.core.binaryrecord2.{MapItemConsumer, RecordBuilder, RecordContaine
 import filodb.core.metadata.Column
 import filodb.core.metadata.Column.ColumnType._
 import filodb.core.store._
-import filodb.memory.{MemFactory, UTF8StringMedium}
+import filodb.memory.{MemFactory, UTF8StringMedium, UTF8StringShort}
 import filodb.memory.data.ChunkMap
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String => UTF8Str}
 
@@ -27,7 +27,7 @@ trait RangeVectorKey extends java.io.Serializable {
 class SeqMapConsumer extends MapItemConsumer {
   val pairs = new collection.mutable.ArrayBuffer[(UTF8Str, UTF8Str)]
   def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
-    val keyUtf8 = new UTF8Str(keyBase, keyOffset + 2, UTF8StringMedium.numBytes(keyBase, keyOffset))
+    val keyUtf8 = new UTF8Str(keyBase, keyOffset + 1, UTF8StringShort.numBytes(keyBase, keyOffset))
     val valUtf8 = new UTF8Str(valueBase, valueOffset + 2, UTF8StringMedium.numBytes(valueBase, valueOffset))
     pairs += (keyUtf8 -> valUtf8)
   }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -220,10 +220,8 @@ object SerializableRangeVector extends StrictLogging {
   val SchemaCacheSize = 100
   val schemaCache = concurrentCache[Seq[ColumnInfo], RecordSchema](SchemaCacheSize)
 
-  def toSchema(colSchema: Seq[ColumnInfo], brColInfos: Map[Int, Seq[ColumnInfo]] = Map.empty): RecordSchema = {
-    val brSchemas = brColInfos.mapValues(toSchema(_))
-    schemaCache.getOrElseUpdate(colSchema, { cols => new RecordSchema(columns = cols, brSchema = brSchemas) })
-  }
+  def toSchema(colSchema: Seq[ColumnInfo], brSchemas: Map[Int, RecordSchema] = Map.empty): RecordSchema =
+    schemaCache.getOrElseUpdate(colSchema, { cols => new RecordSchema(cols, brSchema = brSchemas) })
 
   def toBuilder(schema: RecordSchema): RecordBuilder =
     new RecordBuilder(MemFactory.onHeapFactory, schema, MaxContainerSize)

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -34,7 +34,7 @@ final case class ColumnInfo(name: String, colType: Column.ColumnType)
  * @param colIDs the column IDs of the columns, used to access additional columns if needed
  */
 final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
-                              brSchemas: Map[Int, Seq[ColumnInfo]] = Map.empty,
+                              brSchemas: Map[Int, RecordSchema] = Map.empty,
                               fixedVectorLen: Option[Int] = None,
                               colIDs: Seq[Int] = Nil) {
   import Column.ColumnType._

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -184,9 +184,11 @@ object GdeltTestData {
   // NOTE: For all datasets the row key is GLOBALEVENTID
   // Dataset1: Partition keys (Actor2Code, Year)
   val dataset1 = Dataset("gdelt", Seq(schema(4), schema(3)), schema.patch(3, Nil, 2), DatasetOptions.DefaultOptions)
+  val schema1 = dataset1.schema
 
   // Dataset2: Partition key (MonthYear)
   val dataset2 = Dataset("gdelt", Seq(schema(2)), schema.patch(2, Nil, 1))
+  val schema2 = dataset2.schema
   val partBuilder2 = new RecordBuilder(TestData.nativeMem, 10240)
 
   // Dataset3: same as Dataset1 for now
@@ -427,6 +429,7 @@ object MetricsTestData {
                                   Seq("timestamp:ts", "value:double:detectDrops=true"),
                                   Seq.empty,
                                   DatasetOptions(Seq("__name__", "job"), "__name__")).get
+  val timeseriesSchema = timeseriesDataset.schema
 
   val builder = new RecordBuilder(MemFactory.onHeapFactory)
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{SomeData, TimeSeriesPartitionSpec, WriteBufferPool}
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.metadata.{Dataset, DatasetOptions}
+import filodb.core.metadata.{Dataset, DatasetOptions, Schema}
 import filodb.core.query.RawDataRangeVector
 import filodb.core.store._
 import filodb.core.Types.{PartitionKey, UTF8Map}
@@ -92,8 +92,8 @@ object NamesTestData {
   val lastKey = dataset.timestamp(mapper(names).last)
   def keyForName(rowNo: Int): Long = dataset.timestamp(mapper(names)(rowNo))
 
-  val partKeyBuilder = new RecordBuilder(TestData.nativeMem, dataset.partKeySchema, 2048)
-  val defaultPartKey = partKeyBuilder.addFromObjects(0)
+  val partKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
+  val defaultPartKey = partKeyBuilder.partKeyFromObjects(dataset.schema, 0)
 
   def chunkSetStream(data: Seq[Product] = names): Observable[ChunkSet] =
     TestData.toChunkSetStream(dataset, defaultPartKey, mapper(data))
@@ -145,9 +145,9 @@ object GdeltTestData {
 
   // Routes input records to the dataset schema correctly
   def records(ds: Dataset, readerSeq: Seq[RowReader] = readers): SomeData = {
-    val builder = new RecordBuilder(MemFactory.onHeapFactory, ds.ingestionSchema)
+    val builder = new RecordBuilder(MemFactory.onHeapFactory)
     val routing = ds.ingestRouting(columnNames)
-    readerSeq.foreach { row => builder.addFromReader(RoutingRowReader(row, routing)) }
+    readerSeq.foreach { row => builder.addFromReader(RoutingRowReader(row, routing), ds.schema) }
     builder.allContainers.zipWithIndex.map { case (container, i) => SomeData(container, i) }.head
   }
 
@@ -157,7 +157,7 @@ object GdeltTestData {
   }
 
   def partKeyFromRecords(ds: Dataset, records: SomeData, builder: Option[RecordBuilder] = None): Seq[Long] = {
-    val partKeyBuilder = builder.getOrElse(new RecordBuilder(TestData.nativeMem, ds.partKeySchema))
+    val partKeyBuilder = builder.getOrElse(new RecordBuilder(TestData.nativeMem))
     records.records.map { case (base, offset) =>
       ds.comparator.buildPartKeyFromIngest(base, offset, partKeyBuilder)
     }.toVector
@@ -187,7 +187,7 @@ object GdeltTestData {
 
   // Dataset2: Partition key (MonthYear)
   val dataset2 = Dataset("gdelt", Seq(schema(2)), schema.patch(2, Nil, 1))
-  val partBuilder2 = new RecordBuilder(TestData.nativeMem, dataset2.partKeySchema, 10240)
+  val partBuilder2 = new RecordBuilder(TestData.nativeMem, 10240)
 
   // Dataset3: same as Dataset1 for now
   val dataset3 = dataset1
@@ -230,14 +230,15 @@ object MachineMetricsData {
 
   // Dataset1: Partition keys (series) / Row key timestamp
   val dataset1 = Dataset("metrics", Seq("series:string"), columns)
-  val partKeyBuilder = new RecordBuilder(TestData.nativeMem, dataset1.partKeySchema, 2048)
-  val defaultPartKey = partKeyBuilder.addFromObjects("series0")
+  val schema1 = dataset1.schema
+  val partKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
+  val defaultPartKey = partKeyBuilder.partKeyFromObjects(dataset1.schema, "series0")
 
   // Turns either multiSeriesData() or linearMultiSeries() into SomeData's for ingestion into MemStore
   def records(ds: Dataset, stream: Stream[Seq[Any]], offset: Int = 0): SomeData = {
-    val builder = new RecordBuilder(MemFactory.onHeapFactory, ds.ingestionSchema)
+    val builder = new RecordBuilder(MemFactory.onHeapFactory)
     stream.foreach { row =>
-      builder.startNewRecord()
+      builder.startNewRecord(ds.schema)
       row.foreach { thing => builder.addSlowly(thing) }
       builder.endRecord()
     }
@@ -252,7 +253,7 @@ object MachineMetricsData {
   // Works with linearMultiSeries() or multiSeriesData()
   def filterByPartAndMakeStream(stream: Stream[Seq[Any]], keyRecord: Int): Observable[ChunkSet] = {
     val rawPartKey = stream(keyRecord)(5)
-    val partKey = partKeyBuilder.addFromObjects(rawPartKey)
+    val partKey = partKeyBuilder.partKeyFromObjects(dataset1.schema, rawPartKey)
     TestData.toChunkSetStream(dataset1, partKey, stream.filter(_(5) == rawPartKey).map(SeqRowReader))
   }
 
@@ -280,9 +281,9 @@ object MachineMetricsData {
     }
   }
 
-  def addToBuilder(builder: RecordBuilder, data: Seq[Seq[Any]]): Unit = {
+  def addToBuilder(builder: RecordBuilder, data: Seq[Seq[Any]], schema: Schema = dataset1.schema): Unit = {
     data.foreach { values =>
-      builder.startNewRecord()
+      builder.startNewRecord(schema)
       builder.addLong(values(0).asInstanceOf[Long])     // timestamp
       builder.addDouble(values(1).asInstanceOf[Double])  // min
       builder.addDouble(values(2).asInstanceOf[Double])  // avg
@@ -302,6 +303,7 @@ object MachineMetricsData {
   }
 
   val dataset2 = Dataset("metrics", Seq("series:string", "tags:map"), columns)
+  val schema2 = dataset2.schema
 
   def withMap(data: Stream[Seq[Any]], n: Int = 5, extraTags: UTF8Map = Map.empty): Stream[Seq[Any]] =
     data.zipWithIndex.map { case (row, idx) => row :+ (Map("n".utf8 -> (idx % n).toString.utf8) ++ extraTags) }
@@ -356,8 +358,8 @@ object MachineMetricsData {
       ((row take 3) :+ max) ++ (row drop 3)
     }
 
-  val histKeyBuilder = new RecordBuilder(TestData.nativeMem, histDataset.partKeySchema, 2048)
-  val histPartKey = histKeyBuilder.addFromObjects(extraTags)
+  val histKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
+  val histPartKey = histKeyBuilder.partKeyFromObjects(histDataset.schema, extraTags)
 
   val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024, new MemoryStats(Map("test"-> "test")), null, 16)
   private val histIngestBH = new BlockMemFactory(blockStore, None, histDataset.blockMetaSize, true)
@@ -403,8 +405,8 @@ object CustomMetricsData {
                         columns,
                         Seq.empty,
                         DatasetOptions(Seq("metric", "_ns"), "metric")).get
-  val partKeyBuilder = new RecordBuilder(TestData.nativeMem, metricdataset.partKeySchema, 2048)
-  val defaultPartKey = partKeyBuilder.addFromObjects("metric1", "app1")
+  val partKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
+  val defaultPartKey = partKeyBuilder.partKeyFromObjects(metricdataset.schema, "metric1", "app1")
 
   //Partition Key with single map columns
   val partitionColumns2 = Seq("tags:map")
@@ -413,8 +415,9 @@ object CustomMetricsData {
                         columns,
                         Seq.empty,
                         DatasetOptions(Seq("__name__"), "__name__")).get
-  val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, metricdataset2.partKeySchema, 2048)
-  val defaultPartKey2 = partKeyBuilder2.addFromObjects(Map(ZeroCopyUTF8String("abc") -> ZeroCopyUTF8String("cba")))
+  val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, 2048)
+  val defaultPartKey2 = partKeyBuilder2.partKeyFromObjects(metricdataset2.schema,
+                                                           Map(ZeroCopyUTF8String("abc") -> ZeroCopyUTF8String("cba")))
 
 }
 
@@ -425,7 +428,7 @@ object MetricsTestData {
                                   Seq.empty,
                                   DatasetOptions(Seq("__name__", "job"), "__name__")).get
 
-  val builder = new RecordBuilder(MemFactory.onHeapFactory, timeseriesDataset.ingestionSchema)
+  val builder = new RecordBuilder(MemFactory.onHeapFactory)
 
   final case class TagsRowReader(tags: Map[String, String]) extends SchemaRowReader {
     val extractors = Array[RowReader.TypedFieldExtractor[_]](ColumnType.MapColumn.keyType.extractor)

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -25,7 +25,6 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
   val dataset3 = modify(dataset2)(_.schema.partition.predefinedKeys).setTo(Seq("job", "instance"))
   val schemaWithPredefKeys = dataset3.schema.ingestionSchema
-  schemaWithPredefKeys shouldEqual RecordSchema.ingestion(dataset2, Seq("job", "instance"))
 
   before {
     records.clear()

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -331,7 +331,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       val containers = builder.allContainers
       containers should have length (1)
       // 56 (len + 5 long/double + 2 var + hash) + 10 + 4 + extraTagsLen + 10 * 2)
-      containers.head.numBytes shouldEqual (4 + 3 * align4(70 + extraTagsLen + 2 + 20))
+      containers.head.numBytes shouldEqual (4 + 3 * align4(72 + extraTagsLen + 2 + 20))
 
       containers.head.consumeRecords(consumer)
       records should have length (3)

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -14,12 +14,18 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
   import MachineMetricsData._
   import UTF8StringMedium._
 
-  val schema1 = RecordSchema.ingestion(dataset1)
-  val schema2 = RecordSchema.ingestion(dataset2)
+  val recSchema1 = schema1.ingestionSchema
+  val recSchema2 = schema2.ingestionSchema
   val longStrSchema = new RecordSchema(Seq(ColumnInfo("lc", ColumnType.LongColumn),
                                            ColumnInfo("sc", ColumnType.StringColumn)))
 
   val records = new collection.mutable.ArrayBuffer[(Any, Long)]
+
+  import com.softwaremill.quicklens._
+
+  val dataset3 = modify(dataset2)(_.schema.partition.predefinedKeys).setTo(Seq("job", "instance"))
+  val schemaWithPredefKeys = dataset3.schema.partition.binSchema
+  schemaWithPredefKeys shouldEqual RecordSchema.ingestion(dataset2, Seq("job", "instance"))
 
   before {
     records.clear()
@@ -38,15 +44,15 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
   describe("RecordBuilder & RecordContainer") {
     it("should not allow adding a field before startNewRecord()") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema1)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
       intercept[IllegalArgumentException] {
         builder.addInt(1)
       }
     }
 
     it("should not allow adding a field beyond # of fields in schema") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema1)
-      builder.startNewRecord()
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(schema1)
       val ts = System.currentTimeMillis
       builder.addLong(ts)     // timestamp
       builder.addDouble(1.0)  // min
@@ -61,8 +67,8 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should not allow adding a string longer than 64KB...") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema1)
-      builder.startNewRecord()
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(schema1)
       val ts = System.currentTimeMillis
       builder.addLong(ts)     // timestamp
       builder.addDouble(1.0)  // min
@@ -76,9 +82,9 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should not write hash if schema does not have partition key") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, longStrSchema)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
       val sourceRow = SeqRowReader(Seq(10000L, "ABCDEfghij"))
-      builder.addFromReader(sourceRow)
+      builder.addFromReader(sourceRow, longStrSchema, 2345)
 
       builder.allContainers should have length (1)
       builder.allContainers.head.iterate(longStrSchema).foreach { row =>
@@ -92,7 +98,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     val remainingBytes = RecordBuilder.MinContainerSize - 8 - maxNumRecords*64
 
     it("should add multiple records, return offsets, and roll over record to new container if needed") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema1, RecordBuilder.MinContainerSize)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
 
       val data = linearMultiSeries().take(maxNumRecords + 1)
       addToBuilder(builder, data take maxNumRecords)
@@ -108,8 +114,12 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       // should all have the same base
       records.map(_._1).forall(_ == records.head._1)
       // check min value
-      records.map { case (b, o) => schema1.getDouble(b, o, 1) } shouldEqual (1 to maxNumRecords).map(_.toDouble)
-      records.foreach { case (b, o) => schema1.partitionHash(b, o) should not be (0) }
+      records.map { case (b, o) => schema1.ingestionSchema.getDouble(b, o, 1) } shouldEqual
+        (1 to maxNumRecords).map(_.toDouble)
+      records.foreach { case (b, o) =>
+        schema1.ingestionSchema.partitionHash(b, o) should not be (0)
+        RecordSchema.schemaID(b, o) shouldEqual schema1.data.hash
+      }
       val container1Bytes = builder.allContainers.head.numBytes
 
       // Ok, now add one more record. With only 60 bytes remaining, we should start over again in 2nd container.
@@ -130,7 +140,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should add multiple records and rollover for offheap containers") {
-      val builder = new RecordBuilder(nativeMem, schema1, RecordBuilder.MinContainerSize)
+      val builder = new RecordBuilder(nativeMem, RecordBuilder.MinContainerSize)
 
       val data = linearMultiSeries().take(maxNumRecords + 1)
       addToBuilder(builder, data take maxNumRecords)
@@ -141,8 +151,11 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       val addrs = builder.allContainers.head.allOffsets
       addrs should have length (maxNumRecords)
       // check min value
-      addrs.map(schema1.getDouble(_, 1)) shouldEqual Buffer.fromIterable((1 to maxNumRecords).map(_.toDouble))
-      addrs.foreach { a => schema1.partitionHash(a) should not be (0) }
+      addrs.map(recSchema1.getDouble(_, 1)) shouldEqual Buffer.fromIterable((1 to maxNumRecords).map(_.toDouble))
+      addrs.foreach { a =>
+        recSchema1.partitionHash(a) should not be (0)
+        RecordSchema.schemaID(a) shouldEqual schema1.data.hash
+      }
       val container1Bytes = builder.allContainers.head.numBytes
 
       // Ok, now add one more record. With only 60 bytes remaining, we should start over again in 2nd container.
@@ -164,7 +177,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should add multiple records, return offsets, and rollover to same container if reuseOneContainer=true") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema1, RecordBuilder.MinContainerSize,
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize,
                                       reuseOneContainer=true)
       // when reuseOneContainer = true, one container should be allocated on startup
       builder.allContainers should have length(1)
@@ -191,7 +204,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should add records, reset, and be able to add records again") {
-      val builder = new RecordBuilder(nativeMem, schema1, RecordBuilder.MinContainerSize)
+      val builder = new RecordBuilder(nativeMem, RecordBuilder.MinContainerSize)
       addToBuilder(builder, linearMultiSeries() take 10)
 
       // Now check amount of space left in container, container bytes etc
@@ -219,7 +232,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should add records and iterate") {
-      val builder = new RecordBuilder(nativeMem, schema1, RecordBuilder.MinContainerSize)
+      val builder = new RecordBuilder(nativeMem, RecordBuilder.MinContainerSize)
       val data = linearMultiSeries() take 10
       addToBuilder(builder, data)
 
@@ -228,7 +241,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       builder.allContainers.head.numBytes shouldEqual (4 + 64*10)
       builder.allContainers.head.countRecords shouldEqual 10
 
-      val it = builder.allContainers.head.iterate(schema1)
+      val it = builder.allContainers.head.iterate(recSchema1)
       val doubles = data.map(_(1).asInstanceOf[Double])
       it.map(_.getDouble(1)).toBuffer shouldEqual doubles
     }
@@ -257,8 +270,8 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
   describe("RecordSchema & BinaryRecord") {
     it("should add and get double, long, UTF8 fields correctly") {
-      val builder = new RecordBuilder(nativeMem, schema1)
-      builder.startNewRecord()
+      val builder = new RecordBuilder(nativeMem)
+      builder.startNewRecord(schema1)
       val ts = System.currentTimeMillis
       builder.addLong(ts)     // timestamp
       builder.addDouble(1.0)  // min
@@ -276,36 +289,38 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       containers.head.consumeRecords(consumer)
       records should have length (1)
       val recordAddr = records.head._2
-      schema1.getLong(recordAddr, 0) shouldEqual ts
-      schema1.getDouble(recordAddr, 1) shouldEqual 1.0
-      schema1.getDouble(recordAddr, 2) shouldEqual 2.5
-      schema1.getDouble(recordAddr, 3) shouldEqual 10.1
-      schema1.getLong(recordAddr, 4) shouldEqual 123456L
-      schema1.utf8StringPointer(recordAddr, 5).compare("Series 1".utf8(nativeMem)) shouldEqual 0
+      recSchema1.getLong(recordAddr, 0) shouldEqual ts
+      recSchema1.getDouble(recordAddr, 1) shouldEqual 1.0
+      recSchema1.getDouble(recordAddr, 2) shouldEqual 2.5
+      recSchema1.getDouble(recordAddr, 3) shouldEqual 10.1
+      recSchema1.getLong(recordAddr, 4) shouldEqual 123456L
+      recSchema1.utf8StringPointer(recordAddr, 5).compare("Series 1".utf8(nativeMem)) shouldEqual 0
+      RecordSchema.schemaID(recordAddr) shouldEqual schema1.data.hash
     }
 
     it("should hash correctly with different ways of adding UTF8 fields") {
       // schema for part key with only a string
       val stringSchema = new RecordSchema(Seq(ColumnInfo("sc", ColumnType.StringColumn)), Some(0))
-      val builder = new RecordBuilder(nativeMem, stringSchema)
+      val builder = new RecordBuilder(nativeMem)
+      stringSchema.fixedStart shouldEqual 4
 
       val str = "Serie zero"
       val strBytes = str.getBytes()
       val utf8MedStr = str.utf8(nativeMem)
 
-      builder.startNewRecord()
+      builder.startNewRecord(stringSchema, 123)
       builder.addString(str)
       val addrStringAdd = builder.endRecord()
 
-      builder.startNewRecord()
+      builder.startNewRecord(stringSchema, 123)
       builder.addBlob(strBytes, UnsafeUtils.arayOffset, strBytes.size)
       val addrBlobAdd = builder.endRecord()
 
-      builder.startNewRecord()
+      builder.startNewRecord(stringSchema, 123)
       builder.addSlowly(strBytes)
       val addrAddSlowly = builder.endRecord()
 
-      val addrAddReader = builder.addFromReader(SeqRowReader(Seq(str)))
+      val addrAddReader = builder.addFromReader(SeqRowReader(Seq(str)), stringSchema, 123)
 
       // Should be able to extract and compare strings
       stringSchema.utf8StringPointer(addrStringAdd, 0).compare(utf8MedStr) shouldEqual 0
@@ -321,12 +336,18 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       stringSchema.partitionHash(addrStringAdd) shouldEqual stringSchema.partitionHash(addrBlobAdd)
       stringSchema.partitionHash(addrStringAdd) shouldEqual stringSchema.partitionHash(addrAddReader)
       stringSchema.partitionHash(addrStringAdd) shouldEqual stringSchema.partitionHash(addrAddSlowly)
+
+      // No schemaID should be added
+      RecordSchema.schemaID(addrStringAdd) should not equal (123)
+      RecordSchema.schemaID(addrBlobAdd) should not equal (123)
+      RecordSchema.schemaID(addrAddReader) should not equal (123)
+      RecordSchema.schemaID(addrAddSlowly) should not equal (123)
     }
 
     it("should add and get map fields with no predefined keys") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema2)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
       val data = withMap(linearMultiSeries(), extraTags=extraTags).take(3)
-      addToBuilder(builder, data)
+      addToBuilder(builder, data, schema2)
 
       val containers = builder.allContainers
       containers should have length (1)
@@ -339,19 +360,17 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
       // in sorted order, the keys are: cloudProvider, instance, job, n, region
       lastIndex = -1
-      schema2.consumeMapItems(recordBase, recordOff, 6, keyCheckConsumer)
+      recSchema2.consumeMapItems(recordBase, recordOff, 6, keyCheckConsumer)
       lastIndex shouldEqual 4   // 5 key-value pairs: 0, 1, 2, 3, 4
 
-      schema2.consumeMapItems(recordBase, recordOff, 6, valuesCheckConsumer)
+      recSchema2.consumeMapItems(recordBase, recordOff, 6, valuesCheckConsumer)
     }
 
     it("should add and get map fields with predefined keys") {
-      val schemaWithPredefKeys = RecordSchema.ingestion(dataset2,
-                                                        Seq("job", "instance"))
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schemaWithPredefKeys)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
 
       val data = withMap(linearMultiSeries(), extraTags=extraTags).take(3)
-      addToBuilder(builder, data)
+      addToBuilder(builder, data, dataset3.schema)
 
       val containers = builder.allContainers
       containers should have length (1)
@@ -375,12 +394,12 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
                        "dc" -> "AWS-USE", "instance" -> "0123892E342342A90",
                        "__name__" -> "host_cpu_load")
 
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema2)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
 
       def addRec(n: Int): Long = {
         val pairs = (labels + ("n" -> n.toString)).map { case (k, v) => ZCUTF8(k) -> ZCUTF8(v) }.toMap
 
-        builder.startNewRecord()
+        builder.startNewRecord(schema2)
         val ts = System.currentTimeMillis
         builder.addLong(ts)     // timestamp
         builder.addDouble(1.0)  // min
@@ -400,7 +419,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       val brHashes = new collection.mutable.HashSet[Int]
       var lastHash = -1
       Seq(offset1, offset2, offset3).foreach { off =>
-        lastHash = schema2.partitionHash(basebase, off)
+        lastHash = recSchema2.partitionHash(basebase, off)
         brHashes += lastHash
         // println(s"XXX: offset = $off   hash = $lastHash")
       }
@@ -409,22 +428,22 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
       // Adding the same content should result in the same hash
       val offset4 = addRec(3)
-      schema2.partitionHash(basebase, offset4) shouldEqual lastHash
+      recSchema2.partitionHash(basebase, offset4) shouldEqual lastHash
     }
 
     it("should copy records to new byte arrays and compare equally") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema2)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
       val data = withMap(linearMultiSeries(), extraTags=extraTags).take(3)
-      addToBuilder(builder, data)
+      addToBuilder(builder, data, schema2)
 
       val containers = builder.allContainers
       containers should have length (1)
       containers.head.consumeRecords(consumer)
       records should have length (3)
       val (recordBase, recordOff) = records.head
-      val bytes = schema2.asByteArray(recordBase, recordOff)
+      val bytes = recSchema2.asByteArray(recordBase, recordOff)
       bytes should not equal (recordBase)
-      schema2.equals(recordBase, recordOff, bytes, UnsafeUtils.arayOffset) shouldEqual true
+      recSchema2.equals(recordBase, recordOff, bytes, UnsafeUtils.arayOffset) shouldEqual true
     }
   }
 
@@ -432,7 +451,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
   // just to let us test partitionMatch() independently of buildPartKeyFromIngest()
   private def dataset2AddPartKeys(builder: RecordBuilder, data: Stream[Seq[Any]]) = {
     data.foreach { values =>
-      builder.startNewRecord()
+      builder.startNewRecord(dataset3.schema)
       builder.addString(values(5).asInstanceOf[String])  // series (partition key)
       if (values.length > 6) {
         builder.startMap()
@@ -446,14 +465,12 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
   }
 
   describe("RecordComparator") {
-    val schemaWithPredefKeys = RecordSchema.ingestion(dataset2,
-                                                      Seq("job", "instance"))
-    val comparator2 = new RecordComparator(schemaWithPredefKeys)
+    val comparator2 = dataset3.schema.comparator
     val partSchema2 = comparator2.partitionKeySchema
 
-    val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, schemaWithPredefKeys)
+    val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory)
     val ingestData = withMap(linearMultiSeries(), extraTags=extraTags).take(3)
-    addToBuilder(ingestBuilder, ingestData)
+    addToBuilder(ingestBuilder, ingestData, dataset3.schema)
     records.clear()
     ingestBuilder.allContainers.head.consumeRecords(consumer)
     val ingestRecords = records.toSeq.toBuffer   // make a copy
@@ -466,7 +483,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("partitionMatch() should return false for ingest/partKey records with different contents") {
-      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, partSchema2)
+      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory)
 
       // different sized var areas / length var fields
       val diffData1 = withMap(linearMultiSeries(), extraTags=tagsWithDiffLen) take 1
@@ -489,7 +506,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("partitionMatch() should return true for ingest/partKey records with identical contents") {
-      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, partSchema2)
+      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory)
       dataset2AddPartKeys(partKeyBuilder, ingestData)
 
       partKeyBuilder.allContainers.head.consumeRecords(consumer)
@@ -500,7 +517,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should copy ingest BRs to partition key BRs correctly with buildPartKeyFromIngest()") {
-      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, partSchema2)
+      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory)
 
       ingestRecords.foreach { case (base, off) =>
         comparator2.buildPartKeyFromIngest(base, off, partKeyBuilder)
@@ -524,16 +541,16 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     }
 
     it("should copy ingest BRs to partition key BRs correctly when data columns have a blob/histogram") {
-      val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, histDataset.ingestionSchema)
+      val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory)
       val data = linearHistSeries().take(3)
-      data.foreach { row => ingestBuilder.addFromReader(SeqRowReader(row)) }
+      data.foreach { row => ingestBuilder.addFromReader(SeqRowReader(row), histDataset.schema) }
 
       records.clear()
       ingestBuilder.allContainers.head.consumeRecords(consumer)
       val histRecords = records.toSeq.toBuffer   // make a copy
 
       // Now create partition keys
-      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, histDataset.partKeySchema)
+      val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory)
       histRecords.foreach { case (base, off) =>
         histDataset.comparator.buildPartKeyFromIngest(base, off, partKeyBuilder)
       }
@@ -557,7 +574,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     import collection.JavaConverters._
 
     it("should sortAndComputeHashes") {
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, schema2)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
       val pairs = new java.util.ArrayList(labels.toSeq.asJava)
       val hashes = RecordBuilder.sortAndComputeHashes(pairs)
       hashes.size shouldEqual labels.size
@@ -591,7 +608,6 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
   }
 
   it("should trim metric name for _bucket _sum _count") {
-
     val metricName = RecordBuilder.trimShardColumn(dataset1, "__name__", "heap_usage_bucket")
     metricName shouldEqual "heap_usage"
 

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -19,7 +19,7 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
   import Filter._
 
   val keyIndex = new PartKeyLuceneIndex(dataset6, 0, TestData.storeConf)
-  val partBuilder = new RecordBuilder(TestData.nativeMem, dataset6.partKeySchema)
+  val partBuilder = new RecordBuilder(TestData.nativeMem)
 
   def partKeyOnHeap(dataset: Dataset,
                    base: Any,

--- a/core/src/test/scala/filodb.core/memstore/PartitionKeyIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartitionKeyIndexSpec.scala
@@ -15,7 +15,7 @@ class PartitionKeyIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
   import filodb.memory.format.ZeroCopyUTF8String._
 
   val keyIndex = new PartitionKeyIndex(dataset6)
-  val partBuilder = new RecordBuilder(TestData.nativeMem, dataset6.partKeySchema)
+  val partBuilder = new RecordBuilder(TestData.nativeMem)
 
   before {
     keyIndex.reset()

--- a/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
@@ -34,7 +34,7 @@ class PartitionSetSpec extends MemFactoryCleanupTest with ScalaFutures {
   protected val bufferPool = new WriteBufferPool(memFactory, dataset2, TestData.storeConf)
   private val ingestBlockHolder = new BlockMemFactory(blockStore, None, dataset2.blockMetaSize, true)
 
-  val builder = new RecordBuilder(memFactory, dataset2.ingestionSchema)
+  val builder = new RecordBuilder(memFactory)
   val partSet = PartitionSet.empty()
 
   before {
@@ -42,12 +42,12 @@ class PartitionSetSpec extends MemFactoryCleanupTest with ScalaFutures {
   }
 
   val tenRecords = withMap(linearMultiSeries(), extraTags=extraTags).take(10)
-  addToBuilder(builder, tenRecords)
+  addToBuilder(builder, tenRecords, schema2)
   val ingestRecordAddrs = builder.allContainers.head.allOffsets
   // println(s"XXX container base = ${builder.allContainers.head.base}")
   // println(s"ingestRecordAddrs=$ingestRecordAddrs")
   // println(s"\n---\n${ingestRecordAddrs.foreach(a => println(dataset2.ingestionSchema.stringify(a)))}")
-  val partKeyBuilder = new RecordBuilder(memFactory, dataset2.partKeySchema)
+  val partKeyBuilder = new RecordBuilder(memFactory)
   ingestRecordAddrs.foreach { addr =>
     dataset2.comparator.buildPartKeyFromIngest(null, addr, partKeyBuilder)
   }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 
-import filodb.core.MetricsTestData.{builder, timeseriesDataset}
+import filodb.core.MetricsTestData.{builder, timeseriesDataset, timeseriesSchema}
 import filodb.core.TestData
 import filodb.core.query.{ColumnFilter, Filter, SeqMapConsumer}
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
@@ -39,7 +39,7 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
   }
 
   // NOTE: due to max-chunk-size in storeConf = 100, this will make (numRawSamples / 100) chunks
-  tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }.foreach(builder.addFromReader)
+  tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }.foreach(builder.addFromReader(_, timeseriesSchema))
   val container = builder.allContainers.head
 
   override def beforeAll(): Unit = {

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -285,7 +285,7 @@ class SchemasSpec extends FunSpec with Matchers {
       schemas.schemas("prom").data.timestampColumn.name shouldEqual "timestamp"
       schemas.schemas("hist").data.columns.map(_.columnType) shouldEqual
         Seq(TimestampColumn, LongColumn, LongColumn, HistogramColumn)
-      schemas.schemas("prom").downsample shouldEqual schemas.schemas("prom-ds-gauge")
+      schemas.schemas("prom").downsample.get shouldEqual schemas.schemas("prom-ds-gauge")
     }
   }
 }

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -87,6 +87,18 @@ class SchemasSpec extends FunSpec with Matchers {
       errors.head shouldEqual BadColumnType("str")
     }
 
+    it("should return BadDownsampler if no downsample-schema given when downsamplers present") {
+      val conf2 = ConfigFactory.parseString("""
+                    {
+                      columns = ["timestamp:ts", "value:double:detectDrops=true"]
+                      value-column = "value"
+                      downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
+                    }""")
+      val resp = DataSchema.fromConfig("dataset", conf2)
+      resp.isBad shouldEqual true
+      resp.swap.get shouldBe a[BadDownsampler]
+    }
+
     it("should return NoTimestampRowKey if non timestamp used for row key / first column") {
       val ds1 = DataSchema.make("dataset", Seq("first:string", "age:long"), Nil, "first")
       ds1.isBad shouldEqual true
@@ -212,6 +224,31 @@ class SchemasSpec extends FunSpec with Matchers {
       errors.map(_._2.getClass) shouldEqual Seq(classOf[HashConflict])
     }
 
+    it("should detect and report invalid downsample-schema references") {
+      val conf2 = ConfigFactory.parseString(s"""
+                    {
+                      partition-schema $partSchemaStr
+                      schemas {
+                        prom {
+                          columns = ["timestamp:ts", "value:double"]
+                          value-column = "value"
+                          downsamplers = ["tTime(0)", "dMin(1)"]
+                          downsample-schema = "foo"
+                        }
+                        prom-ds-gauge {
+                          columns = ["timestamp:ts", "min:double"]
+                          value-column = "timestamp"
+                          downsamplers = []
+                        }
+                      }
+                    }""")
+      val resp = Schemas.fromConfig(conf2)
+      resp.isBad shouldEqual true
+      val errors = resp.swap.get
+      errors.map(_._2.getClass) shouldEqual Seq(classOf[BadDownsampler])
+      errors.map(_._1) shouldEqual Seq("prom")
+    }
+
     it("should return Schemas instance with every schema parsed") {
       val conf2 = ConfigFactory.parseString(s"""
                     {
@@ -220,6 +257,12 @@ class SchemasSpec extends FunSpec with Matchers {
                         prom {
                           columns = ["timestamp:ts", "value:double"]
                           value-column = "value"
+                          downsamplers = ["tTime(0)", "dMin(1)"]
+                          downsample-schema = "prom-ds-gauge"
+                        }
+                        prom-ds-gauge {
+                          columns = ["timestamp:ts", "min:double"]
+                          value-column = "timestamp"
                           downsamplers = []
                         }
                         hist {
@@ -236,14 +279,13 @@ class SchemasSpec extends FunSpec with Matchers {
       schemas.part.predefinedKeys shouldEqual Seq("_ns", "app", "__name__", "instance", "dc")
       Dataset.isPartitionID(schemas.part.columns.head.id) shouldEqual true
 
-      schemas.data.keySet shouldEqual Set("prom", "hist")
-      schemas.schemas.keySet shouldEqual Set("prom", "hist")
-      schemas.data("prom").columns.map(_.columnType) shouldEqual Seq(TimestampColumn, DoubleColumn)
-      schemas.data("prom").columns.map(_.id) shouldEqual Seq(0, 1)
-      schemas.data("prom").timestampColumn.name shouldEqual "timestamp"
-      schemas.data("hist").columns.map(_.columnType) shouldEqual
+      schemas.schemas.keySet shouldEqual Set("prom", "hist", "prom-ds-gauge")
+      schemas.schemas("prom").data.columns.map(_.columnType) shouldEqual Seq(TimestampColumn, DoubleColumn)
+      schemas.schemas("prom").data.columns.map(_.id) shouldEqual Seq(0, 1)
+      schemas.schemas("prom").data.timestampColumn.name shouldEqual "timestamp"
+      schemas.schemas("hist").data.columns.map(_.columnType) shouldEqual
         Seq(TimestampColumn, LongColumn, LongColumn, HistogramColumn)
-      // println(schemas.data.values.map(_.hash))
+      schemas.schemas("prom").downsample shouldEqual schemas.schemas("prom-ds-gauge")
     }
   }
 }

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -44,7 +44,7 @@ class RangeVectorSpec  extends FunSpec with Matchers {
   it("should be able to share containers across multiple SerializableRangeVectors") {
     val rvs = Seq(new TuplesRangeVector(tuples take 400), new TuplesRangeVector(tuples drop 400))
     val schema = SerializableRangeVector.toSchema(cols)
-    val builder = SerializableRangeVector.toBuilder(schema)
+    val builder = SerializableRangeVector.newBuilder()
 
     // Sharing one builder across multiple input RangeVectors
     val srvs = rvs.map(rv => SerializableRangeVector(rv, builder, schema, "Unit-test"))

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -105,7 +105,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
 
   it should "read back rows written with multi-column row keys" ignore {
     import GdeltTestData._
-    val stream = toChunkSetStream(dataset2, partBuilder2.addFromObjects(197901), dataRows(dataset2))
+    val stream = toChunkSetStream(dataset2, partBuilder2.partKeyFromObjects(schema2, 197901), dataRows(dataset2))
     colStore.write(dataset2, stream).futureValue should equal (Success)
 
     val paramSet = colStore.getScanSplits(dataset.ref, 1)

--- a/doc/binaryrecord-spec.md
+++ b/doc/binaryrecord-spec.md
@@ -201,5 +201,6 @@ A [RecordContainer](../core/src/main/scala/filodb.core/binaryrecord2/RecordConta
 
 * +0000   4 bytes  total length of container following these length bytes
 * +0004   4 bytes  version and flag word, for future expansion.  For now, upper byte == version, which is currently 1.
-* +0008   BinaryRecord 1  (where first bytes indicates its length)
-* +0008+n  BinaryRecord 2....
+* +0008   8 bytes  server timestamp at container creation/reset
+* +0016   BinaryRecord 1  (where first bytes indicates its length)
+* +0016+n  BinaryRecord 2....

--- a/doc/binaryrecord-spec.md
+++ b/doc/binaryrecord-spec.md
@@ -201,6 +201,6 @@ A [RecordContainer](../core/src/main/scala/filodb.core/binaryrecord2/RecordConta
 
 * +0000   4 bytes  total length of container following these length bytes
 * +0004   4 bytes  version and flag word, for future expansion.  For now, upper byte == version, which is currently 1.
-* +0008   8 bytes  server timestamp at container creation/reset
+* +0008   8 bytes  server timestamp (Millis from 1970 UTC / UNIX Epoch) at container creation/reset
 * +0016   BinaryRecord 1  (where first bytes indicates its length)
 * +0016+n  BinaryRecord 2....

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
@@ -8,7 +8,7 @@ import org.jboss.netty.buffer.ChannelBuffer
 import scalaxy.loops._
 
 import filodb.core.binaryrecord2.RecordBuilder
-import filodb.core.metadata.DatasetOptions
+import filodb.core.metadata.Schema
 
 trait KVVisitor {
   def apply(bytes: Array[Byte], keyIndex: Int, keyLen: Int, valueIndex: Int, valueLen: Int): Unit
@@ -118,7 +118,7 @@ object InfluxProtocolParser extends StrictLogging {
   def keyLen(offsetInt: Int): Int = ((offsetInt >> 16) & 0x0ffff) - (offsetInt & 0x0ffff)
   def valOffset(offsetInt: Int): Int = ((offsetInt >> 16) & 0x0ffff) + 1
 
-  def parse(buffer: ChannelBuffer, dsOptions: DatasetOptions): Option[InfluxRecord] = {
+  def parse(buffer: ChannelBuffer, schema: Schema): Option[InfluxRecord] = {
     val bytes = new Array[Byte](buffer.readableBytes)   // max parsed size is original bytes
     val tagOffsets = debox.Buffer.empty[Int]            // array indices of each tag k=v pair.
 
@@ -155,10 +155,10 @@ object InfluxProtocolParser extends StrictLogging {
     // Create the right InfluxRecord depending on # of fields
     if (fieldOffsets.length == 1) {
       Some(InfluxPromSingleRecord(bytes, measurementLen, tagOffsets,
-                                  fieldOffsets, timeIndex - 1, timestamp, dsOptions))
+                                  fieldOffsets, timeIndex - 1, timestamp, schema))
     } else {
       Some(InfluxPromHistogramRecord(bytes, measurementLen, tagOffsets,
-                                     fieldOffsets, timeIndex - 1, timestamp, dsOptions))
+                                     fieldOffsets, timeIndex - 1, timestamp, schema))
     }
   }
 

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -68,7 +68,7 @@ case class PrometheusInputRecord(tags: Map[String, String],
   final def getMetric: String = metric
 
   final def addToBuilder(builder: RecordBuilder): Unit = {
-    builder.startNewRecord()
+    builder.startNewRecord(dataset.schema)
     builder.addLong(timestamp)
     builder.addDouble(value)
     builder.startMap()
@@ -150,9 +150,7 @@ class MetricTagInputRecord(values: Seq[Any],
   final def getMetric: String = metric
 
   def addToBuilder(builder: RecordBuilder): Unit = {
-    require(builder.schema == dataset.ingestionSchema)
-
     val reader = SeqRowReader(values :+ metric :+ tags)
-    builder.addFromReader(reader)
+    builder.addFromReader(reader, dataset.schema)
   }
 }

--- a/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
@@ -26,7 +26,7 @@ class InfluxRecordSpec extends FunSpec with Matchers {
   def convertToRecords(rawText: Seq[String]): Seq[Option[InfluxRecord]] = {
     rawText.map { line =>
       buffer.writeBytes(line.getBytes())
-      InfluxProtocolParser.parse(buffer, dataset.options)
+      InfluxProtocolParser.parse(buffer, dataset.schema)
     }
   }
 
@@ -72,7 +72,7 @@ class InfluxRecordSpec extends FunSpec with Matchers {
 
     it("should create a full ingestion BinaryRecordV2 with addToBuilder") {
       val recordOpts = convertToRecords(rawInfluxLPs take 1)
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, dataset.ingestionSchema)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
       // println(recordOpts(0).get)
       recordOpts(0).get.addToBuilder(builder)
       builder.allContainers.head.foreach { case (base, offset) =>
@@ -93,7 +93,7 @@ class InfluxRecordSpec extends FunSpec with Matchers {
   describe("InfluxPromHistogramRecord") {
     it("should create multiple BinaryRecordV2s with addToBuilder, one for each bucket") {
       val recordOpts = convertToRecords(rawInfluxLPs drop 5)
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, dataset.ingestionSchema)
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
       println(recordOpts(0).get)
       recordOpts(0).get.addToBuilder(builder)
       builder.allContainers.head.countRecords shouldEqual 17

--- a/gateway/src/test/scala/filodb/gateway/conversion/PrometheusInputRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/PrometheusInputRecordSpec.scala
@@ -28,7 +28,7 @@ class PrometheusInputRecordSpec extends FunSpec with Matchers {
 
   it("should parse from TimeSeries proto and write to RecordBuilder") {
     val proto1 = TimeSeriesFixture.timeseries(0, tagsWithMetric + ("_ns" -> "filodb"))
-    val builder = new RecordBuilder(MemFactory.onHeapFactory, dataset.ingestionSchema)
+    val builder = new RecordBuilder(MemFactory.onHeapFactory)
 
     val records = PrometheusInputRecord(proto1, dataset)
     records should have length (1)

--- a/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
@@ -68,8 +68,7 @@ class GatewayBenchmark extends StrictLogging {
   val histInfluxBuf = ChannelBuffers.buffer(1024)
   histInfluxBuf.writeBytes(histInfluxRec.getBytes)
 
-  val builder = new RecordBuilder(MemFactory.onHeapFactory, dataset.ingestionSchema,
-                                  reuseOneContainer = true)
+  val builder = new RecordBuilder(MemFactory.onHeapFactory, reuseOneContainer = true)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
@@ -90,7 +89,7 @@ class GatewayBenchmark extends StrictLogging {
   def influxCounterConversion(): Int = {
     // reset the ChannelBuffer so it can be read every timeseries
     singleInfluxBuf.resetReaderIndex()
-    val record = InfluxProtocolParser.parse(singleInfluxBuf, dataset.options).get
+    val record = InfluxProtocolParser.parse(singleInfluxBuf, dataset.schema).get
     val partHash = record.partitionKeyHash
     val shardHash = record.shardKeyHash
     record.getMetric
@@ -122,7 +121,7 @@ class GatewayBenchmark extends StrictLogging {
   def influxHistogramConversion(): Int = {
     // reset the ChannelBuffer so it can be read every timeseries
     histInfluxBuf.resetReaderIndex()
-    val record = InfluxProtocolParser.parse(histInfluxBuf, dataset.options).get
+    val record = InfluxProtocolParser.parse(histInfluxBuf, dataset.schema).get
     val partHash = record.partitionKeyHash
     val shardHash = record.shardKeyHash
     record.getMetric

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -36,9 +36,9 @@ class HistogramIngestBenchmark {
   println("Be patient, generating lots of containers of histogram schema data....")
   val histSchemaData = linearHistSeries(numBuckets = 64).map(SeqRowReader)
   // sized just big enough for ~300 entries per container 700 * 300
-  val histSchemaBuilder = new RecordBuilder(MemFactory.onHeapFactory, histDataset.ingestionSchema, 230000)
+  val histSchemaBuilder = new RecordBuilder(MemFactory.onHeapFactory, 230000)
   histSchemaData.take(300*100).grouped(300).foreach { rows =>
-    rows.foreach(histSchemaBuilder.addFromReader)
+    rows.foreach(histSchemaBuilder.addFromReader(_, histDataset.schema))
     println(s"We have ${histSchemaBuilder.allContainers.length} containers, " +
             s"remaining = ${histSchemaBuilder.containerRemaining}")
     histSchemaBuilder.newContainer()   // Force switching to new container
@@ -49,9 +49,9 @@ class HistogramIngestBenchmark {
   println("Be patient, generating lots of containers of prometheus schema data....")
   val promDataset = MetricsTestData.timeseriesDataset
   val promData = MetricsTestData.promHistSeries(numBuckets = 64).map(SeqRowReader)
-  val promBuilder = new RecordBuilder(MemFactory.onHeapFactory, promDataset.ingestionSchema, 4200000)
+  val promBuilder = new RecordBuilder(MemFactory.onHeapFactory, 4200000)
   promData.take(300*66*100).grouped(300*66).foreach { rows =>
-    rows.foreach(promBuilder.addFromReader)
+    rows.foreach(promBuilder.addFromReader(_, promDataset.schema))
     println(s"We have ${promBuilder.allContainers.length} containers, " +
             s"remaining = ${promBuilder.containerRemaining}")
     promBuilder.newContainer()   // Force switching to new container

--- a/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
@@ -47,8 +47,8 @@ class HistogramQueryBenchmark {
   // HistogramColumn data: 10 series, 180 samples per series = 1800 total
   println("Ingesting containers of histogram schema data....")
   val histSchemaData = linearHistSeries(numBuckets = 64).map(SeqRowReader)
-  val histSchemaBuilder = new RecordBuilder(MemFactory.onHeapFactory, histDataset.ingestionSchema, 230000)
-  histSchemaData.take(10 * 180).foreach(histSchemaBuilder.addFromReader)
+  val histSchemaBuilder = new RecordBuilder(MemFactory.onHeapFactory, 230000)
+  histSchemaData.take(10 * 180).foreach(histSchemaBuilder.addFromReader(_, histDataset.schema))
 
   memStore.setup(histDataset, 0, ingestConf)
   val hShard = memStore.getShardE(histDataset.ref, 0)
@@ -59,8 +59,8 @@ class HistogramQueryBenchmark {
   println("Ingesting containers of prometheus schema data....")
   val promDataset = MetricsTestData.timeseriesDataset
   val promData = MetricsTestData.promHistSeries(numBuckets = 64).map(SeqRowReader)
-  val promBuilder = new RecordBuilder(MemFactory.onHeapFactory, promDataset.ingestionSchema, 4200000)
-  promData.take(10*66*180).foreach(promBuilder.addFromReader)
+  val promBuilder = new RecordBuilder(MemFactory.onHeapFactory, 4200000)
+  promData.take(10*66*180).foreach(promBuilder.addFromReader(_, promDataset.schema))
 
   memStore.setup(promDataset, 0, ingestConf)
   val pShard = memStore.getShardE(promDataset.ref, 0)

--- a/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
@@ -35,13 +35,13 @@ class IngestionBenchmark {
   val schemaWithPredefKeys = RecordSchema.ingestion(dataset2,
                                                     Seq("job", "instance"))
   // sized just big enough for a 1000 entries per container
-  val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, schemaWithPredefKeys, 176064)
+  val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, 176064)
   val comparator = new RecordComparator(schemaWithPredefKeys)
   //scalastyle:off
   println("Be patient, generating lots of containers of raw data....")
-  dataStream.take(1000*100).grouped(1000).foreach { data => addToBuilder(ingestBuilder, data) }
+  dataStream.take(1000*100).grouped(1000).foreach { data => addToBuilder(ingestBuilder, data, schema2) }
 
-  val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, comparator.partitionKeySchema)
+  val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory)
 
   val consumer = new BinaryRegionConsumer {
     def onNext(base: Any, offset: Long): Unit = comparator.buildPartKeyFromIngest(base, offset, partKeyBuilder)

--- a/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations.{Level => JMHLevel, _}
 
 import filodb.core.{MachineMetricsData, TestData}
-import filodb.core.binaryrecord2.{RecordBuilder, RecordComparator, RecordSchema}
+import filodb.core.binaryrecord2.{RecordBuilder, RecordComparator}
 import filodb.core.memstore._
 import filodb.core.store._
 import filodb.memory.{BinaryRegionConsumer, MemFactory}
@@ -32,8 +32,9 @@ class IngestionBenchmark {
   // # of records in a container to test ingestion speed
   val dataStream = withMap(linearMultiSeries(), extraTags = extraTags)
 
-  val schemaWithPredefKeys = RecordSchema.ingestion(dataset2,
-                                                    Seq("job", "instance"))
+  val predefKeySchema = dataset2.schema.copy(partition = dataset2.schema.partition.copy(
+                          predefinedKeys = Seq("job", "instance")))
+  val schemaWithPredefKeys = predefKeySchema.ingestionSchema
   // sized just big enough for a 1000 entries per container
   val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, 176064)
   val comparator = new RecordComparator(schemaWithPredefKeys)

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -25,7 +25,7 @@ class PartKeyIndexBenchmark {
   val partKeyIndex = new PartKeyLuceneIndex(dataset, 0, TestData.storeConf)
   val numSeries = 1000000
   val partKeyData = TestTimeseriesProducer.timeSeriesData(0, numSeries) take numSeries
-  val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, dataset.partKeySchema)
+  val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory)
   partKeyData.foreach(_.addToBuilder(partKeyBuilder))
 
   var partId = 1

--- a/memory/src/main/scala/filodb.memory/BinaryRegion.scala
+++ b/memory/src/main/scala/filodb.memory/BinaryRegion.scala
@@ -77,6 +77,9 @@ trait BinaryRegion {
   final def compare(address1: NativePointer, address2: NativePointer): Int =
     compare(UnsafeUtils.ZeroPointer, address1, UnsafeUtils.ZeroPointer, address2)
 
+  /**
+   * Copies the bytes, including the lnegth prefix, to a byte array on heap
+   */
   final def asNewByteArray(base: Any, offset: Long): Array[Byte] = {
     val numBytes1 = numBytes(base, offset)
     val bytes = new Array[Byte](numBytes1 + lenBytes)

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -671,7 +671,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
           if (row.filoUTF8String(i) != CustomRangeVectorKey.emptyAsZcUtf8) {
             val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
             val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.newBuilder())
-            builder.startNewRecord(recSchema, 0)
+            builder.startNewRecord(recSchema)
             builder.addLong(row.getLong(0))
             builder.addDouble(row.getDouble(i + 1))
             builder.endRecord()

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -670,8 +670,8 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
         while (row.notNull(i)) {
           if (row.filoUTF8String(i) != CustomRangeVectorKey.emptyAsZcUtf8) {
             val rvk = CustomRangeVectorKey.fromZcUtf8(row.filoUTF8String(i))
-            val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.toBuilder(recSchema))
-            builder.startNewRecord()
+            val builder = resRvs.getOrElseUpdate(rvk, SerializableRangeVector.newBuilder())
+            builder.startNewRecord(recSchema, 0)
             builder.addLong(row.getLong(0))
             builder.addDouble(row.getDouble(i + 1))
             builder.endRecord()

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -119,7 +119,7 @@ trait ExecPlan extends QueryCommand {
         (transf.apply(acc._1, queryConfig, limit, acc._2), transf.schema(dataset, acc._2))
       }
       val recSchema = SerializableRangeVector.toSchema(finalRes._2.columns, finalRes._2.brSchemas)
-      val builder = SerializableRangeVector.toBuilder(recSchema)
+      val builder = SerializableRangeVector.newBuilder()
       var numResultSamples = 0 // BEWARE - do not modify concurrently!!
       qLogger.debug(s"queryId: ${id} Materializing SRVs from iterators if necessary")
       finalRes._1

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -137,12 +137,9 @@ final case class PartKeysExec(id: String,
     * Schema of QueryResponse returned by running execute()
     */
   def schemaOfDoExecute(dataset: Dataset): ResultSchema = {
-    val partKeyResultSchema = new ResultSchema(dataset.partitionColumns.map(c=>ColumnInfo(c.name, c.columnType)),
-                                               dataset.partitionColumns.length)
     new ResultSchema(Seq(ColumnInfo("TimeSeries", ColumnType.BinaryRecordColumn)), 1,
-      Map(0->partKeyResultSchema.columns.map(c => ColumnInfo(c.name, c.colType))))
+                     Map(0 -> dataset.partKeySchema))
   }
-
 }
 
 final case class  LabelValuesExec(id: String,

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -230,7 +230,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     val recSchema = SerializableRangeVector.toSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
                                                          ColumnInfo("tdig", ColumnType.StringColumn)))
-    val builder = SerializableRangeVector.toBuilder(recSchema)
+    val builder = SerializableRangeVector.newBuilder()
     val srv = SerializableRangeVector(result7(0), builder, recSchema, "Unit-Test")
 
     val resultObs7b = RangeVectorAggregator.present(agg7, Observable.now(srv), 1000)

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -50,7 +50,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
   // Be sure to reset the builder; it is in an Object so static and shared amongst tests
   builder.reset()
   partTagsUTF8s.map( partTagsUTF8 => tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }
-    .foreach(builder.addFromReader))
+    .foreach(builder.addFromReader(_, timeseriesSchema)))
   val container = builder.allContainers.head
 
   implicit val execTimeout = 5.seconds

--- a/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SelectRawPartitionsExecSpec.scala
@@ -58,10 +58,10 @@ class SelectRawPartitionsExecSpec extends FunSpec with Matchers with ScalaFuture
   // NOTE: due to max-chunk-size in storeConf = 100, this will make (numRawSamples / 100) chunks
   // Be sure to reset the builder; it is in an Object so static and shared amongst tests
   builder.reset()
-  tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }.foreach(builder.addFromReader)
+  tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }.foreach(builder.addFromReader(_, timeseriesSchema))
   val container = builder.allContainers.head
 
-  val mmdBuilder = new RecordBuilder(MemFactory.onHeapFactory, MMD.dataset1.ingestionSchema)
+  val mmdBuilder = new RecordBuilder(MemFactory.onHeapFactory)
   val mmdTuples = MMD.linearMultiSeries().take(100)
   val mmdSomeData = MMD.records(MMD.dataset1, mmdTuples)
   val histData = MMD.linearHistSeries().take(100)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

A 2-byte schemaID is added to every `BinaryRecord` which is an ingestion record or partition key.  This schemaID informs of the schema used for this TSPartition or this ingestion sample.  

The implications of this change:
- Each Kafka message or `RecordContainer` may contain ingestion records of different schemas.  For this reason the `RecordBuilder` API has changed so that the schema is supplied with each record.
- Any change in schema implies a new TSPartition
- The schemaID being present in partition key enables validation and checking, and ensures that wrong schema will not be used to read
- Each `RecordContainer` has been updated to a new version, and the version is checked at ingestion time.  Thus older Kafka messages using the older format will be skipped at ingestion time.
- Due to this change the `ShardDownsampler` now takes in destination schema so that we can have the schemaID when writing records to be published
- The dataset configuration also changed slightly, with a new `downsample-schema` field

In addition, the BinaryRecord `MapColumn` field has been shrunk to save space.  Maps are to be no more than 64KB in length, and keys are to be no more than 192 bytes in length, with no more than 64 predefined keys.

**BREAKING CHANGES**

- Kafka message format (but versioning is used so that older messages will simply be skipped)
- Partition key format, as persisted in C* also (C* data needs to be cleared, reading from existing C* will not work)
- Configuration files

### JMH benchmarks ###

Ingestion benchmark shows no difference.

Before:
```
[info] Benchmark                                       Mode  Cnt          Score         Error  Units
[info] IngestionBenchmark.compareBRv2IngestPartition  thrpt   45  242705842.433 ± 6532085.434  ops/s
[info] IngestionBenchmark.ingestEncodeRecords            ss   45          0.028 ±       0.001   s/op
```

Now:
```
[info] Benchmark                                       Mode  Cnt          Score         Error  Units
[info] IngestionBenchmark.compareBRv2IngestPartition  thrpt   45  160749925.962 ± 3082175.128  ops/s
[info] IngestionBenchmark.ingestEncodeRecords            ss   45          0.028 ±       0.001   s/op
```