### PR TITLE
feat(core): Redefine chunk id to incorporate ingestion time.

### DIFF
--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -38,10 +38,11 @@ object ChunkSet {
    * Create a ChunkSet out of a set of rows easily.  Mostly for testing.
    * @param rows a RowReader for the data columns only - partition columns at end might be OK
    */
-  def apply(dataset: Dataset, part: PartitionKey, rows: Seq[RowReader], factory: MemFactory): ChunkSet = {
+  def apply(dataset: Dataset, part: PartitionKey, ingestionTime: Long,
+            rows: Seq[RowReader], factory: MemFactory): ChunkSet = {
     require(rows.nonEmpty)
     val startTime = dataset.timestamp(rows.head)
-    val info = ChunkSetInfo(factory, dataset, chunkID(startTime), rows.length,
+    val info = ChunkSetInfo(factory, dataset, chunkID(startTime, ingestionTime), rows.length,
                             startTime,
                             dataset.timestamp(rows.last))
     val filoSchema = Column.toFiloSchema(dataset.dataColumns)

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -98,19 +98,17 @@ package object store {
    * no wraparound in the middle of the day (full binary encoding supports 48.545 days)
    *
    * @param startTime milliseconds since 1970
+   * @param ingestionTime seconds since 1970
    */
-  @inline final def chunkID(startTime: Long): Long =
-    chunkID(startTime, System.currentTimeMillis() / 1000)
-
-  @inline final def chunkID(startTime: Instant, ingestionTime: Instant): Long =
-    chunkID(startTime.toEpochMilli(), ingestionTime.getEpochSecond())
+  @inline final def chunkID(startTime: Long, ingestionTime: Long): Long =
+    (startTime << startTimeShift) | Math.floorMod(ingestionTime, (48 * 24 * 60 * 60))
 
   /**
    * @param startTime milliseconds since 1970
    * @param ingestionTime seconds since 1970
    */
-  @inline final def chunkID(startTime: Long, ingestionTime: Long): Long =
-    (startTime << startTimeShift) | Math.floorMod(ingestionTime, (48 * 24 * 60 * 60))
+  @inline final def chunkID(startTime: Instant, ingestionTime: Instant): Long =
+    chunkID(startTime.toEpochMilli(), ingestionTime.getEpochSecond())
 
   /**
    * Returns the start time portion of the chunk ID, as milliseconds from 1970.

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -110,7 +110,7 @@ package object store {
    * @param ingestionTime seconds since 1970
    */
   @inline final def chunkID(startTime: Long, ingestionTime: Long): Long =
-    (startTime << startTimeShift) | (Math.floorMod(ingestionTime, (48 * 24 * 60 * 60)) & ingestionTimeMask)
+    (startTime << startTimeShift) | Math.floorMod(ingestionTime, (48 * 24 * 60 * 60))
 
   /**
    * Returns the start time portion of the chunk ID, as milliseconds from 1970.

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -1,7 +1,6 @@
 package filodb.core
 
 import java.nio.ByteBuffer
-import java.time.Instant
 
 import net.jpountz.lz4.{LZ4Compressor, LZ4Factory, LZ4FastDecompressor}
 
@@ -104,13 +103,6 @@ package object store {
     (startTime << startTimeShift) | Math.floorMod(ingestionTime, (48 * 24 * 60 * 60))
 
   /**
-   * @param startTime milliseconds since 1970
-   * @param ingestionTime seconds since 1970
-   */
-  @inline final def chunkID(startTime: Instant, ingestionTime: Instant): Long =
-    chunkID(startTime.toEpochMilli(), ingestionTime.getEpochSecond())
-
-  /**
    * Returns the start time portion of the chunk ID, as milliseconds from 1970.
    */
   @inline final def startTimeFromChunkID(chunkID: Long): Long = chunkID >>> startTimeShift
@@ -118,7 +110,7 @@ package object store {
   /**
    * Returns the ingestion time portion of the chunk ID, as seconds from 1970, modulo 48 days.
    */
-  @inline final def ingestionTimeFromChunkID(chunkID: Long): Long = chunkID & ingestionTimeMask
+  @inline final def modIngestionTimeFromChunkID(chunkID: Long): Long = chunkID & ingestionTimeMask
 
   /**
    * Adds a few useful methods to ChunkSource

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -1,6 +1,7 @@
 package filodb.core
 
 import java.nio.ByteBuffer
+import java.time.Instant
 
 import net.jpountz.lz4.{LZ4Compressor, LZ4Factory, LZ4FastDecompressor}
 
@@ -12,8 +13,8 @@ package object store {
   val compressor = new ThreadLocal[LZ4Compressor]()
   val decompressor = new ThreadLocal[LZ4FastDecompressor]()
 
-  val msBitOffset   = 21
-  val lowerBitsMask = Math.pow(2, msBitOffset).toInt - 1
+  val startTimeShift    = 22
+  val ingestionTimeMask = (1 << startTimeShift) - 1
 
   // Assume LZ4 compressor has state and is not thread safe.  Use ThreadLocals.
   private def getCompressor: LZ4Compressor = {
@@ -87,16 +88,39 @@ package object store {
   }
 
   /**
-   * Formulation for chunkID based on a combo of the start time for a chunk and the current time in the lower
-   * bits to disambiguate two chunks which have the same start time.
+   * Formulation for chunkID based on a combo of the start time for a chunk and the ingestion
+   * time in the lower bits to disambiguate two chunks which have the same start time, and to
+   * help with external downsampling based on when the data was ingested.
    *
-   * bits 63-21 (43 bits):  milliseconds since Unix Epoch (1/1/1970) - enough for 278.7 years or through 2248
-   * bits 20-0  (21 bits):  The lower 21 bits of nanotime for disambiguation
+   * bits 63-22 (42 bits): user data start time, as milliseconds since Unix Epoch (1/1/1970) -
+   * enough for 139 years or through the year 2109
+   * bits 21-0 (22 bits): ingestion time, as seconds since Unix Epoch, modulo 48 days to ensure
+   * no wraparound in the middle of the day (full binary encoding supports 48.545 days)
+   *
+   * @param startTime milliseconds since 1970
    */
-  @inline final def chunkID(startTime: Long): Long = chunkID(startTime, System.nanoTime)
+  @inline final def chunkID(startTime: Long): Long =
+    chunkID(startTime, System.currentTimeMillis() / 1000)
 
-  @inline final def chunkID(startTime: Long, currentTime: Long): Long =
-    (startTime << msBitOffset) | (currentTime & lowerBitsMask)
+  @inline final def chunkID(startTime: Instant, ingestionTime: Instant): Long =
+    chunkID(startTime.toEpochMilli(), ingestionTime.getEpochSecond())
+
+  /**
+   * @param startTime milliseconds since 1970
+   * @param ingestionTime seconds since 1970
+   */
+  @inline final def chunkID(startTime: Long, ingestionTime: Long): Long =
+    (startTime << startTimeShift) | (Math.floorMod(ingestionTime, (48 * 24 * 60 * 60)) & ingestionTimeMask)
+
+  /**
+   * Returns the start time portion of the chunk ID, as milliseconds from 1970.
+   */
+  @inline final def startTimeFromChunkID(chunkID: Long): Long = chunkID >>> startTimeShift
+
+  /**
+   * Returns the ingestion time portion of the chunk ID, as seconds from 1970, modulo 48 days.
+   */
+  @inline final def ingestionTimeFromChunkID(chunkID: Long): Long = chunkID & ingestionTimeMask
 
   /**
    * Adds a few useful methods to ChunkSource

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -23,7 +23,8 @@ object TestData {
                        part: PartitionKey,
                        rows: Seq[RowReader],
                        rowsPerChunk: Int = 10): Observable[ChunkSet] =
-    Observable.fromIterator(rows.grouped(rowsPerChunk).map { chunkRows => ChunkSet(ds, part, chunkRows, nativeMem) })
+    Observable.fromIterator(rows.grouped(rowsPerChunk).map {
+      chunkRows => ChunkSet(ds, part, 0, chunkRows, nativeMem) })
 
   def toRawPartData(chunkSetStream: Observable[ChunkSet]): Task[RawPartData] = {
     var partKeyBytes: Array[Byte] = null
@@ -373,7 +374,7 @@ object MachineMetricsData {
     val histData = linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets).take(numSamples)
     val container = records(ds, histData).records
     val part = TimeSeriesPartitionSpec.makePart(0, ds, partKey=histPartKey, bufferPool=pool)
-    container.iterate(ds.ingestionSchema).foreach { row => part.ingest(row, histIngestBH) }
+    container.iterate(ds.ingestionSchema).foreach { row => part.ingest(0, row, histIngestBH) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(histIngestBH, encode = true)
     (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 3)))  // select timestamp and histogram columns only
@@ -387,7 +388,7 @@ object MachineMetricsData {
     val histData = histMax(linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets)).take(numSamples)
     val container = records(histMaxDS, histData).records
     val part = TimeSeriesPartitionSpec.makePart(0, histMaxDS, partKey=histPartKey, bufferPool=histMaxBP)
-    container.iterate(histMaxDS.ingestionSchema).foreach { row => part.ingest(row, histIngestBH) }
+    container.iterate(histMaxDS.ingestionSchema).foreach { row => part.ingest(0, row, histIngestBH) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(histIngestBH, encode = true)
     // Select timestamp, hist, max

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -67,7 +67,7 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
   def timeValueRV(tuples: Seq[(Long, Double)]): RawDataRangeVector = {
     val part = TimeSeriesPartitionSpec.makePart(0, promDataset, partKeyOffset, bufferPool = tsBufferPool)
     val readers = tuples.map { case (ts, d) => TupleRowReader((Some(ts), Some(d))) }
-    readers.foreach { row => part.ingest(row, ingestBlockHolder) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder, encode = true)
 //    part.encodeAndReleaseBuffers(ingestBlockHolder)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -78,7 +78,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
   it("should be able to read immediately after ingesting one row") {
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(5)
-    part.ingest(data(0), ingestBlockHolder)   // just one row
+    part.ingest(0, data(0), ingestBlockHolder)   // just one row
     part.numChunks shouldEqual 1
     part.appendingChunkLen shouldEqual 1
     part.unflushedChunksets shouldEqual 1
@@ -92,7 +92,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val data = singleSeriesReaders().take(11)
     val minData = data.map(_.getDouble(1))
     val initTS = data(0).getLong(0)
-    data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
 
     val origPoolSize = myBufferPool.poolSize
 
@@ -114,7 +114,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
-    data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
     val chunkSets = flushFut.futureValue
 
     // After flush, the old writebuffers should be returned to pool, but new one allocated for ingesting
@@ -146,7 +146,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val initTS = data(0).getLong(0)
     val appendingTS = data.last.getLong(0)
     val minData = data.map(_.getDouble(1))
-    data.take(10).foreach { r => part.ingest(r, ingestBlockHolder) }
+    data.take(10).foreach { r => part.ingest(0, r, ingestBlockHolder) }
 
     // First 10 rows ingested. Now flush in a separate Future while ingesting the remaining row
     part.switchBuffers(ingestBlockHolder)
@@ -155,7 +155,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
-    data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
 
     // there should be a frozen chunk of 10 records plus 1 record in currently appending chunks
     part.numChunks shouldEqual 2
@@ -202,7 +202,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      part = makePart(0, dataset1)
      val data = singleSeriesReaders().take(21)
      val minData = data.map(_.getDouble(1))
-     data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+     data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
 
      val origPoolSize = myBufferPool.poolSize
 
@@ -212,7 +212,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
-     data.drop(10).take(6).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+     data.drop(10).take(6).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
      val chunkSets = flushFut.futureValue
 
      // After flush, the old writebuffers should be returned to pool, but new one allocated too
@@ -243,7 +243,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      val holder2 = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut2 = Future(part.makeFlushChunks(holder2).toBuffer)
-     data.drop(16).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+     data.drop(16).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
      val chunkSets2 = flushFut2.futureValue
 
      part.numChunks shouldEqual 3
@@ -263,7 +263,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
   it("should not switch buffers and flush when current chunks are empty") {
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(11)
-    data.zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
     part.numChunks shouldEqual 1
     part.appendingChunkLen shouldEqual 11
 
@@ -298,7 +298,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
       makePart(partNo, dataset1)
     }
     (0 to 9).foreach { i =>
-      data.foreach { case d => partitions(i).ingest(d, ingestBlockHolder) }
+      data.foreach { case d => partitions(i).ingest(0, d, ingestBlockHolder) }
       partitions(i).numChunks shouldEqual 1
       partitions(i).appendingChunkLen shouldEqual 10
       val infos = partitions(i).infos(AllChunkScan)
@@ -319,7 +319,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     // Do this 4 more times so that we get old recycled metadata back
     (0 until 4).foreach { n =>
       (0 to 9).foreach { i =>
-        moreData.drop(n*10).take(10).foreach { case d => partitions(i).ingest(d, ingestBlockHolder) }
+        moreData.drop(n*10).take(10).foreach { case d => partitions(i).ingest(0, d, ingestBlockHolder) }
         partitions(i).appendingChunkLen shouldEqual 10
         partitions(i).switchBuffers(ingestBlockHolder, true)
       }
@@ -327,7 +327,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     // Now ingest again but don't switch buffers.  Ensure appendingChunkLen is appropriate.
     (0 to 9).foreach { i =>
-      moreData.drop(40).foreach { case d => partitions(i).ingest(d, ingestBlockHolder) }
+      moreData.drop(40).foreach { case d => partitions(i).ingest(0, d, ingestBlockHolder) }
       partitions(i).appendingChunkLen shouldEqual 10
     }
   }
@@ -338,7 +338,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(maxChunkSize + 10)
-    data.take(maxChunkSize - 10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.take(maxChunkSize - 10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
     part.numChunks shouldEqual 1
     part.appendingChunkLen shouldEqual (maxChunkSize - 10)
     part.unflushedChunksets shouldEqual 1
@@ -346,7 +346,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     myBufferPool.poolSize shouldEqual (origPoolSize - 1)
 
     // Now ingest 20 more.  Verify new chunks encoded.  10 rows after switch at 100. Verify can read everything.
-    data.drop(maxChunkSize - 10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.drop(maxChunkSize - 10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
     part.numChunks shouldEqual 2
     part.appendingChunkLen shouldEqual 10
     part.unflushedChunksets shouldEqual 2
@@ -373,15 +373,15 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val minData = data.map(_.getDouble(1))
 
     // Ingest first 5, then: 8th, 6th, 7th, 9th, 10th
-    data.take(5).foreach { r => part.ingest(r, ingestBlockHolder) }
-    part.ingest(data(7), ingestBlockHolder)
-    part.ingest(data(5), ingestBlockHolder)
-    part.ingest(data(6), ingestBlockHolder)
-    part.ingest(data(8), ingestBlockHolder)
-    part.ingest(data(9), ingestBlockHolder)
+    data.take(5).foreach { r => part.ingest(0, r, ingestBlockHolder) }
+    part.ingest(0, data(7), ingestBlockHolder)
+    part.ingest(0, data(5), ingestBlockHolder)
+    part.ingest(0, data(6), ingestBlockHolder)
+    part.ingest(0, data(8), ingestBlockHolder)
+    part.ingest(0, data(9), ingestBlockHolder)
 
     // Try ingesting old sample now at the end.  Verify that end time of chunkInfo is not incorrectly changed.
-    part.ingest(data(2), ingestBlockHolder)
+    part.ingest(0, data(2), ingestBlockHolder)
     // 8 of first 10 ingested, 2 should be dropped.  Switch buffers, and try ingesting out of order again.
     part.appendingChunkLen shouldEqual 8
     part.infoLast.numRows shouldEqual 8
@@ -391,10 +391,10 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part.appendingChunkLen shouldEqual 0
 
     // Now try ingesting an old smaple again at first element of next chunk.
-    part.ingest(data(8), ingestBlockHolder)   // This one should be dropped
+    part.ingest(0, data(8), ingestBlockHolder)   // This one should be dropped
     part.appendingChunkLen shouldEqual 0
-    part.ingest(data(10), ingestBlockHolder)
-    part.ingest(data(11), ingestBlockHolder)
+    part.ingest(0, data(10), ingestBlockHolder)
+    part.ingest(0, data(11), ingestBlockHolder)
 
     // there should be a frozen chunk of 10 records plus 2 records in currently appending chunks
     part.numChunks shouldEqual 2
@@ -411,7 +411,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val data = singleSeriesReaders().take(11)
     val minData = data.map(_.getDouble(1))
     val initTS = data(0).getLong(0)
-    data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(r, ingestBlockHolder) }
+    data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
 
     val origPoolSize = myBufferPool.poolSize
 

--- a/core/src/test/scala/filodb.core/store/ChunkSetInfoSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ChunkSetInfoSpec.scala
@@ -60,7 +60,7 @@ class ChunkSetInfoSpec extends NativeVectorTest {
 
       assert(startTime == startTimeFromChunkID(id))
 
-      val itSeconds = ingestionTimeFromChunkID(id)
+      val itSeconds = modIngestionTimeFromChunkID(id)
       assert(itSeconds == (ingestionTime.getEpochSecond % 4147200))
 
       if ((i % 48) == 0) {

--- a/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
@@ -31,7 +31,7 @@ class IntSumReadBenchmark {
   import IntSumReadBenchmark._
   val NumRows = 10000
 
-  val chunkSet = ChunkSet(dataset, partKey, rowIt.map(TupleRowReader).take(NumRows).toSeq, TestData.nativeMem)
+  val chunkSet = ChunkSet(dataset, partKey, 0, rowIt.map(TupleRowReader).take(NumRows).toSeq, TestData.nativeMem)
   val intVectAddr = UnsafeUtils.addressFromDirectBuffer(chunkSet.chunks(0))
   val intReader   = bv.IntBinaryVector(intVectAddr)
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -50,7 +50,7 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
   def timeValueRV(tuples: Seq[(Long, Double)]): RawDataRangeVector = {
     val part = TimeSeriesPartitionSpec.makePart(0, timeseriesDataset, bufferPool = tsBufferPool)
     val readers = tuples.map { case (ts, d) => TupleRowReader((Some(ts), Some(d))) }
-    readers.foreach { row => part.ingest(row, ingestBlockHolder) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder, encode = true)
     // part.encodeAndReleaseBuffers(ingestBlockHolder)
@@ -63,7 +63,7 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
     val readers = tuples.map { case (ts, d1, d2, d3, d4, d5) =>
       TupleRowReader((Some(ts), Some(d1), Some(d2), Some(d3), Some(d4), Some(d5)))
     }
-    readers.foreach { row => part.ingest(row, ingestBlockHolder2) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder2) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder2, encode = true)
     // part.encodeAndReleaseBuffers(ingestBlockHolder)
@@ -80,7 +80,7 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
     val part = rv.partition.asInstanceOf[TimeSeriesPartition]
     val startingNumChunks = part.numChunks
     val readers = tuples.map { case (ts, d) => TupleRowReader((Some(ts), Some(d))) }
-    readers.foreach { row => part.ingest(row, ingestBlockHolder) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder) }
     part.switchBuffers(ingestBlockHolder, encode = true)
     part.numChunks shouldEqual (startingNumChunks + 1)
   }

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -225,7 +225,7 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
     val part = rv.partition.asInstanceOf[TimeSeriesPartition]
     val dropData = data.map(d => (d.head.asInstanceOf[Long] + 70000L) +: d.drop(1))
     val container = MachineMetricsData.records(promHistDS, dropData).records
-    container.iterate(promHistDS.ingestionSchema).foreach { row => part.ingest(row, ingestBlockHolder) }
+    container.iterate(promHistDS.ingestionSchema).foreach { row => part.ingest(0, row, ingestBlockHolder) }
     part.switchBuffers(ingestBlockHolder, encode = true)
 
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
ChunkID is defined as a 43 bit user time (millis from 1970) combined with a 21 bit nano time disambiguator.

**New behavior :**
ChunkID is now defined as a 42 bit user time combined with a 22 bit ingestion time (seconds from 1970) modulo 48 days.

**BREAKING CHANGES**
This change in the chunkID definition might create collisions, although it's unlikely.
