### PR TITLE
fix(memory): Don't bother tracking blocks which are marked reclaimable.

### DIFF
--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -235,7 +235,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     chunkSets.head.invokeFlushListener()    // update newestFlushedID
     part.unflushedChunksets shouldEqual 1
 
-     val currBlock = blockHolder.currentBlock.get() // hang on to these; we'll later test reclaiming them manually
+     val currBlock = blockHolder.currentBlock // hang on to these; we'll later test reclaiming them manually
      blockHolder.markUsedBlocksReclaimable()
 
      // Now, switch buffers and flush again, ingesting 5 more rows

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -40,7 +40,7 @@ class BlockMemFactoryPool(blockStore: BlockManager,
 
   def blocksContainingPtr(ptr: BinaryRegion.NativePointer): Seq[Block] =
     factoryPool.flatMap { bmf =>
-      val blocks = bmf.fullBlocks ++ Option(bmf.currentBlock.get).toList
+      val blocks = bmf.fullBlocks ++ Option(bmf.currentBlock).toList
       BlockDetective.containsPtr(ptr, blocks)
     }
 }

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -185,7 +185,7 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     blockManager.numTimeOrderedBlocks shouldEqual 1
     blockManager.hasTimeBucket(10000L) shouldEqual true
 
-    factory.currentBlock.get.owner shouldEqual Some(factory)
+    factory.currentBlock.owner shouldEqual Some(factory)
 
     // Now allocate 4 more regular blocks, that will use up all blocks
     blockManager.requestBlock(None).isDefined shouldEqual true
@@ -197,11 +197,11 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
 
     // Mark as reclaimable the blockMemFactory's block.  Then request more blocks, that one will be reclaimed.
     // Check ownership is now cleared.
-    factory.currentBlock.get.markReclaimable
+    factory.currentBlock.markReclaimable
     blockManager.requestBlock(Some(9000L)).isDefined shouldEqual true
     blockManager.hasTimeBucket(10000L) shouldEqual false
     blockManager.hasTimeBucket(9000L) shouldEqual true
 
-    factory.currentBlock.get.owner shouldEqual None  // new requestor did not have owner
+    factory.currentBlock.owner shouldEqual None  // new requestor did not have owner
   }
 }


### PR DESCRIPTION
fix(memory): Don't bother tracking blocks which are marked reclaimable. Otherwise a slow memory leak develops. Also remove atomic reference, which isn't necessary because the enclosing class isn't designed to be thread safe.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
When markFullBlocksAsReclaimable is enabled (which it is everywhere), the block is marked as reclaimable and still kept in a list.

**New behavior :**
Full blocks which are reclaimed aren't added to the list to be reclaimed later. Also eliminate atomic reference, since it wasn't necessary. Allocation of new blocks is performed before making any other state changes, in case allocation fails.

