### PR TITLE
Add metadata span checks and don't add the first block until it's requested.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -262,7 +262,6 @@ class TimeSeriesShard(val ref: DatasetRef,
 
   /**
    * The maximum blockMetaSize amongst all the schemas this Dataset could ingest
-   * TODO: actually compute the max
    */
   val maxMetaSize = schemas.schemas.values.map(_.data.blockMetaSize).max
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -372,8 +372,10 @@ object MachineMetricsData {
   val histPartKey = histKeyBuilder.partKeyFromObjects(histDataset.schema, "request-latency", extraTags)
 
   val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024, new MemoryStats(Map("test"-> "test")), null, 16)
-  private val histIngestBH = new BlockMemFactory(blockStore, None, histDataset.schema.data.blockMetaSize,
-                                                 dummyContext, true)
+  val histIngestBH = new BlockMemFactory(blockStore, None, histDataset.schema.data.blockMetaSize,
+                                         dummyContext, true)
+  val histMaxBH = new BlockMemFactory(blockStore, None, histMaxDS.schema.data.blockMetaSize,
+                                      dummyContext, true)
   private val histBufferPool = new WriteBufferPool(TestData.nativeMem, histDataset.schema.data, TestData.storeConf)
 
   // Designed explicitly to work with linearHistSeries records and histDataset from MachineMetricsData
@@ -397,9 +399,9 @@ object MachineMetricsData {
     val histData = histMax(linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets)).take(numSamples)
     val container = records(histMaxDS, histData).records
     val part = TimeSeriesPartitionSpec.makePart(0, histMaxDS, partKey=histPartKey, bufferPool=histMaxBP)
-    container.iterate(histMaxDS.ingestionSchema).foreach { row => part.ingest(0, row, histIngestBH) }
+    container.iterate(histMaxDS.ingestionSchema).foreach { row => part.ingest(0, row, histMaxBH) }
     // Now flush and ingest the rest to ensure two separate chunks
-    part.switchBuffers(histIngestBH, encode = true)
+    part.switchBuffers(histMaxBH, encode = true)
     // Select timestamp, hist, max
     (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 4, 3)))
   }

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -225,8 +225,9 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
     val part = rv.partition.asInstanceOf[TimeSeriesPartition]
     val dropData = data.map(d => (d.head.asInstanceOf[Long] + 70000L) +: d.drop(1))
     val container = MachineMetricsData.records(promHistDS, dropData).records
-    container.iterate(promHistDS.ingestionSchema).foreach { row => part.ingest(0, row, ingestBlockHolder) }
-    part.switchBuffers(ingestBlockHolder, encode = true)
+    val bh = MachineMetricsData.histIngestBH
+    container.iterate(promHistDS.ingestionSchema).foreach { row => part.ingest(0, row, bh) }
+    part.switchBuffers(bh, encode = true)
 
 
     val startTs = 99500L


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Sometimes a call to endMetaSpan causes an OutOfOffheapMemoryException to be thrown.

**New behavior :**
Add metadata span checks and don't add the first block until it's requested. This ensures that it has enough room for metadata.