### PR TITLE
Signed chunkid

### DIFF
--- a/core/src/test/scala/filodb.core/store/ChunkSetInfoSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ChunkSetInfoSpec.scala
@@ -71,4 +71,20 @@ class ChunkSetInfoSpec extends NativeVectorTest {
       ingestionTime = ingestionTime.plus(1, ChronoUnit.DAYS)
     }
   }
+
+  it("should check min and max bounds") {
+    val minTime = startTimeFromChunkID(java.lang.Long.MIN_VALUE)
+    val maxTime = startTimeFromChunkID(java.lang.Long.MAX_VALUE)
+
+    assert(minTime == minChunkUserTime)
+    assert(maxTime == maxChunkUserTime)
+
+    // No exceptions thrown.
+    chunkID(minTime, 0)
+    chunkID(maxTime, 0)
+
+    // These are just out of bounds.
+    intercept[IllegalArgumentException] { chunkID(minTime - 1, 0) }
+    intercept[IllegalArgumentException] { chunkID(maxTime + 1, 0) }
+  }
 }

--- a/core/src/test/scala/filodb.core/store/ChunkSetInfoSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ChunkSetInfoSpec.scala
@@ -87,4 +87,17 @@ class ChunkSetInfoSpec extends NativeVectorTest {
     intercept[IllegalArgumentException] { chunkID(minTime - 1, 0) }
     intercept[IllegalArgumentException] { chunkID(maxTime + 1, 0) }
   }
+
+  it("should maintain proper chunk id order over the whole range") {
+    val minTime = startTimeFromChunkID(java.lang.Long.MIN_VALUE)
+    val maxTime = startTimeFromChunkID(java.lang.Long.MAX_VALUE)
+    val step = (maxTime - minTime) / 1000
+    var lastId = java.lang.Long.MIN_VALUE
+
+    for (time <- minTime + 1 to maxTime by step) {
+      val id = chunkID(time, 0)
+      assert(id > lastId)
+      lastId = id
+    }
+  }
 }

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -273,7 +273,7 @@ class BlockMemFactory(blockStore: BlockManager,
     * @param metadataWriter the function to write metadata to each block.  Param is the long metadata address.
     * @param metaSize the number of bytes the piece of metadata takes
     * @return the Long native address of the last metadata block written
-    * @throws IllegalStateException if startMetaSpan wasn't called, or if metaSize is larger
+    * throws IllegalStateException if startMetaSpan wasn't called, or if metaSize is larger
     * than max allowed, or if nothing was allocated
     */
   def endMetaSpan(metadataWriter: Long => Unit, metaSize: Short): Long = {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Chunk IDs don't follow expected ordering when stored in Cassandra, because the underlying type is signed.

**New behavior :**
Flip the upper bit for signed comparisons to work.
