### PR TITLE
fix(memory): Protect blocks from being marked as reclaimable multiple times.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -73,21 +73,23 @@ extends RawToPartitionMaker with StrictLogging {
       tsShard.shardStats.numChunksPagedIn.increment(rawPartition.chunkSets.size)
       // One chunkset at a time, load them into offheap and populate the partition
       rawPartition.chunkSets.foreach { case RawChunkSet(infoBytes, rawVectors) =>
-        val memFactory = getMemFactory(timeBucketForChunkSet(infoBytes))
-        val chunkID = ChunkSetInfo.getChunkID(infoBytes)
+        if (!rawVectors.isEmpty) {
+          val memFactory = getMemFactory(timeBucketForChunkSet(infoBytes))
+          val chunkID = ChunkSetInfo.getChunkID(infoBytes)
 
-        memFactory.startMetaSpan()
-        val chunkPtrs = copyToOffHeap(rawVectors, memFactory)
-        val metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),
-                                              tsPart.schema.data.blockMetaSize.toShort)
-        require(metaAddr != 0)
-        val infoAddr = metaAddr + 4   // Important: don't point at partID
-        val inserted = tsPart.addChunkInfoIfAbsent(chunkID, infoAddr)
+          memFactory.startMetaSpan()
+          val chunkPtrs = copyToOffHeap(rawVectors, memFactory)
+          val metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),
+                                                tsPart.schema.data.blockMetaSize.toShort)
+          require(metaAddr != 0)
+          val infoAddr = metaAddr + 4   // Important: don't point at partID
+          val inserted = tsPart.addChunkInfoIfAbsent(chunkID, infoAddr)
 
-        if (!inserted) {
-          logger.info(s"Chunks not copied to partId=${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
-            s"$chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
-            s"${ChunkSetInfo.getEndTime(infoBytes)}) partition earliestTime=${tsPart.earliestTime}")
+          if (!inserted) {
+            logger.info(s"Chunks not copied to partId=${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
+              s"$chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
+              s"${ChunkSetInfo.getEndTime(infoBytes)}) partition earliestTime=${tsPart.earliestTime}")
+          }
         }
       }
       tsPart

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -135,7 +135,7 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
   }
 
   /**
-   * Maerks this block as reclaimable if unowned, or if the owner hasn't used the block in a while.
+   * Marks this block as reclaimable if unowned, or if the owner hasn't used the block in a while.
    */
   def tryMarkReclaimable(): Unit = {
     owner match {

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -135,6 +135,16 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
   }
 
   /**
+   * Maerks this block as reclaimable if unowned, or if the owner hasn't used the block in a while.
+   */
+  def tryMarkReclaimable(): Unit = {
+    owner match {
+      case None => markReclaimable
+      case Some(bmf) => bmf.tryMarkReclaimable
+    }
+  }
+
+  /**
     * Marks this memory as free. Also zeroes all the bytes from the beginning address until capacity
     */
   override protected def free(): Unit = {

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -254,7 +254,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
       val keys = usedBlocksTimeOrdered.headMap(upTo).keySet.asScala
       logger.info(s"timeBlockReclaim: Marking lists $keys as reclaimable")
       usedBlocksTimeOrdered.headMap(upTo).values.asScala.foreach { list =>
-        list.asScala.foreach(_.markReclaimable)
+        list.asScala.foreach(_.tryMarkReclaimable)
       }
     } finally {
       lock.unlock()

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -243,7 +243,7 @@ class BlockMemFactory(blockStore: BlockManager,
   }
 
   /**
-    * Marks all blocks known by this factory as reclaimable, but only of this factory hasn't
+    * Marks all blocks known by this factory as reclaimable, but only if this factory hasn't
     * been used recently.
     */
   def tryMarkReclaimable(): Unit = synchronized {


### PR DESCRIPTION


**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
A background task can call BlockManager.markBucketedBlocksReclaimable, which can then steal blocks which are owned by BlockMemFactory instances. Because the BlockMemFactory isn't notified, it thinks it can still access the current block and mark it reclaimable again later. This makes it possible for the block to be shared, leading to corruption.

**New behavior :**
If there is a block owner assigned, it's consulted first. It can reject the attempt to mark its current block as reclaimable, if it's still being written to. If the attempt is accepted, then all blocks tracked by mem factory are marked as reclaimable, and all references to them are discarded.

