### PR TITLE
misc(core,gateway):Add old binaryRecord for backward compatibility

### DIFF
--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
@@ -1,0 +1,633 @@
+package filodb.core.legacy.binaryrecord
+
+import com.typesafe.scalalogging.StrictLogging
+import org.agrona.DirectBuffer
+import scalaxy.loops._
+
+import filodb.core.metadata.{Column, Dataset}
+import filodb.core.metadata.Column.ColumnType.{DoubleColumn, LongColumn, MapColumn, StringColumn}
+import filodb.core.query.ColumnInfo
+import filodb.memory._
+import filodb.memory.format.{RowReader, SeqRowReader, UnsafeUtils, ZeroCopyUTF8String => ZCUTF8}
+import filodb.memory.format.vectors.Histogram
+
+
+// scalastyle:off number.of.methods
+/**
+ * A RecordBuilder allocates fixed size containers and builds BinaryRecords within them.
+ * The size of the container should be much larger than the average size of a record for efficiency.
+ * Many BinaryRecords are built within one container.
+ * This is very much a mutable, stateful class and should be run within a single thread or stream of execution.
+ * It is NOT multi-thread safe.
+ * The idea is to use one RecordBuilder per context/stream/thread. The context should make sense; as the list of
+ * containers can then be 1) sent over the wire, with no further transformations needed, 2) obtained and maybe freed
+ *
+ * @param memFactory the MemFactory used to allocate containers for building BinaryRecords in
+ * @param schema the RecordSchema for the BinaryRecord to build
+ * @param containerSize the size of each container
+ * @param reuseOneContainer if true, resets the container when we run out of container space.  Designed for scenario
+ *                   where one copies the BinaryRecord somewhere else every time, and allocation is minimized by
+ *                   reusing the same container over and over.
+ */
+@Deprecated
+final class RecordBuilder(memFactory: MemFactory,
+                          val schema: RecordSchema,
+                          containerSize: Int = RecordBuilder.DefaultContainerSize,
+                          reuseOneContainer: Boolean = false,
+                          // Put fields here so scalac won't generate stupid and slow initialization check logic
+                          // Seriously this makes var updates like twice as fast
+                          private var curBase: Any = UnsafeUtils.ZeroPointer,
+                          private var fieldNo: Int = -1,
+
+                          private var curRecordOffset: Long = -1L,
+                          private var curRecEndOffset: Long = -1L,
+                          private var maxOffset: Long = -1L,
+                          private var mapOffset: Long = -1L,
+                          private var recHash: Int = -1) extends StrictLogging {
+  import RecordBuilder._
+  import UnsafeUtils._
+  require(containerSize >= RecordBuilder.MinContainerSize, s"RecordBuilder.containerSize < minimum")
+
+  private val containers = new collection.mutable.ArrayBuffer[RecordContainer]
+  private val firstPartField = schema.partitionFieldStart.getOrElse(Int.MaxValue)
+  private val hashOffset = schema.fieldOffset(schema.numFields)
+
+  if (reuseOneContainer) newContainer()
+
+  // Reset last container and all pointers
+  def reset(): Unit = if (containers.nonEmpty) {
+    resetContainerPointers()
+    fieldNo = -1
+    mapOffset = -1L
+    recHash = -1
+  }
+
+  // Only reset the container offsets, but not the fieldNo, mapOffset, recHash
+  private def resetContainerPointers(): Unit = {
+    curRecordOffset = containers.last.offset + ContainerHeaderLen
+    curRecEndOffset = curRecordOffset
+    containers.last.updateLengthWithOffset(curRecordOffset)
+    curBase = containers.last.base
+  }
+
+  /**
+   * Start building a new BinaryRecord.
+   * This must be called after a previous endRecord() or when the builder just started.
+   */
+  final def startNewRecord(): Unit = {
+    require(curRecEndOffset == curRecordOffset, s"Illegal state: $curRecEndOffset != $curRecordOffset")
+    requireBytes(schema.variableAreaStart)
+
+    // write length header and update RecEndOffset
+    setInt(curBase, curRecordOffset, schema.variableAreaStart - 4)
+    curRecEndOffset = curRecordOffset + schema.variableAreaStart
+
+    fieldNo = 0
+    recHash = HASH_INIT
+  }
+
+  /**
+   * Adds an integer to the record.  This must be called in the right order or the data might be corrupted.
+   * Also this must be called between startNewRecord and endRecord.
+   * Calling this method after all fields of a record has been filled will lead to an error.
+   */
+  final def addInt(data: Int): Unit = {
+    checkFieldNo()
+    setInt(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
+    fieldNo += 1
+  }
+
+  /**
+   * Adds a Long to the record.  This must be called in the right order or the data might be corrupted.
+   * Also this must be called between startNewRecord and endRecord.
+   * Calling this method after all fields of a record has been filled will lead to an error.
+   */
+  final def addLong(data: Long): Unit = {
+    checkFieldNo()
+    setLong(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
+    fieldNo += 1
+  }
+
+  /**
+   * Adds a Double to the record.  This must be called in the right order or the data might be corrupted.
+   * Also this must be called between startNewRecord and endRecord.
+   * Calling this method after all fields of a record has been filled will lead to an error.
+   */
+  final def addDouble(data: Double): Unit = {
+    checkFieldNo()
+    setDouble(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
+    fieldNo += 1
+  }
+
+  /**
+   * Adds a string or raw bytes to the record.  They must fit in within 64KB.
+   * The variable length area of the BinaryRecord will be extended.
+   */
+  final def addString(bytes: Array[Byte]): Unit =
+    addBlob(bytes, UnsafeUtils.arayOffset, bytes.size)
+
+  final def addString(s: String): Unit = addString(s.getBytes)
+
+  final def addBlob(base: Any, offset: Long, numBytes: Int): Unit = {
+    require(numBytes < 65536, s"bytes too large ($numBytes bytes) for addBlob")
+    checkFieldAndMemory(numBytes + 2)
+    UnsafeUtils.setShort(curBase, curRecEndOffset, numBytes.toShort) // length of blob
+    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset + 2, numBytes)
+    updateFieldPointerAndLens(numBytes + 2)
+    if (fieldNo >= firstPartField) recHash = combineHash(recHash, BinaryRegion.hash32(base, offset, numBytes))
+    fieldNo += 1
+  }
+
+  final def addBlob(strPtr: ZCUTF8): Unit = addBlob(strPtr.base, strPtr.offset, strPtr.numBytes)
+
+  // Adds a blob from another buffer which already has the length bytes as the first two bytes
+  // For example: buffers created by BinaryHistograms.  OR, a UTF8String medium.
+  final def addBlob(buf: DirectBuffer): Unit = {
+    val numBytes = buf.getShort(0).toInt
+    require(numBytes < buf.capacity)
+    addBlob(buf.byteArray, buf.addressOffset + 2, numBytes)
+  }
+
+  /**
+    * IMPORTANT: Internal method, does not update hash values for the map key/values individually.
+    * If this method is used, then caller needs to also update the partitionHash manually.
+    */
+  private def addMap(base: Any, offset: Long, numBytes: Int): Unit = {
+    require(numBytes < 65536, s"bytes too large ($numBytes bytes) for addBlob")
+    checkFieldAndMemory(numBytes + 4)
+    UnsafeUtils.setInt(curBase, curRecEndOffset, numBytes) // length of blob
+    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset + 4, numBytes)
+    updateFieldPointerAndLens(numBytes + 4)
+    fieldNo += 1
+  }
+
+  private def addBlobFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    val blobDataOffset = schema.blobOffset(base, offset, col)
+    val blobNumBytes = schema.blobNumBytes(base, offset, col)
+    addBlob(base, blobDataOffset, blobNumBytes)
+  }
+
+  /**
+    * IMPORTANT: Internal method, does not update hash values for the data.
+    * If this method is used, then caller needs to also update the partitionHash manually.
+    */
+  private def addLargeBlobFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    val strDataOffset = schema.utf8StringOffset(base, offset, col)
+    addMap(base, strDataOffset + 4, BinaryRegionLarge.numBytes(base, strDataOffset))
+  }
+
+  private def addLongFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    addLong(schema.getLong(base, offset, col))
+  }
+
+  private def addDoubleFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    addDouble(schema.getDouble(base, offset, col))
+  }
+
+  /**
+    * Adds fields of a Partition Key Binary Record into the record builder as column values in
+    * the same order. Typically used for the downsampling use case where we copy partition key from
+    * the TimeSeriesPartition into the ingest record for the downsample data.
+    *
+    * This also updates the hash for this record. OK since partKeys are added at the very end
+    * of the record.
+    */
+  final def addPartKeyRecordFields(base: Any, offset: Long, partKeySchema: RecordSchema): Unit = {
+    var id = 0
+    partKeySchema.columns.foreach {
+      case ColumnInfo(_, MapColumn) => addLargeBlobFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, StringColumn) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, LongColumn) => addLongFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, DoubleColumn) => addDoubleFromBr(base, offset, id, partKeySchema); id += 1
+      case _ => ???
+    }
+    // finally copy the partition hash over
+    recHash = partKeySchema.partitionHash(base, offset)
+  }
+
+  import Column.ColumnType._
+
+  /**
+   * A SLOW but FLEXIBLE method to add data to the current field.  Boxes for sure but can take any data.
+   * Relies on passing in an object (Any) and using match, lots of allocations here.
+   * PLEASE don't use it in high performance code / hot paths.  Meant for ease of testing.
+   */
+  def addSlowly(item: Any): Unit = {
+    (schema.columnTypes(fieldNo), item) match {
+      case (IntColumn, i: Int)       => addInt(i)
+      case (LongColumn, l: Long)     => addLong(l)
+      case (TimestampColumn, l: Long) => addLong(l)
+      case (DoubleColumn, d: Double) => addDouble(d)
+      case (StringColumn, s: String) => addString(s)
+      case (StringColumn, a: Array[Byte]) => addString(a)
+      case (StringColumn, z: ZCUTF8) => addBlob(z)
+      case (MapColumn, m: Map[ZCUTF8, ZCUTF8] @unchecked) => addMap(m)
+      case (HistogramColumn, h: Histogram) => addBlob(h.serialize())
+      case (other: Column.ColumnType, v) =>
+        throw new UnsupportedOperationException(s"Column type of $other and value of class ${v.getClass}")
+    }
+  }
+
+  /**
+   * Adds an entire record from a RowReader, with no boxing, using builderAdders
+   * @return the offset or NativePointer if the memFactory is an offheap one, to the new BinaryRecord
+   */
+  final def addFromReader(row: RowReader): Long = {
+    startNewRecord()
+    for { pos <- 0 until schema.numFields optimized } {
+      schema.builderAdders(pos)(row, this)
+    }
+    endRecord()
+  }
+
+  // Really only for testing. Very slow.
+  def addFromObjects(parts: Any*): Long = addFromReader(SeqRowReader(parts.toSeq))
+
+  /**
+   * Sorts and adds keys and values from a map.  The easiest way to add a map to a BinaryRecord.
+   */
+  def addMap(map: Map[ZCUTF8, ZCUTF8]): Unit = {
+    startMap()
+    map.toSeq.sortBy(_._1).foreach { case (k, v) =>
+      addMapKeyValue(k.bytes, v.bytes)
+    }
+    endMap()
+  }
+
+  final def updatePartitionHash(newHash: Int): Unit = {
+    recHash = combineHash(recHash, newHash)
+  }
+
+  /**
+   * Low-level function to start adding a map field.  Must be followed by addMapKeyValue() in sorted order of
+   * keys (UTF8 byte sort).  Might want to use one of the higher level functions.
+   */
+  final def startMap(): Unit = {
+    require(mapOffset == -1L)
+    checkFieldAndMemory(4)   // 4 bytes for map length header
+    mapOffset = curRecEndOffset
+    setInt(curBase, mapOffset, 0)
+    updateFieldPointerAndLens(4)
+    // Don't update fieldNo, we'll be working on map for a while
+  }
+
+  /**
+   * Adds a single key-value pair to the map field started by startMap().
+   * Takes care of matching and translating predefined keys into short codes.
+   * Keys must be < 60KB and values must be < 64KB
+   * Hash is not computed or added for you - it must be separately added by you!
+   */
+  final def addMapKeyValue(keyBytes: Array[Byte], keyOffset: Int, keyLen: Int,
+                           valueBytes: Array[Byte], valueOffset: Int, valueLen: Int,
+                           keyHash: Int = 7): Unit = {
+    require(mapOffset > curRecordOffset, "illegal state, did you call startMap() first?")
+    // check key size, must be < 60KB
+    require(keyLen < 60*1024, s"key is too large: ${keyLen} bytes")
+    require(valueLen < 64*1024, s"value is too large: $valueLen bytes")
+
+    // Check if key is a predefined key
+    val predefKeyNum =  // but if there are no predefined keys, skip the cost of hashing the key
+      if (schema.predefinedKeys.isEmpty) { -1 }
+      else {
+        val keyKey = RecordSchema.makeKeyKey(keyBytes, keyOffset, keyLen, keyHash)
+        schema.predefKeyNumMap.getOrElse(keyKey, -1)
+      }
+    val keyValueSize = if (predefKeyNum >= 0) { valueLen + 4 } else { keyLen + valueLen + 4 }
+    requireBytes(keyValueSize)
+    if (predefKeyNum >= 0) {
+      setShort(curBase, curRecEndOffset, (0xF000 | predefKeyNum).toShort)
+      curRecEndOffset += 2
+    } else {
+      UTF8StringMedium.copyByteArrayTo(keyBytes, keyOffset, keyLen, curBase, curRecEndOffset)
+      curRecEndOffset += keyLen + 2
+    }
+    UTF8StringMedium.copyByteArrayTo(valueBytes, valueOffset, valueLen, curBase, curRecEndOffset)
+    curRecEndOffset += valueLen + 2
+
+    // update map length, BR length
+    setInt(curBase, mapOffset, (curRecEndOffset - mapOffset - 4).toInt)
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
+  }
+
+  final def addMapKeyValue(key: Array[Byte], value: Array[Byte]): Unit =
+    addMapKeyValue(key, 0, key.size, value, 0, value.size)
+
+  /**
+   * An alternative to above for adding a known key with precomputed key hash
+   * along with a value, to the map, while updating the hash too.
+   * Saves computing the key hash twice.
+   * TODO: deprecate this.  We are switching to computing a hash for all keys at the same time.
+   */
+  final def addMapKeyValueHash(keyBytes: Array[Byte], keyHash: Int,
+                               valueBytes: Array[Byte], valueOffset: Int, valueLen: Int): Unit = {
+    addMapKeyValue(keyBytes, 0, keyBytes.size, valueBytes, valueOffset, valueLen, keyHash)
+    val valueHash = BinaryRegion.hasher32.hash(valueBytes, valueOffset, valueLen, BinaryRegion.Seed)
+    updatePartitionHash(combineHash(keyHash, valueHash))
+  }
+
+  /**
+   * Ends creation of a map field.  Recompute the hash for all fields at once.
+   * @param bulkHash if true (default), computes the hash for all key/values.
+   *                 Some users use the older alternate, sortAndComputeHashes() - then set this to false.
+   */
+  final def endMap(bulkHash: Boolean = true): Unit = {
+    if (bulkHash) {
+      val mapHash = BinaryRegion.hash32(curBase, mapOffset, (curRecEndOffset - mapOffset).toInt)
+      updatePartitionHash(mapHash)
+    }
+    mapOffset = -1L
+    fieldNo += 1
+  }
+
+  /**
+   * Ends the building of the current BinaryRecord.  Makes sures RecordContainer state is updated.
+   * Aligns the next record on a 4-byte/short word boundary.
+   * Returns the Long offset of the just finished BinaryRecord.  If the container is offheap, then this is the
+   * full NativePointer.  If it is onHeap, you will need to access the current container and get the base
+   * to form the (base, offset) pair needed to access the BinaryRecord.
+   */
+  final def endRecord(writeHash: Boolean = true): Long = {
+    val recordOffset = curRecordOffset
+
+    if (writeHash && firstPartField < Int.MaxValue) setInt(curBase, curRecordOffset + hashOffset, recHash)
+
+    // Bring RecordOffset up to endOffset w/ align.  Now the state is complete at end of a record again.
+    curRecEndOffset = align(curRecEndOffset)
+    curRecordOffset = curRecEndOffset
+    fieldNo = -1
+
+    // Update container length.  This is atomic so it is updated only when the record is complete.
+    val lastContainer = containers.last
+    lastContainer.updateLengthWithOffset(curRecEndOffset)
+    lastContainer.numRecords += 1
+
+    recordOffset
+  }
+
+  final def align(offset: Long): Long = (offset + 3) & ~3
+
+  /**
+   * Used only internally by RecordComparator etc. to shortcut create a new BR by copying bytes from an existing BR.
+   * You BETTER know what you are doing.
+   */
+  private[binaryrecord] def copyFixedAreasFrom(base: Any, offset: Long, numBytes: Int): Unit = {
+    require(curRecEndOffset == curRecordOffset, s"Illegal state: $curRecEndOffset != $curRecordOffset")
+    requireBytes(numBytes + 4)
+
+    // write length header, copy bytes, and update RecEndOffset
+    setInt(curBase, curRecordOffset, numBytes)
+    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecordOffset + 4, numBytes)
+    curRecEndOffset = curRecordOffset + numBytes + 4
+  }
+
+  // Extend current variable area with stuff from somewhere else
+  private[binaryrecord] def copyVarAreasFrom(base: Any, offset: Long, numBytes: Int): Unit = {
+    requireBytes(numBytes)
+    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset, numBytes)
+    // Increase length of current BR.  Then bump curRecEndOffset so we are consistent
+    setInt(curBase, curRecordOffset, getInt(curBase, curRecordOffset) + numBytes)
+    curRecEndOffset += numBytes
+  }
+
+  private[binaryrecord] def adjustFieldOffset(fieldNo: Int, adjustment: Int): Unit = {
+    val offset = curRecordOffset + schema.fieldOffset(fieldNo)
+    UnsafeUtils.setInt(curBase, offset, UnsafeUtils.getInt(curBase, offset) + adjustment)
+  }
+
+  // resets or empties current container.  Only used for testing.  Also ensures there's at least one container
+  private[filodb] def resetCurrent(): Unit = {
+    if (containers.isEmpty) requireBytes(100)
+    curBase = currentContainer.get.base
+    curRecordOffset = currentContainer.get.offset + 4
+    currentContainer.get.updateLengthWithOffset(curRecordOffset)
+    curRecEndOffset = curRecordOffset
+  }
+
+  /**
+   * Returns Some(container) reference to the current RecordContainer or None if there is no container
+   */
+  def currentContainer: Option[RecordContainer] = containers.lastOption
+
+  /**
+   * Returns the list of all current containers
+   */
+  def allContainers: Seq[RecordContainer] = containers
+
+
+  /**
+    * Returns all the full containers other than currentContainer as byte arrays.
+    * Assuming all of the containers except the last one is full,
+    * calls array() on all the non-last container excluding the currentContainer.
+    * The memFactory needs to be an on heap one otherwise UnsupportedOperationException will be thrown.
+    * The sequence of byte arrays can be for example sent to Kafka as a sequence of messages - one message
+    * per byte array.
+    * @param reset if true, clears out all the containers other than lastContainer.
+    *              Allows a producer of containers to obtain the
+    *              byte arrays for sending somewhere else, while clearing containers for the next batch.
+    */
+  def nonCurrentContainerBytes(reset: Boolean = false): Seq[Array[Byte]] = {
+    val bytes = allContainers.dropRight(1).map(_.array)
+    if (reset) removeAndFreeContainers(containers.size - 1)
+    bytes
+  }
+
+  /**
+   * Returns the containers as byte arrays.  Assuming all of the containers except the last one is full,
+   * calls array() on the non-last container and trimmedArray() on the last one.
+   * The memFactory needs to be an on heap one otherwise UnsupportedOperationException will be thrown.
+   * The sequence of byte arrays can be for example sent to Kafka as a sequence of messages - one message
+   * per byte array.
+   * @param reset if true, clears out all the containers EXCEPT the last one.  Pointers to the last container
+   *              are simply reset, which avoids an extra container buffer allocation.
+   */
+  def optimalContainerBytes(reset: Boolean = false): Seq[Array[Byte]] = {
+    val bytes = allContainers.dropRight(1).map(_.array) ++
+      allContainers.takeRight(1).filterNot(_.isEmpty).map(_.trimmedArray)
+    if (reset) {
+      removeAndFreeContainers(containers.size - 1)
+      this.reset()
+    }
+    bytes
+  }
+
+  /**
+   * Remove the first numContainers containers and release the memory they took up.
+   * If no more containers are left, then everything will be reset.
+   * @param numContainers the # of containers to remove
+   */
+  def removeAndFreeContainers(numContainers: Int): Unit = if (numContainers > 0) {
+    require(numContainers <= containers.length)
+    if (numContainers == containers.length) reset()
+    containers.take(numContainers).foreach { c => memFactory.freeMemory(c.offset) }
+    containers.remove(0, numContainers)
+  }
+
+  /**
+   * Returns the number of free bytes in the current container, or 0 if container is not initialized
+   */
+  def containerRemaining: Long = maxOffset - curRecEndOffset
+
+  private def requireBytes(numBytes: Int): Unit =
+    // if container is none, allocate a new one, make sure it has enough space, reset length, update offsets
+    if (containers.isEmpty) {
+      newContainer()
+    // if we don't have enough space left, get a new container and move existing BR being written into new space
+    } else if (curRecEndOffset + numBytes > maxOffset) {
+      val oldBase = curBase
+      val recordNumBytes = curRecEndOffset - curRecordOffset
+      val oldOffset = curRecordOffset
+      if (reuseOneContainer) resetContainerPointers() else newContainer()
+      logger.debug(s"Moving $recordNumBytes bytes from end of old container to new container")
+      require((containerSize - ContainerHeaderLen) > (recordNumBytes + numBytes), "Record too big for container")
+      unsafe.copyMemory(oldBase, oldOffset, curBase, curRecordOffset, recordNumBytes)
+      if (mapOffset != -1L) mapOffset = curRecordOffset + (mapOffset - oldOffset)
+      curRecEndOffset = curRecordOffset + recordNumBytes
+    }
+
+  private[filodb] def newContainer(): Unit = {
+    val (newBase, newOff, _) = memFactory.allocate(containerSize)
+    val container = new RecordContainer(newBase, newOff, containerSize)
+    containers += container
+    logger.debug(s"Creating new RecordContainer with $containerSize bytes using $memFactory")
+    curBase = newBase
+    curRecordOffset = newOff + ContainerHeaderLen
+    curRecEndOffset = curRecordOffset
+    container.updateLengthWithOffset(curRecordOffset)
+    container.writeVersionWord()
+    maxOffset = newOff + containerSize
+  }
+
+  private def checkFieldNo(): Unit = require(fieldNo >= 0 && fieldNo < schema.numFields)
+
+  private def checkFieldAndMemory(bytesRequired: Int): Unit = {
+    checkFieldNo()
+    requireBytes(bytesRequired)
+  }
+
+  private def updateFieldPointerAndLens(varFieldLen: Int): Unit = {
+    // update fixed field area, which is a 4-byte offset to the var field
+    setInt(curBase, curRecordOffset + schema.fieldOffset(fieldNo), (curRecEndOffset - curRecordOffset).toInt)
+    curRecEndOffset += varFieldLen
+
+    // update BinaryRecord length header as well
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset).toInt - 4)
+  }
+}
+
+@Deprecated
+object RecordBuilder {
+  val DefaultContainerSize = 256 * 1024
+  val MinContainerSize = 2048
+  val HASH_INIT = 7
+
+  // Please do not change this.  It should only be changed with a change in BinaryRecord and/or RecordContainer
+  // format, and only then REALLY carefully.
+  val Version = 0
+  val ContainerHeaderLen = 8
+
+  val stringPairComparator = new java.util.Comparator[(String, String)] {
+    def compare(pair1: (String, String), pair2: (String, String)): Int = pair1._1 compare pair2._1
+  }
+
+  /**
+    * Make is a convenience factory method to access from java.
+    */
+  def make(memFactory: MemFactory,
+           schema: RecordSchema,
+           containerSize: Int = RecordBuilder.DefaultContainerSize): RecordBuilder = {
+    new RecordBuilder(memFactory, schema, containerSize)
+  }
+
+  /**
+    * == Auxiliary functions to compute hashes. ==
+    */
+
+  import filodb.core._
+
+  val keyHashCache = concurrentCache[String, Int](1000)
+
+  /**
+    * Sorts an incoming list of key-value pairs and then computes a hash value
+    * for each pair.  The output can be fed into the combineHash methods to produce an overall hash.
+    * NOTE: we use XXHash, it gives a MUCH higher quality hash than the default String hashCode.
+    * @param pairs an unsorted list of key-value pairs.  Will be mutated and sorted.
+    */
+  final def sortAndComputeHashes(pairs: java.util.ArrayList[(String, String)]): Array[Int] = {
+    pairs.sort(stringPairComparator)
+    val hashes = new Array[Int](pairs.size)
+    for { i <- 0 until pairs.size optimized } {
+      val (k, v) = pairs.get(i)
+      // This is not very efficient, we have to convert String to bytes first to get the hash
+      // TODO: work on different API which is far more efficient and saves memory allocation
+      val valBytes = v.getBytes
+      val keyHash = keyHashCache.getOrElseUpdate(k, { key =>
+        val keyBytes = key.getBytes
+        BinaryRegion.hasher32.hash(keyBytes, 0, keyBytes.size, BinaryRegion.Seed)
+      })
+      hashes(i) = combineHash(keyHash, BinaryRegion.hasher32.hash(valBytes, 0, valBytes.size, BinaryRegion.Seed))
+    }
+    hashes
+  }
+
+  // NOTE: I've tried many different hash combiners, but nothing tried (including Murmur3) seem any better than
+  // XXHash + the simple formula below.
+  @inline
+  final def combineHash(hash1: Int, hash2: Int): Int = 31 * hash1 + hash2
+
+  /**
+    * Combines the hashes from sortAndComputeHashes, excluding certain keys, into an overall hash value.
+    * @param sortedPairs sorted pairs of byte key values, from sortAndComputeHashes
+    * @param hashes the output from sortAndComputeHashes
+    * @param excludeKeys set of String keys to exclude
+    */
+  final def combineHashExcluding(sortedPairs: java.util.ArrayList[(String, String)],
+                                 hashes: Array[Int],
+                                 excludeKeys: Set[String]): Int = {
+    var hash = 7
+    for { i <- 0 until sortedPairs.size optimized } {
+      if (!(excludeKeys contains sortedPairs.get(i)._1))
+        hash = combineHash(hash, hashes(i))
+    }
+    hash
+  }
+
+  /**
+   * Computes a shard key hash from the metric name and the values of the non-metric shard key columns
+   * @param shardKeyValues the non-metric shard key values (such as the job/exporter/app), sorted in order of
+   *        the key name.  For example, it should be Seq(exporter, job).
+   * @param metric the metric value to use in the calculation.
+   */
+  final def shardKeyHash(shardKeyValues: Seq[Array[Byte]], metric: Array[Byte]): Int = {
+    var hash = 7
+    shardKeyValues.foreach { value => hash = combineHash(hash, BinaryRegion.hash32(value)) }
+    combineHash(hash, BinaryRegion.hash32(metric))
+  }
+
+  final def shardKeyHash(shardKeyValues: Seq[String], metric: String): Int =
+    shardKeyHash(shardKeyValues.map(_.getBytes), metric.getBytes)
+
+  /**
+    * Removes the ignoreShardKeyColumnSuffixes from LabelPair as configured in DataSet.
+    *
+    * Few metric types like Histogram, Summary exposes multiple time
+    * series for the same metric during a scrape by appending suffixes _bucket,_sum,_count.
+    *
+    * In order to ingest all these multiple time series of a single metric to the
+    * same shard, we have to trim the suffixes while calculating shardKeyHash.
+    *
+    * @param dataSet    - Current DataSet
+    * @param shardKeyColName  - ShardKey label name as String
+    * @param shardKeyColValue - ShardKey label value as String
+    * @return - Label value after removing the suffix
+    */
+  final def trimShardColumn(dataSet: Dataset, shardKeyColName: String, shardKeyColValue: String): String = {
+    dataSet.options.ignoreShardKeyColumnSuffixes.get(shardKeyColName) match {
+      case Some(trimMetricSuffixColumn) => trimMetricSuffixColumn.find(shardKeyColValue.endsWith) match {
+                                            case Some(s)  => shardKeyColValue.dropRight(s.length)
+                                            case _        => shardKeyColValue
+                                           }
+      case _                            => shardKeyColValue
+    }
+  }
+
+}

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
@@ -14,6 +14,8 @@ import filodb.memory.format.vectors.Histogram
 
 // scalastyle:off number.of.methods
 /**
+ * WARNING: THIS CLASS IS DEPRECATED!! ADDED TO SUPPORT BACKWARD COMPATIBILITY FOR MULTI-SCHEMA.
+ *
  * A RecordBuilder allocates fixed size containers and builds BinaryRecords within them.
  * The size of the container should be much larger than the average size of a record for efficiency.
  * Many BinaryRecords are built within one container.

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
@@ -5,6 +5,8 @@ import scalaxy.loops._
 import filodb.memory.format.UnsafeUtils
 
 /**
+ * WARNING: THIS CLASS IS DEPRECATED!! ADDED TO SUPPORT BACKWARD COMPATIBILITY FOR MULTI-SCHEMA.
+ *
  * A fast, no-heap-allocation comparator and copier specifically designed for two tasks:
  * 1) Compare an ingestion-based BinaryRecord2 with a partition key only BinaryRecord2
  * 2) Copy an ingestion BinaryRecord2 to a partition key BinaryRecord2

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
@@ -1,0 +1,138 @@
+package filodb.core.legacy.binaryrecord
+
+import scalaxy.loops._
+
+import filodb.memory.format.UnsafeUtils
+
+/**
+ * A fast, no-heap-allocation comparator and copier specifically designed for two tasks:
+ * 1) Compare an ingestion-based BinaryRecord2 with a partition key only BinaryRecord2
+ * 2) Copy an ingestion BinaryRecord2 to a partition key BinaryRecord2
+ *
+ * One instance of these should exist for each unique ingestSchema.  The methods are to be shared for all BRs.
+ *
+ * An "ingestion" BinaryRecord2 will have data fields before the partition key fields.
+ * A partition key BinaryRecord2 will not have the data fields but have the SAME partition key fields.
+ * Thus we can make some optimizations when comparing and copying; namely, for the tags/labels/MapColumn, we can
+ * simply compare the bytes (since all Map fields are sorted by key).  In fact we can simply compare the
+ * variable field bytes and the fixed field bytes.
+ */
+@Deprecated
+final class RecordComparator(ingestSchema: RecordSchema) {
+  require(ingestSchema.partitionFieldStart.isDefined)
+  require(ingestSchema.columnTypes.length > ingestSchema.partitionFieldStart.get, "no partition fields")
+
+  val partitionKeySchema = new RecordSchema(ingestSchema.columns.drop(ingestSchema.partitionFieldStart.get),
+                                            Some(0),
+                                            ingestSchema.predefinedKeys)
+  // NOTE: remember that private final val results in a Java field, much much faster
+  // the ingest BR offset of the first partition fixed area field
+  private final val ingestPartOffset = ingestSchema.fieldOffset(ingestSchema.partitionFieldStart.get)
+
+  // the offsets of the variable areas for partition keys (from beginning of BR)
+  private final val partVarAreaOffset = partitionKeySchema.variableAreaStart
+
+  // The number of bytes of the partition fields fixed area
+  private final val fixedAreaNumBytes = ingestSchema.fieldOffset(ingestSchema.numFields) - ingestPartOffset
+  private final val fixedAreaNumWords = fixedAreaNumBytes / 4
+
+  require(fixedAreaNumWords < 32, "Too many partition key fields to use RecordComparator")
+
+  // Make a bitmap for which 32-bit words need to be compared (int, long, bool fields)
+  private final val compareBitmap: Int = {
+    import filodb.core.metadata.Column.ColumnType._
+    var bitmap = 0
+    partitionKeySchema.columnTypes.reverse.foreach {
+      case IntColumn    => bitmap <<= 1;  bitmap |= 0x01
+      case DoubleColumn => bitmap <<= 2;  bitmap |= 0x03
+      case LongColumn   => bitmap <<= 2;  bitmap |= 0x03
+      case _            => bitmap <<= 1   // both MapColumn and StringColumn use 4-byte fields
+    }
+    bitmap
+  }
+
+  private final val anyPrimitiveFieldsToCompare = compareBitmap != 0
+
+  // Find the fixed area of the first non-primitive (variable area pointer) partition key field
+  private val ingestPartNonPrimOffset =
+    if (!anyPrimitiveFieldsToCompare) ingestPartOffset else {
+      // NOTE: this algorithm fails if the partition key has all primitive fields.  This should not happen.
+      var nonPrimOffset = ingestPartOffset
+      var wordsBitmap = compareBitmap
+      while ((wordsBitmap & 0x01) == 1) { nonPrimOffset += 4; wordsBitmap >>= 1 }
+      nonPrimOffset
+    }
+
+  // Finds the offset from beginning of ingest record to the var area of first partition field.
+  // We have to take into account that data columns might have variable areas too.
+  private def ingestVarOffset(ingestBase: Any, ingestOffset: Long): Int =
+    UnsafeUtils.getInt(ingestBase, ingestOffset + ingestPartNonPrimOffset)
+
+  /**
+   * Returns true if the partition part of the ingest BinaryRecord matches (all partition fields match identically)
+   * to the partition key BR.  Uses optimized byte comparisons which is faster than field by field comparison.
+   * @param ingestBase the base (null if offheap) of the BinaryRecord built using the ingestSchema
+   * @param ingestOffset the offset or native address of the BinaryRecord built using the ingestSchema
+   * @param partKeyBase the base (null if offheap) of the BinaryRecord built using partitionKeySchema
+   * @param partKeyOffset the offset (null if offheap) of the BinaryRecord built using partitionKeySchema
+   */
+  final def partitionMatch(ingestBase: Any, ingestOffset: Long, partKeyBase: Any, partKeyOffset: Long): Boolean = {
+    // comparison: first get lengths of two BRs
+    val ingestNumBytes = UnsafeUtils.getInt(ingestBase, ingestOffset)
+    val partKeyNumBytes = UnsafeUtils.getInt(partKeyBase, partKeyOffset)
+
+    // compare lengths of variable areas (map tags & strings)
+    val ingestVarAreaOffset = ingestVarOffset(ingestBase, ingestOffset)
+    val ingestVarSize = ingestNumBytes + 4 - ingestVarAreaOffset
+    val partKeyVarSize = partKeyNumBytes + 4 - partVarAreaOffset
+    if (ingestVarSize != partKeyVarSize) return false
+
+    // compare variable area bytes
+    if (!UnsafeUtils.equate(ingestBase, ingestOffset + ingestVarAreaOffset,
+                            partKeyBase, partKeyOffset + partVarAreaOffset,
+                            ingestVarSize)) return false
+
+    // finally compare primitive fields if needed
+    if (anyPrimitiveFieldsToCompare) {
+      var ingestPtr = ingestOffset + ingestPartOffset
+      var partKeyPtr = partKeyOffset + 4
+      var bitmap = compareBitmap
+      while (bitmap != 0) {
+        if (((bitmap & 0x01) == 1) &&
+            UnsafeUtils.getInt(ingestBase, ingestPtr) != UnsafeUtils.getInt(partKeyBase, partKeyPtr)) return false
+        ingestPtr += 4   // advance one 32-bit word at a time
+        partKeyPtr += 4
+        bitmap >>= 1
+      }
+    }
+    return true
+  }
+
+  /**
+   * Efficiently builds a partition key BinaryRecord from an ingest BinaryRecord.  This is done by copying the
+   * variable and fixed area bytes directly, and adjusting the offsets.
+   * @param ingestBase the base (null if offheap) of the BinaryRecord built using the ingestSchema
+   * @param ingestOffset the offset or native address of the BinaryRecord built using the ingestSchema
+   * @param builder a RecordBuilder which uses the partitionKeySchema
+   * @return the Long offset or native address of the new partition key BR
+   */
+  final def buildPartKeyFromIngest(ingestBase: Any, ingestOffset: Long, builder: RecordBuilder): Long = {
+    require(builder.schema == partitionKeySchema, s"${builder.schema} is not part key schema $partitionKeySchema")
+
+    // Copy fixed area + hash over, then variable areas
+    val ingestNumBytes = UnsafeUtils.getInt(ingestBase, ingestOffset)
+    val ingestVarAreaOffset = ingestVarOffset(ingestBase, ingestOffset)
+    builder.copyFixedAreasFrom(ingestBase, ingestOffset + ingestPartOffset, fixedAreaNumBytes + 4)
+    builder.copyVarAreasFrom(ingestBase, ingestOffset + ingestVarAreaOffset, ingestNumBytes + 4 - ingestVarAreaOffset)
+
+    // adjust offsets to var fields
+    val adjustment = partVarAreaOffset - ingestVarAreaOffset
+    for { i <- 0 until fixedAreaNumWords optimized } {
+      if ((compareBitmap & (1 << i)) == 0) {    // not a primitive field, but an offset to String or Map
+        builder.adjustFieldOffset(i, adjustment)
+      }
+    }
+
+    builder.endRecord(writeHash = false)
+  }
+}

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordContainer.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordContainer.scala
@@ -1,0 +1,161 @@
+package filodb.core.legacy.binaryrecord
+
+import java.nio.ByteBuffer
+
+import scala.reflect.ClassTag
+
+import debox.Buffer
+
+import filodb.memory.{BinaryRegionConsumer, BinaryRegionLarge}
+import filodb.memory.format.{RowReader, UnsafeUtils}
+
+/**
+ * A RecordContainer is a binary, wire-compatible container for BinaryRecords V2.
+ * Example uses: for holding/batching multiple BinaryRecords for Kafka, or as a set of partition keys.
+ * It is also the container to which the RecordBuilder writes into.
+ *
+ * A RecordContainer is compatible with BinaryRegionLarge.
+ *
+ * +0000 4 bytes  length header - number of bytes following this
+ *
+ * @param base null for offheap, or an Array[Byte] for onheap
+ * @param offset 64-bit native pointer or offset into Array[Byte] object memory
+ * @param maxLength the maximum allocated size the container can grow to, including the initial length bytes
+ */
+@Deprecated
+final class RecordContainer(val base: Any, val offset: Long, maxLength: Int,
+                            // INTERNAL variable placed here to avoid Scalac using a bitfield and slowing things down
+                            var numRecords: Int = 0) {
+  import RecordBuilder._
+
+  @inline final def numBytes: Int = UnsafeUtils.getInt(base, offset)
+  @inline final def isEmpty: Boolean = numBytes <= 4
+
+  /**
+   * Used only by the RecordBuilder to update the length field.
+   */
+  private[binaryrecord] def updateLengthWithOffset(endOffset: Long): Unit = {
+    val newLength = endOffset - offset - 4
+    require(newLength >= 0 && newLength <= (maxLength - 4))
+    UnsafeUtils.setInt(base, offset, newLength.toInt)
+  }
+
+  private[binaryrecord] def writeVersionWord(): Unit = {
+    val word = Version << 24
+    UnsafeUtils.setInt(base, offset + 4, word)
+  }
+
+  /**
+   * Iterates through each BinaryRecord location, passing it to the Consumer so that no object allocations
+   * are done.  Method returns when we have iterated through all the records.
+   */
+  final def consumeRecords(consumer: BinaryRegionConsumer): Unit = {
+    val endOffset = offset + 4 + numBytes
+    var curOffset = offset + ContainerHeaderLen
+    while (curOffset < endOffset) {
+      val recordLen = BinaryRegionLarge.numBytes(base, curOffset)
+      consumer.onNext(base, curOffset)
+      curOffset += (recordLen + 7) & ~3   // +4, then aligned/rounded up to next 4 bytes
+    }
+  }
+
+  /**
+   * Iterates through each BinaryRecord as a RowReader.  Results in two allocations: the Iterator
+   * as well as a BinaryRecordRowReader.
+   */
+  final def iterate(schema: RecordSchema): Iterator[RowReader] = new Iterator[RowReader] {
+    val reader = new BinaryRecordRowReader(schema, base)
+    val endOffset = offset + 4 + numBytes
+    var curOffset = offset + ContainerHeaderLen
+
+    final def hasNext: Boolean = curOffset < endOffset
+    final def next: RowReader = {
+      val recordLen = BinaryRegionLarge.numBytes(base, curOffset)
+      reader.recordOffset = curOffset
+      curOffset += (recordLen + 7) & ~3   // +4, then aligned/rounded up to next 4 bytes
+      reader
+    }
+  }
+
+  class FunctionalConsumer(func: (Any, Long) => Unit) extends BinaryRegionConsumer {
+    def onNext(base: Any, offset: Long): Unit = func(base, offset)
+  }
+
+  /**
+   * A convenience method to iterate through each BinaryRecord using a function.  Probably not as efficient
+   * as directly calling consumeRecords, but easier to write.
+   * TODO: make this a MACRO and rewrite it as a custom BinaryRegionConsumer.
+   */
+  def foreach(func: (Any, Long) => Unit): Unit = consumeRecords(new FunctionalConsumer(func))
+
+  /**
+   * Convenience functional method to map the BinaryRecords to something else and returns a Buffer which
+   * can be unboxed and efficient.  If you want performance, consider using consumeRecords instead.
+   */
+  def map[@specialized B: ClassTag](func: (Any, Long) => B): Buffer[B] = {
+    val result = Buffer.empty[B]
+    foreach { case (b, o) => result += func(b, o) }
+    result
+  }
+
+  /**
+   * A convenient method to return all of the record offsets (or native pointers if offheap) for this container.
+   * @return a debox.Buffer[Long], which conveniently does not box, and minimizes memory use.
+   */
+  final def allOffsets: Buffer[Long] = map { case (b, o) => o }
+
+  class CountingConsumer(var count: Int = 0) extends BinaryRegionConsumer {
+    final def onNext(base: Any, offset: Long): Unit = count += 1
+  }
+
+  /**
+   * Uses consumeRecords with a consumer that counts the # of records
+   */
+  final def countRecords(): Int = {
+    val counter = new CountingConsumer()
+    consumeRecords(counter)
+    counter.count
+  }
+
+  /**
+   * Returns true if this RecordContainer is backed by a byte array object on heap.
+   */
+  def hasArray: Boolean = base match {
+    case UnsafeUtils.ZeroPointer => false
+    case b: Array[Byte]          => true
+    case other: Any              => false
+  }
+
+  /**
+   * IF this is an on-heap container, return the Array[Byte] object AS IS (meaning might not be full)
+   * Otherwise throw an Exception
+   */
+  def array: Array[Byte] =
+    if (hasArray) base.asInstanceOf[Array[Byte]] else throw new UnsupportedOperationException("Not an array container")
+
+  /**
+   * Returns a NEW byte array which is of minimal size by copying only the filled bytes.
+   * Can also be used to copy offheap containers to onheap byte array.
+   */
+  def trimmedArray: Array[Byte] = {
+    val newBytes = new Array[Byte](numBytes + 4)
+    UnsafeUtils.unsafe.copyMemory(base, offset, newBytes, UnsafeUtils.arayOffset, numBytes + 4)
+    newBytes
+  }
+}
+
+@Deprecated
+object RecordContainer {
+  /**
+   * Returns a read-only container; updateLength will never work.
+   */
+  def apply(array: Array[Byte]): RecordContainer = new RecordContainer(array, UnsafeUtils.arayOffset, 0)
+
+  /**
+   * Returns a read-only container given a ByteBuffer wrapper
+   */
+  def apply(buf: ByteBuffer): RecordContainer = {
+    val (base, offset, _) = UnsafeUtils.BOLfromBuffer(buf)
+    new RecordContainer(base, offset, 0)
+  }
+}

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordContainer.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordContainer.scala
@@ -10,6 +10,8 @@ import filodb.memory.{BinaryRegionConsumer, BinaryRegionLarge}
 import filodb.memory.format.{RowReader, UnsafeUtils}
 
 /**
+ * WARNING: THIS CLASS IS DEPRECATED!! ADDED TO SUPPORT BACKWARD COMPATIBILITY FOR MULTI-SCHEMA.
+ *
  * A RecordContainer is a binary, wire-compatible container for BinaryRecords V2.
  * Example uses: for holding/batching multiple BinaryRecords for Kafka, or as a set of partition keys.
  * It is also the container to which the RecordBuilder writes into.

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordSchema.scala
@@ -15,6 +15,8 @@ import filodb.memory.format.{vectors => bv}
 // scalastyle:off number.of.methods
 
 /**
+ * WARNING: THIS CLASS IS DEPRECATED!! ADDED TO SUPPORT BACKWARD COMPATIBILITY FOR MULTI-SCHEMA.
+ *
  * A RecordSchema is the schema for a BinaryRecord - what type of each field a BR holds.
  * Since it knows the schema it can also read values out efficiently.  It does not mutate memory or BinaryRecords.
  *

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordSchema.scala
@@ -1,0 +1,454 @@
+package filodb.core.legacy.binaryrecord
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.agrona.DirectBuffer
+import org.agrona.concurrent.UnsafeBuffer
+
+import filodb.core.metadata.{Column, Dataset}
+import filodb.core.metadata.Column.ColumnType.{LongColumn, TimestampColumn}
+import filodb.core.query.ColumnInfo
+import filodb.memory.{BinaryRegion, BinaryRegionLarge, UTF8StringMedium}
+import filodb.memory.format.{RowReader, UnsafeUtils, ZeroCopyUTF8String}
+import filodb.memory.format.{vectors => bv}
+
+// scalastyle:off number.of.methods
+
+/**
+ * A RecordSchema is the schema for a BinaryRecord - what type of each field a BR holds.
+ * Since it knows the schema it can also read values out efficiently.  It does not mutate memory or BinaryRecords.
+ *
+ * One instance of this class is meant to serve all of the BinaryRecords of this schema.
+ * Note that BinaryRecords are not regular Java objects, but rather just a memory location or pointer.
+ * The methods of this class must be used for access.
+ *
+ * RecordSchema v2 has a feature called partition key fields.  The idea is that all fields starting at an optional
+ * partitionFieldStart belong to the "partition key".  Special features for partition key fields:
+ * - A hashcode is calculated for all partition key fields and stored in the record itself for fast comparisons
+ *   and raw data recovery
+ * - The partition key fields between BinaryRecords can be compared very fast for equality, so long as all the
+ *   partition key fields share the same schema (they can start at differend field #'s).  This takes advantage of
+ *   the fact that all variable length fields after the partitionFieldStart are contiguous and can be binary compared
+ *
+ * @param columns In order, the column of each field in this schema
+ * @param brSchema schema of any binary record type column
+ * @param partitionFieldStart Some(n) from n to the last field are considered the partition key.  A field number.
+ * @param predefinedKeys A list of predefined keys to save space for the tags/MapColumn field(s)
+ */
+@Deprecated
+final class RecordSchema(val columns: Seq[ColumnInfo],
+                         val partitionFieldStart: Option[Int] = None,
+                         val predefinedKeys: Seq[String] = Nil,
+                         val brSchema: Map[Int, RecordSchema] = Map.empty) {
+  import RecordSchema._
+  import BinaryRegion.NativePointer
+
+  override def toString: String = s"RecordSchema<$columns, $partitionFieldStart>"
+
+  val colNames = columns.map(_.name)
+  val columnTypes = columns.map(_.colType)
+  require(columnTypes.nonEmpty, "columnTypes cannot be empty")
+  require(predefinedKeys.length < 4096, "Too many predefined keys")
+  require(partitionFieldStart.isEmpty ||
+          partitionFieldStart.get < columnTypes.length, s"partitionFieldStart $partitionFieldStart is too high")
+
+  // Offset to fixed area for each field.  Extra elemnt at end is end of fixed size area / hash.
+  // Note: these offsets start at 4, after the length header
+  private val offsets = columnTypes.map(colTypeToFieldSize).scan(4)(_ + _).toArray
+
+  // Offset from BR start to beginning of variable area.  Also the minimum length of a BR.
+  val variableAreaStart = partitionFieldStart.map(x => 4).getOrElse(0) + offsets.last
+
+  val (predefKeyOffsets, predefKeyBytes, predefKeyNumMap) = makePredefinedStructures(predefinedKeys)
+
+  val numFields = columnTypes.length
+
+  // Typed, efficient functions, one for each field/column, to add to a RecordBuilder efficiently from a RowReader
+  // with no boxing or extra allocations involved
+  val builderAdders = columnTypes.zipWithIndex.map {
+    case (Column.ColumnType.LongColumn, colNo) =>
+      (row: RowReader, builder: RecordBuilder) => builder.addLong(row.getLong(colNo))
+    case (Column.ColumnType.TimestampColumn, colNo) =>
+      (row: RowReader, builder: RecordBuilder) => builder.addLong(row.getLong(colNo))
+    case (Column.ColumnType.DoubleColumn, colNo) =>
+      (row: RowReader, builder: RecordBuilder) => builder.addDouble(row.getDouble(colNo))
+    case (Column.ColumnType.HistogramColumn, colNo) =>
+      (row: RowReader, builder: RecordBuilder) => builder.addBlob(row.getHistogram(colNo).serialize())
+    case (Column.ColumnType.IntColumn, colNo) =>
+      (row: RowReader, builder: RecordBuilder) => builder.addInt(row.getInt(colNo))
+    case (Column.ColumnType.StringColumn, colNo) =>
+      // TODO: we REALLY need a better API than ZeroCopyUTF8String as it creates so much garbage
+      (row: RowReader, builder: RecordBuilder) => builder.addBlob(row.filoUTF8String(colNo))
+    case (Column.ColumnType.BinaryRecordColumn, colNo) =>
+      (row: RowReader, builder: RecordBuilder) =>
+        builder.addBlob(row.getBlobBase(colNo), row.getBlobOffset(colNo), row.getBlobNumBytes(colNo))
+    case (t: Column.ColumnType, colNo) =>
+      // TODO: add more efficient methods
+      (row: RowReader, builder: RecordBuilder) => builder.addSlowly(row.getAny(colNo))
+  }.toArray
+
+  def numColumns: Int = columns.length
+
+  def isTimeSeries: Boolean = columnTypes.length >= 1 &&
+    (columnTypes.head == LongColumn || columnTypes.head == TimestampColumn)
+
+  /**
+    * Offset to the fixed field primitive or pointer which are at the beginning of the BR
+    * @param index column number (and not column id)
+    */
+  def fieldOffset(index: Int): Int = offsets(index)
+
+  def numBytes(base: Any, offset: Long): Int = BinaryRegionLarge.numBytes(base, offset)
+
+  /**
+   * Retrieves the partition hash field from a BinaryRecord.  If partitionFieldStart is None, the results
+   * of this will be undefined.
+   */
+  def partitionHash(base: Any, offset: Long): Int = UnsafeUtils.getInt(base, offset + offsets.last)
+  def partitionHash(address: NativePointer): Int = UnsafeUtils.getInt(address + offsets.last)
+
+  /**
+   * Retrieves an Int from field # index.  No schema matching is done for speed - you must use this only when
+   * the columnType at that field is really an int.
+   */
+  def getInt(address: NativePointer, index: Int): Int = UnsafeUtils.getInt(address + offsets(index))
+  def getInt(base: Any, offset: Long, index: Int): Int = UnsafeUtils.getInt(base, offset + offsets(index))
+
+  /**
+   * Retrieves a Long from field # index.  No schema matching is done for speed - you must use this only when
+   * the columnType at that field is really a Long.
+   */
+  def getLong(address: NativePointer, index: Int): Long = UnsafeUtils.getLong(address + offsets(index))
+  def getLong(base: Any, offset: Long, index: Int): Long = UnsafeUtils.getLong(base, offset + offsets(index))
+
+  /**
+   * Retrieves a Double from field # index.  No schema matching is done for speed - you must use this only when
+   * the columnType at that field is really a Double.
+   */
+  def getDouble(address: NativePointer, index: Int): Double = UnsafeUtils.getDouble(address + offsets(index))
+  def getDouble(base: Any, offset: Long, index: Int): Double = UnsafeUtils.getDouble(base, offset + offsets(index))
+
+  /**
+   * Retrieves the value class for a native BinaryRecord UTF8 string field.  This should not result in any
+   * allocations so long as the severe restrictions for value classes are followed.  Don't use in a collection!
+   */
+  def utf8StringPointer(address: NativePointer, index: Int): UTF8StringMedium = {
+    val utf8Addr = address + UnsafeUtils.getInt(address + offsets(index))
+    new UTF8StringMedium(utf8Addr)
+  }
+
+  /**
+   * Extracts out the base, offset, length of a string/blob field.  Much preferable to using
+   * asJavaString/asZCUTF8Str methods due to not needing allocations.
+   */
+  def blobBase(base: Any, offset: Long, index: Int): Any = base
+  def blobOffset(base: Any, offset: Long, index: Int): Long =
+    offset + UnsafeUtils.getInt(base, offset + offsets(index)) + 2
+  def blobNumBytes(base: Any, offset: Long, index: Int): Int =
+    UTF8StringMedium.numBytes(base, offset + UnsafeUtils.getInt(base, offset + offsets(index)))
+
+  /**
+   * Sets an existing DirectBuffer to wrap around the given blob/UTF8/Histogram bytes, including the
+   * 2-byte length prefix.  Since the DirectBuffer is already allocated, this results in no new allocations.
+   * Could be used to efficiently retrieve blobs or histograms again and again.
+   */
+  def blobAsBuffer(base: Any, offset: Long, index: Int, buf: DirectBuffer): Unit = {
+    // Number of bytes to give out should not be beyond range of record
+    val blobLen = Math.min(numBytes(base, offset), blobNumBytes(base, offset, index) + 2)
+    base match {
+      case a: Array[Byte] =>
+        buf.wrap(a, utf8StringOffset(base, offset, index).toInt - UnsafeUtils.arayOffset, blobLen)
+      case UnsafeUtils.ZeroPointer =>
+        buf.wrap(utf8StringOffset(base, offset, index), blobLen)
+    }
+  }
+
+  // Same as above but allocates a new UnsafeBuffer wrapping the blob as a reference
+  def blobAsBuffer(base: Any, offset: Long, index: Int): DirectBuffer = {
+    val newBuf = new UnsafeBuffer(Array.empty[Byte])
+    blobAsBuffer(base, offset, index, newBuf)
+    newBuf
+  }
+
+  /**
+    * Used for extracting the offset for a UTF8StringMedium.
+    * Note that blobOffset method is for the offset to the actual blob bytes, not including length header.
+    */
+  def utf8StringOffset(base: Any, offset: Long, index: Int): Long =
+    offset + UnsafeUtils.getInt(base, offset + offsets(index))
+
+  /**
+   * COPIES the BinaryRecord field # index out as a new Java String on the heap.  Allocation + copying cost.
+   */
+  def asJavaString(base: Any, offset: Long, index: Int): String =
+    UTF8StringMedium.toString(base, offset + UnsafeUtils.getInt(base, offset + offsets(index)))
+
+  // TEMPorary: to be deprecated
+  def asZCUTF8Str(base: Any, offset: Long, index: Int): ZeroCopyUTF8String = {
+    val realOffset = offset + UnsafeUtils.getInt(base, offset + offsets(index))
+    new ZeroCopyUTF8String(base, realOffset + 2, UTF8StringMedium.numBytes(base, realOffset))
+  }
+  def asZCUTF8Str(address: NativePointer, index: Int): ZeroCopyUTF8String =
+    asZCUTF8Str(UnsafeUtils.ZeroPointer, address, index)
+
+  /**
+   * EXPENSIVE to do at server side. Creates a easy-to-read string
+   * representation of the contents of this BinaryRecord.
+   */
+  def stringify(base: Any, offset: Long): String = {
+    import Column.ColumnType._
+    val result = new ArrayBuffer[String]()
+    columnTypes.zipWithIndex.map {
+      case (IntColumn, i)    => result += s"${colNames(i)}=${getInt(base, offset, i)}"
+      case (LongColumn, i)   => result += s"${colNames(i)}=${getLong(base, offset, i)}"
+      case (DoubleColumn, i) => result += s"${colNames(i)}=${getDouble(base, offset, i)}"
+      case (StringColumn, i) => result += s"${colNames(i)}=${asJavaString(base, offset, i)}"
+      case (TimestampColumn, i) => result += s"${colNames(i)}=${getLong(base, offset, i)}"
+      case (MapColumn, i)    => val consumer = new StringifyMapItemConsumer
+                                consumeMapItems(base, offset, i, consumer)
+                                result += s"${colNames(i)}=${consumer.prettyPrint}"
+      case (BinaryRecordColumn, i)  => result += s"${colNames(i)}=${brSchema(i).stringify(base, offset)}"
+      case (HistogramColumn, i) =>
+        result += s"${colNames(i)}= ${bv.BinaryHistogram.BinHistogram(blobAsBuffer(base, offset, i))}"
+    }
+    s"b2[${result.mkString(",")}]"
+  }
+
+  def stringify(address: NativePointer): String = stringify(UnsafeUtils.ZeroPointer, address)
+  def stringify(bytes: Array[Byte]): String = stringify(bytes, UnsafeUtils.arayOffset)
+
+  /**
+    * EXPENSIVE to do at server side. Creates a stringified map with contents of this BinaryRecord.
+    */
+  def toStringPairs(base: Any, offset: Long): Seq[(String, String)] = {
+    import Column.ColumnType._
+    val resultMap = new collection.mutable.ArrayBuffer[(String, String)]()
+    columnTypes.zipWithIndex.map {
+      case (IntColumn, i)    => resultMap += ((colNames(i), getInt(base, offset, i).toString))
+      case (LongColumn, i)   => resultMap += ((colNames(i), getLong(base, offset, i).toString))
+      case (DoubleColumn, i) => resultMap += ((colNames(i), getDouble(base, offset, i).toString))
+      case (StringColumn, i) => resultMap += ((colNames(i), asJavaString(base, offset, i).toString))
+      case (TimestampColumn, i) => resultMap += ((colNames(i), getLong(base, offset, i).toString))
+      case (MapColumn, i)    => val consumer = new StringifyMapItemConsumer
+                                consumeMapItems(base, offset, i, consumer)
+                                resultMap ++= consumer.stringPairs
+      case (BinaryRecordColumn, i)  => resultMap ++= brSchema(i).toStringPairs(base, offset)
+      case (HistogramColumn, i) =>
+        resultMap += ((colNames(i), bv.BinaryHistogram.BinHistogram(blobAsBuffer(base, offset, i)).toString))
+    }
+    resultMap
+  }
+
+  /**
+   * Iterates through each key/value pair of a MapColumn field without any object allocations.
+   * How is this done?  By calling the consumer for each pair and directly passing the base and offset.
+   * The consumer would use the UTF8StringMedium object to work with the UTF8String blobs.
+   *
+   * TODO: have a version of consumer that is passed the value class if both key and value are offheap.
+   * This can only be done however if we move the predefined keys offheap.
+   */
+  def consumeMapItems(base: Any, offset: Long, index: Int, consumer: MapItemConsumer): Unit = {
+    val mapOffset = offset + UnsafeUtils.getInt(base, offset + offsets(index))
+    val mapNumBytes = UnsafeUtils.getInt(base, mapOffset)
+    var curOffset = mapOffset + 4
+    val endOffset = curOffset + mapNumBytes
+    var itemIndex = 0
+    while (curOffset < endOffset) {
+      // Read key length.  Is it a predefined key?
+      val keyLen = UnsafeUtils.getShort(base, curOffset) & 0x0FFFF
+      val keyIndex = keyLen ^ 0x0F000
+      if (keyIndex < 0x1000) {   // predefined key; no key bytes
+        consumer.consume(predefKeyBytes, predefKeyOffsets(keyIndex), base, curOffset + 2, itemIndex)
+        curOffset += 4 + (UnsafeUtils.getShort(base, curOffset + 2) & 0x0FFFF)
+      } else {
+        consumer.consume(base, curOffset, base, curOffset + 2 + keyLen, itemIndex)
+        curOffset += 4 + keyLen + (UnsafeUtils.getShort(base, curOffset + 2 + keyLen) & 0x0FFFF)
+      }
+      itemIndex += 1
+    }
+  }
+
+  /**
+    * Returns the offset from start of the BinaryRecord to the
+    * UTF8StringMedium (2 byte length header + UTF8 string bytes)
+    */
+  def getStringOffset(base: Any, offset: Long, index: Int): Int = {
+    UnsafeUtils.getInt(base, offset + offsets(index))
+  }
+
+  def consumeMapItems(address: NativePointer, index: Int, consumer: MapItemConsumer): Unit =
+    consumeMapItems(UnsafeUtils.ZeroPointer, address, index, consumer)
+
+  /**
+   * Returns true if the two BinaryRecords are equal
+   */
+  def equals(base1: Any, offset1: Long, base2: Any, offset2: Long): Boolean =
+    BinaryRegionLarge.equals(base1, offset1, base2, offset2)
+  def equals(record1: NativePointer, record2: NativePointer): Boolean =
+    BinaryRegionLarge.equals(UnsafeUtils.ZeroPointer, record1, UnsafeUtils.ZeroPointer, record2)
+
+  /**
+   * Returns the BinaryRecordv2 as its own byte array, copying if needed
+   */
+  def asByteArray(base: Any, offset: Long): Array[Byte] = base match {
+    case a: Array[Byte] if offset == UnsafeUtils.arayOffset => a
+    case other: Any              => BinaryRegionLarge.asNewByteArray(base, offset)
+    case UnsafeUtils.ZeroPointer => BinaryRegionLarge.asNewByteArray(base, offset)
+  }
+  def asByteArray(address: NativePointer): Array[Byte] = asByteArray(UnsafeUtils.ZeroPointer, address)
+
+  /**
+   * Allows us to compare two RecordSchemas against each other
+   */
+  override def equals(other: Any): Boolean = other match {
+    case r: RecordSchema => columnTypes == r.columnTypes &&
+                            partitionFieldStart == r.partitionFieldStart &&
+                            predefinedKeys == r.predefinedKeys
+    case other: Any      => false
+  }
+
+  override def hashCode: Int = ((columnTypes.hashCode * 31) + partitionFieldStart.hashCode) * 31 +
+                               predefinedKeys.hashCode
+
+  import debox.{Map => DMap}   // An unboxed, fast Map
+
+  private def makePredefinedStructures(predefinedKeys: Seq[String]): (Array[Long], Array[Byte], DMap[Long, Int]) = {
+    // Convert predefined keys to UTF8StringMediums.  First estimate size they would all take.
+    val totalNumBytes = predefinedKeys.map(_.length + 2).sum
+    val stringBytes = new Array[Byte](totalNumBytes)
+    val keyToNum = DMap.empty[Long, Int]
+    var index = 0
+    val offsets = predefinedKeys.scanLeft(UnsafeUtils.arayOffset.toLong) { case (offset, str) =>
+                    val bytes = str.getBytes
+                    UTF8StringMedium.copyByteArrayTo(bytes, stringBytes, offset)
+                    keyToNum(makeKeyKey(bytes)) = index
+                    index += 1
+                    offset + bytes.size + 2
+                  }.toArray
+    (offsets, stringBytes, keyToNum)
+  }
+
+  // For serialization purposes
+  private[filodb] def toSerializableTuple: (Seq[ColumnInfo], Option[Int], Seq[String], Map[Int, RecordSchema]) =
+    (columns, partitionFieldStart, predefinedKeys, brSchema)
+}
+
+@Deprecated
+trait MapItemConsumer {
+  /**
+   * Invoked for each key and value pair.  The (base, offset) points to a UTF8StringMedium, use that objects
+   * methods to work with each UTF8 string.
+   * @param (keyBase,keyOffset) pointer to the key UTF8String
+   * @param (valueBase, valueOffset) pointer to the value UTF8String
+   * @param index an increasing index of the pair within the map, starting at 0
+   */
+  def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit
+}
+
+/**
+ * A MapItemConsumer which turns the key and value pairs into strings
+ */
+@Deprecated
+class StringifyMapItemConsumer extends MapItemConsumer {
+  val stringPairs = new collection.mutable.ArrayBuffer[(String, String)]
+  def prettyPrint: String = "{" + stringPairs.map { case (k, v) => s"$k: $v" }.mkString(", ") + "}"
+  def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
+    stringPairs += (UTF8StringMedium.toString(keyBase, keyOffset) ->
+                    UTF8StringMedium.toString(valueBase, valueOffset))
+  }
+}
+
+@Deprecated
+object RecordSchema {
+  import Column.ColumnType._
+
+  val colTypeToFieldSize = Map[Column.ColumnType, Int](IntColumn -> 4,
+                                                       LongColumn -> 8,
+                                                       DoubleColumn -> 8,
+                                                       TimestampColumn -> 8,  // Just a long ms timestamp
+                                                       StringColumn -> 4,
+                                                       BinaryRecordColumn -> 4,
+                                                       MapColumn -> 4,
+                                                       HistogramColumn -> 4)
+
+  /**
+   * Creates a "unique" Long key for each incoming predefined key for quick lookup.  This will not be perfect
+   * but probably good enough for the beginning.
+   * TODO: improve on this.  One reason for difficulty is that we need custom hashCode and equals functions and
+   * we don't want to box.
+   * In the output, the lower 32 bits is the hashcode of the bytes.
+   */
+  private[binaryrecord] def makeKeyKey(strBytes: Array[Byte]): Long = {
+    val hash = BinaryRegion.hasher32.hash(strBytes, 0, strBytes.size, BinaryRegion.Seed)
+    (UnsafeUtils.getInt(strBytes, UnsafeUtils.arayOffset).toLong << 32) | hash
+  }
+
+  private[binaryrecord] def makeKeyKey(strBytes: Array[Byte], index: Int, len: Int, keyHash: Int): Long = {
+    val hash = if (keyHash != 7) { keyHash }
+               else { BinaryRegion.hasher32.hash(strBytes, index, len, BinaryRegion.Seed) }
+    (UnsafeUtils.getInt(strBytes, index + UnsafeUtils.arayOffset).toLong << 32) | hash
+  }
+
+  /**
+   * Create an "ingestion" RecordSchema with the data columns followed by the partition columns.
+   */
+  def ingestion(dataset: Dataset, predefinedKeys: Seq[String] = Nil): RecordSchema = {
+    val columns = dataset.dataColumns ++ dataset.partitionColumns
+    new RecordSchema(columns.map(c => ColumnInfo(c.name, c.columnType)),
+                     Some(dataset.dataColumns.length),
+                     predefinedKeys)
+  }
+
+  def fromSerializableTuple(tuple: (Seq[ColumnInfo],
+                                    Option[Int], Seq[String], Map[Int, RecordSchema])): RecordSchema =
+    new RecordSchema(tuple._1, tuple._2, tuple._3, tuple._4)
+}
+
+// Used with PartitionTimeRangeReader, when a user queries for a partition column
+@Deprecated
+final class PartKeyUTF8Iterator(schema: RecordSchema, base: Any, offset: Long, fieldNo: Int) extends bv.UTF8Iterator {
+  val blob = schema.asZCUTF8Str(base, offset, fieldNo)
+  final def next: ZeroCopyUTF8String = blob
+}
+
+@Deprecated
+final class PartKeyLongIterator(schema: RecordSchema, base: Any, offset: Long, fieldNo: Int) extends bv.LongIterator {
+  val num = schema.getLong(base, offset, fieldNo)
+  final def next: Long = num
+}
+
+/**
+ * This is a class meant to provide a RowReader API for the new BinaryRecord v2.
+ * NOTE: Strings cause an allocation of a ZeroCopyUTF8String instance.  TODO: provide a better API that does
+ * not result in allocations.
+ * It is meant to be reused again and again and is MUTABLE.
+ */
+@Deprecated
+final class BinaryRecordRowReader(schema: RecordSchema,
+                                  var recordBase: Any = UnsafeUtils.ZeroPointer,
+                                  var recordOffset: Long = 0L) extends RowReader {
+  // BinaryRecordV2 fields always have a value
+  def notNull(columnNo: Int): Boolean = columnNo >= 0 && columnNo < schema.numFields
+  def getBoolean(columnNo: Int): Boolean = schema.getInt(recordBase, recordOffset, columnNo) != 0
+  def getInt(columnNo: Int): Int = schema.getInt(recordBase, recordOffset, columnNo)
+  def getLong(columnNo: Int): Long = schema.getLong(recordBase, recordOffset, columnNo)
+  def getDouble(columnNo: Int): Double = schema.getDouble(recordBase, recordOffset, columnNo)
+  def getFloat(columnNo: Int): Float = ???
+  def getString(columnNo: Int): String = filoUTF8String(columnNo).toString
+  override def getHistogram(columnNo: Int): bv.Histogram =
+    bv.BinaryHistogram.BinHistogram(blobAsBuffer(columnNo)).toHistogram
+  def getAny(columnNo: Int): Any = schema.columnTypes(columnNo).keyType.extractor.getField(this, columnNo)
+  override def filoUTF8String(i: Int): ZeroCopyUTF8String = schema.asZCUTF8Str(recordBase, recordOffset, i)
+
+  def getBlobBase(columnNo: Int): Any = schema.blobBase(recordBase, recordOffset, columnNo)
+  def getBlobOffset(columnNo: Int): Long = schema.blobOffset(recordBase, recordOffset, columnNo)
+  def getBlobNumBytes(columnNo: Int): Int = schema.blobNumBytes(recordBase, recordOffset, columnNo)
+
+  val buf = new UnsafeBuffer(Array.empty[Byte])
+  // NOTE: this method reuses the same buffer to avoid allocations.
+  override def blobAsBuffer(columnNo: Int): DirectBuffer = {
+    UnsafeUtils.wrapDirectBuf(recordBase, schema.utf8StringOffset(recordBase, recordOffset, columnNo),
+                              getBlobNumBytes(columnNo) + 2, buf)
+    buf
+  }
+}

--- a/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
@@ -10,6 +10,8 @@ import filodb.core.metadata.Dataset
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String => ZCUTF8}
 
 /**
+ * WARNING: THIS CLASS IS DEPRECATED!! ADDED TO SUPPORT BACKWARD COMPATIBILITY FOR MULTI-SCHEMA.
+ *
  * An InputRecord represents one "record" of timeseries data for input to FiloDB system.
  * It knows how to extract the information necessary for shard calculation as well as
  * how to add the right fields to the RecordBuilder.

--- a/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
@@ -1,0 +1,162 @@
+package filodb.gateway.legacy.conversion
+
+import scala.language.postfixOps
+
+import remote.RemoteStorage.TimeSeries
+import scalaxy.loops._
+
+import filodb.core.legacy.binaryrecord.RecordBuilder
+import filodb.core.metadata.Dataset
+import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String => ZCUTF8}
+
+/**
+ * An InputRecord represents one "record" of timeseries data for input to FiloDB system.
+ * It knows how to extract the information necessary for shard calculation as well as
+ * how to add the right fields to the RecordBuilder.
+ */
+@Deprecated
+trait InputRecord {
+  /**
+   * The shardKeyHash and partitionKeyHash for ShardMappers.ingestionShard method
+   */
+  def shardKeyHash: Int
+  def partitionKeyHash: Int
+
+  /**
+   * The values for each of the tag keys found in DatasetOptions.nonMetricShardColumns
+   * @return the nonMetricShardColumns tag values, in the same order as nonMetricShardColumns
+   *         If any tag/key is not found, then the Seq will be truncated at the last found value.
+   */
+  def nonMetricShardValues: Seq[String]
+
+  // This is the metric value needed for shard spread calculation
+  def getMetric: String
+
+  /**
+   * Adds the contents of this record to RecordBuilder as one or more Filo records
+   */
+  def addToBuilder(builder: RecordBuilder): Unit
+}
+
+/**
+ * A Prometheus-format time series input record.
+ * Logic in here does the following conversions:
+ * - Shard/partition hashes are calculated scuh that histogram time series go to the same shard.
+ *   IE _bucket _sum _count are stripped off of all metric names.
+ *   Similarly "le" is stripped off of Prom tags for shard calculation purposes
+ * shardKeys in tags are used to compute the shardKeyHash, all other tags are used to compute
+ * the partition key hash.
+ * The tags should NOT include the metric name.
+ */
+@Deprecated
+case class PrometheusInputRecord(tags: Map[String, String],
+                                 metric: String,
+                                 dataset: Dataset,
+                                 timestamp: Long,
+                                 value: Double) extends InputRecord {
+  import collection.JavaConverters._
+
+  val trimmedMetric = RecordBuilder.trimShardColumn(dataset, dataset.options.metricColumn, metric)
+  val javaTags = new java.util.ArrayList(tags.toSeq.asJava)
+
+  // Get hashes and sort tags of the keys/values for shard calculation
+  val hashes = RecordBuilder.sortAndComputeHashes(javaTags)
+
+  final def shardKeyHash: Int = RecordBuilder.shardKeyHash(nonMetricShardValues, trimmedMetric)
+  final def partitionKeyHash: Int = RecordBuilder.combineHashExcluding(javaTags, hashes,
+                                                    dataset.options.ignorePartKeyHashTags)
+
+  val nonMetricShardValues: Seq[String] = dataset.options.nonMetricShardColumns.flatMap(tags.get)
+  final def getMetric: String = metric
+
+  final def addToBuilder(builder: RecordBuilder): Unit = {
+    builder.startNewRecord()
+    builder.addLong(timestamp)
+    builder.addDouble(value)
+    builder.startMap()
+    val metricBytes = metric.getBytes
+    builder.addMapKeyValueHash(dataset.options.metricBytes, dataset.options.metricHash,
+                               metricBytes, 0, metricBytes.size)
+    for { i <- 0 until javaTags.size optimized } {
+      val (k, v) = javaTags.get(i)
+      builder.addMapKeyValue(k.getBytes, v.getBytes)
+      builder.updatePartitionHash(hashes(i))
+    }
+    builder.endMap(bulkHash = false)
+
+    builder.endRecord()
+  }
+}
+
+@Deprecated
+object PrometheusInputRecord {
+  val DefaultShardHash = -1
+
+  // Create PrometheusInputRecords from a TimeSeries protobuf object
+  def apply(tsProto: TimeSeries, dataset: Dataset): Seq[PrometheusInputRecord] = {
+    val tags = (0 until tsProto.getLabelsCount).map { i =>
+      val labelPair = tsProto.getLabels(i)
+      (labelPair.getName, labelPair.getValue)
+    }
+    val metricTags = tags.filter(_._1 == dataset.options.metricColumn)
+    if (metricTags.isEmpty) {
+      Nil
+    } else {
+      val metric = metricTags.head._2
+      val transformedTags = transformTags(tags.filterNot(_._1 == dataset.options.metricColumn), dataset)
+      (0 until tsProto.getSamplesCount).map { i =>
+        val sample = tsProto.getSamples(i)
+        PrometheusInputRecord(transformedTags, metric, dataset, sample.getTimestampMs, sample.getValue)
+      }
+    }
+  }
+
+  /**
+   * Uses DatasetOptions.copyTags to copy missing tags.
+   * If a tag in copyTags is found and the destination tag is missing, then the destination tag is created
+   * with the value from the source tag.
+   */
+  def transformTags(tags: Seq[(String, String)], dataset: Dataset): Map[String, String] = {
+    val extraTags = new collection.mutable.HashMap[String, String]()
+    val tagsMap = tags.toMap
+    for ((k, v) <- dataset.options.copyTags) {
+      if (!extraTags.contains(v)
+        && !tagsMap.contains(v)
+        && tagsMap.contains(k)) {
+        extraTags += v -> tagsMap(k)
+      }
+    }
+    tagsMap ++ extraTags
+  }
+}
+
+/**
+ * A generic InputRecord that can serve different data schemas, so long as the partition key consists of:
+ *  - a single metric StringColumn
+ *  - a MapColumn of tags
+ *
+ * Can be used to adapt custom dataset/schemas for input into FiloDB using the gateway.
+ * Not going to be the fastest InputRecord but extremely flexible.
+ *
+ * @param values the data column values, first one is probably timestamp
+ */
+@Deprecated
+class MetricTagInputRecord(values: Seq[Any],
+                           metric: String,
+                           tags: Map[ZCUTF8, ZCUTF8],
+                           dataset: Dataset) extends InputRecord {
+  final def shardKeyHash: Int = RecordBuilder.shardKeyHash(nonMetricShardValues, metric)
+  // NOTE: this is probably not very performant right now.
+  final def partitionKeyHash: Int = tags.hashCode
+
+  val nonMetricShardValues: Seq[String] =
+    dataset.options.nonMetricShardKeyUTF8.flatMap(tags.get).map(_.toString).toSeq
+  final def getMetric: String = metric
+
+  def addToBuilder(builder: RecordBuilder): Unit = {
+    require(builder.schema == dataset.ingestionSchema)
+
+    val reader = SeqRowReader(values :+ metric :+ tags)
+    builder.addFromReader(reader)
+  }
+}


### PR DESCRIPTION
Need to keep old RecordContainer around for sometime to support backward compatibility stories. Hence, copied the RecordContainer and related classes from master branch to a new `legacy` package.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Changes are manually tested in a local gateway and filodb is able to consume the same.