### PR TITLE
misc(query):  add metric column as parameter to Binary Join Execs

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -280,10 +280,10 @@ class QueryEngine(dsRef: DatasetRef,
     val targetActor = pickDispatcher(stitchedLhs ++ stitchedRhs)
     val joined = if (lp.operator.isInstanceOf[SetOperator])
       Seq(exec.SetOperatorExec(queryId, targetActor, stitchedLhs, stitchedRhs, lp.operator,
-        lp.on, lp.ignoring))
+        lp.on, lp.ignoring, dsOptions.metricColumn))
     else
       Seq(BinaryJoinExec(queryId, targetActor, stitchedLhs, stitchedRhs, lp.operator, lp.cardinality,
-        lp.on, lp.ignoring, lp.include))
+        lp.on, lp.ignoring, lp.include, dsOptions.metricColumn))
     PlanResult(joined, false)
   }
 

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -34,12 +34,13 @@ final case class SetOperatorExec(id: String,
                                 rhs: Seq[ExecPlan],
                                 binaryOp: BinaryOperator,
                                 on: Seq[String],
-                                ignoring: Seq[String]) extends NonLeafExecPlan {
+                                ignoring: Seq[String],
+                                 metricColumn: String) extends NonLeafExecPlan {
   require(on == Nil || ignoring == Nil, "Cannot specify both 'on' and 'ignoring' clause")
-  require(!on.contains("__name__"), "On cannot contain metric name")
+  require(!on.contains(metricColumn), "On cannot contain metric name")
 
   val onLabels = on.map(Utf8Str(_)).toSet
-  val ignoringLabels = ignoring.map(Utf8Str(_)).toSet + "__name__".utf8
+  val ignoringLabels = ignoring.map(Utf8Str(_)).toSet + metricColumn.utf8
   // if onLabels is non-empty, we are doing matching based on on-label, otherwise we are
   // doing matching based on ignoringLabels even if it is empty
   val onMatching = onLabels.nonEmpty

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -258,7 +258,6 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
   }
   it("should join one-to-one when metric name is not _name_") {
 
-
     val execPlan = BinaryJoinExec("someID", dummyDispatcher,
       Array(dummyPlan),       // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -89,7 +89,7 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Nil, Nil)
+      Nil, Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema)))
@@ -119,7 +119,7 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Nil, Nil)
+      Nil, Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema)))
@@ -156,7 +156,7 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Seq("tag1"), Nil)
+      Nil, Seq("tag1"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema)))
@@ -182,12 +182,12 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
 
     val samplesLhs2 = scala.util.Random.shuffle(duplicate +: samplesLhs.toList) // they may come out of order
 
-    val execPlan = BinaryJoinExec("someID", dummyDispatcher,
+    val execPlan = BinaryJoinExec("some ID", dummyDispatcher,
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Seq("tag1"), Nil)
+      Nil, Seq("tag1"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs2.map(rv => SerializableRangeVector(rv, schema)))
@@ -207,7 +207,7 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Seq("tag2"), Nil)
+      Nil, Seq("tag2"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializableRangeVector(rv, schema)))
@@ -236,7 +236,7 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Seq("tag1", "job"), Nil, Nil)
+      Seq("tag1", "job"), Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializableRangeVector(rv, schema)))

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -118,7 +118,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
-      Seq("instance"), Nil, Seq("role"))
+      Seq("instance"), Nil, Seq("role"), "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializableRangeVector(rv, schema)))
@@ -153,7 +153,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1),
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
-      Nil,  Seq("role", "mode"), Seq("role"))
+      Nil,  Seq("role", "mode"), Seq("role"), "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializableRangeVector(rv, schema)))
@@ -193,7 +193,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1),
       BinaryOperator.DIV,
       Cardinality.ManyToOne,
-      Seq("instance"), Nil, Nil)
+      Seq("instance"), Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializableRangeVector(rv, schema)))
@@ -238,7 +238,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
       BinaryOperator.MUL,
       Cardinality.OneToMany,
       Nil, Seq("role"),
-      Seq("role"))
+      Seq("role"), "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeRole.map(rv => SerializableRangeVector(rv, schema)))
@@ -272,7 +272,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1),
       BinaryOperator.DIV,
       Cardinality.ManyToOne, Nil,
-      Seq("mode"), Seq("dummy"))
+      Seq("mode"), Seq("dummy"), "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializableRangeVector(rv, schema)))

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -181,7 +181,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Nil)
+      Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleCanary.map(rv => SerializableRangeVector(rv, schema)))
@@ -216,7 +216,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Nil)
+      Nil, Nil, "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -253,7 +253,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Seq("instance", "job"), Nil)
+      Seq("instance", "job"), Nil, "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -290,7 +290,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Seq("instance"), Nil)
+      Seq("instance"), Nil, "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -326,7 +326,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Seq("group"))
+      Nil, Seq("group"), "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -361,7 +361,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Seq("group", "job"))
+      Nil, Seq("group", "job"), "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -396,7 +396,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Seq("dummy"), Nil)
+      Seq("dummy"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleHttpRequests.map(rv => SerializableRangeVector(rv, schema)))
@@ -418,7 +418,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Seq("group", "instance", "job"))
+      Nil, Seq("group", "instance", "job"), "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleHttpRequests.map(rv => SerializableRangeVector(rv, schema)))
@@ -440,7 +440,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil)
+      Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleCanary.map(rv => SerializableRangeVector(rv, schema)))
@@ -468,7 +468,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil)
+      Nil, Nil, "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -528,7 +528,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil)
+      Nil, Nil, "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -543,7 +543,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Seq("instance"), Nil)
+      Seq("instance"), Nil, "__name__")
 
     // scalastyle:off
     val lhs2 = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -599,7 +599,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil)
+      Nil, Nil, "__name__")
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), queryConfig, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -614,7 +614,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Seq("l", "group", "job"))
+      Nil, Seq("l", "group", "job"), "__name__")
 
     // scalastyle:off
     val lhs2 = QueryResult("someId", null, canaryPlusOne.map(rv => SerializableRangeVector(rv, schema)))
@@ -669,7 +669,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Nil, Nil)
+      Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleCanary.map(rv => SerializableRangeVector(rv, schema)))
@@ -703,7 +703,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job"), Nil)
+      Seq("job"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleCanary.map(rv => SerializableRangeVector(rv, schema)))
@@ -734,7 +734,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job", "instance"), Nil)
+      Seq("job", "instance"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleCanary.map(rv => SerializableRangeVector(rv, schema)))
@@ -769,7 +769,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job"), Nil)
+      Seq("job"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleCanary.map(rv => SerializableRangeVector(rv, schema)))
@@ -801,7 +801,7 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job", "instance"), Nil)
+      Seq("job", "instance"), Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleCanary.map(rv => SerializableRangeVector(rv, schema)))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Metric column is always` __name__` in Binary Join

**New behavior :**
Metric column of dataset options is used






