### PR TITLE
debug(query): Add debugging for binary join failures; don't require equal response size

### DIFF
--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -56,7 +56,9 @@ final case class SetOperatorExec(id: String,
       case (QueryResult(_, _, result), i) => (result, i)
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map { resp =>
-      require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
+      // NOTE: We can't require this any more, as multischema queries may result in not a QueryResult if the
+      //       filter returns empty results.  The reason is that the schema will be undefined.
+      // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
       val lhsRvs = resp.filter(_._2 < lhs.size).flatMap(_._1)
       val rhsRvs = resp.filter(_._2 >= lhs.size).flatMap(_._1)
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

BinaryJoins after multi schema query change often fail.

**New behavior :**

- Add debugging to joinKeys when cardinality is expected to be 1-1, but somehow is not.
- Disable check that responses equal LHS + RHS.  This is no longer true with multi schema as filters may return no QueryResult (unknown schema)

**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: