### PR TITLE
feat(downsampler): Successful run of downsampler functional testing

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -219,7 +219,14 @@ filodb {
     # cass-session-provider-fqcn = fqcn
 
     # Number of time series to operate on at one time. Reduce if there is much less memory available
-    num-partitions-per-cass-write = 10000
+    cass-write-batch-size = 10000
+
+    # Maximum time to wait during cassandra reads to form a batch of partitions to downsample
+    cass-write-batch-time = 3s
+
+    # amount of parallelism to introduce in the spark job. This controls number of spark partitions
+    # increase if the number of splits seen in cassandra reads is low and spark jobs are slow.
+    splits-per-node = 1
 
     # This block memory is used for overflow of write buffers and for storing encoded downsample chunks
     # Configure to NumPartitionsPerCassWrite * (EstChunkSize * EstNumChunksPerPartition) + buffer

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -252,8 +252,12 @@ object BatchDownsampler extends StrictLogging with Instance {
                                     downsampledChunksToPersist: MMap[FiniteDuration, Iterator[ChunkSet]]): Unit = {
     // write all chunks to cassandra
     val writeFut = downsampledChunksToPersist.map { case (res, chunks) =>
+      // FIXME if listener below is not overridden to no-op, we get a SEGV because
+      // of a bug in either monix's mapAsync or cassandra driver where the future is completed prematurely.
+      // This causes a race condition between free memory and chunkInfo.id access in updateFlushedId.
+      val chunksToPersist = chunks.map(_.copy(listener = _ => {}))
       cassandraColStore.write(downsampleDatasetRefs(res),
-        Observable.fromIterator(chunks), settings.ttlByResolution(res))
+        Observable.fromIterator(chunksToPersist), settings.ttlByResolution(res))
     }
 
     writeFut.foreach { fut =>

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -252,7 +252,7 @@ object BatchDownsampler extends StrictLogging with Instance {
                                     downsampledChunksToPersist: MMap[FiniteDuration, Iterator[ChunkSet]]): Unit = {
     // write all chunks to cassandra
     val writeFut = downsampledChunksToPersist.map { case (res, chunks) =>
-      // FIXME if listener below is not overridden to no-op, we get a SEGV because
+      // FIXME if listener in chunkset below is not copied + overridden to no-op, we get a SEGV because
       // of a bug in either monix's mapAsync or cassandra driver where the future is completed prematurely.
       // This causes a race condition between free memory and chunkInfo.id access in updateFlushedId.
       val chunksToPersist = chunks.map(_.copy(listener = _ => {}))

--- a/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
@@ -39,7 +39,11 @@ object DownsamplerSettings extends StrictLogging {
 
   val ttlByResolution = downsampleResolutions.zip(downsampleTtls).toMap
 
-  val batchSize = downsamplerConfig.getInt("num-partitions-per-cass-write")
+  val batchSize = downsamplerConfig.getInt("cass-write-batch-size")
+
+  val batchTime = downsamplerConfig.as[FiniteDuration]("cass-write-batch-time")
+
+  val splitsPerNode = downsamplerConfig.getInt("splits-per-node")
 
   val blockMemorySize = downsamplerConfig.getMemorySize("off-heap-block-memory-size").toBytes
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Worked around a possible monix/cass driver issue where futures were being terminated prematurely causing race conditions between freeing of offheap memory and the persistence operation.
* Added more configuration to be able to tune spark job in multiple ways
