### PR TITLE
bug(query) Fix for handling different schemas for instant query responses

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -89,9 +89,12 @@ object PrometheusModel {
       // remove NaN in HTTP results
       // Known Issue: Until we support NA in our vectors, we may not be able to return NaN as an end-of-time-series
       // in HTTP raw query results.
-      srv.rows.filter(!_.getDouble(1).isNaN).map { r =>
+      Some(
+        srv.rows.filter(!_.getDouble(1).isNaN).map { r =>
           Sampl(r.getLong(0) / 1000, r.getDouble(1))
-      }.toSeq
+        }.toSeq
+      ),
+      None
     )
   }
 

--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -1,11 +1,8 @@
 package filodb.query
 
-import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
+import io.circe.{Decoder, Encoder, HCursor, Json}
 
 object PromCirceSupport {
-
-  import io.circe.syntax._
-
   // necessary to encode sample in promql response as an array with long and double value as string
   implicit val encodeSampl: Encoder[Sampl] = new Encoder[Sampl] {
     final def apply(a: Sampl): Json = Json.arr(Json.fromLong(a.timestamp), Json.fromString(a.value.toString))
@@ -20,35 +17,4 @@ object PromCirceSupport {
       }
     }
   }
-
-  implicit val decodeResult: Decoder[Result] = new Decoder[Result] {
-    override def apply(c: HCursor): Decoder.Result[Result] = {
-      val valuesDecoder = c.downField("values").as[Seq[Sampl]] match {
-        case Left(_) => Right[DecodingFailure, Seq[Sampl]](Seq.empty)
-        case Right(s) => Right[DecodingFailure, Seq[Sampl]](s)
-      }
-      val valueDecoder = c.downField("value").as[Sampl] match {
-        case Left(_) => Right[DecodingFailure, Sampl](Sampl(-1, -1))
-        case Right(s) => Right[DecodingFailure, Sampl](s)
-      }
-      for {
-        metric <- c.downField("metric").as[Map[String, String]].right
-        values <- valuesDecoder.right
-        value <- valueDecoder.right
-      } yield {
-        Result(metric, values, value)
-      }
-    }
-  }
-
-  implicit val encodeResult: Encoder[Result] = new Encoder[Result] {
-    final def apply(a: Result): Json = {
-      if (a.values.nonEmpty) {
-        Json.obj(("metric", a.metric.asJson), ("values", a.values.asJson))
-      } else {
-        Json.obj(("metric", a.metric.asJson), ("value", a.value.asJson))
-      }
-    }
-  }
-
 }

--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -1,8 +1,11 @@
 package filodb.query
 
-import io.circe.{Decoder, Encoder, HCursor, Json}
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 
 object PromCirceSupport {
+
+  import io.circe.syntax._
+
   // necessary to encode sample in promql response as an array with long and double value as string
   implicit val encodeSampl: Encoder[Sampl] = new Encoder[Sampl] {
     final def apply(a: Sampl): Json = Json.arr(Json.fromLong(a.timestamp), Json.fromString(a.value.toString))
@@ -17,4 +20,35 @@ object PromCirceSupport {
       }
     }
   }
+
+  implicit val decodeResult: Decoder[Result] = new Decoder[Result] {
+    override def apply(c: HCursor): Decoder.Result[Result] = {
+      val valuesDecoder = c.downField("values").as[Seq[Sampl]] match {
+        case Left(_) => Right[DecodingFailure, Seq[Sampl]](Seq.empty)
+        case Right(s) => Right[DecodingFailure, Seq[Sampl]](s)
+      }
+      val valueDecoder = c.downField("value").as[Sampl] match {
+        case Left(_) => Right[DecodingFailure, Sampl](Sampl(-1, -1))
+        case Right(s) => Right[DecodingFailure, Sampl](s)
+      }
+      for {
+        metric <- c.downField("metric").as[Map[String, String]].right
+        values <- valuesDecoder.right
+        value <- valueDecoder.right
+      } yield {
+        Result(metric, values, value)
+      }
+    }
+  }
+
+  implicit val encodeResult: Encoder[Result] = new Encoder[Result] {
+    final def apply(a: Result): Json = {
+      if (a.values.nonEmpty) {
+        Json.obj(("metric", a.metric.asJson), ("values", a.values.asJson))
+      } else {
+        Json.obj(("metric", a.metric.asJson), ("value", a.value.asJson))
+      }
+    }
+  }
+
 }

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -12,7 +12,7 @@ final case class ExplainPlanResponse(debugInfo: Seq[String], status: String = "s
 
 final case class Data(resultType: String, result: Seq[Result])
 
-final case class Result(metric: Map[String, String], values: Seq[Sampl])
+final case class Result(metric: Map[String, String], values: Seq[Sampl], value: Sampl = Sampl(-1, -1))
 
 /**
   * Metric value for a given timestamp

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -12,7 +12,7 @@ final case class ExplainPlanResponse(debugInfo: Seq[String], status: String = "s
 
 final case class Data(resultType: String, result: Seq[Result])
 
-final case class Result(metric: Map[String, String], values: Seq[Sampl], value: Sampl = Sampl(-1, -1))
+final case class Result(metric: Map[String, String], values: Option[Seq[Sampl]], value: Option[Sampl] = None)
 
 /**
   * Metric value for a given timestamp

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -92,7 +92,7 @@ case class PromQlExec(id: String,
         override def numRows: Option[Int] = Option(samples.size)
 
       }
-      SerializableRangeVector(rv, builder, recSchema, "test")
+      SerializableRangeVector(rv, builder, recSchema, printTree(useNewline = false))
     }
     QueryResult(id, resultSchema, rangeVectors)
   }

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -74,31 +74,18 @@ case class PromQlExec(id: String,
 
     val rangeVectors = data.result.map { r =>
 
+      val samples = r.values.getOrElse(Seq(r.value.get))
       val rv: RangeVector = new RangeVector {
         val row = new TransientRow()
         override def key: RangeVectorKey = CustomRangeVectorKey(r.metric.map(m => m._1.utf8 -> m._2.utf8))
         override def rows: Iterator[RowReader] = {
-          if (r.values.nonEmpty) {
-            r.values.iterator.map { v =>
-              row.setLong(0, v.timestamp * 1000)
-              row.setDouble(1, v.value)
-              row
-            }
-          } else {
-            Iterator {
-              row.setLong(0, r.value.timestamp * 1000)
-              row.setDouble(1, r.value.value)
-              row
-            }
+          samples.iterator.map { v =>
+            row.setLong(0, v.timestamp * 1000)
+            row.setDouble(1, v.value)
+            row
           }
         }
-        override def numRows: Option[Int] = {
-          if (r.values.nonEmpty) {
-            Option(r.values.size)
-          } else {
-            Option(1)
-          }
-        }
+        override def numRows: Option[Int] = Option(samples.size)
       }
 
       SerializableRangeVector(rv, builder, recSchema, "test")

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -10,11 +10,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.sys.ShutdownHookThread
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-
 import filodb.core.DatasetRef
-import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Dataset
 import filodb.core.query._
@@ -32,7 +28,7 @@ case class PromQlExec(id: String,
   protected def args: String = params.toString
   import PromQlExec._
 
-  val builder: RecordBuilder = SerializableRangeVector.toBuilder(recSchema)
+  val builder = SerializableRangeVector.toBuilder(recSchema)
 
   /**
     * Limit on number of samples returned by this ExecPlan
@@ -106,13 +102,13 @@ object PromQlExec extends  StrictLogging{
 
   val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
    ColumnInfo("value", ColumnType.DoubleColumn))
-  val recSchema: RecordSchema = SerializableRangeVector.toSchema(columns)
+  val recSchema = SerializableRangeVector.toSchema(columns)
   val resultSchema = ResultSchema(columns, 1)
 
   // DO NOT REMOVE PromCirceSupport import below assuming it is unused - Intellij removes it in auto-imports :( .
   // Needed to override Sampl case class Encoder.
   import PromCirceSupport._
-  implicit val backend: SttpBackend[Future, Source[ByteString, Any]] = AkkaHttpBackend()
+  implicit val backend = AkkaHttpBackend()
 
   ShutdownHookThread(shutdown())
 

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -75,9 +75,12 @@ case class PromQlExec(id: String,
     val rangeVectors = data.result.map { r =>
 
       val samples = r.values.getOrElse(Seq(r.value.get))
-      val rv: RangeVector = new RangeVector {
+
+      val rv = new RangeVector {
         val row = new TransientRow()
-        override def key: RangeVectorKey = CustomRangeVectorKey(r.metric.map(m => m._1.utf8 -> m._2.utf8))
+
+        override def key: RangeVectorKey = CustomRangeVectorKey(r.metric.map (m => m._1.utf8 -> m._2.utf8))
+
         override def rows: Iterator[RowReader] = {
           samples.iterator.map { v =>
             row.setLong(0, v.timestamp * 1000)
@@ -85,9 +88,10 @@ case class PromQlExec(id: String,
             row
           }
         }
-        override def numRows: Option[Int] = Option(samples.size)
-      }
 
+        override def numRows: Option[Int] = Option(samples.size)
+
+      }
       SerializableRangeVector(rv, builder, recSchema, "test")
     }
     QueryResult(id, resultSchema, rangeVectors)

--- a/query/src/test/scala/filodb/query/exec/PromQlExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlExecSpec.scala
@@ -29,7 +29,7 @@ class PromQlExecSpec extends FunSpec with Matchers with ScalaFutures {
   it ("should convert matrix Data to QueryResponse ") {
     val expectedResult = List((1000000, 1.0), (2000000, 2.0), (3000000, 3.0))
     val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams("", "", 0, 0 , 0))
-    val result = query.Result (Map("instance" ->"inst1"), Seq(Sampl(1000, 1), Sampl(2000, 2), Sampl(3000, 3)))
+    val result = query.Result (Map("instance" ->"inst1"), Some(Seq(Sampl(1000, 1), Sampl(2000, 2), Sampl(3000, 3))), None)
     val res = exec.toQueryResponse(Data("vector", Seq(result)), "id")
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
@@ -42,7 +42,7 @@ class PromQlExecSpec extends FunSpec with Matchers with ScalaFutures {
   it ("should convert vector Data to QueryResponse ") {
     val expectedResult = List((1000000, 1.0))
     val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams("", "", 0, 0 , 0))
-    val result = query.Result (Map("instance" ->"inst1"), Seq.empty, Sampl(1000, 1))
+    val result = query.Result (Map("instance" ->"inst1"), None, Some(Sampl(1000, 1)))
     val res = exec.toQueryResponse(Data("vector", Seq(result)), "id")
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]

--- a/query/src/test/scala/filodb/query/exec/PromQlExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlExecSpec.scala
@@ -26,7 +26,7 @@ class PromQlExecSpec extends FunSpec with Matchers with ScalaFutures {
                           timeout: FiniteDuration): Task[QueryResponse] = ???
   }
 
-  it ("should convert Data to QueryResponse ") {
+  it ("should convert matrix Data to QueryResponse ") {
     val expectedResult = List((1000000, 1.0), (2000000, 2.0), (3000000, 3.0))
     val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams("", "", 0, 0 , 0))
     val result = query.Result (Map("instance" ->"inst1"), Seq(Sampl(1000, 1), Sampl(2000, 2), Sampl(3000, 3)))
@@ -38,4 +38,18 @@ class PromQlExecSpec extends FunSpec with Matchers with ScalaFutures {
     data.shouldEqual(expectedResult)
 
   }
+
+  it ("should convert vector Data to QueryResponse ") {
+    val expectedResult = List((1000000, 1.0))
+    val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams("", "", 0, 0 , 0))
+    val result = query.Result (Map("instance" ->"inst1"), Seq.empty, Sampl(1000, 1))
+    val res = exec.toQueryResponse(Data("vector", Seq(result)), "id")
+    res.isInstanceOf[QueryResult] shouldEqual true
+    val queryResult = res.asInstanceOf[QueryResult]
+    queryResult.result(0).numRows.get shouldEqual(1)
+    val data = queryResult.result.flatMap(x=>x.rows.map{ r => (r.getLong(0) , r.getDouble(1)) }.toList)
+    data.shouldEqual(expectedResult)
+
+  }
+
 }

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -205,7 +205,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val url = uri"http://localhost:8080/promql/prometheus/api/v1/query?query=$query&time=${queryTimestamp/1000}"
     info(s"Querying: $url")
     val result1 = sttp.get(url).response(asJson[SuccessResponse]).send().futureValue.unsafeBody.right.get.data.result
-    val result = result1.flatMap(_.values.map { d => (d.timestamp, d.value) })
+    val result = result1.flatMap(_.values.get.map { d => (d.timestamp, d.value) })
     info(s"result values were $result")
     result.length should be > 0
     val sum = result.map(_._2).sum


### PR DESCRIPTION
**Pull Request checklist**

- [x ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
A instant query can return different schema for Result case class. This is not handled by PromQlExec json decoder. When there are failure records present for such instant queries, it can result in decoding failure.

Example: Result with single value sample.
```curl "http://localhost:31007/prometheus/api/v1/query?query=sum_over_time(heap_usage%7B_ns%3D%22App-1%22,instance%3D%22Instance-11%22%7D%5B30m%5D)&time=1565405456"
{
  "status" : "success",
  "data" : {
    "resultType" : "scalar",
    "result" : [ {
      "metric" : {
        "__name__" : "heap_usage",
        "partition" : "partition-1",
        "instance" : "Instance-11",
        "_ns" : "App-1",
        "host" : "H0",
        "dc" : "DC1"
      },
      "value" : [ 1565405456, "3725.0943236510516" ]
    } ]
  },
  "errorType" : null,
  "error" : null
}
```

OR

```
curl -s "http://localhost:8080/promql/prometheus/api/v1/query?query=heap_usage%7B_ns%3D%22App-1%22,instance%3D%22Instance-11%22%7D%5B1m%5D&time=1565405456"  | jq -S
{
  "data": {
    "result": [
      {
        "metric": {
          "__name__": "heap_usage",
          "_ns": "App-1",
          "dc": "DC1",
          "host": "H0",
          "instance": "Instance-11",
          "partition": "partition-1"
        },
        "values": [
          [
            1565405396,
            "15.760230555789974"
          ],
          [
            1565405405,
            "14.815896707726472"
          ],
          [
            1565405406,
            "14.640756121613748"
          ],
          [
            1565405416,
            "13.723098763173278"
          ],
          [
            1565405426,
            "16.190987308885447"
          ],
          [
            1565405436,
            "15.407548500588934"
          ],
          [
            1565405445,
            "15.00976798335835"
          ],
          [
            1565405446,
            "14.171951010611153"
          ]
        ]
      }
    ],
    "resultType": "matrix"
  },
  "status": "success"
}
```


**New behavior :**
For Result case class, added a new value field and made both values and value field as Option.
After change, promqlexec remote call is working fine.

example
```curl -s "http://localhost:31007/prometheus/api/v1/query?query=sum_over_time(heap_usage%7B_ns%3D%22App-1%22,instance%3D%22Instance-11%22%7D%5B1m%5D)&time=1565405456"  | jq -S
{
  "data": {
    "result": [
      {
        "metric": {
          "__name__": "heap_usage",
          "_ns": "App-1",
          "dc": "DC1",
          "host": "H0",
          "instance": "Instance-11",
          "partition": "partition-1"
        },
        "value": [
          1565405456,
          "119.72023695174734"
        ]
      }
    ],
    "resultType": "scalar"
  },
  "error": null,
  "errorType": null,
  "status": "success"
}
```