### PR TITLE
feat(memory, core): BlockDetective: detailed block corruption ownership/reclaim analysis

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -44,12 +44,16 @@ extends RawToPartitionMaker with StrictLogging {
   import TimeSeriesShard._
   import collection.JavaConverters._
 
+  private val baseContext = Map("dataset" -> tsShard.dataset.name,
+                                "shard"   -> tsShard.shardNum.toString)
+
   private def getMemFactory(bucket: Long): BlockMemFactory = {
     val factory = memFactories.get(bucket)
     if (factory == UnsafeUtils.ZeroPointer) {
       val newFactory = new BlockMemFactory(blockManager,
                                            Some(bucket),
                                            tsShard.dataset.blockMetaSize,
+                                           baseContext ++ Map("bucket" -> bucket.toString),
                                            markFullBlocksAsReclaimable = true)
       memFactories.put(bucket, newFactory)
       newFactory

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -13,7 +13,7 @@ import filodb.core.downsample.DownsampleConfig
 import filodb.core.metadata.{Column, Dataset}
 import filodb.core.metadata.Column.ColumnType._
 import filodb.core.query.ColumnFilter
-import filodb.core.store.{ChunkSource, ColumnStore, MetaStore, StoreConfig}
+import filodb.core.store._
 import filodb.memory.MemFactory
 import filodb.memory.format.{vectors => bv, _}
 
@@ -194,6 +194,11 @@ trait MemStore extends ChunkSource {
    * Commits the index immediately so that queries can pick up the latest changes.  Used for testing.
    */
   def refreshIndexForTesting(dataset: DatasetRef): Unit
+
+  /**
+   * Analyzes a corrupt pointer/vector for reclaim and ownership history, and logs details
+   */
+  def analyzeAndLogCorruptPtr(ref: DatasetRef, cve: CorruptVectorException): Unit
 
   /**
    * WARNING: truncates all the data in the memstore for the given dataset, and also the data

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -240,6 +240,9 @@ extends MemStore with StrictLogging {
   def groupsInDataset(dataset: Dataset): Int =
     datasets.get(dataset.ref).map(_.values.asScala.head.storeConfig.groupsPerShard).getOrElse(1)
 
+  def analyzeAndLogCorruptPtr(ref: DatasetRef, cve: CorruptVectorException): Unit =
+    getShard(ref, cve.shard).get.analyzeAndLogCorruptPtr(cve)
+
   def reset(): Unit = {
     datasets.clear()
     downsamplePublishers.valuesIterator.foreach { _.stop() }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1259,6 +1259,9 @@ class TimeSeriesShard(val dataset: Dataset,
     id
   }
 
+  def analyzeAndLogCorruptPtr(cve: CorruptVectorException): Unit =
+    logger.error(cve.getMessage + "\n" + BlockDetective.stringReport(cve.ptr, blockStore, blockFactoryPool))
+
   /**
    * Check and evict partitions to free up memory and heap space.  NOTE: This must be called in the ingestion
    * stream so that there won't be concurrent other modifications.  Ideally this is called when trying to add partitions

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -259,13 +259,15 @@ class TimeSeriesShard(val dataset: Dataset,
   private[memstore] final val partSetLock = new StampedLock
 
   // The off-heap block store used for encoded chunks
+  private val context = Map("dataset" -> dataset.ref.dataset, "shard" -> shardNum.toString)
   private val blockStore = new PageAlignedBlockManager(blockMemorySize, shardStats.memoryStats, reclaimListener,
     storeConfig.numPagesPerBlock)
-  private val blockFactoryPool = new BlockMemFactoryPool(blockStore, dataset.blockMetaSize)
+  private val blockFactoryPool = new BlockMemFactoryPool(blockStore, dataset.blockMetaSize, context)
 
   // Each shard has a single ingestion stream at a time.  This BlockMemFactory is used for buffer overflow encoding
   // strictly during ingest() and switchBuffers().
-  private[core] val overflowBlockFactory = new BlockMemFactory(blockStore, None, dataset.blockMetaSize, true)
+  private[core] val overflowBlockFactory = new BlockMemFactory(blockStore, None, dataset.blockMetaSize,
+                                             context ++ Map("overflow" -> "true"), true)
   val partitionMaker = new DemandPagedChunkStore(this, blockStore, chunkRetentionHours)
 
   private val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, reuseOneContainer = true)
@@ -780,7 +782,7 @@ class TimeSeriesShard(val dataset: Dataset,
       .withTag("shard", shardNum).start()
 
     // Only allocate the blockHolder when we actually have chunks/partitions to flush
-    val blockHolder = blockFactoryPool.checkout()
+    val blockHolder = blockFactoryPool.checkout(Map("flushGroup" -> flushGroup.groupNum.toString))
 
     // This initializes the containers for the downsample records. Yes, we create new containers
     // and not reuse them at the moment and there is allocation for every call of this method

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -338,6 +338,13 @@ final case class ChunkQueryInfo(infoPtr: NativePointer,
   def info: ChunkSetInfo = ChunkSetInfo(infoPtr)
 }
 
+final case class CorruptVectorException(ptr: NativePointer,
+                                        chunkStartTime: Long,
+                                        partKeyString: String,
+                                        shard: Int,
+                                        innerErr: Throwable) extends
+Exception(f"CorruptVector at 0x$ptr%016x startTime=$chunkStartTime shard=$shard partition=$partKeyString", innerErr)
+
 /**
  * A sliding window based iterator over the chunks needed to be read from for each window.
  * Assumes the ChunkInfos are in increasing time order.
@@ -403,9 +410,9 @@ extends Iterator[ChunkQueryInfo] {
           val valueReader = rv.partition.chunkReader(rv.valueColID, valueVector)
           windowInfos += ChunkQueryInfo(next.infoAddr, tsVector, tsReader, valueVector, valueReader)
         } catch {
-          case e: Throwable => {
-            ChunkSetInfo.log.error(s"Corrupt vector at ${java.lang.Long.toHexString(tsVector)}", e)
-          }
+          case m: MatchError =>
+            throw CorruptVectorException(tsVector, next.startTime, rv.partition.stringPartition,
+                                         rv.partition.shard, m)
         }
         lastEndTime = Math.max(next.endTime, lastEndTime)
       }

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -216,6 +216,7 @@ object MachineMetricsData {
   import scala.util.Random.nextInt
 
   val columns = Seq("timestamp:long", "min:double", "avg:double", "max:double", "count:long")
+  val dummyContext = Map("test" -> "test")
 
   def singleSeriesData(initTs: Long = System.currentTimeMillis,
                        incr: Long = 1000): Stream[Product] = {
@@ -364,7 +365,7 @@ object MachineMetricsData {
   val histPartKey = histKeyBuilder.partKeyFromObjects(histDataset.schema, extraTags)
 
   val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024, new MemoryStats(Map("test"-> "test")), null, 16)
-  private val histIngestBH = new BlockMemFactory(blockStore, None, histDataset.blockMetaSize, true)
+  private val histIngestBH = new BlockMemFactory(blockStore, None, histDataset.blockMetaSize, dummyContext, true)
   private val histBufferPool = new WriteBufferPool(TestData.nativeMem, histDataset, TestData.storeConf)
 
   // Designed explicitly to work with linearHistSeries records and histDataset from MachineMetricsData

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -14,7 +14,7 @@ import filodb.memory._
 import filodb.memory.format.{TupleRowReader, ZeroCopyUTF8String, vectors => bv}
 
 // scalastyle:off null
-class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll {
+class ShardDownsamplerSpec extends FunSpec with Matchers with BeforeAndAfterAll {
 
   val promDataset = Dataset.make("custom1",
     Seq("someStr:string", "tags:map"),
@@ -42,7 +42,8 @@ class ShardDownsamplerSpec extends FunSpec with Matchers  with BeforeAndAfterAll
   val customSchema = customDataset.schema
 
   private val blockStore = MMD.blockStore
-  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, promDataset.blockMetaSize, true)
+  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, promDataset.blockMetaSize,
+                                                        MMD.dummyContext, true)
 
   val storeConf = TestData.storeConf.copy(maxChunksSize = 200)
   protected val tsBufferPool = new WriteBufferPool(TestData.nativeMem, promDataset, storeConf)

--- a/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
@@ -32,7 +32,7 @@ class PartitionSetSpec extends MemFactoryCleanupTest with ScalaFutures {
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
     new MemoryStats(Map("test"-> "test")), reclaimer, 1)
   protected val bufferPool = new WriteBufferPool(memFactory, dataset2, TestData.storeConf)
-  private val ingestBlockHolder = new BlockMemFactory(blockStore, None, dataset2.blockMetaSize, true)
+  private val ingestBlockHolder = new BlockMemFactory(blockStore, None, dataset2.blockMetaSize, dummyContext, true)
 
   val builder = new RecordBuilder(memFactory)
   val partSet = PartitionSet.empty()

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -69,7 +69,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
     new MemoryStats(Map("test"-> "test")), reclaimer, 1)
-  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, true)
+  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, dummyContext, true)
 
   before {
     colStore.truncate(dataset1.ref).futureValue
@@ -111,7 +111,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val data1 = part.timeRangeRows(AllChunkScan, Array(1)).map(_.getDouble(0)).toBuffer
     data1 shouldEqual (minData take 10)
 
-    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
+    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, dummyContext)
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
     data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -152,7 +152,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part.switchBuffers(ingestBlockHolder)
     part.appendingChunkLen shouldEqual 0
 
-    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
+    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, dummyContext)
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
     data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -209,7 +209,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      // First 10 rows ingested. Now flush in a separate Future while ingesting 6 more rows
      part.switchBuffers(ingestBlockHolder)
      myBufferPool.poolSize shouldEqual origPoolSize    // current chunks become null, no new allocation yet
-     val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
+     val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, dummyContext)
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
      data.drop(10).take(6).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -240,7 +240,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      // Now, switch buffers and flush again, ingesting 5 more rows
      // There should now be 3 chunks total, the current write buffers plus the two flushed ones
      part.switchBuffers(ingestBlockHolder)
-     val holder2 = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
+     val holder2 = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, dummyContext)
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut2 = Future(part.makeFlushChunks(holder2).toBuffer)
      data.drop(16).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -269,7 +269,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     // Now, switch buffers and flush.  Appenders will be empty.
     part.switchBuffers(ingestBlockHolder)
-    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
+    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, dummyContext)
     val chunkSets = part.makeFlushChunks(blockHolder)
     chunkSets.isEmpty shouldEqual false
     part.numChunks shouldEqual 1
@@ -359,7 +359,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     // Now simulate a flush, verify that both chunksets flushed
     // Now, switch buffers and flush.  Appenders will be empty.
     part.switchBuffers(ingestBlockHolder)
-    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize)
+    val blockHolder = new BlockMemFactory(blockStore, None, dataset1.blockMetaSize, dummyContext)
     val chunkSets = part.makeFlushChunks(blockHolder).toSeq
     chunkSets should have length (2)
     part.numChunks shouldEqual 2

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -1,6 +1,5 @@
 package filodb.memory
 
-import java.lang.{Long => jLong}
 import java.nio.ByteBuffer
 import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
@@ -93,7 +92,6 @@ trait ReusableMemory extends StrictLogging {
     * Marks this memory as free and calls reclaimListener for every piece of metadata.
     */
   protected def free() = {
-    logger.info(s"Reclaiming block at ${jLong.toHexString(address)}...")
     reclaimWithMetadata()
   }
 
@@ -121,6 +119,20 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
 
   protected var _position: Int = 0
   protected var _metaPosition: Int = capacity.toInt
+
+  /**
+   * Keeps track of which BlockMemFactory "owns" this block.  Set when block is requested by a BMF,
+   * cleared when the block is reclaimed.
+   */
+  var owner: Option[BlockMemFactory] = None
+
+  def setOwner(bmf: BlockMemFactory): Unit = {
+    owner = bmf.optionSelf
+  }
+
+  def clearOwner(): Unit = {
+    owner = None
+  }
 
   /**
     * Marks this memory as free. Also zeroes all the bytes from the beginning address until capacity
@@ -183,6 +195,8 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
     byteArr.foreach(b => stringBuf.append(b))
     stringBuf.toString
   }
+
+  def debugString: String = f"Block @0x$address%016x canReclaim=$canReclaim remaining=$remaining"
 
   // debug method to set memory to specific value for testing
   private[memory] def set(value: Byte): Unit =

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -5,6 +5,7 @@ import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import com.typesafe.scalalogging.StrictLogging
+import org.joda.time.DateTime
 
 /*
 * Useful to establish thread ownership of a buffer.
@@ -196,11 +197,48 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
     stringBuf.toString
   }
 
-  def debugString: String = f"Block @0x$address%016x canReclaim=$canReclaim remaining=$remaining"
+  def debugString: String = f"Block @0x$address%016x canReclaim=$canReclaim remaining=$remaining " +
+                            s"owner: ${owner.map(_.debugString).getOrElse("--")}"
 
   // debug method to set memory to specific value for testing
   private[memory] def set(value: Byte): Unit =
     UnsafeUtils.unsafe.setMemory(address, capacity, value)
 }
 
+/**
+ * BlockDetective has utilities for recovering blocks and their reclaim histories, given a corrupt pointer.
+ * This helps to track down ownership and causes for corruption issues.
+ */
+object BlockDetective {
+  import collection.JavaConverters._
 
+  def containsPtr(ptr: BinaryRegion.NativePointer, blocks: Seq[Block]): Seq[Block] =
+    blocks.filter { blk => ptr >= blk.address && ptr < (blk.address + blk.capacity) }
+
+  def containsPtr(ptr: BinaryRegion.NativePointer, blocks: java.util.List[Block]): Seq[Block] =
+    containsPtr(ptr, blocks.asScala)
+
+  /**
+   * Produces a string report containing reclaim history and ownership changes for
+   * blocks containing a given pointer.
+   * Reclaim history is limited by MaxReclaimLogSize above, thus
+   * the bet is that corruption happens soon after reclaim events.
+   */
+  def stringReport(ptr: BinaryRegion.NativePointer,
+                   manager: PageAlignedBlockManager,
+                   pool: BlockMemFactoryPool): String = {
+    val reclaimEvents = manager.reclaimEventsForPtr(ptr)
+    val timeBucketBlocks = manager.timeBlocksForPtr(ptr)
+    val flushBlocks = pool.blocksContainingPtr(ptr)
+
+    f"=== BlockDetective Report for 0x$ptr%016x ===\nReclaim Events:\n" +
+    reclaimEvents.map { case ReclaimEvent(blk, reclaimTime, oldOwner, remaining) =>
+      f"  Block 0x${blk.address}%016x at ${(new DateTime(reclaimTime)).toString()}%s with $remaining%d bytes left" +
+      oldOwner.map { bmf => s"\tfrom ${bmf.debugString}" }.getOrElse("")
+    }.mkString("\n") +
+    "Time bucketed blocks:\n" +
+    timeBucketBlocks.map(_.debugString).mkString("\n") +
+    "Flush block lists:\n" +
+    flushBlocks.map(_.debugString).mkString("\n")
+  }
+}

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -5,7 +5,6 @@ import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import com.typesafe.scalalogging.StrictLogging
-import org.joda.time.DateTime
 
 /*
 * Useful to establish thread ownership of a buffer.
@@ -203,42 +202,4 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
   // debug method to set memory to specific value for testing
   private[memory] def set(value: Byte): Unit =
     UnsafeUtils.unsafe.setMemory(address, capacity, value)
-}
-
-/**
- * BlockDetective has utilities for recovering blocks and their reclaim histories, given a corrupt pointer.
- * This helps to track down ownership and causes for corruption issues.
- */
-object BlockDetective {
-  import collection.JavaConverters._
-
-  def containsPtr(ptr: BinaryRegion.NativePointer, blocks: Seq[Block]): Seq[Block] =
-    blocks.filter { blk => ptr >= blk.address && ptr < (blk.address + blk.capacity) }
-
-  def containsPtr(ptr: BinaryRegion.NativePointer, blocks: java.util.List[Block]): Seq[Block] =
-    containsPtr(ptr, blocks.asScala)
-
-  /**
-   * Produces a string report containing reclaim history and ownership changes for
-   * blocks containing a given pointer.
-   * Reclaim history is limited by MaxReclaimLogSize above, thus
-   * the bet is that corruption happens soon after reclaim events.
-   */
-  def stringReport(ptr: BinaryRegion.NativePointer,
-                   manager: PageAlignedBlockManager,
-                   pool: BlockMemFactoryPool): String = {
-    val reclaimEvents = manager.reclaimEventsForPtr(ptr)
-    val timeBucketBlocks = manager.timeBlocksForPtr(ptr)
-    val flushBlocks = pool.blocksContainingPtr(ptr)
-
-    f"=== BlockDetective Report for 0x$ptr%016x ===\nReclaim Events:\n" +
-    reclaimEvents.map { case ReclaimEvent(blk, reclaimTime, oldOwner, remaining) =>
-      f"  Block 0x${blk.address}%016x at ${(new DateTime(reclaimTime)).toString()}%s with $remaining%d bytes left" +
-      oldOwner.map { bmf => s"\tfrom ${bmf.debugString}" }.getOrElse("")
-    }.mkString("\n") +
-    "Time bucketed blocks:\n" +
-    timeBucketBlocks.map(_.debugString).mkString("\n") +
-    "Flush block lists:\n" +
-    flushBlocks.map(_.debugString).mkString("\n")
-  }
 }

--- a/memory/src/main/scala/filodb.memory/BlockDetective.scala
+++ b/memory/src/main/scala/filodb.memory/BlockDetective.scala
@@ -1,0 +1,41 @@
+package filodb.memory
+
+import org.joda.time.DateTime
+
+/**
+ * BlockDetective has utilities for recovering blocks and their reclaim histories, given a corrupt pointer.
+ * This helps to track down ownership and causes for corruption issues.
+ */
+object BlockDetective {
+  import collection.JavaConverters._
+
+  def containsPtr(ptr: BinaryRegion.NativePointer, blocks: Seq[Block]): Seq[Block] =
+    blocks.filter { blk => ptr >= blk.address && ptr < (blk.address + blk.capacity) }
+
+  def containsPtr(ptr: BinaryRegion.NativePointer, blocks: java.util.List[Block]): Seq[Block] =
+    containsPtr(ptr, blocks.asScala)
+
+  /**
+   * Produces a string report containing reclaim history and ownership changes for
+   * blocks containing a given pointer.
+   * Reclaim history is limited by MaxReclaimLogSize above, thus
+   * the bet is that corruption happens soon after reclaim events.
+   */
+  def stringReport(ptr: BinaryRegion.NativePointer,
+                   manager: PageAlignedBlockManager,
+                   pool: BlockMemFactoryPool): String = {
+    val reclaimEvents = manager.reclaimEventsForPtr(ptr)
+    val timeBucketBlocks = manager.timeBlocksForPtr(ptr)
+    val flushBlocks = pool.blocksContainingPtr(ptr)
+
+    f"=== BlockDetective Report for 0x$ptr%016x ===\nReclaim Events:\n" +
+    reclaimEvents.map { case ReclaimEvent(blk, reclaimTime, oldOwner, remaining) =>
+      f"  Block 0x${blk.address}%016x at ${(new DateTime(reclaimTime)).toString()}%s with $remaining%d bytes left" +
+      oldOwner.map { bmf => s"\tfrom ${bmf.debugString}" }.getOrElse("")
+    }.mkString("\n") +
+    "Time bucketed blocks:\n" +
+    timeBucketBlocks.map(_.debugString).mkString("\n") +
+    "Flush block lists:\n" +
+    flushBlocks.map(_.debugString).mkString("\n")
+  }
+}

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -184,8 +184,12 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     while ( reclaimed < num &&
             timeOrderedListIt.hasNext ) {
       val entry = timeOrderedListIt.next
-      logger.info(s"timeBlockReclaim: Attempting to reclaim time ordered block list at t=${}")
+      val prevReclaimed = reclaimed
       reclaimFrom(entry.getValue, stats.timeOrderedBlocksReclaimedMetric)
+      if (reclaimed > prevReclaimed) {
+        logger.info(s"timeBlockReclaim: Reclaimed ${reclaimed - prevReclaimed} time ordered blocks " +
+                    s"from list at t=${entry.getKey} (${(System.currentTimeMillis - entry.getKey)/3600000} hrs ago)")
+      }
       // If the block list is now empty, remove it from tree map
       if (entry.getValue.isEmpty) timeOrderedListIt.remove()
     }

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -7,19 +7,23 @@ import com.typesafe.scalalogging.StrictLogging
  * and half empty.  It has a checkout and return semantics.  Multiple parallel tasks each do their own
  * checkout and return, thus there should be one blockholder outstanding per task.
  */
-class BlockMemFactoryPool(blockStore: BlockManager, metadataAllocSize: Int) extends StrictLogging {
+class BlockMemFactoryPool(blockStore: BlockManager,
+                          metadataAllocSize: Int,
+                          baseContext: Map[String, String]) extends StrictLogging {
   private val factoryPool = new collection.mutable.Queue[BlockMemFactory]()
 
   def poolSize: Int = factoryPool.length
 
-  def checkout(): BlockMemFactory = synchronized {
-    if (factoryPool.nonEmpty) {
+  def checkout(moreContext: Map[String, String] = Map.empty): BlockMemFactory = synchronized {
+    val fact = if (factoryPool.nonEmpty) {
       logger.debug(s"Checking out BlockMemFactory from pool.  poolSize=$poolSize")
       factoryPool.dequeue
     } else {
       logger.debug(s"Nothing in BlockMemFactory pool.  Creating a new one")
-      new BlockMemFactory(blockStore, None, metadataAllocSize)
+      new BlockMemFactory(blockStore, None, metadataAllocSize, baseContext)
     }
+    fact.context = baseContext ++ moreContext
+    fact
   }
 
   def release(factory: BlockMemFactory): Unit = synchronized {

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -30,4 +30,10 @@ class BlockMemFactoryPool(blockStore: BlockManager,
     logger.debug(s"Returning factory $factory to the pool.  New size ${poolSize + 1}")
     factoryPool += factory
   }
+
+  def blocksContainingPtr(ptr: BinaryRegion.NativePointer): Seq[Block] =
+    factoryPool.flatMap { bmf =>
+      val blocks = bmf.fullBlocks ++ Option(bmf.currentBlock.get).toList
+      BlockDetective.containsPtr(ptr, blocks)
+    }
 }

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -6,6 +6,10 @@ import com.typesafe.scalalogging.StrictLogging
  * This class allows BlockMemFactory's to be reused so that the blocks can be fully utilized, instead of left stranded
  * and half empty.  It has a checkout and return semantics.  Multiple parallel tasks each do their own
  * checkout and return, thus there should be one blockholder outstanding per task.
+ *
+ * @param blockStore the underlying BlockManager to allocate blocks from for each BlockMemFactory
+ * @param metadataAllocSize size of each metadata set per allocation
+ * @param baseContext a set of labels to identify each BlockMemFactory, used only for debugging
  */
 class BlockMemFactoryPool(blockStore: BlockManager,
                           metadataAllocSize: Int,
@@ -14,6 +18,9 @@ class BlockMemFactoryPool(blockStore: BlockManager,
 
   def poolSize: Int = factoryPool.length
 
+  /**
+   * Checks out a BlockMemFactory, optionally adding in extra labels for this particular BMF
+   */
   def checkout(moreContext: Map[String, String] = Map.empty): BlockMemFactory = synchronized {
     val fact = if (factoryPool.nonEmpty) {
       logger.debug(s"Checking out BlockMemFactory from pool.  poolSize=$poolSize")

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -9,27 +9,27 @@ import com.typesafe.scalalogging.StrictLogging
  *
  * @param blockStore the underlying BlockManager to allocate blocks from for each BlockMemFactory
  * @param metadataAllocSize size of each metadata set per allocation
- * @param baseContext a set of labels to identify each BlockMemFactory, used only for debugging
+ * @param baseTags a set of tags to identify each BlockMemFactory, used only for debugging
  */
 class BlockMemFactoryPool(blockStore: BlockManager,
                           metadataAllocSize: Int,
-                          baseContext: Map[String, String]) extends StrictLogging {
+                          baseTags: Map[String, String]) extends StrictLogging {
   private val factoryPool = new collection.mutable.Queue[BlockMemFactory]()
 
   def poolSize: Int = factoryPool.length
 
   /**
-   * Checks out a BlockMemFactory, optionally adding in extra labels for this particular BMF
+   * Checks out a BlockMemFactory, optionally adding in extra tags for this particular BMF
    */
-  def checkout(moreContext: Map[String, String] = Map.empty): BlockMemFactory = synchronized {
+  def checkout(moreTags: Map[String, String] = Map.empty): BlockMemFactory = synchronized {
     val fact = if (factoryPool.nonEmpty) {
       logger.debug(s"Checking out BlockMemFactory from pool.  poolSize=$poolSize")
       factoryPool.dequeue
     } else {
       logger.debug(s"Nothing in BlockMemFactory pool.  Creating a new one")
-      new BlockMemFactory(blockStore, None, metadataAllocSize, baseContext)
+      new BlockMemFactory(blockStore, None, metadataAllocSize, baseTags)
     }
-    fact.context = baseContext ++ moreContext
+    fact.tags = baseTags ++ moreTags
     fact
   }
 

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -197,14 +197,14 @@ class ArrayBackedMemFactory extends MemFactory {
   *                   block is full.
   * @param bucketTime the timebucket (timestamp) from which to allocate block(s), or None for the general list
   * @param metadataAllocSize the additional size in bytes to ensure is free for writing metadata, per chunk
-  * @param context a set of keys/values to identify the purpose of this MemFactory for debugging
+  * @param tags a set of keys/values to identify the purpose of this MemFactory for debugging
   * @param markFullBlocksAsReclaimable Immediately mark and fully used block as reclaimable.
   *                                    Typically true during on-demand paging of optimized chunks from persistent store
   */
 class BlockMemFactory(blockStore: BlockManager,
                       bucketTime: Option[Long],
                       metadataAllocSize: Int,
-                      var context: Map[String, String],
+                      var tags: Map[String, String],
                       markFullBlocksAsReclaimable: Boolean = false) extends MemFactory with StrictLogging {
   def numFreeBytes: Long = blockStore.numFreeBlocks * blockStore.blockSizeInBytes
   val optionSelf = Some(this)
@@ -301,7 +301,7 @@ class BlockMemFactory(blockStore: BlockManager,
   def shutdown(): Unit = {}
 
   def debugString: String =
-    s"BlockMemFactory($bucketTime) ${context.map { case (k, v) => s"$k=$v" }.mkString(" ")}"
+    s"BlockMemFactory($bucketTime) ${tags.map { case (k, v) => s"$k=$v" }.mkString(" ")}"
 }
 
 

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -197,14 +197,17 @@ class ArrayBackedMemFactory extends MemFactory {
   *                   block is full.
   * @param bucketTime the timebucket (timestamp) from which to allocate block(s), or None for the general list
   * @param metadataAllocSize the additional size in bytes to ensure is free for writing metadata, per chunk
+  * @param context a set of keys/values for debugging context
   * @param markFullBlocksAsReclaimable Immediately mark and fully used block as reclaimable.
   *                                    Typically true during on-demand paging of optimized chunks from persistent store
   */
 class BlockMemFactory(blockStore: BlockManager,
                       bucketTime: Option[Long],
                       metadataAllocSize: Int,
+                      var context: Map[String, String],
                       markFullBlocksAsReclaimable: Boolean = false) extends MemFactory with StrictLogging {
   def numFreeBytes: Long = blockStore.numFreeBlocks * blockStore.blockSizeInBytes
+  val optionSelf = Some(this)
 
   // tracks fully populated blocks not marked reclaimable yet (typically waiting for flush)
   val fullBlocks = ListBuffer[Block]()
@@ -215,7 +218,7 @@ class BlockMemFactory(blockStore: BlockManager,
   // tracks blocks that should share metadata
   private val metadataSpan: ListBuffer[Block] = ListBuffer[Block]()
 
-  currentBlock.set(blockStore.requestBlock(bucketTime).get)
+  currentBlock.set(blockStore.requestBlock(bucketTime, optionSelf).get)
 
   /**
     * Starts tracking a span of multiple Blocks over which the same metadata should be applied.
@@ -254,7 +257,7 @@ class BlockMemFactory(blockStore: BlockManager,
         currentBlock.get().markReclaimable()
       }
       fullBlocks += currentBlock.get()
-      val newBlock = blockStore.requestBlock(bucketTime).get
+      val newBlock = blockStore.requestBlock(bucketTime, optionSelf).get
       currentBlock.set(newBlock)
       metadataSpan += newBlock
     }

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -299,6 +299,9 @@ class BlockMemFactory(blockStore: BlockManager,
   // We don't free memory, because many BlockHolders will share a single BlockManager, and we rely on
   // the BlockManager's own shutdown mechanism
   def shutdown(): Unit = {}
+
+  def debugString: String =
+    s"BlockMemFactory($bucketTime) ${context.map { case (k, v) => s"$k=$v" }.mkString(" ")}"
 }
 
 

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -197,7 +197,7 @@ class ArrayBackedMemFactory extends MemFactory {
   *                   block is full.
   * @param bucketTime the timebucket (timestamp) from which to allocate block(s), or None for the general list
   * @param metadataAllocSize the additional size in bytes to ensure is free for writing metadata, per chunk
-  * @param context a set of keys/values for debugging context
+  * @param context a set of keys/values to identify the purpose of this MemFactory for debugging
   * @param markFullBlocksAsReclaimable Immediately mark and fully used block as reclaimable.
   *                                    Typically true during on-demand paging of optimized chunks from persistent store
   */

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -168,4 +168,40 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
 
     blockManager.releaseBlocks()
   }
+
+  it should ("allocate blocks using BlockMemFactory with ownership and reclaims") in {
+    val stats = new MemoryStats(Map("test5" -> "test5"))
+    // This block manager has 5 blocks capacity
+    val blockManager = new PageAlignedBlockManager(5 * pageSize, stats, testReclaimer, 1)
+
+    blockManager.usedBlocks.size() shouldEqual 0
+    blockManager.numTimeOrderedBlocks shouldEqual 0
+    blockManager.usedBlocksTimeOrdered.size shouldEqual 0
+
+    val factory = new BlockMemFactory(blockManager, Some(10000L), 24, Map("foo" -> "bar"), false)
+
+    // There should be one time ordered block allocated, owned by factory
+    blockManager.usedBlocks.size shouldEqual 0
+    blockManager.numTimeOrderedBlocks shouldEqual 1
+    blockManager.hasTimeBucket(10000L) shouldEqual true
+
+    factory.currentBlock.get.owner shouldEqual Some(factory)
+
+    // Now allocate 4 more regular blocks, that will use up all blocks
+    blockManager.requestBlock(None).isDefined shouldEqual true
+    blockManager.requestBlock(None).isDefined shouldEqual true
+    blockManager.requestBlock(None).isDefined shouldEqual true
+    blockManager.requestBlock(None).isDefined shouldEqual true
+    blockManager.usedBlocks.size shouldEqual 4
+    blockManager.numTimeOrderedBlocks shouldEqual 1
+
+    // Mark as reclaimable the blockMemFactory's block.  Then request more blocks, that one will be reclaimed.
+    // Check ownership is now cleared.
+    factory.currentBlock.get.markReclaimable
+    blockManager.requestBlock(Some(9000L)).isDefined shouldEqual true
+    blockManager.hasTimeBucket(10000L) shouldEqual false
+    blockManager.hasTimeBucket(9000L) shouldEqual true
+
+    factory.currentBlock.get.owner shouldEqual None  // new requestor did not have owner
+  }
 }

--- a/memory/src/test/scala/filodb.memory/format/vectors/IntBinaryVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/IntBinaryVectorTest.scala
@@ -100,7 +100,7 @@ class IntBinaryVectorTest extends NativeVectorTest {
       val blockStore = new PageAlignedBlockManager(10 * 1024 * 1024, new MemoryStats(Map("test"-> "test")), null, 16) {
         freeBlocks.asScala.foreach(_.set(0x55))   // initialize blocks to nonzero value
       }
-      val blockFactory = new BlockMemFactory(blockStore, None, 24, true)
+      val blockFactory = new BlockMemFactory(blockStore, None, 24, Map("foo" -> "bar"), true)
 
       // original values will get mixed with nonzero contents if append does not overwrite original memory
       val builder = IntBinaryVector.appendingVectorNoNA(blockFactory, 10, nbits=4, signed=false)

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -23,10 +23,12 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
     new MemoryStats(Map("test"-> "test")), null, 16)
   val storeConf = TestData.storeConf.copy(maxChunksSize = 200)
-  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, timeseriesDataset.blockMetaSize, true)
+  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, timeseriesDataset.blockMetaSize,
+                                      MMD.dummyContext, true)
   protected val tsBufferPool = new WriteBufferPool(TestData.nativeMem, timeseriesDataset, storeConf)
 
-  protected val ingestBlockHolder2 = new BlockMemFactory(blockStore, None, downsampleDataset.blockMetaSize, true)
+  protected val ingestBlockHolder2 = new BlockMemFactory(blockStore, None, downsampleDataset.blockMetaSize,
+                                      MMD.dummyContext, true)
   protected val tsBufferPool2 = new WriteBufferPool(TestData.nativeMem, downsampleDataset, storeConf)
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

When a `MatchError` details in-memory vector corruption, all we get is a pointer.

**New behavior :**

When a `MatchError` occurs during queries, a very detailed report is logged, showing the current owning block(s), which `BlockMemFactory`s own them and the context (type, dataset, other info), and the reclaim history (previous BlockMemFactories that owned before).  This should allow us to figure out how the conflict happened.

The plumbing added (context info for each BlockMemFactory, owner for each Block, analysis tools) can be used to analyze any future corruption issues.
