### PR TITLE
bug(downsampler): Thread local memory constructs for multi-threaded spark executors

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -218,11 +218,14 @@ filodb {
     # Number of time series to operate on at one time. Reduce if there is much less memory available
     num-partitions-per-cass-write = 10000
 
-    # This block memory is used for overflow of write buffers
+    # This block memory is used for overflow of write buffers and for storing encoded chunks
+    # Configure to NumPartitionsPerCassWrite * (EstChunkSize * EstNumChunksPerPartition) + buffer
+    # 10000 * (5KB * 3) + buffer
     off-heap-block-memory-size = 500 MB
 
-    # Configure to NumPartitionsPerCassWrite * (EstChunkSize * EstNumChunksPerPartition + PartKeySize) + buffer
-    # 10000 * (1KB * 2 + 500 bytes) + buffer
+    # Used for part keys, ODPed raw chunks, write buffers for downsampled data
+    # Configure to NumPartitionsPerCassWrite * (EstRawChunkSize * EstNumRawChunksPerPartition + PartKeySize + BytesPerDownsampledRow * NumDownsampledRowsPerPart) + buffer
+    # 10000 * (1KB * 2 + 500 bytes + 20b * 360) + buffer
     off-heap-native-memory-size = 500 MB
 
     # Amount of time to wait for a Cassandra write to finish before proceeding to next batch of partitions

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -218,15 +218,15 @@ filodb {
     # Number of time series to operate on at one time. Reduce if there is much less memory available
     num-partitions-per-cass-write = 10000
 
-    # This block memory is used for overflow of write buffers and for storing encoded chunks
+    # This block memory is used for overflow of write buffers and for storing encoded downsample chunks
     # Configure to NumPartitionsPerCassWrite * (EstChunkSize * EstNumChunksPerPartition) + buffer
-    # 10000 * (5KB * 3) + buffer
-    off-heap-block-memory-size = 500 MB
+    # 10000 * (1KB per col * 6 cols * 3 chunks) + buffer
+    off-heap-block-memory-size = 400 MB
 
     # Used for part keys, ODPed raw chunks, write buffers for downsampled data
     # Configure to NumPartitionsPerCassWrite * (EstRawChunkSize * EstNumRawChunksPerPartition + PartKeySize + BytesPerDownsampledRow * NumDownsampledRowsPerPart) + buffer
-    # 10000 * (1KB * 2 + 500 bytes + 20b * 360) + buffer
-    off-heap-native-memory-size = 500 MB
+    # 10000 * (1KB * 2 cols * 8 chunks + 500 bytes + 20B * 360 samples) + buffer
+    off-heap-native-memory-size = 400 MB
 
     # Amount of time to wait for a Cassandra write to finish before proceeding to next batch of partitions
     cassandra-write-timeout = 10.minutes

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -75,7 +75,9 @@ object BatchDownsampler extends StrictLogging with Instance {
     */
   private[downsampler] val rawDatasetRef = DatasetRef(settings.rawDatasetName)
 
-  private val maxMetaSize = dsSchemas.map(_.data.blockMetaSize).max
+  // FIXME * 2 exists to workaround an issue where we see underallocation for metaspan due to
+  // possible mis-calculation of max block meta size.
+  private val maxMetaSize = dsSchemas.map(_.data.blockMetaSize).max * 2
 
   /**
     * Datasets to which we write downsampled data. Keyed by Downsample resolution.

--- a/spark-jobs/src/main/scala/filodb.downsampler/PerThreadOffHeapMemory.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/PerThreadOffHeapMemory.scala
@@ -1,0 +1,35 @@
+package filodb.downsampler
+
+import filodb.core.memstore.WriteBufferPool
+import filodb.core.metadata.Schema
+import filodb.downsampler.BatchDownsampler.settings
+import filodb.memory._
+
+class PerThreadOffHeapMemory(rawSchemas: Seq[Schema], kamonTags: Map[String, String], maxMetaSize: Int) {
+
+  val blockMemFactory = {
+      val blockStore = new PageAlignedBlockManager(settings.blockMemorySize,
+        stats = new MemoryStats(kamonTags),
+        reclaimer = new ReclaimListener {
+          override def onReclaim(metadata: Long, numBytes: Int): Unit = {}
+        },
+        numPagesPerBlock = 50)
+      new BlockMemFactory(blockStore, None, maxMetaSize,
+        kamonTags, false)
+    }
+
+  val nativeMemoryManager = new NativeMemoryManager(settings.nativeMemManagerSize, kamonTags)
+
+  /**
+    * Buffer Pool keyed by Raw schema Id
+    */
+  val bufferPools = {
+      val bufferPoolByRawSchemaId = debox.Map.empty[Int, WriteBufferPool]
+      rawSchemas.foreach { s =>
+        val pool = new WriteBufferPool(nativeMemoryManager, s.downsample.get.data, settings.downsampleStoreConfig)
+        bufferPoolByRawSchemaId += s.schemaHash -> pool
+      }
+      bufferPoolByRawSchemaId
+  }
+
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

When there are multiple executors per box, each thread needs its own memory constructs. Earlier, downsampler job was sharing memory constructs among all executors on a worker. 

Tested locally by spawning 3 node cass cluster causing multiple spark partitions and executors to be spun off.

