### PR TITLE
bug(query): store the array across multiple chunks

### DIFF
--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -622,6 +622,7 @@ abstract class QuantileOverTimeChunkedFunction(funcParams: Seq[Any],
 
 class QuantileOverTimeChunkedFunctionD(funcParams: Seq[Any]) extends QuantileOverTimeChunkedFunction(funcParams)
   with ChunkedDoubleRangeFunction {
+  require(funcParams.size == 1, "quantile_over_time function needs a single quantile argument")
   require(funcParams.head.isInstanceOf[Number], "quantile parameter must be a number")
   final def addTimeDoubleChunks(doubleVect: BinaryVector.BinaryVectorPtr,
                                 doubleReader: bv.DoubleVectorDataReader,
@@ -647,6 +648,7 @@ class QuantileOverTimeChunkedFunctionD(funcParams: Seq[Any]) extends QuantileOve
 
 class QuantileOverTimeChunkedFunctionL(funcParams: Seq[Any])
   extends QuantileOverTimeChunkedFunction(funcParams) with ChunkedLongRangeFunction {
+  require(funcParams.size == 1, "quantile_over_time function needs a single quantile argument")
   require(funcParams.head.isInstanceOf[Number], "quantile parameter must be a number")
   final def addTimeLongChunks(longVect: BinaryVector.BinaryVectorPtr,
                               longReader: bv.LongVectorDataReader,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Doesn't calculate quantile across multiple chunks in the same window

**New behavior :**
Correctly calculates the quantile across multiple chunks