### PR TITLE
feat(query):Support multiple shard keys in QueryOptions.simpleMapSpreadFunc

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -15,7 +15,6 @@ import filodb.coordinator.queryengine2.{EmptyFailureProvider, QueryEngine}
 import filodb.core._
 import filodb.core.memstore.{FiloSchedulers, MemStore, TermInfo}
 import filodb.core.metadata.Dataset
-import filodb.core.query.ColumnFilter
 import filodb.core.store.CorruptVectorException
 import filodb.query._
 import filodb.query.exec.ExecPlan
@@ -60,7 +59,7 @@ final class QueryActor(memStore: MemStore,
   val config = context.system.settings.config
 
   var filodbSpreadMap = new collection.mutable.HashMap[collection.Map[String, String], Int]
-  val applicationShardKeyName = dataset.options.nonMetricShardColumns.headOption
+  val applicationShardKeyNames = dataset.options.nonMetricShardColumns
   val defaultSpread = config.getInt("filodb.spread-default")
 
   implicit val spreadOverrideReader: ValueReader[SpreadAssignment] = ValueReader.relative { spreadAssignmentConfig =>
@@ -73,9 +72,7 @@ final class QueryActor(memStore: MemStore,
   val spreadAssignment : List[SpreadAssignment]= config.as[List[SpreadAssignment]]("filodb.spread-assignment")
   spreadAssignment.foreach{ x => filodbSpreadMap.put(x.shardKeysMap, x.spread)}
 
-  val spreadFunc = applicationShardKeyName.map { appKey =>
-                     QueryOptions.simpleMapSpreadFunc(appKey, filodbSpreadMap, defaultSpread)
-                   }.getOrElse { x: Seq[ColumnFilter] => Seq(SpreadChange(defaultSpread)) }
+  val spreadFunc = QueryOptions.simpleMapSpreadFunc(applicationShardKeyNames, filodbSpreadMap, defaultSpread)
   val functionalSpreadProvider = FunctionalSpreadProvider(spreadFunc)
 
   val queryEngine2 = new QueryEngine(dataset, shardMapFunc,

--- a/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryengine2/QueryEngineSpec.scala
@@ -164,7 +164,7 @@ class QueryEngineSpec extends FunSpec with Matchers {
     var filodbSpreadMap = new collection.mutable.HashMap[collection.Map[String, String], Int]
     filodbSpreadMap.put(collection.Map(("job" -> "myService")), 2)
 
-    val spreadFunc = QueryOptions.simpleMapSpreadFunc("job", filodbSpreadMap, 1)
+    val spreadFunc = QueryOptions.simpleMapSpreadFunc(Seq("job"), filodbSpreadMap, 1)
 
     // final logical plan
     val logicalPlan = BinaryJoin(summed1, BinaryOperator.DIV, Cardinality.OneToOne, summed2)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Only one shard key is accepted as an input for QueryOptions.simpleMapSpreadFunc.

**New behavior :**
Multiple shard keys can be provided as part of input field for QueryOptions.simpleMapSpreadFunc.