### PR TITLE
fix(query): Small fixes to the parser

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -15,10 +15,6 @@ trait BaseParser extends Expressions with JavaTokenParsers with RegexParsers wit
     "[a-zA-Z_:][a-zA-Z0-9_:\\-\\.]*".r ^^ { str => Identifier(str) }
   }
 
-  lazy val string: PackratParser[Identifier] = {
-    "[a-zA-Z_][a-zA-Z0-9_:|`~!@$#%^&*()s+=?><:;{}-]*".r ^^ { str => Identifier(str) }
-  }
-
   protected lazy val quotedSeries: PackratParser[Identifier] =
     "([\"'])(?:\\\\\\1|.)*?\\1".r ^^ { str =>  Identifier(str.substring(1, str.size-1)) } //remove quotes
 

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -15,7 +15,7 @@ trait BaseParser extends Expressions with JavaTokenParsers with RegexParsers wit
     "[a-zA-Z_:][a-zA-Z0-9_:\\-\\.]*".r ^^ { str => Identifier(str) }
   }
 
-  protected lazy val quotedSeries: PackratParser[Identifier] =
+  protected lazy val labelValueIdentifier: PackratParser[Identifier] =
     "([\"'])(?:\\\\\\1|.)*?\\1".r ^^ { str =>  Identifier(str.substring(1, str.size-1)) } //remove quotes
 
   protected val OFFSET = Keyword("OFFSET")
@@ -65,7 +65,7 @@ trait Operator extends BaseParser {
 
   lazy val comparisionOp = gte | lte | notEqual | gt | lt | equal
 
-  lazy val labelMatch: PackratParser[LabelMatch] = labelNameIdentifier ~ labelMatchOp ~ quotedSeries ^^ {
+  lazy val labelMatch: PackratParser[LabelMatch] = labelNameIdentifier ~ labelMatchOp ~ labelValueIdentifier ^^ {
     case label ~ op ~ value => LabelMatch(label.str, op, value.str)
   }
 

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -134,7 +134,7 @@ class ParserSpec extends FunSpec with Matchers {
     parseSuccessfully("foo:bar{a=\"bc\"}")
     parseSuccessfully("foo{NaN='bc'}")
     parseSuccessfully("foo{a=\"b\", foo!=\"bar\", test=~\"test\", bar!~\"baz\"}")
-
+    parseSuccessfully(":node_memory_utilisation:{_ns=\"piepubliccloud\"}")
 
     parseError("{")
     parseError("}")


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

:  was not allowed at the beginning of the metric name in a promQL statement.

**New behavior :**

Added ":" to be included into the metric name.
Also cleaned up the identifier variable names to avoid confusion



**BREAKING CHANGES**

No breaking changes.

**Other information**: