### PR TITLE
fix(query): Preserve child task index in NonLeafExecPlan (fix joins)

### DIFF
--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -82,8 +82,8 @@ final case class BinaryJoinExec(id: String,
       oneSide.foreach { rv =>
         val jk = joinKeys(rv.key)
         if (oneSideMap.contains(jk)) {
-          qLogger.info(s"BinaryJoinError: RV ${rv.key} produced $jk, but\nalready found in map: " +
-                      s"RV ${oneSideMap(jk).key}")
+          qLogger.info(s"BinaryJoinError: RV ${rv.key} (IDs ${rv.key.partIds}) produced $jk, but already in map: " +
+                      s"RV ${oneSideMap(jk).key} (IDs ${oneSideMap(jk).key.partIds})")
           throw new BadQueryException(s"Cardinality $cardinality was used, but many found instead of one for $jk")
         }
         oneSideMap.put(jk, rv)

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -284,16 +284,17 @@ abstract class NonLeafExecPlan extends ExecPlan {
                      (implicit sched: Scheduler,
                       timeout: FiniteDuration): ExecResult = {
     val spanFromHelper = Kamon.currentSpan()
-    // Create tasks for all results
-    val childTasks = Observable.fromIterable(children)
-                               .mapAsync(Runtime.getRuntime.availableProcessors()) { plan =>
-                                 dispatchRemotePlan(plan, spanFromHelper)
+    // Create tasks for all results.
+    // NOTE: It's really important to preserve the "index" of the child task, as joins depend on it
+    val childTasks = Observable.fromIterable(children.zipWithIndex)
+                               .mapAsync(Runtime.getRuntime.availableProcessors()) { case (plan, i) =>
+                                 dispatchRemotePlan(plan, spanFromHelper).map((_, i))
                                }
 
     // The first valid schema is returned as the Task.  If all results are empty, then return
     // an empty schema.  Validate that the other schemas are the same.  Skip over empty schemas.
     var sch = ResultSchema.empty
-    val processedTasks = childTasks.zipWithIndex.collect {
+    val processedTasks = childTasks.collect {
       case (res @ QueryResult(_, schema, _), i) if schema != ResultSchema.empty =>
         sch = reduceSchemas(sch, res, i.toInt)
         (res, i.toInt)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The index of the child plans in `NonLeafExecPlan` was not preserved.  It gets added with `zipWithIndex` after collecting responses, by which the order could be completely different.

This could be an explanation of why joins are failing with the same key being seen twice.

**New behavior :**

The index is added back the way it used to be before multi schema PR, and preserves the index number no matter what order the tasks complete.
