### PR TITLE
feat(core): Add metric to default partkey; include partkey in schemaID 

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,10 +349,10 @@ that part of the cluster could be with the old config and the rest could have ne
 
 ### Prometheus FiloDB Schema for Operational Metrics
 
-* Partition key = `tags:map`
+* Partition key = `metric:string,tags:map`
 * Columns: `timestamp:ts,value:double:detectDrops=true`
 
-The above is the classic Prometheus-compatible schema.  It supports indexing on any tag.  Thus standard Prometheus queries that filter by a tag such as `hostname` or `datacenter` for example would work fine.  Note that the Prometheus metric name is encoded as a key `__name__`, which is the Prometheus standard when exporting tags.
+The above is the classic Prometheus-compatible schema.  It supports indexing on any tag.  Thus standard Prometheus queries that filter by a tag such as `hostname` or `datacenter` for example would work fine.  Note that the Prometheus metric name, which in Prometheus data is a label/tag with the key `__name__`, is separated out to an explicit metric column.
 
 Note that in the Prometheus data model, more complex metrics such as histograms are represented as individual time series.  This has some simplicity benefits, but does use up more time series and incur extra I/O overhead when transmitting raw data records.
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -188,7 +188,7 @@ class QueryEngine(dataset: Dataset,
         // So to compute the shard hash we need shardCol == value filter (exact equals) for each shardColumn
         filters.find(f => f.column == shardCol) match {
           case Some(ColumnFilter(_, Filter.Equals(filtVal: String))) =>
-            shardCol -> RecordBuilder.trimShardColumn(dataset, shardCol, filtVal)
+            shardCol -> RecordBuilder.trimShardColumn(dataset.schema, shardCol, filtVal)
           case Some(ColumnFilter(_, filter)) =>
             throw new BadQueryException(s"Found filter for shard column $shardCol but " +
               s"$filter cannot be used for shard key routing")

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -16,26 +16,33 @@ filodb {
 
   # Definition of cluster-wide partition key scheme.  The partition key defines each unique time series,
   # such as labels or tags, and is used for sharding time series across the cluster.
-  # The below definition is standard for Prometheus schema
+  # The below definition is standard for Prometheus schema.
+  # Please do not modify unless you know what you are doing; some internal code esp in gateway module is sensitive
+  # to the exact definitions.
   partition-schema {
     # Typical column types used: map, string.  Also possible: ts,long,double
-    columns = ["tags:map"]
+    columns = ["metric:string", "tags:map"]
 
     # Predefined keys allow space to be saved for over the wire tags with the given keys
-    predefined-keys = ["_ns", "app", "__name__", "instance", "dc", "le"]
+    predefined-keys = ["_ns", "app", "__name__", "instance", "dc", "le", "job", "exporter"]
 
     options {
-      copyTags = {}
+      copyTags = {
+        exporter = "_ns"
+        job = "_ns"
+      }
       ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
       ignoreTagsOnPartitionKeyHash = ["le"]
-      metricColumn = "__name__"
-      shardKeyColumns = [ "__name__", "_ns" ]
+      metricColumn = "metric"
+      shardKeyColumns = [ "metric", "_ns" ]
     }
   }
 
   # Definitions of possible data schemas to be used in all datasets
   # Each one must have a unique name and column schema.
   # FiloDB will refuse to start if the schema definitions have errors.  Use the validateSchemas CLI command to check.
+  # Please do not modify unless you know what you are doing; some internal code esp in gateway module is sensitive
+  # to the exact definitions.
   schemas {
     prometheus {
       # Each column def is of name:type format.  Type may be ts,long,double,string,int

--- a/core/src/main/scala/filodb.core/GlobalConfig.scala
+++ b/core/src/main/scala/filodb.core/GlobalConfig.scala
@@ -12,6 +12,8 @@ import com.typesafe.scalalogging.StrictLogging
   * - all other reference.conf's
   */
 object GlobalConfig extends StrictLogging {
+  val defaultsFromUrl = ConfigFactory.load("filodb-defaults")
+  val defaultFiloConfig = defaultsFromUrl.getConfig("filodb")
 
   val systemConfig: Config = {
     ConfigFactory.invalidateCaches()
@@ -22,7 +24,6 @@ object GlobalConfig extends StrictLogging {
     // ConfigFactory.parseResources() does NOT work in Spark 1.4.1 executors
     // and only the below works.
     // filodb-defaults.conf sets cluster.roles=["worker"] as the default
-    val defaultsFromUrl = ConfigFactory.load("filodb-defaults")
     ConfigFactory.defaultOverrides.withFallback(customConfig) // spark overrides cluster.roles, cli doesn't
                  .withFallback(defaultsFromUrl)
                  .withFallback(ConfigFactory.defaultReference())

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -108,7 +108,7 @@ final class RecordBuilder(memFactory: MemFactory,
 
   // startNewRecord for an ingestion schema.  Use this if creating an ingestion record, ensures right ID is used.
   final def startNewRecord(schema: Schema): Unit =
-    startNewRecord(schema.ingestionSchema, schema.data.hash)
+    startNewRecord(schema.ingestionSchema, schema.schemaHash)
 
   final def startNewRecord(partSchema: PartitionSchema, schemaID: Int): Unit =
     startNewRecord(partSchema.binSchema, schemaID)
@@ -268,11 +268,11 @@ final class RecordBuilder(memFactory: MemFactory,
   }
 
   final def addFromReader(row: RowReader, schema: Schema): Long =
-    addFromReader(row, schema.ingestionSchema, schema.data.hash)
+    addFromReader(row, schema.ingestionSchema, schema.schemaHash)
 
   // Really only for testing. Very slow.  Only for partition keys
   def partKeyFromObjects(schema: Schema, parts: Any*): Long =
-    addFromReader(SeqRowReader(parts.toSeq), schema.partKeySchema, schema.data.hash)
+    addFromReader(SeqRowReader(parts.toSeq), schema.partKeySchema, schema.schemaHash)
 
   /**
    * Sorts and adds keys and values from a map.  The easiest way to add a map to a BinaryRecord.

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.StrictLogging
 import org.agrona.DirectBuffer
 import scalaxy.loops._
 
-import filodb.core.metadata.{Column, Dataset, PartitionSchema, Schema}
+import filodb.core.metadata.{Column, PartitionSchema, Schema}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, LongColumn, MapColumn, StringColumn}
 import filodb.core.query.ColumnInfo
 import filodb.memory._
@@ -650,13 +650,13 @@ object RecordBuilder {
     * In order to ingest all these multiple time series of a single metric to the
     * same shard, we have to trim the suffixes while calculating shardKeyHash.
     *
-    * @param dataSet    - Current DataSet
+    * @param schema - affected schema
     * @param shardKeyColName  - ShardKey label name as String
     * @param shardKeyColValue - ShardKey label value as String
     * @return - Label value after removing the suffix
     */
-  final def trimShardColumn(dataSet: Dataset, shardKeyColName: String, shardKeyColValue: String): String = {
-    dataSet.options.ignoreShardKeyColumnSuffixes.get(shardKeyColName) match {
+  final def trimShardColumn(schema: Schema, shardKeyColName: String, shardKeyColValue: String): String = {
+    schema.options.ignoreShardKeyColumnSuffixes.get(shardKeyColName) match {
       case Some(trimMetricSuffixColumn) => trimMetricSuffixColumn.find(shardKeyColValue.endsWith) match {
                                             case Some(s)  => shardKeyColValue.dropRight(s.length)
                                             case _        => shardKeyColValue

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -8,6 +8,7 @@ import filodb.core.binaryrecord2._
 import filodb.core.downsample.ChunkDownsampler
 import filodb.core.query.ColumnInfo
 import filodb.core.store.ChunkSetInfo
+import filodb.core.GlobalConfig
 import filodb.core.Types._
 import filodb.memory.BinaryRegion
 import filodb.memory.format.{BinaryVector, RowReader, TypedIterator, UnsafeUtils}
@@ -306,4 +307,11 @@ object Schemas {
       Schemas(partSchema, schemas.toMap)
     }
   }
+
+  /**
+   * Global/universal schemas used for supporting the basic Prometheus / metric types.
+   * They are put here so they can be used in Query Engine, testing, etc.
+   */
+  val global = fromConfig(GlobalConfig.defaultFiloConfig).get
+  val promCounter = global.schemas("prometheus")
 }

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -118,7 +118,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
         (1 to maxNumRecords).map(_.toDouble)
       records.foreach { case (b, o) =>
         schema1.ingestionSchema.partitionHash(b, o) should not be (0)
-        RecordSchema.schemaID(b, o) shouldEqual schema1.data.hash
+        RecordSchema.schemaID(b, o) shouldEqual schema1.schemaHash
       }
       val container1Bytes = builder.allContainers.head.numBytes
 
@@ -158,7 +158,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       addrs.map(recSchema1.getDouble(_, 1)) shouldEqual Buffer.fromIterable((1 to maxNumRecords).map(_.toDouble))
       addrs.foreach { a =>
         recSchema1.partitionHash(a) should not be (0)
-        RecordSchema.schemaID(a) shouldEqual schema1.data.hash
+        RecordSchema.schemaID(a) shouldEqual schema1.schemaHash
       }
       val container1Bytes = builder.allContainers.head.numBytes
 
@@ -304,7 +304,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       recSchema1.getDouble(recordAddr, 3) shouldEqual 10.1
       recSchema1.getLong(recordAddr, 4) shouldEqual 123456L
       recSchema1.utf8StringPointer(recordAddr, 5).compare("Series 1".utf8(nativeMem)) shouldEqual 0
-      RecordSchema.schemaID(recordAddr) shouldEqual schema1.data.hash
+      RecordSchema.schemaID(recordAddr) shouldEqual schema1.schemaHash
     }
 
     it("should hash correctly with different ways of adding UTF8 fields") {
@@ -460,7 +460,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
   // just to let us test partitionMatch() independently of buildPartKeyFromIngest()
   private def dataset2AddPartKeys(builder: RecordBuilder, data: Stream[Seq[Any]]) = {
     data.foreach { values =>
-      builder.startNewRecord(dataset3.schema.partKeySchema, dataset3.schema.data.hash)
+      builder.startNewRecord(dataset3.schema.partKeySchema, dataset3.schema.schemaHash)
       builder.addString(values(5).asInstanceOf[String])  // series (partition key)
       if (values.length > 6) {
         builder.startMap()

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -617,13 +617,13 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
   }
 
   it("should trim metric name for _bucket _sum _count") {
-    val metricName = RecordBuilder.trimShardColumn(dataset1, "__name__", "heap_usage_bucket")
+    val metricName = RecordBuilder.trimShardColumn(schema1, "__name__", "heap_usage_bucket")
     metricName shouldEqual "heap_usage"
 
-    val metricName2 = RecordBuilder.trimShardColumn(dataset1, "__name__", "heap_usage_sum")
+    val metricName2 = RecordBuilder.trimShardColumn(schema1, "__name__", "heap_usage_sum")
     metricName2 shouldEqual "heap_usage"
 
-    val metricName3 = RecordBuilder.trimShardColumn(dataset1, "__name__", "heap_usage_count")
+    val metricName3 = RecordBuilder.trimShardColumn(schema1, "__name__", "heap_usage_count")
     metricName3 shouldEqual "heap_usage"
 
     val timeseriesDataset = Dataset.make("timeseries",
@@ -631,10 +631,10 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       Seq("timestamp:ts", "value:double"),
       Seq.empty,
       DatasetOptions(Seq("__name__", "job"), "__name__", false, Map("dummy" -> Seq("_bucket")))).get
-    val metricName4 = RecordBuilder.trimShardColumn(timeseriesDataset, "__name__", "heap_usage_bucket")
+    val metricName4 = RecordBuilder.trimShardColumn(timeseriesDataset.schema, "__name__", "heap_usage_bucket")
     metricName4 shouldEqual "heap_usage_bucket"
 
-    val metricName5 = RecordBuilder.trimShardColumn(dataset1, "__name__", "heap_usage_sum_count")
+    val metricName5 = RecordBuilder.trimShardColumn(schema1, "__name__", "heap_usage_sum_count")
     metricName5 shouldEqual "heap_usage_sum"
   }
 

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -57,7 +57,7 @@ class ShardDownsamplerSpec extends FunSpec with Matchers with BeforeAndAfterAll 
   val partKeyTags = Map("dc".utf8 -> "dc1".utf8, "instance".utf8 -> "instance1".utf8)
 
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, 4096)
-  partKeyBuilder.startNewRecord(promDataset.partKeySchema, promDataset.schema.data.hash)
+  partKeyBuilder.startNewRecord(promDataset.partKeySchema, promDataset.schema.schemaHash)
   partKeyBuilder.addString("someStringValue")
   partKeyBuilder.addMap(partKeyTags)
   partKeyBuilder.endRecord(true)

--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -103,7 +103,7 @@ object GatewayServer extends StrictLogging {
       val initIndex = buf.readerIndex
       val len = buf.readableBytes
       numInfluxMessages.increment
-      InfluxProtocolParser.parse(buf, dataset.schema) map { record =>
+      InfluxProtocolParser.parse(buf) map { record =>
         logger.trace(s"Enqueuing: $record")
         val shard = shardMapper.ingestionShard(record.shardKeyHash, record.partitionKeyHash, spread)
         if (!shardQueues(shard).offer(record)) {

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
@@ -8,7 +8,6 @@ import org.jboss.netty.buffer.ChannelBuffer
 import scalaxy.loops._
 
 import filodb.core.binaryrecord2.RecordBuilder
-import filodb.core.metadata.Schema
 
 trait KVVisitor {
   def apply(bytes: Array[Byte], keyIndex: Int, keyLen: Int, valueIndex: Int, valueLen: Int): Unit
@@ -118,7 +117,7 @@ object InfluxProtocolParser extends StrictLogging {
   def keyLen(offsetInt: Int): Int = ((offsetInt >> 16) & 0x0ffff) - (offsetInt & 0x0ffff)
   def valOffset(offsetInt: Int): Int = ((offsetInt >> 16) & 0x0ffff) + 1
 
-  def parse(buffer: ChannelBuffer, schema: Schema): Option[InfluxRecord] = {
+  def parse(buffer: ChannelBuffer): Option[InfluxRecord] = {
     val bytes = new Array[Byte](buffer.readableBytes)   // max parsed size is original bytes
     val tagOffsets = debox.Buffer.empty[Int]            // array indices of each tag k=v pair.
 
@@ -155,10 +154,10 @@ object InfluxProtocolParser extends StrictLogging {
     // Create the right InfluxRecord depending on # of fields
     if (fieldOffsets.length == 1) {
       Some(InfluxPromSingleRecord(bytes, measurementLen, tagOffsets,
-                                  fieldOffsets, timeIndex - 1, timestamp, schema))
+                                  fieldOffsets, timeIndex - 1, timestamp))
     } else {
       Some(InfluxPromHistogramRecord(bytes, measurementLen, tagOffsets,
-                                     fieldOffsets, timeIndex - 1, timestamp, schema))
+                                     fieldOffsets, timeIndex - 1, timestamp))
     }
   }
 

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -132,7 +132,7 @@ object TestTimeseriesProducer extends StrictLogging {
                      "host"     -> s"H$host",
                      "instance" -> s"Instance-$instance")
 
-      PrometheusInputRecord(tags, "heap_usage", dataset, timestamp, value)
+      PrometheusInputRecord(tags, "heap_usage", timestamp, value)
     }
   }
 
@@ -185,7 +185,7 @@ object TestTimeseriesProducer extends StrictLogging {
                      hostUTF8 -> s"H$host".utf8,
                      instUTF8 -> s"Instance-$instance".utf8)
 
-      new MetricTagInputRecord(Seq(timestamp, sum, count, hist), "http_request_latency", tags, dataset)
+      new MetricTagInputRecord(Seq(timestamp, sum, count, hist), "http_request_latency", tags, dataset.schema)
     }
   }
 }

--- a/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
@@ -4,8 +4,8 @@ import org.jboss.netty.buffer.ChannelBuffers
 import org.scalatest.{FunSpec, Matchers}
 
 import filodb.core.binaryrecord2.{RecordBuilder, StringifyMapItemConsumer}
+import filodb.core.metadata.Schemas
 import filodb.memory.MemFactory
-import filodb.prometheus.FormatConversion
 
 class InfluxRecordSpec extends FunSpec with Matchers {
   // First one has app tag
@@ -20,13 +20,13 @@ class InfluxRecordSpec extends FunSpec with Matchers {
     "span_processing_time_seconds,error=false,host=MacBook-Pro-229.local,operation=memstore-recover-index-latency +Inf=2,0.005=0,0.01=0,0.025=0,0.05=0,0.075=0,0.1=1,0.25=2,0.5=2,0.75=2,1=2,10=2,2.5=2,5=2,7.5=2,count=2,sum=0.230162432 1536790212000000000"
   )
 
-  val dataset = FormatConversion.dataset
+  val schema = Schemas.promCounter
   val buffer = ChannelBuffers.buffer(8192)
 
   def convertToRecords(rawText: Seq[String]): Seq[Option[InfluxRecord]] = {
     rawText.map { line =>
       buffer.writeBytes(line.getBytes())
-      InfluxProtocolParser.parse(buffer, dataset.schema)
+      InfluxProtocolParser.parse(buffer)
     }
   }
 
@@ -76,16 +76,17 @@ class InfluxRecordSpec extends FunSpec with Matchers {
       // println(recordOpts(0).get)
       recordOpts(0).get.addToBuilder(builder)
       builder.allContainers.head.foreach { case (base, offset) =>
-        dataset.ingestionSchema.partitionHash(base, offset) should not equal (7)
-        dataset.ingestionSchema.getLong(base, offset, 0) shouldEqual 1536790212000L
-        dataset.ingestionSchema.getDouble(base, offset, 1) shouldEqual 0.0
+        schema.ingestionSchema.partitionHash(base, offset) should not equal (7)
+        schema.ingestionSchema.getLong(base, offset, 0) shouldEqual 1536790212000L
+        schema.ingestionSchema.getDouble(base, offset, 1) shouldEqual 0.0
+
+        schema.ingestionSchema.asJavaString(base, offset, 2) shouldEqual "recovery_row_skipped_total"
 
         val consumer = new StringifyMapItemConsumer()
-        dataset.ingestionSchema.consumeMapItems(base, offset, 2, consumer)
+        schema.ingestionSchema.consumeMapItems(base, offset, 3, consumer)
         consumer.stringPairs.toMap shouldEqual Map("dataset" -> "timeseries",
                                                    "host" -> "MacBook-Pro-229.local",
-                                                   "_ns" -> "filodb",
-                                                   "__name__" -> "recovery_row_skipped_total")
+                                                   "_ns" -> "filodb")
       }
     }
   }
@@ -98,16 +99,19 @@ class InfluxRecordSpec extends FunSpec with Matchers {
       recordOpts(0).get.addToBuilder(builder)
       builder.allContainers.head.countRecords shouldEqual 17
       builder.allContainers.head.foreach { case (base, offset) =>
-        dataset.ingestionSchema.partitionHash(base, offset) should not equal (7)
-        dataset.ingestionSchema.getLong(base, offset, 0) shouldEqual 1536790212000L
+        schema.ingestionSchema.partitionHash(base, offset) should not equal (7)
+        schema.ingestionSchema.getLong(base, offset, 0) shouldEqual 1536790212000L
         val consumer = new StringifyMapItemConsumer()
-        dataset.ingestionSchema.consumeMapItems(base, offset, 2, consumer)
+        schema.ingestionSchema.consumeMapItems(base, offset, 3, consumer)
         val map = consumer.stringPairs.toMap
-        map("__name__") should startWith ("span_processing_time_seconds")
         map("operation") shouldEqual "memstore-recover-index-latency"
-        map("__name__").drop("span_processing_time_seconds".length) match {
-          case "_sum"    => dataset.ingestionSchema.getDouble(base, offset, 1) shouldEqual 0.230162432 +- 0.00000001
-          case "_count"  => dataset.ingestionSchema.getDouble(base, offset, 1) shouldEqual 2
+        (map.keySet - "le") shouldEqual Set("operation", "host", "error")
+
+        val metric = schema.ingestionSchema.asJavaString(base, offset, 2)
+        metric should startWith ("span_processing_time_seconds")
+        metric.drop("span_processing_time_seconds".length) match {
+          case "_sum"    => schema.ingestionSchema.getDouble(base, offset, 1) shouldEqual 0.230162432 +- 0.00000001
+          case "_count"  => schema.ingestionSchema.getDouble(base, offset, 1) shouldEqual 2
           case "_bucket" => map.contains("le") shouldEqual true
         }
       }

--- a/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
@@ -41,7 +41,7 @@ class GatewayBenchmark extends StrictLogging {
 
   val singlePromTSBytes = timeseries(tagMap).toByteArray
 
-  val singleInfluxRec = s"${tagMap("__name__")}, ${influxTags.map{case (k, v) => s"$k=$v"}.mkString(",")} " +
+  val singleInfluxRec = s"${tagMap("__name__")},${influxTags.map{case (k, v) => s"$k=$v"}.mkString(",")} " +
                         s"counter=$value ${initTimestamp}000000"
   val singleInfluxBuf = ChannelBuffers.buffer(1024)
   singleInfluxBuf.writeBytes(singleInfluxRec.getBytes)
@@ -59,8 +59,8 @@ class GatewayBenchmark extends StrictLogging {
              timeseries(tagMap ++ Map("__name__" -> "heap_usage_count"), histBuckets.size))
   val histPromBytes = histPromSeries.map(_.toByteArray)
 
-  val histInfluxRec = s"${tagMap("__name__")}, ${influxTags.map{case (k, v) => s"$k=$v"}.mkString(",")} " +
-                      s"${histBuckets.map { case (k, v) => s"$k=$v"}.mkString(",") }, sum=$histSum,count=8 " +
+  val histInfluxRec = s"${tagMap("__name__")},${influxTags.map{case (k, v) => s"$k=$v"}.mkString(",")} " +
+                      s"${histBuckets.map { case (k, v) => s"$k=$v"}.mkString(",") },sum=$histSum,count=8 " +
                       s"${initTimestamp}000000"
   val histInfluxBuf = ChannelBuffers.buffer(1024)
   histInfluxBuf.writeBytes(histInfluxRec.getBytes)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

* The default partition key was simply the tags
* schemaID only calculated from data columns names and types

**New behavior :**

* Default partition key changed to metric name + tags
* schemaID calculated from partition key also; the column type params are now also included.  This makes schemaID more sensitive to changes in the above.
* The default prometheus schema is now accessible in the code
* Gateway module updated for partition key changes.  The changes include removing the dataset as a param.... it was lame because really the output depended on a specific dataset, passing in other datasets was actually a potentially huge problem.

Tests passing and local default pipeline was re-ran to ensure correct operation

**BREAKING CHANGES**

Change in schemaID scheme and partition key means previous data in C* cannot be read or parsed.  Clean start and rewipe of data is needed.