### PR TITLE
misc(http): Add exceptionhandler in http route

### DIFF
--- a/http/src/main/scala/filodb/http/FiloHttpServer.scala
+++ b/http/src/main/scala/filodb/http/FiloHttpServer.scala
@@ -4,12 +4,14 @@ import java.io.{PrintWriter, StringWriter}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.FiniteDuration
+
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{ExceptionHandler, Route}
+import akka.http.scaladsl.server.ExceptionHandler
+import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.StrictLogging
 

--- a/http/src/main/scala/filodb/http/FiloHttpServer.scala
+++ b/http/src/main/scala/filodb/http/FiloHttpServer.scala
@@ -1,7 +1,5 @@
 package filodb.http
 
-import java.io.{PrintWriter, StringWriter}
-
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.FiniteDuration
 
@@ -29,10 +27,10 @@ class FiloHttpServer(actorSystem: ActorSystem) extends StrictLogging {
     ExceptionHandler {
       case ex: Exception =>
         extractUri { uri =>
-          logger.error(s"Request to $uri could not be handled normally", ex)
-          val sw = new StringWriter()
-          ex.printStackTrace(new PrintWriter(sw))
-          complete(HttpResponse(InternalServerError, entity = sw.toString))
+          logger.error(s"Request to uri=$uri failed", ex)
+          val errorString = s"Request to uri=$uri failed with ${ex.getClass.getName} ${ex.getMessage}\n" +
+            ex.getStackTrace.map(_.toString).mkString("\n")
+          complete(HttpResponse(InternalServerError, entity = errorString))
         }
     }
 

--- a/http/src/main/scala/filodb/http/FiloHttpServer.scala
+++ b/http/src/main/scala/filodb/http/FiloHttpServer.scala
@@ -1,12 +1,15 @@
 package filodb.http
 
+import java.io.{PrintWriter, StringWriter}
+
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.FiniteDuration
-
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.StrictLogging
 
@@ -19,6 +22,17 @@ class FiloHttpServer(actorSystem: ActorSystem) extends StrictLogging {
   val settings = new HttpSettings(actorSystem.settings.config)
 
   private var binding: Http.ServerBinding = _
+
+  def filoExceptionHandler: ExceptionHandler =
+    ExceptionHandler {
+      case ex: Exception =>
+        extractUri { uri =>
+          logger.error(s"Request to $uri could not be handled normally", ex)
+          val sw = new StringWriter()
+          ex.printStackTrace(new PrintWriter(sw))
+          complete(HttpResponse(InternalServerError, entity = sw.toString))
+        }
+    }
 
   /**
     * Starts the HTTP Server, blocks until it is up.
@@ -38,7 +52,9 @@ class FiloHttpServer(actorSystem: ActorSystem) extends StrictLogging {
                                            new HealthRoute(coordinatorRef),
                                            new PrometheusApiRoute(coordinatorRef, settings))
     val reduced = filoRoutes.foldLeft[Route](reject)((acc, r) => r.route ~ acc)
-    val finalRoute = reduced ~ externalRoutes
+    val finalRoute = handleExceptions(filoExceptionHandler) {
+      reduced ~ externalRoutes
+    }
     val bindingFuture = Http().bindAndHandle(finalRoute,
       settings.httpServerBindHost,
       settings.httpServerBindPort)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Exceptions are not being printed in logs while accessing prometheus http api endpoints.

**New behavior :**

As per https://doc.akka.io/docs/akka-http/current/routing-dsl/exception-handling.html, added an exception handler. Hence, during any exception, the corresponding stackTrace is being logged.