### PR TITLE
bug(memory): Fix handling of blocks which are too full for more metadata.

### DIFF
--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -167,7 +167,7 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
    * Allocates metaSize bytes for metadata storage.
    * @param metaSize the number of bytes to use for metadata storage.
    * @return the Long address of the metadata space.  The metaSize is written to the location 2 bytes before this.
-   *         If there is no capacity then OutOfOffheapMemoryException is thrown.
+   *         If there is no capacity then 0 is returned
    */
   def allocMetadata(metaSize: Short): Long = {
     val rem = remaining()
@@ -177,7 +177,7 @@ class Block(val address: Long, val capacity: Long, val reclaimListener: ReclaimL
       UnsafeUtils.setShort(UnsafeUtils.ZeroPointer, metaAddr, metaSize)
       metaAddr + 2
     } else {
-      throw new OutOfOffheapMemoryException(metaSize, rem)
+      0
     }
   }
 

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -281,8 +281,6 @@ class BlockMemFactory(blockStore: BlockManager,
       if (metaAddr != 0) metadataWriter(metaAddr)
     }
 
-    print("meta: " + metaAddr + "\n")
-
     if (metaAddr == 0) {
       // Can be caused by the first block being nearly full, and allocateOffheap was never
       // called.  Always make sure that a non-zero address is returned by this method.

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -281,6 +281,8 @@ class BlockMemFactory(blockStore: BlockManager,
       if (metaAddr != 0) metadataWriter(metaAddr)
     }
 
+    print("meta: " + metaAddr + "\n")
+
     if (metaAddr == 0) {
       // Can be caused by the first block being nearly full, and allocateOffheap was never
       // called.  Always make sure that a non-zero address is returned by this method.

--- a/memory/src/test/scala/filodb.memory/BlockSpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockSpec.scala
@@ -42,7 +42,7 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
 
     block.position(3800)
     block.remaining shouldEqual (4096-3800)
-    intercept[OutOfOffheapMemoryException] { block.allocMetadata(300) }
+    block.allocMetadata(300) shouldEqual 0
     block.remaining shouldEqual (4096-3800)   // still same space remaining
   }
 

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -209,11 +209,11 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     val stats = new MemoryStats(Map("test5" -> "test5"))
     val capacity = (5 * pageSize).toInt
     val blockManager = new PageAlignedBlockManager(capacity, stats, testReclaimer, 1)
-    val metaSize: Short = 271
+    val metaSize: Short = 271 // nothing special about this value
     val factory = new BlockMemFactory(blockManager, Some(10000L), metaSize, Map("foo" -> "bar"), false)
 
-    // Make sure that no excpeptions are thrown or any internal assertions fail. Don't allocate
-    // more than the block manager allows.
+    // Make sure that no exceptions are thrown or any internal assertions fail. Don't allocate
+    // more than what the block manager allows.
     for (i <- 1 to (capacity / metaSize)) {
       factory.startMetaSpan()
       factory.endMetaSpan(_ => {}, metaSize) should not be 0

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -204,4 +204,19 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
 
     factory.currentBlock.owner shouldEqual None  // new requestor did not have owner
   }
+
+  it should ("allow empty meta spans") in {
+    val stats = new MemoryStats(Map("test5" -> "test5"))
+    val capacity = (5 * pageSize).toInt
+    val blockManager = new PageAlignedBlockManager(capacity, stats, testReclaimer, 1)
+    val metaSize: Short = 271
+    val factory = new BlockMemFactory(blockManager, Some(10000L), metaSize, Map("foo" -> "bar"), false)
+
+    // Make sure that no excpeptions are thrown or any internal assertions fail. Don't allocate
+    // more than the block manager allows.
+    for (i <- 1 to (capacity / metaSize)) {
+      factory.startMetaSpan()
+      factory.endMetaSpan(_ => {}, metaSize) should not be 0
+    }
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Sometimes a call to Block.allocMetadata fails with OutOfOffheapMemoryException, and this can also cause some unit tests to fail. It used to be that this method returned 0 instead of throwing an exception. Returning of zero was generally considered safe, except it was bad if all spanned blocks had no room for metadata.

**New behavior :**
Ensure that a non-zero address is returned from MemFactory.endMetaSpan, possibly by allocating another block. Don't throw an exception from Block.allocMetadata, since this is a regression.
