### PR TITLE
bug(query): RecordBuilder should be part of PromQlExec

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -28,6 +28,9 @@ case class PromQlExec(id: String,
   protected def args: String = params.toString
   import PromQlExec._
 
+  val recSchema = SerializableRangeVector.toSchema(columns)
+  val builder = SerializableRangeVector.toBuilder(recSchema)
+
   /**
     * Limit on number of samples returned by this ExecPlan
     */
@@ -98,8 +101,6 @@ object PromQlExec extends  StrictLogging{
 
   val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
    ColumnInfo("value", ColumnType.DoubleColumn))
-  val recSchema = SerializableRangeVector.toSchema(columns)
-  val builder = SerializableRangeVector.toBuilder(recSchema)
   val resultSchema = ResultSchema(columns, 1)
 
   // DO NOT REMOVE PromCirceSupport import below assuming it is unused - Intellij removes it in auto-imports :( .

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -28,7 +28,6 @@ case class PromQlExec(id: String,
   protected def args: String = params.toString
   import PromQlExec._
 
-  val recSchema = SerializableRangeVector.toSchema(columns)
   val builder = SerializableRangeVector.toBuilder(recSchema)
 
   /**
@@ -101,6 +100,7 @@ object PromQlExec extends  StrictLogging{
 
   val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
    ColumnInfo("value", ColumnType.DoubleColumn))
+  val recSchema = SerializableRangeVector.toSchema(columns)
   val resultSchema = ResultSchema(columns, 1)
 
   // DO NOT REMOVE PromCirceSupport import below assuming it is unused - Intellij removes it in auto-imports :( .


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
When there are multiple remote queries RecordBuilder throws IllegalArgumentException in checkFieldNo as the same builder is getting used in generating QueryResponse

**New behavior :**
Every PromQlExec has its own builder

