### PR TITLE
fix(coordinator): Use default settings if initialized() not called

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -83,6 +83,13 @@ object FilodbSettings {
     global().get
   }
 
+  def globalOrDefault: FilodbSettings =
+    global().getOrElse {
+      val settings = new FilodbSettings()
+      global := Some(settings)
+      settings
+    }
+
   def reset(): Unit = global := None
 }
 

--- a/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
@@ -151,13 +151,13 @@ class PartSchemaSerializer extends KryoSerializer[PartitionSchema] {
   override def read(kryo: Kryo, input: Input, typ: Class[PartitionSchema]): PartitionSchema = {
     // We have to dynamically obtain the global schemas as we don't know when they will be initialized
     // but for sure when the serialization needs to happen, Akka is up already
-    val schemas = FilodbSettings.global().get.schemas
+    val schemas = FilodbSettings.globalOrDefault.schemas
 
     schemas.part
   }
 
   override def write(kryo: Kryo, output: Output, schema: PartitionSchema): Unit = {
-    val schemas = FilodbSettings.global().get.schemas
+    val schemas = FilodbSettings.globalOrDefault.schemas
     require(schema == schemas.part)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Serialization of `PartKeysExec` would fail if `FilodbSettings.initialize()` was not called.

**New behavior :**

If initialize is not called, just get the settings from the default config.  

