### PR TITLE
misc(query): add logic to return partkeys for metadata queries that match evicted partitions

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -10,6 +10,7 @@ import net.ceedubs.ficus.Ficus._
 import filodb.core.{DatasetRef, ErrorResponse, Response}
 import filodb.core.binaryrecord2.RecordContainer
 import filodb.core.downsample.DownsampleConfig
+import filodb.core.memstore.TimeSeriesShard.PartKey
 import filodb.core.metadata.{Column, DataSchema, Schemas}
 import filodb.core.metadata.Column.ColumnType._
 import filodb.core.query.ColumnFilter
@@ -164,7 +165,7 @@ trait MemStore extends ChunkSource {
     * @return an Iterator for the TimeSeriesPartition
     */
   def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                          end: Long, start: Long, limit: Int): Iterator[TimeSeriesPartition]
+                          end: Long, start: Long, limit: Int): Iterator[PartKey]
 
   /**
    * Returns the number of partitions being maintained in the memtable for a given shard

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -12,6 +12,7 @@ import org.jctools.maps.NonBlockingHashMapLong
 
 import filodb.core.{DatasetRef, Response, Types}
 import filodb.core.downsample.{DownsampleConfig, DownsamplePublisher}
+import filodb.core.memstore.TimeSeriesShard.PartKey
 import filodb.core.metadata.Schemas
 import filodb.core.query.ColumnFilter
 import filodb.core.store._
@@ -198,7 +199,7 @@ extends MemStore with StrictLogging {
         .map(_.labelValuesWithFilters(filters, labelNames, end, start, limit)).getOrElse(Iterator.empty)
 
   def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                             end: Long, start: Long, limit: Int): Iterator[TimeSeriesPartition] =
+                             end: Long, start: Long, limit: Int): Iterator[PartKey] =
     getShard(dataset, shard).map(_.partKeysWithFilters(filters, end, start, limit)).getOrElse(Iterator.empty)
 
   def numPartitions(dataset: DatasetRef, shard: Int): Int =

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -5,6 +5,7 @@ import scalaxy.loops._
 
 import filodb.core.DatasetRef
 import filodb.core.Types._
+import filodb.core.memstore.TimeSeriesShard.PartKey
 import filodb.core.metadata.{Column, PartitionSchema, Schema}
 import filodb.core.store._
 import filodb.memory.{BinaryRegion, BinaryRegionLarge, BlockMemFactory, MemFactory}
@@ -458,8 +459,8 @@ TimeSeriesPartition(partID, schema, partitionKey, shard, bufferPool, shardStats,
 }
 
 
-final case class PartKeyRowReader(records: Iterator[TimeSeriesPartition]) extends Iterator[RowReader] {
-  var currVal: TimeSeriesPartition = _
+final case class PartKeyRowReader(records: Iterator[PartKey]) extends Iterator[RowReader] {
+  var currVal: PartKey = _
 
   private val rowReader = new RowReader {
     def notNull(columnNo: Int): Boolean = true
@@ -471,10 +472,10 @@ final case class PartKeyRowReader(records: Iterator[TimeSeriesPartition]) extend
     def getString(columnNo: Int): String = ???
     def getAny(columnNo: Int): Any = ???
 
-    def getBlobBase(columnNo: Int): Any = currVal.partKeyBase
-    def getBlobOffset(columnNo: Int): Long = currVal.partKeyOffset
+    def getBlobBase(columnNo: Int): Any = currVal.base
+    def getBlobOffset(columnNo: Int): Long = currVal.offset
     def getBlobNumBytes(columnNo: Int): Int =
-      BinaryRegionLarge.numBytes(currVal.partKeyBase, currVal.partKeyOffset) + BinaryRegionLarge.lenBytes
+      BinaryRegionLarge.numBytes(currVal.base, currVal.offset) + BinaryRegionLarge.lenBytes
   }
 
   override def hasNext: Boolean = records.hasNext

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -202,8 +202,8 @@ class TimeSeriesShard(val ref: DatasetRef,
                      (implicit val ioPool: ExecutionContext) extends StrictLogging {
   import collection.JavaConverters._
 
-  import TimeSeriesShard._
   import FiloSchedulers._
+  import TimeSeriesShard._
 
   val shardStats = new TimeSeriesShardStats(ref, shardNum)
 
@@ -638,12 +638,12 @@ class TimeSeriesShard(val ref: DatasetRef,
       var foundValue = false
       while(partIterator.hasNext && index < limit && !foundValue) {
         val partId = partIterator.next()
-        val nextPart = getPartitionFromPartId(partId)
+        val nextPart = partKeyFromPartId(partId)
         if (nextPart != UnsafeUtils.ZeroPointer) {
           // FIXME This is non-performant and temporary fix for fetching label values based on filter criteria.
           // Other strategies needs to be evaluated for making this performant - create facets for predefined fields or
           // have a centralized service/store for serving metadata
-          currVal = schemas.part.binSchema.toStringPairs(nextPart.partKeyBase, nextPart.partKeyOffset)
+          currVal = schemas.part.binSchema.toStringPairs(nextPart.base, nextPart.offset)
             .filter(labelNames contains _._1).map(pair => {
             (pair._1.utf8 -> pair._2.utf8)
           }).toMap
@@ -667,9 +667,9 @@ class TimeSeriesShard(val ref: DatasetRef,
   def partKeysWithFilters(filter: Seq[ColumnFilter],
                           endTime: Long,
                           startTime: Long,
-                          limit: Int): Iterator[TimeSeriesPartition] = {
+                          limit: Int): Iterator[PartKey] = {
     partKeyIndex.partIdsFromFilters(filter, startTime, endTime)
-      .map(getPartitionFromPartId, limit)
+      .map(partKeyFromPartId, limit)
       .filter(_ != UnsafeUtils.ZeroPointer) // Needed since we have not addressed evicted partitions yet
   }
 
@@ -684,18 +684,17 @@ class TimeSeriesShard(val ref: DatasetRef,
   }
 
   /**
-    * WARNING, returns null for evicted partitions
+    * retrieve partKey for a given PartId
     */
-  private def getPartitionFromPartId(partId: Int): TimeSeriesPartition = {
+  private def partKeyFromPartId(partId: Int): PartKey = {
     val nextPart = partitions.get(partId)
-    if (nextPart == UnsafeUtils.ZeroPointer)
-      logger.warn(s"PartId=$partId was not found in memory and was not included in metadata query result. ")
-    // TODO Revisit this code for evicted partitions
-    /*if (nextPart == UnsafeUtils.ZeroPointer) {
-      val partKey = partKeyIndex.partKeyFromPartId(partId)
-      //map partKey bytes to UTF8String
-    }*/
-    nextPart
+    (if (nextPart != UnsafeUtils.ZeroPointer)
+      PartKey(nextPart.partKeyBase, nextPart.partKeyOffset)
+    else { //retrieving PartKey from lucene index
+      val partKeyByteBuf = partKeyIndex.partKeyFromPartId(partId)
+      if (partKeyByteBuf.isDefined) PartKey(partKeyByteBuf.get.bytes, UnsafeUtils.arayOffset)
+      else UnsafeUtils.ZeroPointer
+    }).asInstanceOf[PartKey]
   }
 
   /**

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -13,6 +13,7 @@ import filodb.core.TestData
 import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, Filter, SeqMapConsumer}
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
+import filodb.core.binaryrecord2.RecordContainer
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 
 class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
@@ -24,24 +25,17 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
 
-  val partKeyLabelValues = Map("__name__"->"http_req_total", "job"->"myCoolService", "instance"->"someHost:8787")
   val metadataKeyLabelValues = Map("ignore" -> "ignore")
   val jobQueryResult1 = Map(("job".utf8, "myCoolService".utf8))
   val jobQueryResult2 = ArrayBuffer(("__name__".utf8, "http_req_total".utf8),
+    ("id".utf8, "0".utf8),
     ("instance".utf8, "someHost:8787".utf8),
     ("job".utf8, "myCoolService".utf8))
 
-  val partTagsUTF8 = partKeyLabelValues.map { case (k, v) => (k.utf8, v.utf8) }
   val now = System.currentTimeMillis()
   val numRawSamples = 1000
   val reportingInterval = 10000
-  val tuples = (numRawSamples until 0).by(-1).map { n =>
-    (now - n * reportingInterval, n.toDouble)
-  }
-
-  // NOTE: due to max-chunk-size in storeConf = 100, this will make (numRawSamples / 100) chunks
-  tuples.map { t => SeqRowReader(Seq(t._1, t._2, partTagsUTF8)) }.foreach(builder.addFromReader(_, timeseriesSchema))
-  val container = builder.allContainers.head
+  val container = createRecordContainer(0, 10)
 
   override def beforeAll(): Unit = {
     memStore.setup(timeseriesDataset.ref, Schemas(timeseriesSchema), 0, TestData.storeConf)
@@ -49,14 +43,51 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     memStore.refreshIndexForTesting(timeseriesDataset.ref)
   }
 
-  it ("should read the metadata") {
-    import ZeroCopyUTF8String._
+  def createRecordContainer(start: Int, end: Int): RecordContainer = {
+    for(i <- start until end) {
+      val partKey = Map("__name__".utf8 -> "http_req_total".utf8,
+        "job".utf8 -> "myCoolService".utf8,
+        "instance".utf8 -> "someHost:8787".utf8,
+        "id".utf8 -> i.toString.utf8)
+      builder.addFromReader(SeqRowReader(Seq(now - i * reportingInterval, 10.0, partKey)),
+        timeseriesSchema)
+    }
+    builder.allContainers.head
+  }
+
+  it ("should search the metadata of in-memory partitions") {
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
-      ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+      ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
+        ColumnFilter("id", Filter.Equals("0".utf8)))
     val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, now, now - 5000, 10)
     val seqMapConsumer = new SeqMapConsumer()
     val tsPart = metadata.next()
-    timeseriesDataset.partKeySchema.consumeMapItems(tsPart.partKeyBase, tsPart.partKeyOffset, 0, seqMapConsumer)
+    timeseriesDataset.partKeySchema.consumeMapItems(tsPart.base, tsPart.offset, 0, seqMapConsumer)
+    seqMapConsumer.pairs shouldEqual jobQueryResult2
+  }
+
+  it("should search the metadata of evicted partitions") {
+
+    //Evict partition "0"
+    val shard = memStore.getShardE(timeseriesDataset.ref, 0)
+    val blockFactory = shard.overflowBlockFactory
+    val part = shard.partitions.get(0)
+    part.switchBuffers(blockFactory, encode = true)
+    shard.updatePartEndTimeInIndex(part, part.timestampOfLatestSample)
+    memStore.refreshIndexForTesting(timeseriesDataset.ref)
+    val endTime = part.timestampOfLatestSample
+
+    memStore.ingest(timeseriesDataset.ref, 0, SomeData(createRecordContainer(10, 20), 0))
+    memStore.refreshIndexForTesting(timeseriesDataset.ref)
+
+    //Search metadata after eviction
+    val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
+      ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
+      ColumnFilter("id", Filter.Equals("0".utf8)))
+    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, endTime, endTime - 5000, 10)
+    val seqMapConsumer = new SeqMapConsumer()
+    val tsPart = metadata.next()
+    timeseriesDataset.partKeySchema.consumeMapItems(tsPart.base, tsPart.offset, 0, seqMapConsumer)
     seqMapConsumer.pairs shouldEqual jobQueryResult2
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

**Current behavior :** Metadata query results do not include evicted partitions. 

**New behavior :** When a matching partition is not found in In-Memory map, lookup the PartitionKey using PartitionId from PartKeyLuceneIndex and include in the query results