### PR TITLE
feat(cass): Faster Cassandra reads for raw partition data

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -153,12 +153,14 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     * Reads chunks by querying partitions by ingestion time range and subsequently filtering by user time range.
     * ** User/Ingestion End times are exclusive **
     */
+  // scalastyle:off parameter.number
   def getChunksByIngestionTimeRange(datasetRef: DatasetRef,
                                     splits: Iterator[ScanSplit],
                                     ingestionTimeStart: Long,
                                     ingestionTimeEnd: Long,
                                     userTimeStart: Long,
                                     userTimeEnd: Long,
+                                    maxChunkTime: Long,
                                     batchSize: Int,
                                     batchTime: FiniteDuration): Observable[Seq[RawPartData]] = {
     val partKeys = Observable.fromIterator(splits).flatMap {
@@ -178,7 +180,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
         s"userTimeEnd=$userTimeEnd")
       // TODO evaluate if we can increase parallelism here. This needs to be tuneable
       // based on how much faster downsampling should run, and how much additional read load cassandra can take.
-      chunksTable.readRawPartitionRangeBB(parts, userTimeStart, userTimeEnd).toIterator().toSeq
+      chunksTable.readRawPartitionRangeBB(parts, userTimeStart - maxChunkTime, userTimeEnd).toIterator().toSeq
     }
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -305,8 +305,9 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
           case SinglePartitionScan(p, _) => Seq(p)
           case p => throw new UnsupportedOperationException(s"PartitionScan $p to be implemented later")
         }
-        val startTime = if (chunkMethod == AllChunkScan) Long.MinValue else chunkMethod.startTime - maxChunkTime
-        chunkTable.readRawPartitionRange(partitions, startTime, chunkMethod.endTime)
+        val (start, end) = if (chunkMethod == AllChunkScan) (minChunkUserTime, maxChunkUserTime)
+                           else (chunkMethod.startTime - maxChunkTime, chunkMethod.endTime)
+        chunkTable.readRawPartitionRange(partitions, start, end)
     }
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -305,7 +305,7 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
     * relevant data but may have a startTime outside the query range.
     *
     * @param ref dataset ref
-    * @param maxChunkTime maximum userTime allowed in a single chunk. This restriction makes it
+    * @param maxChunkTime maximum userTime (in millis) allowed in a single chunk. This restriction makes it
     *                     possible to issue single CQL query to fetch all relevant chunks from cassandra
     * @param partMethod selector for partitions
     * @param chunkMethod selector for chunks

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -114,7 +114,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
     val query = readChunkRangeCql.bind().setList(0, partitions.asJava, classOf[ByteBuffer])
                                         .setLong(1, chunkID(startTime, 0))
                                         .setLong(2, chunkID(endTimeExclusive, 0))
-    val futRawParts = session.executeAsync(query)
+    val futRawParts: Future[Iterator[RawPartData]] = session.executeAsync(query)
                              .toIterator.handleErrors
                              .map { rowIt =>
                                rowIt.map { row => (row.getBytes(0), chunkSetFromRow(row, 1)) }
@@ -123,7 +123,10 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
                                    RawPartData(partKeyBuffer.array, chunkSetIt.map(_._2).toBuffer)
                                  }
                              }
-    Observable.fromFuture(futRawParts).flatMap { it: Iterator[RawPartData] => Observable.fromIterator(it) }
+    for {
+      it <- Observable.fromFuture(futRawParts)
+      rpd <- Observable.fromIterator(it)
+    } yield rpd
   }
 
   def scanPartitionsBySplit(tokens: Seq[(String, String)]): Observable[RawPartData] = {
@@ -139,7 +142,12 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
                   }
               }
     }
-    res.flatMap{ f => Observable.fromFuture(f).flatMap { it: Iterator[RawPartData] => Observable.fromIterator(it) } }
+
+    for {
+      fut <- res
+      it <- Observable.fromFuture(fut)
+      rpd <- Observable.fromIterator(it)
+    } yield rpd
   }
 
 

--- a/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
@@ -1,5 +1,7 @@
 package filodb.cassandra
 
+import scala.concurrent.duration._
+
 import monix.reactive.Observable
 
 import filodb.core._
@@ -55,7 +57,7 @@ class MemstoreCassandraSinkSpec extends AllTablesTest {
     // Verify data is in Cassandra ... but only groups 0, 1 which has following partitions:
     // Series 3, Series 4, Series 8, Series 9
     val splits2 = columnStore.getScanSplits(dataset1.ref, 1)
-    val rawParts = columnStore.readRawPartitions(dataset1.ref, FilteredPartitionScan(splits2.head))
+    val rawParts = columnStore.readRawPartitions(dataset1.ref, 1.hour.toMillis, FilteredPartitionScan(splits2.head))
                               .toListL.runAsync.futureValue
     val writtenNums = (5 to 95 by 10) ++ (6 to 96 by 10) ++ (8 to 98 by 10)
     // Cannot check the result, because FilteredPartitionScan() will be broken until indices are implemented

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -1,5 +1,7 @@
 package filodb.cassandra.columnstore
 
+import scala.concurrent.duration._
+
 import com.typesafe.config.ConfigFactory
 
 import filodb.core._
@@ -41,7 +43,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
 
     val sourceChunks = chunkSetStream(names take 3).toListL.runAsync.futureValue
 
-    val parts = lz4ColStore.readRawPartitions(dataset.ref, partScan).toListL.runAsync.futureValue
+    val parts = lz4ColStore.readRawPartitions(dataset.ref, 0.millis.toMillis, partScan).toListL.runAsync.futureValue
     parts should have length (1)
     parts(0).chunkSets should have length (1)
     parts(0).chunkSets(0).vectors.toSeq shouldEqual sourceChunks.head.chunks

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -36,6 +36,11 @@
         # We need to have a minimum of x hours free blocks or else init won't work.
         demand-paged-chunk-retention-period = 12 hours
 
+        # maximum userTime range allowed in a single chunk. This needs to be longer than flush interval
+        # to ensure that normal flushes result in only one chunk.
+        # If not specified, max-chunk-time = 1.1 * flush-interval
+        # max-chunk-time = 66 minutes
+
         max-chunks-size = 400
 
         # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -27,7 +27,7 @@
       # Values controlling in-memory store chunking, flushing, etc.
       store {
         # Interval it takes to flush ALL time series in a shard.  This time is further divided by groups-per-shard
-        flush-interval = 1h
+        flush-interval = 2m
 
         # TTL for on-disk / C* data.  Data older than this may be purged.
         disk-time-to-live = 24 hours

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -92,9 +92,13 @@
       }
       downsample {
         # can be disabled by setting this flag to false
-        enabled = true
-        # array of integers representing one or more downsample intervals in millisecond
-        resolutions-ms = [ 60000 ]
+        enabled = false
+        # Resolutions for downsampled data ** in ascending order **
+        resolutions = [ 1 minute, 5 minutes ]
+        # Retention of downsampled data for the corresponding resolution
+        ttls = [ 30 days, 183 days ]
+        # Raw schemas from which to downsample
+        raw-schema-names = [ "gauge", "untyped" ]
         # class implementing the dispatch of downsample metrics to another dataset
         publisher-class = "filodb.kafka.KafkaDownsamplePublisher"
         publisher-config {

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -27,7 +27,7 @@
       # Values controlling in-memory store chunking, flushing, etc.
       store {
         # Interval it takes to flush ALL time series in a shard.  This time is further divided by groups-per-shard
-        flush-interval = 2m
+        flush-interval = 1h
 
         # TTL for on-disk / C* data.  Data older than this may be purged.
         disk-time-to-live = 24 hours

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -31,9 +31,6 @@ filodb {
 
   downsampler {
     raw-dataset-name = "prometheus"
-    raw-schema-names = [ "prom-counter", "untyped" ]
-    resolutions = [ 1 minute, 5 minutes ]
-    ttls = [ 30 days, 183 days ]
   }
 }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -206,15 +206,6 @@ filodb {
     # Name of the dataset from which to downsample
     # raw-dataset-name = "prometheus"
 
-    # Raw schemas from which to downsample
-    # raw-schema-names = [ "prometheus" ]
-
-    # Resolutions for downsampled data
-    # resolutions = [ 1 minute, 5 minutes ]
-
-    # Retention of downsampled data for the corresponding resolution
-    # ttls = [ 30 days, 183 days ]
-
     # Use to override cassandra Session Provider class name used by downsampler
     # cass-session-provider-fqcn = fqcn
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -7,10 +7,16 @@ import net.ceedubs.ficus.Ficus._
 
 final case class DownsampleConfig(config: Config) {
   val enabled = config.hasPath("enabled") && config.getBoolean("enabled")
-  val resolutions = config.as[Seq[FiniteDuration]]("resolutions")
-  val ttls = config.as[Array[FiniteDuration]]("ttls").map(_.toSeconds.toInt)
+
+  val resolutions = if (config.hasPath ("resolutions")) config.as[Seq[FiniteDuration]]("resolutions")
+                    else Seq.empty
+
+  val ttls = if (config.hasPath ("ttls")) config.as[Seq[FiniteDuration]]("ttls").map(_.toSeconds.toInt)
+             else Seq.empty
   require(resolutions.length == ttls.length)
-  val schemas = config.as[Seq[String]]("raw-schema-names")
+
+  val schemas = if (config.hasPath ("raw-schema-names")) config.as[Seq[String]]("raw-schema-names")
+                else Seq.empty
 
   def makePublisher(): DownsamplePublisher = {
     if (!enabled) {

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -1,11 +1,16 @@
 package filodb.core.downsample
 
+import scala.concurrent.duration.FiniteDuration
+
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 
 final case class DownsampleConfig(config: Config) {
   val enabled = config.hasPath("enabled") && config.getBoolean("enabled")
-  val resolutions = if (enabled) config.as[Seq[Int]]("resolutions-ms") else Seq.empty
+  val resolutions = config.as[Seq[FiniteDuration]]("resolutions")
+  val ttls = config.as[Array[FiniteDuration]]("ttls").map(_.toSeconds.toInt)
+  require(resolutions.length == ttls.length)
+  val schemas = config.as[Seq[String]]("raw-schema-names")
 
   def makePublisher(): DownsamplePublisher = {
     if (!enabled) {

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -100,7 +100,7 @@ TimeSeriesShard(ref, schemas, storeConfig, shardNum, bufferMemoryManager, rawSto
           val multiPart = MultiPartitionScan(partKeyBytesToPage, shardNum)
           if (partKeyBytesToPage.nonEmpty) {
             val span = startODPSpan()
-            rawStore.readRawPartitions(ref, multiPart, computeBoundingMethod(pagingMethods))
+            rawStore.readRawPartitions(ref, maxChunkTime, multiPart, computeBoundingMethod(pagingMethods))
               // NOTE: this executes the partMaker single threaded.  Needed for now due to concurrency constraints.
               // In the future optimize this if needed.
               .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
@@ -115,7 +115,7 @@ TimeSeriesShard(ref, schemas, storeConfig, shardNum, bufferMemoryManager, rawSto
             val span = startODPSpan()
             Observable.fromIterable(partKeyBytesToPage.zip(pagingMethods))
               .mapAsync(storeConfig.demandPagingParallelism) { case (partBytes, method) =>
-                rawStore.readRawPartitions(ref, SinglePartitionScan(partBytes, shardNum), method)
+                rawStore.readRawPartitions(ref, maxChunkTime, SinglePartitionScan(partBytes, shardNum), method)
                   .mapAsync { rawPart => partitionMaker.populateRawChunks(rawPart).executeOn(singleThreadPool) }
                   .asyncBoundary(strategy) // This is needed so future computations happen in a different thread
                   .defaultIfEmpty(getPartition(partBytes).get)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -191,7 +191,7 @@ extends MemStore with StrictLogging {
   def numPartitions(dataset: DatasetRef, shard: Int): Int =
     getShard(dataset, shard).map(_.numActivePartitions).getOrElse(-1)
 
-  def readRawPartitions(ref: DatasetRef,
+  def readRawPartitions(ref: DatasetRef, maxChunkTime: Long,
                         partMethod: PartitionScanMethod,
                         chunkMethod: ChunkScanMethod = AllChunkScan): Observable[RawPartData] = Observable.empty
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -129,10 +129,10 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
     if (newChunk) initNewChunk(ts, ingestionTime)
 
     if (ts - currentInfo.startTime > maxChunkTime) {
+      // we have reached maximum userTime in chunk. switch buffers, start a new chunk and ingest
       switchBuffersAndIngest(ingestionTime, ts, row, blockHolder, maxChunkTime)
     } else {
-
-      for {col <- 0 until schema.numDataColumns optimized} {
+      for { col <- 0 until schema.numDataColumns optimized} {
         currentChunks(col).addFromReaderNoNA(row, col) match {
           case r: VectorTooSmall =>
             switchBuffersAndIngest(ingestionTime, ts, row, blockHolder, maxChunkTime)
@@ -164,7 +164,6 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
     if (switchBuffers(blockHolder, encode = true)) { ingest(ingestionTime, row, blockHolder, maxChunkTime) }
     else { _log.warn("EMPTY WRITEBUFFERS when switchBuffers called!  Likely a severe bug!!! " +
       s"Part=$stringPartition userTime=$userTime numRows=${currentInfo.numRows}") }
-
   }
 
   protected def initNewChunk(startTime: Long, ingestionTime: Long): Unit = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -275,6 +275,7 @@ class TimeSeriesShard(val ref: DatasetRef,
    */
   val maxMetaSize = schemas.schemas.values.map(_.data.blockMetaSize).max
 
+  require (storeConfig.maxChunkTime > storeConfig.flushInterval, "MaxChunkTime should be greater than FlushInterval")
   val maxChunkTime = storeConfig.maxChunkTime.toMillis
 
   // Called to remove chunks from ChunkMap of a given partition, when an offheap block is reclaimed

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -275,6 +275,8 @@ class TimeSeriesShard(val ref: DatasetRef,
    */
   val maxMetaSize = schemas.schemas.values.map(_.data.blockMetaSize).max
 
+  val maxChunkTime = storeConfig.maxChunkTime.toMillis
+
   // Called to remove chunks from ChunkMap of a given partition, when an offheap block is reclaimed
   private val reclaimListener = new ReclaimListener {
     def onReclaim(metaAddr: Long, numBytes: Int): Unit = {
@@ -1293,7 +1295,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         val tsp = part.asInstanceOf[TimeSeriesPartition]
         brRowReader.schema = schema.ingestionSchema
         brRowReader.recordOffset = recordOff
-        tsp.ingest(ingestionTime, brRowReader, overflowBlockFactory)
+        tsp.ingest(ingestionTime, brRowReader, overflowBlockFactory, maxChunkTime)
         // Below is coded to work concurrently with logic in updateIndexWithEndTime
         // where we try to de-activate an active time series
         if (!tsp.ingesting) {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -927,8 +927,9 @@ class TimeSeriesShard(val ref: DatasetRef,
     // This initializes the containers for the downsample records. Yes, we create new containers
     // and not reuse them at the moment and there is allocation for every call of this method
     // (once per minute). We can perhaps use a thread-local or a pool if necessary after testing.
-    val downsampleRecords = ShardDownsampler.newEmptyDownsampleRecords(downsampleConfig.resolutions,
-                                                                       downsampleConfig.enabled)
+    val downsampleRecords = ShardDownsampler
+                               .newEmptyDownsampleRecords(downsampleConfig.resolutions.map(_.toMillis.toInt),
+                                                          downsampleConfig.enabled)
 
     val chunkSetIter = partitionIt.flatMap { p =>
       // TODO re-enable following assertion. Am noticing that monix uses TrampolineExecutionContext

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -129,7 +129,7 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
 
   override def shutdown(): Unit = {}
 
-  def readRawPartitions(ref: DatasetRef,
+  def readRawPartitions(ref: DatasetRef, maxChunkTime: Long,
                         partMethod: PartitionScanMethod,
                         chunkMethod: ChunkScanMethod = AllChunkScan): Observable[RawPartData] = Observable.empty
 

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -45,6 +45,7 @@ trait RawChunkSource {
    * Implemented by lower-level persistent ChunkSources to return "raw" partition data
    */
   def readRawPartitions(ref: DatasetRef,
+                        maxChunkTime: Long,
                         partMethod: PartitionScanMethod,
                         chunkMethod: ChunkScanMethod = AllChunkScan): Observable[RawPartData]
 }

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -89,6 +89,8 @@ object StoreConfig {
   def apply(storeConfig: Config): StoreConfig = {
     val config = storeConfig.withFallback(defaults)
     val flushInterval = config.as[FiniteDuration]("flush-interval")
+    // maxChunkTime should atleast be length of flush interval to accommodate all data within one chunk.
+    // better to be slightly greater so if more samples arrive within that flush period, two chunks are not created.
     val fallbackMaxChunkTime = (flushInterval.toMillis * 1.1).toLong.millis
     val maxChunkTime = config.as[Option[FiniteDuration]]("max-chunk-time").getOrElse(fallbackMaxChunkTime)
     StoreConfig(flushInterval,

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -16,7 +16,7 @@ package object store {
   private val ingestionTimeMask = (1 << startTimeShift) - 1
 
   // Inclusive minumum allowed user time for chunk ids.
-  val minChunkUserTime = 0 // 1970
+  val minChunkUserTime = 0L // 1970
 
   // Inclusive maximum allowed user time for chunk ids.
   val maxChunkUserTime = (java.lang.Long.MAX_VALUE << startTimeShift) >>> startTimeShift // 2109

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -141,6 +141,23 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part.unflushedChunksets shouldEqual 1
   }
 
+  it("should enforce user time length in each chunk") {
+    part = makePart(0, dataset1)
+    // user time maximum is not enforced, so just one chunk
+    singleSeriesReaders().take(35).foreach { r => part.ingest(0, r, ingestBlockHolder, Long.MaxValue) }
+    part.numChunks shouldEqual 1
+
+    part = makePart(0, dataset1)
+    // 11 samples per chunk since maxChunkTime is 10 seconds
+    singleSeriesReaders().take(33).foreach { r => part.ingest(0, r, ingestBlockHolder, 10000) }
+    part.numChunks shouldEqual 3
+
+    part = makePart(0, dataset1)
+    // 11 samples per chunk since maxChunkTime is 10 seconds
+    singleSeriesReaders().take(34).foreach { r => part.ingest(0, r, ingestBlockHolder, 10000) }
+    part.numChunks shouldEqual 4
+  }
+
   it("should be able to read a time range of ingested data") {
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(11)

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -1,5 +1,7 @@
 package filodb.core.store
 
+import scala.concurrent.duration._
+
 import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.reactive.Observable
@@ -79,14 +81,14 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
 
     // partition exists but no chunks in range > 1000, this should find nothing
     val noChunkScan = TimeRangeChunkScan(1000L, 2000L)
-    val parts = colStore.readRawPartitions(dataset.ref, partScan, noChunkScan).toListL.runAsync.futureValue
-    parts should have length (1)
-    parts.head.chunkSets should have length (0)
+    val parts = colStore.readRawPartitions(dataset.ref, 1.millis.toMillis,
+                             partScan, noChunkScan).toListL.runAsync.futureValue
+    parts should have length (0)
   }
 
   it should "return empty iterator if cannot find partition or version" in {
     // Don't write any data
-    colStore.readRawPartitions(dataset.ref, partScan)
+    colStore.readRawPartitions(dataset.ref, 1.hour.toMillis, partScan)
             .toListL.runAsync.futureValue should have length (0)
   }
 

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -56,7 +56,8 @@ case class UnsupportedChunkSource() extends ChunkSource {
   override def getScanSplits(dataset: DatasetRef, splitsPerNode: Int): Seq[ScanSplit] =
     throw new UnsupportedOperationException("This operation is not supported")
 
-  override def readRawPartitions(ref: DatasetRef, partMethod: PartitionScanMethod,
+  override def readRawPartitions(ref: DatasetRef, maxChunkTime: Long,
+                                 partMethod: PartitionScanMethod,
                                  chunkMethod: ChunkScanMethod): Observable[RawPartData] =
     throw new UnsupportedOperationException("This operation is not supported")
 }

--- a/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerMain.scala
@@ -74,7 +74,7 @@ object DownsamplerMain extends App with StrictLogging with Serializable {
         import filodb.core.Iterators._
         val rawDataSource = cassandraColStore
         rawDataSource.getChunksByIngestionTimeRange(rawDatasetRef, splitIter,
-          ingestionTimeStart, ingestionTimeEnd,
+          ingestionTimeStart, ingestionTimeEnd, rawDatasetIngestionConfig.storeConfig.maxChunkTime.toMillis,
           userTimeStart, userTimeEnd, batchSize, batchTime).toIterator()
       }
       .foreach { rawPartsBatch =>

--- a/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerMain.scala
@@ -37,6 +37,9 @@ object DownsamplerMain extends App with StrictLogging with Serializable {
 
   mainFunction()
 
+  // Gotcha!! Needed a separate mainFunction
+  // to create a closure for spark to serialize and move to executors.
+  // Otherwise, config values below were not being sent over.
   private def mainFunction() = {
 
     val spark = SparkSession.builder()
@@ -65,7 +68,7 @@ object DownsamplerMain extends App with StrictLogging with Serializable {
       s"userTimeStart=${ofEpochMilli(userTimeStart)} userTimeEnd=${ofEpochMilli(userTimeEnd)}")
 
     val splits = cassandraColStore.getScanSplits(rawDatasetRef, splitsPerNode)
-    logger.info(s"Cassandra split size: ${splits.size}. We will have this may spark partitions. " +
+    logger.info(s"Cassandra split size: ${splits.size}. We will have this many spark partitions. " +
       s"Tune splitsPerNode which was $splitsPerNode if parallelism is low")
 
     spark.sparkContext

--- a/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
@@ -6,8 +6,8 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 import net.ceedubs.ficus.Ficus._
 
-import filodb.coordinator.{FilodbSettings}
-import filodb.core.store.StoreConfig
+import filodb.coordinator.{FilodbSettings, NodeClusterActor}
+import filodb.core.store.{IngestionConfig, StoreConfig}
 
 /**
   * DownsamplerSettings is always used in the context of an object so that it need not be serialized to a spark executor
@@ -28,12 +28,15 @@ object DownsamplerSettings extends StrictLogging {
 
   val rawDatasetName = downsamplerConfig.getString("raw-dataset-name")
 
+  val rawDatasetIngestionConfig = filodbSettings.streamConfigs.map { config =>
+        IngestionConfig(config, NodeClusterActor.noOpSource.streamFactoryClass).get
+      }.find(_.ref.toString == rawDatasetName).get
+
   val rawSchemaNames = downsamplerConfig.as[Seq[String]]("raw-schema-names")
 
-  val downsampleResolutions = downsamplerConfig.as[Array[FiniteDuration]]("resolutions")
+  val downsampleResolutions = rawDatasetIngestionConfig.downsampleConfig.resolutions
 
-  val downsampleTtls = downsamplerConfig.as[Array[FiniteDuration]]("ttls").map(_.toSeconds.toInt)
-  require(downsampleResolutions.length == downsampleTtls.length)
+  val downsampleTtls = rawDatasetIngestionConfig.downsampleConfig.ttls
 
   val downsampleStoreConfig = StoreConfig(downsamplerConfig.getConfig("downsample-store-config"))
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

There is no limit on user time length of a chunk. Because of this, it is not simple to issue one cassandra query and get only the relevant chunks for a given user time range in query. Currently, ODP logic currently load ALL chunkInfos for a partition into memory and then decide which chunk time ranges to page in. This involves two cassandra reads per partition and is expensive (or not even viable) especially when serving long term retained (downsampled) data which is almost always not going to be in memory.

**New behavior :**
This PR 
* limits the time-length of a chunk during ingestion
* issues just one CQL query to fetch the chunks. The maxChunkTime is subtracted from the startTime so bordering chunk that contain relevant data is included.
* Also refactors downsampler config so that maxChunkTime and related downsample config is available per dataset rather than in server config.
