### PR TITLE
misc(memory, core): Log block reclaim as info; log corrupt vector address and skip.

### DIFF
--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -401,12 +401,12 @@ extends Iterator[ChunkQueryInfo] {
           val valueVector = next.vectorPtr(rv.valueColID)
           val valueReader = rv.partition.chunkReader(rv.valueColID, valueVector)
           windowInfos += ChunkQueryInfo(next.infoAddr, tsVector, tsReader, valueVector, valueReader)
-          lastEndTime = Math.max(next.endTime, lastEndTime)
         } catch {
           case e: Throwable => {
             ChunkSetInfo.log.error(s"Corrupt vector at ${java.lang.Long.toHexString(tsVector)}", e)
           }
         }
+        lastEndTime = Math.max(next.endTime, lastEndTime)
       }
     }
   }

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -93,7 +93,7 @@ trait ReusableMemory extends StrictLogging {
     * Marks this memory as free and calls reclaimListener for every piece of metadata.
     */
   protected def free() = {
-    logger.debug(s"Reclaiming block at ${jLong.toHexString(address)}...")
+    logger.info(s"Reclaiming block at ${jLong.toHexString(address)}...")
     reclaimWithMetadata()
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Block reclamation is logged at debug, but logging at info will actually help debug the MatchError.

**New behavior :**
Block reclamation is logged at info, and also catch the MatchError. Log the corruption and move on.
