### PR TITLE
feat(coordinator) : routing for instant queries

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -137,7 +137,7 @@ class QueryEngine(dataset: Dataset,
         val promQlQueryParams = tsdbQueryParams.asInstanceOf[PromQlQueryParams]
         val routes : Seq[Route] = if (promQlQueryParams.start == promQlQueryParams.end) { // Instant Query
           if (failures.forall(_.isRemote.equals(false))) {
-          Seq(RemoteRoute(Some(TimeRange(periodicSeriesTime.startInMillis, periodicSeriesTime.endInMillis))))
+            Seq(RemoteRoute(Some(TimeRange(periodicSeriesTime.startInMillis, periodicSeriesTime.endInMillis))))
           } else {
             Seq(LocalRoute(None))
           }

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -136,7 +136,7 @@ class QueryEngine(dataset: Dataset,
       } else {
         val promQlQueryParams = tsdbQueryParams.asInstanceOf[PromQlQueryParams]
         val routes : Seq[Route] = if (promQlQueryParams.start == promQlQueryParams.end) { // Instant Query
-          if (failures.forall(_.isRemote.equals(true))) {
+          if (failures.forall(_.isRemote.equals(false))) {
           Seq(RemoteRoute(Some(TimeRange(periodicSeriesTime.startInMillis, periodicSeriesTime.endInMillis))))
           } else {
             Seq(LocalRoute(None))

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -530,7 +530,6 @@ class QueryEngineSpec extends FunSpec with Matchers {
 
     execPlan.isInstanceOf[ReduceAggregateExec] shouldEqual (true)
 
-    // Should ignore smaller local failure which is from 1500 - 4000 and generate local exec plan
     val reduceAggregateExec = execPlan.asInstanceOf[ReduceAggregateExec]
 
     reduceAggregateExec.children.length shouldEqual (2) //default spread is 1 so 2 shards

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -544,7 +544,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
     }
   }
 
-  it("should generate PromQlExec for InstantQueries when all failures are remote") {
+  it("should generate PromQlExec for InstantQueries when all failures are local") {
     val to = 900
     val from = 900
     val lookBack = 300000
@@ -558,8 +558,8 @@ class QueryEngineSpec extends FunSpec with Matchers {
     val failureProvider = new FailureProvider {
       override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
         Seq(FailureTimeRange("local", datasetRef,
-          TimeRange(910000, 1030000), true), FailureTimeRange("remote", datasetRef,
-          TimeRange(2000000, 2500000), true))
+          TimeRange(910000, 1030000), false), FailureTimeRange("remote", datasetRef,
+          TimeRange(2000000, 2500000), false))
       }
     }
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -64,7 +64,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
   val raw2 = RawSeries(rangeSelector = intervalSelector, filters= f2, columns = Seq("value"))
   val windowed2 = PeriodicSeriesWithWindowing(raw2, from, 1000, to, 5000, RangeFunctionId.Rate)
   val summed2 = Aggregate(AggregationOperator.Sum, windowed2, Nil, Seq("job"))
-  val promQlQueryParams = PromQlQueryParams("sum(heap_usage)", 0, 1, 0, None)
+  val promQlQueryParams = PromQlQueryParams("sum(heap_usage)", 100, 1, 1000, None)
 
   it ("should generate ExecPlan for LogicalPlan") {
     // final logical plan
@@ -503,6 +503,76 @@ class QueryEngineSpec extends FunSpec with Matchers {
     child.params.start shouldEqual 900
     child.params.end shouldEqual 1980
     child.params.step shouldEqual 60
+    child.params.processFailure shouldEqual(false)
+  }
+
+  it("should not do routing for InstantQueries when there are local and remote failures") {
+    val to = 900
+    val from = 900
+    val lookBack = 300000
+    val step = 1000
+    val intervalSelector = IntervalSelector(from * 1000 - lookBack , to * 1000) // Lookback of 300
+    val raw = RawSeries(rangeSelector = intervalSelector, filters = f1, columns = Seq("value"))
+    val windowed = PeriodicSeriesWithWindowing(raw, from * 1000, step * 1000, to * 1000, 5000, RangeFunctionId.Rate)
+    val summed = Aggregate(AggregationOperator.Sum, windowed, Nil, Seq("job"))
+    val promQlQueryParams = PromQlQueryParams("dummy query", from, step, to, None)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        Seq(FailureTimeRange("local", datasetRef,
+          TimeRange(910000, 1030000), false), FailureTimeRange("remote", datasetRef,
+          TimeRange(2000000, 2500000), true))
+      }
+    }
+
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
+
+    execPlan.isInstanceOf[ReduceAggregateExec] shouldEqual (true)
+
+    // Should ignore smaller local failure which is from 1500 - 4000 and generate local exec plan
+    val reduceAggregateExec = execPlan.asInstanceOf[ReduceAggregateExec]
+
+    reduceAggregateExec.children.length shouldEqual (2) //default spread is 1 so 2 shards
+
+    reduceAggregateExec.children.foreach { l1 =>
+      l1.isInstanceOf[SelectRawPartitionsExec] shouldEqual true
+      l1.rangeVectorTransformers.size shouldEqual 2
+      l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].start shouldEqual from *1000
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].end shouldEqual  to * 1000
+      l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
+    }
+  }
+
+  it("should generate PromQlExec for InstantQueries when all failures are remote") {
+    val to = 900
+    val from = 900
+    val lookBack = 300000
+    val step = 1000
+    val intervalSelector = IntervalSelector(from * 1000 - lookBack , to * 1000) // Lookback of 300
+    val raw = RawSeries(rangeSelector = intervalSelector, filters = f1, columns = Seq("value"))
+    val windowed = PeriodicSeriesWithWindowing(raw, from * 1000, step * 1000, to * 1000, 5000, RangeFunctionId.Rate)
+    val summed = Aggregate(AggregationOperator.Sum, windowed, Nil, Seq("job"))
+    val promQlQueryParams = PromQlQueryParams("dummy query", from, step, to, None)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        Seq(FailureTimeRange("local", datasetRef,
+          TimeRange(910000, 1030000), true), FailureTimeRange("remote", datasetRef,
+          TimeRange(2000000, 2500000), true))
+      }
+    }
+
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
+
+    execPlan.isInstanceOf[PromQlExec] shouldEqual (true)
+
+    val child = execPlan.asInstanceOf[PromQlExec]
+    child.params.start shouldEqual from
+    child.params.end shouldEqual to
+    child.params.step shouldEqual step
     child.params.processFailure shouldEqual(false)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Route instant queries to remote if all failures are local, else execute query locally.