### PR TITLE
feat(core): Honor order in copyTags

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -29,6 +29,10 @@ filodb {
     predefined-keys = ["_ws_", "_ns_", "app", "__name__", "instance", "dc", "le", "job", "exporter"]
 
     options {
+      # Copy tags can be used to create a new labelPair from one of the existing labelPair in a TimeSeries.
+      # It honors the order in which the label keys are represented against a new key.
+      # Eg: For copyTags `"_ns_" = [ "exporter", "job" ]`, when an incoming TimeSeries already has both `exporter`
+      #     and `job`, then it will pickup only the value from `exporter` for `_ns_`.
       copyTags = {
         "_ns_" = [ "_ns", "exporter", "job" ]
       }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -30,8 +30,7 @@ filodb {
 
     options {
       copyTags = {
-        exporter = "_ns_"
-        job = "_ns_"
+        "_ns_" = [ "_ns", "exporter", "job" ]
       }
       ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
       ignoreTagsOnPartitionKeyHash = ["le"]

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -89,7 +89,7 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
       "ignoreShardKeyColumnSuffixes" ->
         ignoreShardKeyColumnSuffixes.mapValues(_.asJava).asJava,
       "ignoreTagsOnPartitionKeyHash" -> ignoreTagsOnPartitionKeyHash.asJava,
-      "copyTags" -> copyTags.asJava)
+      "copyTags" -> copyTags.groupBy(_._2).map { case (k, v) => (k, v.map(_._1).asJava)}.asJava)
 
     ConfigFactory.parseMap(map.asJava)
   }

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -117,7 +117,9 @@ object DatasetOptions {
     fromConfig(ConfigFactory.parseString(s).withFallback(DefaultOptionsConfig))
 
   def fromConfig(config: Config): DatasetOptions = {
-    val copyTagsValue = config.as[Map[String, Seq[String]]]("copyTags").toSeq.flatMap{case (key, value) => value.map (_ -> key)}
+    val copyTagsValue = config.as[Map[String, Seq[String]]]("copyTags")
+                         .toSeq
+                         .flatMap { case (key, value) => value.map (_ -> key) }
     DatasetOptions(shardKeyColumns = config.as[Seq[String]]("shardKeyColumns"),
                    metricColumn = config.getString("metricColumn"),
                    hasDownsampledData = config.as[Option[Boolean]]("hasDownsampledData").getOrElse(false),

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -106,9 +106,7 @@ object PrometheusInputRecord {
     } else {
       val metric = metricTags.head._2
       val metricKey = metricTags.head._1
-      println(tags)
       val transformedTags = transformTags(tags.filterNot(_._1 == metricKey), promCounter.options)
-      println(transformedTags)
       (0 until tsProto.getSamplesCount).map { i =>
         val sample = tsProto.getSamples(i)
         PrometheusInputRecord(transformedTags, metric, sample.getTimestampMs, sample.getValue)

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -120,7 +120,8 @@ object PrometheusInputRecord {
    * If a tag in copyTags is found and the destination tag is missing, then the destination tag is created
    * with the value from the source tag.
    */
-  def transformTags(tags: collection.mutable.HashMap[String, String], options: DatasetOptions): collection.mutable.Map[String, String] = {
+  def transformTags(tags: collection.mutable.HashMap[String, String],
+                    options: DatasetOptions): collection.mutable.Map[String, String] = {
     for ((k, v) <- options.copyTags) {
       if (!tags.contains(v) && tags.contains(k)) {
         tags += v -> tags(k)

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -128,7 +128,7 @@ object TestTimeseriesProducer extends StrictLogging {
       val timestamp = startTime + (n.toLong / numTimeSeries) * 10000 // generate 1 sample every 10s for each instance
       val value = 15 + Math.sin(n + 1) + rand.nextGaussian()
 
-      val tags = Map("dc"       -> s"DC$dc",
+      val tags = collection.mutable.Map("dc"       -> s"DC$dc",
                      "_ws_"      -> "demo",
                      "_ns_"      -> s"App-$app",
                      "partition" -> s"partition-$partition",

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -128,7 +128,7 @@ object TestTimeseriesProducer extends StrictLogging {
       val timestamp = startTime + (n.toLong / numTimeSeries) * 10000 // generate 1 sample every 10s for each instance
       val value = 15 + Math.sin(n + 1) + rand.nextGaussian()
 
-      val tags = collection.mutable.Map("dc"       -> s"DC$dc",
+      val tags = Map("dc"       -> s"DC$dc",
                      "_ws_"      -> "demo",
                      "_ns_"      -> s"App-$app",
                      "partition" -> s"partition-$partition",


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Currently, we do not honor order in which tags are represented in DatasetOptions `copyTags`. Because of which gateway is not consistent w.r.t adding new tags.

**New behavior :**
Gateway will consistently add the new tag in the order in which it is added in `copytTags`