### PR TITLE
bug(cass): takeWhile can cause premature completion of future

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -108,15 +108,16 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
                val partBytes = BinaryRegionLarge.asNewByteArray(chunkset.partition)
                val future =
                  for { writeChunksResp   <- writeChunks(ref, partBytes, chunkset, diskTimeToLive)
+                       if writeChunksResp == Success
                        writeIndicesResp  <- writeIndices(ref, partBytes, chunkset, diskTimeToLive)
-                                            if writeChunksResp == Success
+                       if writeIndicesResp == Success
                  } yield {
                    span.finish()
                    sinkStats.chunksetWrite()
                    writeIndicesResp
                  }
                Task.fromFuture(future)
-             }.takeWhile(_ == Success)
+             }
              .countL.runAsync
              .map { chunksWritten =>
                if (chunksWritten > 0) Success else NotApplied
@@ -171,7 +172,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     import filodb.core.Iterators._
 
     val chunksTable = getOrCreateChunkTable(datasetRef)
-    partKeys.bufferTimedAndCounted(1.second, batchSize).map { parts =>
+    partKeys.bufferTimedAndCounted(30.seconds, batchSize).map { parts =>
       logger.debug(s"Querying cassandra for chunks from ${parts.size} partitions userTimeStart=$userTimeStart " +
         s"userTimeEnd=$userTimeEnd")
       // TODO evaluate if we can increase parallelism here. This needs to be tuneable

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -239,9 +239,6 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
     encodeAndReleaseBuffers(blockHolder)
     infosToBeFlushed
       .map { info =>
-        // FIXME Two traces below to debug SEGV seen on read of info.id during downsampling
-        // Remove after debug is done
-        _log.trace(s"Preparing to flush part $stringPartition")
         _log.trace(s"Preparing to flush chunk ${info.debugString} of part $stringPartition")
         ChunkSet(info, partitionKey, Nil,
                  (0 until schema.numDataColumns).map { i => BinaryVector.asBuffer(info.vectorPtr(i)) },


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

takeWhile on an observable with mapAsync can potentially cause premature completion of future when runAsync is invoked. Applying this fix to fix the race condition caused between off-heap memory free and the completion of write operation during downsampling.