### PR TITLE
misc(core): Add new shard key _ws_ and rename _ns to _ns_

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The number of shards in each dataset is preconfigured in the source config.  Ple
 
 Metrics are routed to shards based on factors:
 
-1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency. Currently `_ws_`, `_ns_`, `metric` labels are mandatory to calculate shard key.
+1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency. Currently `_ws_`, `_ns_`, `metric` labels are mandatory to calculate shard key along with `metric` column.
 2. The rest of the tags or components of a partition key are then used to compute which shard within the group of shards to assign to.
 
 ## Querying FiloDB

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The number of shards in each dataset is preconfigured in the source config.  Ple
 
 Metrics are routed to shards based on factors:
 
-1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency.
+1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency. Currently `_ws_`, `_ns_`, `__name__` labels are mandatory to calculate shard key.
 2. The rest of the tags or components of a partition key are then used to compute which shard within the group of shards to assign to.
 
 ## Querying FiloDB

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The number of shards in each dataset is preconfigured in the source config.  Ple
 
 Metrics are routed to shards based on factors:
 
-1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency. Currently `_ws_`, `_ns_`, `__name__` labels are mandatory to calculate shard key.
+1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency. Currently `_ws_`, `_ns_`, `metric` labels are mandatory to calculate shard key.
 2. The rest of the tags or components of a partition key are then used to compute which shard within the group of shards to assign to.
 
 ## Querying FiloDB

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ At this point, you should be able to confirm such a message in the server logs: 
 Now you are ready to query FiloDB for the ingested data. The following command should return matching subset of the data that was ingested by the producer.
 
 ```
-./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus --promql 'heap_usage{_ns="App-2"}'
+./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus --promql 'heap_usage{_ws_="demo", _ns_="App-2"}'
 ```
 
 You can also look at Cassandra to check for persisted data. Look at the tables in `filodb` and `filodb-admin` keyspaces.
@@ -396,7 +396,7 @@ FiloDB can be queried using the [Prometheus Query Language](https://prometheus.i
 
 Since FiloDB supports multiple schemas, there needs to be a way to specify the target column to query.  This is done using the special `__col__` tag filter, like this request which pulls out the "min" column:
 
-    http_req_timer{_ns="foo",__col__="min"}
+    http_req_timer{_ws_="demo", _ns_="foo",__col__="min"}
 
 By default if `__col__` is not specified then the `valueColumn` option of the Dataset is used.
 
@@ -410,7 +410,7 @@ Some special functions exist to aid debugging and for other purposes:
 
 Example of debugging chunk metadata using the CLI:
 
-    ./filo-cli --host 127.0.0.1 --dataset prometheus --promql '_filodb_chunkmeta_all(heap_usage{_ns="App-0"})' --start XX --end YY
+    ./filo-cli --host 127.0.0.1 --dataset prometheus --promql '_filodb_chunkmeta_all(heap_usage{_ws_="demo",_ns_="App-0"})' --start XX --end YY
 
 ### First-Class Histogram Support
 
@@ -432,7 +432,7 @@ Please see the [HTTP API](doc/http_api.md) doc.
 
 Example:
 
-    curl 'localhost:8080/promql/timeseries/api/v1/query?query=memstore_rows_ingested_total%_ns="filodb"%7D%5B1m%5D&time=1539908476'
+    curl 'localhost:8080/promql/timeseries/api/v1/query?query=memstore_rows_ingested_total{_ws_="demo", _ns_="filodb"}[5m]&time=1568756529'
 
 ```json
 {
@@ -445,7 +445,8 @@ Example:
           "shard": "1",
           "__name__": "memstore_rows_ingested_total",
           "dataset": "prometheus",
-          "_ns": "filodb"
+          "_ws_": "demo"
+          "_ns_": "filodb"
         },
         "values": [
           [
@@ -480,7 +481,8 @@ Example:
           "shard": "0",
           "__name__": "memstore_rows_ingested_total",
           "dataset": "prometheus",
-          "_ns": "filodb"
+          "_ws_": "demo"
+          "_ns_": "filodb"
         },
         "values": [
           [
@@ -589,7 +591,7 @@ memstore_encoded_bytes_allocated_bytes_total  1
 
 Now, let's query a particular metric:
 
-    ./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus --promql 'memstore_rows_ingested_total{_ns="filodb"}'
+    ./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus --promql 'memstore_rows_ingested_total{_ws_="demo", _ns_="filodb"}'
 
 ```
 Sending query command to server for prometheus with options QueryOptions(<function1>,16,60,100,None)...

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -14,11 +14,13 @@ filodb {
   # Override default spread for application using override block which will have non metric shard keys and spread.
   spread-assignment = [
     {
-      _ns = App-0,
+      _ws_ = demo,
+      _ns_ = App-0,
       _spread_ = 2
     },
     {
-      _ns = App-5,
+      _ws_ = demo,
+      _ns_ = App-5,
       _spread_ = 0
     }
   ]

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -289,7 +289,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
   it ("should serialize and deserialize result involving Metadata") {
     val input = Seq(Map(UTF8Str("App-0") -> UTF8Str("App-1")))
     val expected = Seq(Map("App-0" -> "App-1"))
-    val schema = new ResultSchema(Seq(new ColumnInfo("_ns", ColumnType.MapColumn)), 1)
+    val schema = new ResultSchema(Seq(new ColumnInfo("_ns_", ColumnType.MapColumn)), 1)
     val cols = Seq(ColumnInfo("value", ColumnType.MapColumn))
     val ser = Seq(SerializableRangeVector(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
       new UTF8MapIteratorRowReader(input.toIterator)), cols))

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -24,17 +24,17 @@ filodb {
     columns = ["metric:string", "tags:map"]
 
     # Predefined keys allow space to be saved for over the wire tags with the given keys
-    predefined-keys = ["_ns", "app", "__name__", "instance", "dc", "le", "job", "exporter"]
+    predefined-keys = ["_ws_", "_ns_", "app", "__name__", "instance", "dc", "le", "job", "exporter"]
 
     options {
       copyTags = {
-        exporter = "_ns"
-        job = "_ns"
+        exporter = "_ns_"
+        job = "_ns_"
       }
       ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
       ignoreTagsOnPartitionKeyHash = ["le"]
       metricColumn = "metric"
-      shardKeyColumns = [ "metric", "_ns" ]
+      shardKeyColumns = [ "metric", "_ws_", "_ns_" ]
     }
   }
 
@@ -125,7 +125,7 @@ filodb {
   spread-default = 1
   # default spread can be overriden for a specific sharding key combination.
   # Eg: If "__name__, _ns" are your sharding key, for a _ns "App-Test001" the spread can be overriden as follows:
-  # spread-assignment = [ { _ns = App-Test001, _spread_ = 5 } ]
+  # spread-assignment = [ { _ws_ = demo, _ns_ = App-Test001, _spread_ = 5 } ]
   spread-assignment = []
 
   query {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -24,6 +24,8 @@ filodb {
     columns = ["metric:string", "tags:map"]
 
     # Predefined keys allow space to be saved for over the wire tags with the given keys
+    # WARN: It is suggested to only ADD to predefined keys.
+    #       Changing/Renaming existing keys will cause incorrect tags to be reported and probably require a clean wipe.
     predefined-keys = ["_ws_", "_ns_", "app", "__name__", "instance", "dc", "le", "job", "exporter"]
 
     options {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -65,7 +65,8 @@ filodb {
 
   spread-assignment = [
     {
-      _ns = App-0,
+      _ws_ = "demo",
+      _ns_ = "App-0",
       _spread_ = 2
     }
   ]

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -61,7 +61,7 @@ object TestData {
     ignoreTagsOnPartitionKeyHash = ["le"]
     metricColumn = "__name__"
     valueColumn = "value"
-    shardKeyColumns = ["__name__", "_ns"]
+    shardKeyColumns = ["__name__", "_ns_", "_ws_"]
   }
   """
 }
@@ -197,12 +197,12 @@ object GdeltTestData {
 
   // Proj 6: partition Actor2Code,Actor2Name to test partition key bitmap indexing
   val datasetOptions = DatasetOptions.DefaultOptions.copy(
-    shardKeyColumns = Seq( "__name__","_ns"))
+    shardKeyColumns = Seq( "__name__","_ns_","_ws_"))
   val dataset6 = Dataset("gdelt", schema.slice(4, 6), schema.patch(4, Nil, 2), datasetOptions)
 
   val datasetOptionConfig = """
     options {
-      shardKeyColumns = ["__name__","_ns"]
+      shardKeyColumns = ["__name__","_ns_","_ws_"]
       ignoreShardKeyColumnSuffixes = {}
       valueColumn = "AvgTone"
       metricColumn = "__name__"
@@ -414,7 +414,7 @@ object CustomMetricsData {
                         partitionColumns,
                         columns,
                         Seq.empty,
-                        DatasetOptions(Seq("metric", "_ns"), "metric", true)).get
+                        DatasetOptions(Seq("metric", "_ns_", "_ws_"), "metric", true)).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
   val defaultPartKey = partKeyBuilder.partKeyFromObjects(metricdataset.schema, "metric1", "app1")
 

--- a/doc/downsampling.md
+++ b/doc/downsampling.md
@@ -50,7 +50,7 @@ Downsampling for prometheus counters will come soon.
 Downsampling is configured at the time of dataset creation. For example:
 
 ```
-./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus --dataColumns timestamp:ts,value:double --partitionColumns tags:map --shardKeyColumns __name__,_ns --downsamplers "tTime(0),dMin(1),dMax(1),dSum(1),dCount(1),dAvg(1)"
+./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus --dataColumns timestamp:ts,value:double --partitionColumns tags:map --shardKeyColumns __name__,_ns_,_ws_ --downsamplers "tTime(0),dMin(1),dMax(1),dSum(1),dCount(1),dAvg(1)"
 ```
 
 In the above example, the data column `value` with index 1 is configured with the dMin, dMax, sSum, dCount and dAvg downsamplers.
@@ -65,7 +65,7 @@ order as the downsample type configuration. For the above example, we would crea
 dataset as:
 
 ```
-./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus_ds_1m --dataColumns timestamp:ts,min:double,max:double,sum:double,count:double,avg:double --partitionColumns tags:map --shardKeyColumns __name__,_ns
+./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus_ds_1m --dataColumns timestamp:ts,min:double,max:double,sum:double,count:double,avg:double --partitionColumns tags:map --shardKeyColumns __name__,_ns_,_ws_
 ```
 
 Note that there is no downsampling configuration here in the above dataset. Note that partition
@@ -105,7 +105,7 @@ downsampler on the downsampled dataset.
  
 Downsampled data for individual time series can be queried from the downsampled dataset. The PromQL
 filters in the query needs to include the `__col__` tag with the value of the downsample column name
-chosen in the downsample dataset. For example `heap_usage{_ns="myApp" __col__="avg"}`
+chosen in the downsample dataset. For example `heap_usage{_ws_="demo",_ns_="myApp" __col__="avg"}`
 
 Coming soon in subsequent PR: Automatic selection of column based on the time window function applied in the query.
 
@@ -115,7 +115,7 @@ Run main class [filodb.prom.downsample.GaugeDownsampleValidator](../http/src/tes
 
 ```
 -Dquery-endpoint=https://myFiloDbEndpoint.com
--Draw-data-promql=jvm_threads{_ns=\"myApplication\",measure=\"daemon\",__col__=\"value\"}[@@@@s]
+-Draw-data-promql=jvm_threads{_ws_=\"demo\",_ns_=\"myApplication\",measure=\"daemon\",__col__=\"value\"}[@@@@s]
 -Dflush-interval=12h
 -Dquery-range=6h
 ```

--- a/doc/downsampling.md
+++ b/doc/downsampling.md
@@ -47,10 +47,27 @@ emit timestamp value. One could later have downsamplers that emit histogram or l
 
 Downsampling for prometheus counters will come soon.
 
-Downsampling is configured at the time of dataset creation. For example:
+Downsampling is configured from the Schema.
+
+For example, a schema will contain downsampler config as follows:
 
 ```
-./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command create --dataset prometheus --dataColumns timestamp:ts,value:double --partitionColumns tags:map --shardKeyColumns __name__,_ns_,_ws_ --downsamplers "tTime(0),dMin(1),dMax(1),dSum(1),dCount(1),dAvg(1)"
+  schemas {
+    gauge {
+      # Each column def is of name:type format.  Type may be ts,long,double,string,int
+      # The first column must be ts or long
+      columns = ["timestamp:ts", "value:double:detectDrops=false"]
+
+      # Default column to query using PromQL
+      value-column = "value"
+
+      # Downsampling configuration.  See doc/downsampling.md
+      downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
+
+      # If downsamplers are defined, then the downsample schema must also be defined
+      downsample-schema = "ds-gauge"
+    }
+  }
 ```
 
 In the above example, the data column `value` with index 1 is configured with the dMin, dMax, sSum, dCount and dAvg downsamplers.

--- a/doc/sharding.md
+++ b/doc/sharding.md
@@ -43,11 +43,13 @@ The **spread** determines how many shards a given shard key is mapped to.  The n
 ```
 spread-assignment = [
     {
-      _ns = App-0,
+      _ws_ = demo,
+      _ns_ = App-0,
       _spread_ = 2
     },
     {
-      _ns = App-5,
+      _ws_ = demo,
+      _ns_ = App-5,
       _spread_ = 0
     }
   ]

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -66,7 +66,7 @@ object TestTimeseriesProducer extends StrictLogging {
     logger.info(s"Finished producing $numSamples records for ${samplesDuration / 1000} seconds")
     val startQuery = startTime / 1000
     val endQuery = startQuery + 300
-    val periodicPromQL = """heap_usage{dc="DC0",_ns="App-0"}"""
+    val periodicPromQL = """heap_usage{dc="DC0",_ns_="App-0",_ws_="demo"}"""
     val query =
       s"""./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus """ +
       s"""--promql '$periodicPromQL' --start $startQuery --end $endQuery --limit 15"""
@@ -77,12 +77,12 @@ object TestTimeseriesProducer extends StrictLogging {
       s"query=$periodicSamplesQ&start=$startQuery&end=$endQuery&step=15"
     logger.info(s"Periodic Samples query URL: \n$periodicSamplesUrl")
 
-    val rawSamplesQ = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0"}[2m]""",
+    val rawSamplesQ = URLEncoder.encode("""heap_usage{dc="DC0",_ws_="demo",_ns_="App-0"}[2m]""",
       StandardCharsets.UTF_8.toString)
     val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$rawSamplesQ&time=$endQuery"
     logger.info(s"Raw Samples query URL: \n$rawSamplesUrl")
 
-    val downsampledQ = URLEncoder.encode("""heap_usage{dc="DC0",_ns="App-0",__col__="sum"}[2m]""",
+    val downsampledQ = URLEncoder.encode("""heap_usage{dc="DC0",_ws_="demo",_ns_="App-0",__col__="sum"}[2m]""",
       StandardCharsets.UTF_8.toString)
     val downsampledSamplesUrl = s"http://localhost:8080/promql/prometheus_ds_1m/api/v1/query?" +
       s"query=$downsampledQ&time=$endQuery"
@@ -129,7 +129,8 @@ object TestTimeseriesProducer extends StrictLogging {
       val value = 15 + Math.sin(n + 1) + rand.nextGaussian()
 
       val tags = Map("dc"       -> s"DC$dc",
-                     "_ns"      -> s"App-$app",
+                     "_ws_"      -> "demo",
+                     "_ns_"      -> s"App-$app",
                      "partition" -> s"partition-$partition",
                      "host"     -> s"H$host",
                      "instance" -> s"Instance-$instance")
@@ -142,7 +143,8 @@ object TestTimeseriesProducer extends StrictLogging {
   import Column.ColumnType._
 
   val dcUTF8 = "dc".utf8
-  val nsUTF8 = "_ns".utf8
+  val wsUTF8 = "_ws_".utf8
+  val nsUTF8 = "_ns_".utf8
   val partUTF8 = "partition".utf8
   val hostUTF8 = "host".utf8
   val instUTF8 = "instance".utf8
@@ -182,6 +184,7 @@ object TestTimeseriesProducer extends StrictLogging {
       val sum = buckets.sum
 
       val tags = Map(dcUTF8   -> s"DC$dc".utf8,
+                     wsUTF8   -> "demo".utf8,
                      nsUTF8   -> s"App-$app".utf8,
                      partUTF8 -> s"partition-$partition".utf8,
                      hostUTF8 -> s"H$host".utf8,

--- a/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
@@ -12,10 +12,10 @@ class InfluxRecordSpec extends FunSpec with Matchers {
   // Second one does not
   // Third one is a histogram
   val rawInfluxLPs = Seq(
-    "recovery_row_skipped_total,dataset=timeseries,host=MacBook-Pro-229.local,_ns=filodb counter=0 1536790212000000000",
+    "recovery_row_skipped_total,dataset=timeseries,host=MacBook-Pro-229.local,_ws_=demo,_ns_=filodb counter=0 1536790212000000000",
     "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1 counter=0 1536790212000000000",
-    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,_ns=filodb counter=0 1536790212000000000",
-    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,_ns=filodb counter=0 1536790212000000000",
+    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,_ws_=demo,_ns_=filodb counter=0 1536790212000000000",
+    "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,_ws_=demo,_ns_=filodb counter=0 1536790212000000000",
     "memstore_flushes_success_total,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,url=http://localhost:9095 counter=0 1536628260000000000",
     "span_processing_time_seconds,error=false,host=MacBook-Pro-229.local,operation=memstore-recover-index-latency +Inf=2,0.005=0,0.01=0,0.025=0,0.05=0,0.075=0,0.1=1,0.25=2,0.5=2,0.75=2,1=2,10=2,2.5=2,5=2,7.5=2,count=2,sum=0.230162432 1536790212000000000"
   )
@@ -86,7 +86,8 @@ class InfluxRecordSpec extends FunSpec with Matchers {
         schema.ingestionSchema.consumeMapItems(base, offset, 3, consumer)
         consumer.stringPairs.toMap shouldEqual Map("dataset" -> "timeseries",
                                                    "host" -> "MacBook-Pro-229.local",
-                                                   "_ns" -> "filodb")
+                                                   "_ws_" -> "demo",
+                                                   "_ns_" -> "filodb")
       }
     }
   }

--- a/gateway/src/test/scala/filodb/gateway/conversion/PrometheusInputRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/PrometheusInputRecordSpec.scala
@@ -9,7 +9,7 @@ import filodb.core.metadata.Schemas
 import filodb.memory.MemFactory
 
 object TimeSeriesFixture {
-  //  "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,_ns=filodb counter=0 1536790212000000000",
+  //  "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,_ws_=demo,_ns_=filodb counter=0 1536790212000000000",
   def timeseries(no: Int, tags: Map[String, String]): TimeSeries = {
     val builder = TimeSeries.newBuilder
                     .addSamples(Sample.newBuilder.setTimestampMs(1000000L + no).setValue(1.1 + no).build)
@@ -27,17 +27,17 @@ class PrometheusInputRecordSpec extends FunSpec with Matchers {
   val tagsWithMetric = baseTags + ("__name__" -> "num_partitions")
 
   it("should parse from TimeSeries proto and write to RecordBuilder") {
-    val proto1 = TimeSeriesFixture.timeseries(0, tagsWithMetric + ("_ns" -> "filodb"))
+    val proto1 = TimeSeriesFixture.timeseries(0, tagsWithMetric + ("_ns_" -> "filodb", "_ws_" -> "demo"))
     val builder = new RecordBuilder(MemFactory.onHeapFactory)
 
     val records = PrometheusInputRecord(proto1)
     records should have length (1)
     val record1 = records.head
-    record1.tags shouldEqual (baseTags + ("_ns" -> "filodb"))
+    record1.tags shouldEqual (baseTags + ("_ns_" -> "filodb", "_ws_" -> "demo"))
     record1.getMetric shouldEqual "num_partitions"
-    record1.nonMetricShardValues shouldEqual Seq("filodb")
+    record1.nonMetricShardValues shouldEqual Seq("filodb", "demo")
 
-    record1.shardKeyHash shouldEqual RecordBuilder.shardKeyHash(Seq("filodb"), "num_partitions")
+    record1.shardKeyHash shouldEqual RecordBuilder.shardKeyHash(Seq("filodb", "demo"), "num_partitions")
 
     record1.addToBuilder(builder)
     builder.allContainers.head.foreach { case (base, offset) =>
@@ -48,7 +48,7 @@ class PrometheusInputRecordSpec extends FunSpec with Matchers {
 
       val consumer = new StringifyMapItemConsumer()
       schema.ingestionSchema.consumeMapItems(base, offset, 3, consumer)
-      consumer.stringPairs.toMap shouldEqual (baseTags + ("_ns" -> "filodb"))
+      consumer.stringPairs.toMap shouldEqual (baseTags + ("_ns_" -> "filodb", "_ws_" -> "demo"))
     }
   }
 
@@ -60,14 +60,14 @@ class PrometheusInputRecordSpec extends FunSpec with Matchers {
 
   it("should copy tags from another key if copyTags defined and original key missing") {
     // add exporter and see if it gets renamed
-    val tagsWithExporter = tagsWithMetric + ("exporter" -> "gateway")
+    val tagsWithExporter = tagsWithMetric + ("exporter" -> "gateway", "_ws_" -> "demo")
     val proto1 = TimeSeriesFixture.timeseries(0, tagsWithExporter)
     val records = PrometheusInputRecord(proto1)
     records should have length (1)
     val record1 = records.head
-    record1.tags shouldEqual (tagsWithExporter - "__name__" + ("_ns" -> "gateway"))
+    record1.tags shouldEqual (tagsWithExporter - "__name__" + ("_ns_" -> "gateway"))
     record1.getMetric shouldEqual "num_partitions"
-    record1.nonMetricShardValues shouldEqual Seq("gateway")
+    record1.nonMetricShardValues shouldEqual Seq("gateway", "demo")
 
     // no exporter.  Nothing added
     val proto2 = TimeSeriesFixture.timeseries(0, tagsWithMetric)

--- a/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
@@ -60,7 +60,7 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   }
 
   it("should get explainPlan for query") {
-    val query = "heap_usage{_ns=\"App-0\"}"
+    val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-0\"}"
 
     Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
       s"start=1555427432&end=1555447432&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
@@ -80,7 +80,7 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   }
 
   it("should take spread override value from config for app") {
-    val query = "heap_usage{_ns=\"App-0\"}"
+    val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-0\"}"
 
     Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
       s"start=1555427432&end=1555447432&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
@@ -95,7 +95,7 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   }
 
   it("should get explainPlan for query based on spread as query parameter") {
-    val query = "heap_usage{_ns=\"App-1\"}"
+    val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-1\"}"
 
     Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
       s"start=1555427432&end=1555447432&step=15&explainOnly=true&spread=2") ~> prometheusAPIRoute ~> check {
@@ -110,7 +110,7 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   }
 
     it("should take default spread value if there is no override") {
-      val query = "heap_usage{_ns=\"App-1\"}"
+      val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-1\"}"
 
       Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
         s"start=1555427432&end=1555447432&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {

--- a/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/GatewayBenchmark.scala
@@ -22,7 +22,8 @@ class GatewayBenchmark extends StrictLogging {
   val tagMap = Map(
     "__name__" -> "heap_usage",
     "dc"       -> "DC1",
-    "_ns"      -> "App-123",
+    "_ws_"      -> "demo",
+    "_ns_"      -> "App-123",
     "partition" -> "partition-2",
     "host"     -> "abc.xyz.company.com",
     "instance" -> s"Instance-123"

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -123,10 +123,10 @@ class QueryAndIngestBenchmark extends StrictLogging {
    * ## ========  Queries ===========
    * They are designed to match all the time series (common case) under a particular metric and job
    */
-  val queries = Seq("heap_usage{_ns=\"App-2\"}",  // raw time series
-                    """sum(rate(heap_usage{_ns="App-2"}[1m]))""",
-                    """quantile(0.75, heap_usage{_ns="App-2"})""",
-                    """sum_over_time(heap_usage{_ns="App-2"}[1m])""")
+  val queries = Seq("heap_usage{_ws_=\"demo\",_ns_=\"App-2\"}",  // raw time series
+                    """sum(rate(heap_usage{_ws_="demo",_ns_="App-2"}[1m]))""",
+                    """quantile(0.75, heap_usage{_ws_="demo",_ns_="App-2"})""",
+                    """sum_over_time(heap_usage{_ws_="demo",_ns_="App-2"}[1m])""")
   val queryTime = startTime + (5 * 60 * 1000)  // 5 minutes from start until 60 minutes from start
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
   val logicalPlans = queries.map { q => Parser.queryRangeToLogicalPlan(q, qParams) }

--- a/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
@@ -124,7 +124,7 @@ class QueryHiCardInMemoryBenchmark extends StrictLogging {
     cluster.shutdown()
   }
 
-  val scanSumOfRate = toExecPlan("""sum(rate(heap_usage{_ns="App-2"}[5m]))""")
+  val scanSumOfRate = toExecPlan("""sum(rate(heap_usage{_ws_="demo",_ns_="App-2"}[5m]))""")
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -135,7 +135,7 @@ class QueryHiCardInMemoryBenchmark extends StrictLogging {
     }
   }
 
-  val scanSumSumOverTime = toExecPlan("""sum(sum_over_time(heap_usage{_ns="App-2"}[5m]))""")
+  val scanSumSumOverTime = toExecPlan("""sum(sum_over_time(heap_usage{_ws_="demo",_ns_="App-2"}[5m]))""")
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
   @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -110,12 +110,12 @@ class QueryInMemoryBenchmark extends StrictLogging {
    * ## ========  Queries ===========
    * They are designed to match all the time series (common case) under a particular metric and job
    */
-  val rawQuery = "heap_usage{_ns=\"App-2\"}"
-  val sumQuery = """sum_over_time(heap_usage{_ns="App-2"}[5m])"""
-  val sumRateQuery = """sum(rate(heap_usage{_ns="App-2"}[5m]))"""
+  val rawQuery = "heap_usage{_ws_=\"demo\",_ns_=\"App-2\"}"
+  val sumQuery = """sum_over_time(heap_usage{_ws_="demo",_ns_="App-2"}[5m])"""
+  val sumRateQuery = """sum(rate(heap_usage{_ws_="demo",_ns_="App-2"}[5m]))"""
   val queries = Seq(rawQuery,  // raw time series
                     sumRateQuery,
-                    """quantile(0.75, heap_usage{_ns="App-2"})""",
+                    """quantile(0.75, heap_usage{_ws_="demo",_ns_="App-2"})""",
                     sumQuery)
   val queryTime = startTime + (7 * 60 * 1000)  // 5 minutes from start until 60 minutes from start
   val qParams = TimeStepParams(queryTime/1000, queryStep, (queryTime/1000) + queryIntervalMin*60)
@@ -193,7 +193,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
     Await.result(f, 60.seconds)
   }
 
-  val minQuery = """min_over_time(heap_usage{_ns="App-2"}[5m])"""
+  val minQuery = """min_over_time(heap_usage{_ws_="demo",_ns_="App-2"}[5m])"""
   val minLP = Parser.queryRangeToLogicalPlan(minQuery, qParams)
   val minEP = engine.materialize(minLP, qOptions, UnavailablePromQlQueryParams).children.head
 

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -158,7 +158,8 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
       rangeEnd   = rangeStart + 15.minutes.toMillis
 
       // Print the top values in each shard just for debugging
-      topValuesInShards(client1, "_ns", 0 to 3)
+      topValuesInShards(client1, "_ws_", 0 to 3)
+      topValuesInShards(client1, "_ns_", 0 to 3)
       topValuesInShards(client1, "dc", 0 to 3)
 
       query1Response = runCliQuery(client1, queryTimestamp)

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -140,8 +140,8 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     }
   }
 
-  val query = "heap_usage{dc=\"DC0\",_ns=\"App-2\"}[1m]"
-  val query1 = "heap_usage{dc=\"DC0\",_ns=\"App-2\"}"
+  val query = "heap_usage{dc=\"DC0\",_ws_=\"demo\",_ns_=\"App-2\"}[1m]"
+  val query1 = "heap_usage{dc=\"DC0\",_ws_=\"demo\",_ns_=\"App-2\"}"
 
   // queryTimestamp is in millis
   def runCliQuery(client: LocalClient, queryTimestamp: Long): Double = {
@@ -188,7 +188,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
   }
 
   def printChunkMeta(client: LocalClient): Unit = {
-    val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",_ns=\"App-2\"})"
+    val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",_ws_=\"demo\",_ns_=\"App-2\"})"
     val logicalPlan = Parser.queryRangeToLogicalPlan(chunkMetaQuery, TimeStepParams(0, 60, Int.MaxValue))
     client.logicalPlan2Query(dataset, logicalPlan, UnavailablePromQlQueryParams) match {
       case QueryResult2(_, schema, result) => result.foreach(rv => println(rv.prettyPrint()))
@@ -220,8 +220,10 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val end = queryTimestamp / 1000 * 1000
     val nameMatcher = LabelMatcher.newBuilder().setName("__name__").setValue("heap_usage")
     val dcMatcher = LabelMatcher.newBuilder().setName("dc").setValue("DC0")
-    val jobMatcher = LabelMatcher.newBuilder().setName("_ns").setValue("App-2")
-    val query = Query.newBuilder().addMatchers(nameMatcher)
+    val wsMatcher = LabelMatcher.newBuilder().setName("_ws_").setValue("demo")
+    val jobMatcher = LabelMatcher.newBuilder().setName("_ns_").setValue("App-2")
+    val query = Query.newBuilder().addMatchers(wsMatcher)
+                                  .addMatchers(nameMatcher)
                                   .addMatchers(dcMatcher)
                                   .addMatchers(jobMatcher)
                                   .setStartTimestampMs(start)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
We have `_ns, __name__` as shard key.

**New behavior :**

1. All internal reserved label names to start and end with single underscore(`_`). Hence, the shard key `_ns` will be updated to `_ns_`. 
2. Also, adding workspace `_ws_` to the shard key.

**BREAKING CHANGES**

Users will not be able to query Timeseries with old shard key. Hence, the idea is to setup and run a new cluster with new shard key changes in parallel to the existing cluster until the TTL is met.
