### PR TITLE
bug(query) : replace AkkaHttpBackend with AsyncHttpClientFutureBackend

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -3,7 +3,7 @@ package filodb.coordinator.queryengine2
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 import akka.actor.ActorRef
 import com.typesafe.config.{Config, ConfigFactory}
@@ -82,13 +82,13 @@ class QueryEngine(dataset: Dataset,
         case route: RemoteRoute =>
           val timeRange = route.timeRange.get
           val queryParams = tsdbQueryParams.asInstanceOf[PromQlQueryParams]
-          val endpoint = queryEngineConfig.isEmpty() match {
-            case false => queryEngineConfig.getString("routing.buddy.http.endpoint")
-            case _     => ""
-          }
+          val endpoint = if (queryEngineConfig.hasPath("routing.buddy.http.endpoint"))
+            queryEngineConfig.getString("routing.buddy.http.endpoint") else ""
+          val readTimeout = if (queryEngineConfig.hasPath("routing.buddy.http.timeout"))
+            Duration(queryEngineConfig.getString("routing.buddy.http.timeout")) else 60.seconds
 
           val promQlInvocationParams = PromQlInvocationParams(endpoint, queryParams.promQl, (timeRange.startInMillis
-            /1000), queryParams.step, (timeRange.endInMillis / 1000), queryParams.spread, false)
+            /1000), queryParams.step, (timeRange.endInMillis / 1000), readTimeout, queryParams.spread, false)
           logger.debug("PromQlExec params:" + promQlInvocationParams)
           PromQlExec(queryId, InProcessPlanDispatcher(dataset), dataset.ref, promQlInvocationParams, submitTime)
       }

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -82,13 +82,9 @@ class QueryEngine(dataset: Dataset,
         case route: RemoteRoute =>
           val timeRange = route.timeRange.get
           val queryParams = tsdbQueryParams.asInstanceOf[PromQlQueryParams]
-          val endpoint = if (queryEngineConfig.hasPath("routing.buddy.http.endpoint"))
-            queryEngineConfig.getString("routing.buddy.http.endpoint") else ""
-          val readTimeout = if (queryEngineConfig.hasPath("routing.buddy.http.timeout"))
-            Duration(queryEngineConfig.getString("routing.buddy.http.timeout")) else 60.seconds
-
-          val promQlInvocationParams = PromQlInvocationParams(endpoint, queryParams.promQl, (timeRange.startInMillis
-            /1000), queryParams.step, (timeRange.endInMillis / 1000), readTimeout, queryParams.spread, false)
+          val routingConfig = queryEngineConfig.getConfig("routing")
+          val promQlInvocationParams = PromQlInvocationParams(routingConfig, queryParams.promQl, (timeRange.startInMillis
+            /1000), queryParams.step, (timeRange.endInMillis / 1000), queryParams.spread, false)
           logger.debug("PromQlExec params:" + promQlInvocationParams)
           PromQlExec(queryId, InProcessPlanDispatcher(dataset), dataset.ref, promQlInvocationParams, submitTime)
       }

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -83,8 +83,9 @@ class QueryEngine(dataset: Dataset,
           val timeRange = route.timeRange.get
           val queryParams = tsdbQueryParams.asInstanceOf[PromQlQueryParams]
           val routingConfig = queryEngineConfig.getConfig("routing")
-          val promQlInvocationParams = PromQlInvocationParams(routingConfig, queryParams.promQl, (timeRange.startInMillis
-            /1000), queryParams.step, (timeRange.endInMillis / 1000), queryParams.spread, false)
+          val promQlInvocationParams = PromQlInvocationParams(routingConfig, queryParams.promQl,
+            (timeRange.startInMillis / 1000), queryParams.step, (timeRange.endInMillis / 1000), queryParams.spread,
+            false)
           logger.debug("PromQlExec params:" + promQlInvocationParams)
           PromQlExec(queryId, InProcessPlanDispatcher(dataset), dataset.ref, promQlInvocationParams, submitTime)
       }

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -5,8 +5,9 @@ import akka.testkit.TestProbe
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{FunSpec, Matchers}
-
 import scala.concurrent.duration.FiniteDuration
+
+import com.typesafe.config.ConfigFactory
 
 import filodb.coordinator.ShardMapper
 import filodb.coordinator.client.QueryCommands._
@@ -16,7 +17,7 @@ import filodb.core.store.TimeRangeChunkScan
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
 import filodb.query
-import filodb.query.{_}
+import filodb.query._
 import filodb.query.exec._
 
 class QueryEngineSpec extends FunSpec with Matchers {
@@ -38,6 +39,9 @@ class QueryEngineSpec extends FunSpec with Matchers {
 
   val engine = new QueryEngine(dataset, mapperRef, EmptyFailureProvider)
 
+  val queryEngineConfigString = "routing {\n  buddy {\n    http {\n      timeout = 10.seconds\n    }\n  }\n}"
+
+  val queryEngineConfig = ConfigFactory.parseString(queryEngineConfigString)
   /*
   This is the PromQL
 
@@ -295,7 +299,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[PromQlExec] shouldEqual (true)
@@ -320,7 +324,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[StitchRvsExec] shouldEqual (true)
@@ -367,7 +371,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[PromQlExec] shouldEqual (true)
@@ -390,7 +394,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[PromQlExec] shouldEqual (true)
@@ -413,7 +417,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[PromQlExec] shouldEqual (true)
@@ -441,7 +445,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
     }
     //900K to 1020K and 1020+60 k to 2000K
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[StitchRvsExec] shouldEqual (true)
@@ -493,7 +497,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[PromQlExec] shouldEqual (true)
@@ -525,7 +529,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[ReduceAggregateExec] shouldEqual (true)
@@ -563,7 +567,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
       }
     }
 
-    val engine = new QueryEngine(dataset, mapperRef, failureProvider)
+    val engine = new QueryEngine(dataset, mapperRef, failureProvider, StaticSpreadProvider(), queryEngineConfig)
     val execPlan = engine.materialize(summed, QueryOptions(), promQlQueryParams)
 
     execPlan.isInstanceOf[PromQlExec] shouldEqual (true)

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -235,10 +235,10 @@ object FiloBuild extends Build {
   )
 
   lazy val queryDeps = commonDeps ++ Seq(
-    "com.tdunning"         % "t-digest"           % "3.1",
-    "com.softwaremill.sttp" %% "circe"                   % sttpVersion ,
-    "com.softwaremill.sttp" %% "akka-http-backend"       % sttpVersion,
-    "com.softwaremill.sttp" %% "core"                    % sttpVersion,
+    "com.tdunning"          % "t-digest"                              % "3.1",
+    "com.softwaremill.sttp" %% "circe"                                % sttpVersion ,
+    "com.softwaremill.sttp" %% "async-http-client-backend-future"     % sttpVersion,
+    "com.softwaremill.sttp" %% "core"                                 % sttpVersion,
     circeGeneric,
     scalaxyDep
   )

--- a/query/src/main/scala/filodb/query/PromQlInvocationParams.scala
+++ b/query/src/main/scala/filodb/query/PromQlInvocationParams.scala
@@ -1,5 +1,8 @@
 package filodb.query
 
+import scala.concurrent.duration._
+
 case class PromQlInvocationParams(endpoint: String, promQl: String, start: Long, step: Long, end: Long,
-                             spread: Option[Int] = None, processFailure: Boolean = true)
+                                  readTimeout: Duration = 60.seconds, spread: Option[Int] = None,
+                                  processFailure: Boolean = true)
 

--- a/query/src/main/scala/filodb/query/PromQlInvocationParams.scala
+++ b/query/src/main/scala/filodb/query/PromQlInvocationParams.scala
@@ -1,8 +1,7 @@
 package filodb.query
 
-import scala.concurrent.duration._
+import com.typesafe.config.Config
 
-case class PromQlInvocationParams(endpoint: String, promQl: String, start: Long, step: Long, end: Long,
-                                  readTimeout: Duration = 60.seconds, spread: Option[Int] = None,
-                                  processFailure: Boolean = true)
+case class PromQlInvocationParams(config: Config, promQl: String, start: Long, step: Long, end: Long,
+                                  spread: Option[Int] = None, processFailure: Boolean = true)
 

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -1,5 +1,6 @@
 package filodb.query.exec
 
+import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
 import com.softwaremill.sttp.circe._
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
@@ -8,8 +9,6 @@ import monix.reactive.Observable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.sys.ShutdownHookThread
-
-import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
 
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -1,14 +1,15 @@
 package filodb.query.exec
 
-import com.softwaremill.sttp.akkahttp.AkkaHttpBackend
 import com.softwaremill.sttp.circe._
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.sys.ShutdownHookThread
+
+import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
 
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType
@@ -108,7 +109,7 @@ object PromQlExec extends  StrictLogging{
   // DO NOT REMOVE PromCirceSupport import below assuming it is unused - Intellij removes it in auto-imports :( .
   // Needed to override Sampl case class Encoder.
   import PromCirceSupport._
-  implicit val backend = AkkaHttpBackend()
+  implicit val backend = AsyncHttpClientFutureBackend()
 
   ShutdownHookThread(shutdown())
 
@@ -122,7 +123,11 @@ object PromQlExec extends  StrictLogging{
     val endpoint = params.endpoint
     val url = uri"$endpoint?$urlParams"
     logger.debug("promqlexec url is {}", url)
-    sttp.get(url).response(asJson[SuccessResponse]).send()
+    sttp
+      .get(url)
+      .readTimeout(params.readTimeout)
+      .response(asJson[SuccessResponse])
+      .send()
   }
 
   def shutdown(): Unit =

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -116,7 +116,7 @@ object PromQlExec extends  StrictLogging{
 
   def httpGet(params: PromQlInvocationParams)(implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], SuccessResponse]]] = {
-    val endpoint = params.config.as[Option[String]]("buddy.http.endpoint").getOrElse("")
+    val endpoint = params.config.as[Option[String]]("buddy.http.endpoint").get
     val readTimeout = params.config.as[Option[FiniteDuration]]("buddy.http.timeout").getOrElse(60.seconds)
     var urlParams = Map("query" -> params.promQl, "start" -> params.start, "end" -> params.end, "step" -> params.step,
       "processFailure" -> params.processFailure)

--- a/query/src/test/scala/filodb/query/exec/PromQlExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlExecSpec.scala
@@ -2,6 +2,7 @@ package filodb.query.exec
 
 import scala.concurrent.duration.FiniteDuration
 
+import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{FunSpec, Matchers}
@@ -28,7 +29,7 @@ class PromQlExecSpec extends FunSpec with Matchers with ScalaFutures {
 
   it ("should convert matrix Data to QueryResponse ") {
     val expectedResult = List((1000000, 1.0), (2000000, 2.0), (3000000, 3.0))
-    val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams("", "", 0, 0 , 0))
+    val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams(ConfigFactory.empty(), "", 0, 0 , 0))
     val result = query.Result (Map("instance" ->"inst1"), Some(Seq(Sampl(1000, 1), Sampl(2000, 2), Sampl(3000, 3))), None)
     val res = exec.toQueryResponse(Data("vector", Seq(result)), "id")
     res.isInstanceOf[QueryResult] shouldEqual true
@@ -41,7 +42,7 @@ class PromQlExecSpec extends FunSpec with Matchers with ScalaFutures {
 
   it ("should convert vector Data to QueryResponse ") {
     val expectedResult = List((1000000, 1.0))
-    val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams("", "", 0, 0 , 0))
+    val exec = PromQlExec("test", dummyDispatcher, timeseriesDataset.ref, PromQlInvocationParams(ConfigFactory.empty(), "", 0, 0 , 0))
     val result = query.Result (Map("instance" ->"inst1"), None, Some(Sampl(1000, 1)))
     val res = exec.toQueryResponse(Data("vector", Seq(result)), "id")
     res.isInstanceOf[QueryResult] shouldEqual true


### PR DESCRIPTION
**Pull Request checklist**
- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :
AkkaHttpBackend internally creates a new actor system which binds to a random port. On compute, we will need to manage a new port in this case otherwise it can fail with `address already in use` error.

**New behavior :**
Replacing akka backend with async-client backend. Also adding a read timeout to http request.
