### PR TITLE
misc(query) : add metric column for Binary Join with Non Arithmetic operators

### DIFF
--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -51,7 +51,7 @@ final case class BinaryJoinExec(id: String,
 
   val onLabels = on.map(Utf8Str(_)).toSet
   val ignoringLabels = ignoring.map(Utf8Str(_)).toSet
-  val ignoringLabelsForJoin = ignoring.map(Utf8Str(_)).toSet + metricColumn.utf8
+  val ignoringLabelsForJoin = ignoringLabels + metricColumn.utf8
   // if onLabels is non-empty, we are doing matching based on on-label, otherwise we are
   // doing matching based on ignoringLabels even if it is empty
   val onMatching = onLabels.nonEmpty
@@ -119,7 +119,6 @@ final case class BinaryJoinExec(id: String,
     // start from otherSideKey which could be many or one
     var result = otherSideKey.labelValues
     // drop metric name if math operator
-    // TODO use dataset's metricName column name here instead of hard-coding column
     if (binaryOp.isInstanceOf[MathOperator]) result = result - Utf8Str(metricColumn)
 
     if (cardinality == Cardinality.OneToOne) {

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -50,7 +50,8 @@ final case class BinaryJoinExec(id: String,
   require(!on.contains(metricColumn), "On cannot contain metric name")
 
   val onLabels = on.map(Utf8Str(_)).toSet
-  val ignoringLabels = ignoring.map(Utf8Str(_)).toSet + metricColumn.utf8
+  val ignoringLabels = ignoring.map(Utf8Str(_)).toSet
+  val ignoringLabelsForJoin = ignoring.map(Utf8Str(_)).toSet + metricColumn.utf8
   // if onLabels is non-empty, we are doing matching based on on-label, otherwise we are
   // doing matching based on ignoringLabels even if it is empty
   val onMatching = onLabels.nonEmpty
@@ -111,7 +112,7 @@ final case class BinaryJoinExec(id: String,
 
   private def joinKeys(rvk: RangeVectorKey): Map[Utf8Str, Utf8Str] = {
     if (onLabels.nonEmpty) rvk.labelValues.filter(lv => onLabels.contains(lv._1))
-    else rvk.labelValues.filterNot(lv => ignoringLabels.contains(lv._1))
+    else rvk.labelValues.filterNot(lv => ignoringLabelsForJoin.contains(lv._1))
   }
 
   private def resultKeys(oneSideKey: RangeVectorKey, otherSideKey: RangeVectorKey): RangeVectorKey = {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -316,7 +316,6 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializableRangeVector(rv, schema)))
-    // val lhs = QueryResult("someId", null, samplesLhs.filter(rv => rv.key.labelValues.get(ZeroCopyUTF8String("tag2")).get.equals("tag1-1")).map(rv => SerializableRangeVector(rv, schema)))
     val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializableRangeVector(rv, schema)))
     // scalastyle:on
     // note below that order of lhs and rhs is reversed, but index is right. Join should take that into account

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -307,27 +307,47 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
 
   it("should have metric name when operator is not MathOperator") {
 
+    val samplesLhs: Array[RangeVector] = Array.tabulate(200) { i =>
+      new RangeVector {
+        val key: RangeVectorKey = CustomRangeVectorKey(
+          Map("metric".utf8 -> s"someMetricLhs".utf8,
+            "tag1".utf8 -> s"tag1-$i".utf8,
+            "tag2".utf8 -> s"tag2-$i".utf8))
+        val rows: Iterator[RowReader] = data(i).iterator
+      }
+    }
+
+    val samplesRhs: Array[RangeVector] = Array.tabulate(200) { i =>
+      new RangeVector {
+        val key: RangeVectorKey = CustomRangeVectorKey(
+          Map("metric".utf8 -> s"someMetricRhs".utf8,
+            "tag1".utf8 -> samplesLhs(i).key.labelValues("tag1".utf8),
+            "tag2".utf8 -> samplesLhs(i).key.labelValues("tag2".utf8)))
+        val rows: Iterator[RowReader] = data(i).iterator
+      }
+    }
+
     val execPlan = BinaryJoinExec("someID", dummyDispatcher,
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
-      BinaryOperator.LTE,
+      BinaryOperator.GTR,
       Cardinality.OneToOne,
-      Nil, Seq("tag2"), Nil, "__name__")
+      Nil, Seq("tag2"), Nil, "metric")
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializableRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializableRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializableRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializableRangeVector(rv, schema)))
     // scalastyle:on
     // note below that order of lhs and rhs is reversed, but index is right. Join should take that into account
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, queryConfig)
       .toListL.runAsync.futureValue
 
     result.foreach { rv =>
-      rv.key.labelValues.contains("__name__".utf8) shouldEqual true
+      rv.key.labelValues.contains("metric".utf8) shouldEqual true
       rv.key.labelValues.contains("tag1".utf8) shouldEqual true
       rv.key.labelValues.contains("tag2".utf8) shouldEqual false
     }
 
-    result.map(_.key).toSet.size shouldEqual 2
+    result.map(_.key).toSet.size shouldEqual 200
   }
 }

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -139,7 +139,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
     )
 
     result.size shouldEqual 2
-    result.map(_.key.labelValues) sameElements(expectedLabels)
+    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
     result(0).rows.map(_.getDouble(1)).toList shouldEqual List(3)
     result(1).rows.map(_.getDouble(1)).toList shouldEqual List(1)
   }
@@ -174,7 +174,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
     )
 
     result.size shouldEqual 2
-    result.map(_.key.labelValues) sameElements(expectedLabels)
+    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
     result(0).rows.map(_.getDouble(1)).toList shouldEqual List(3)
     result(1).rows.map(_.getDouble(1)).toList shouldEqual List(1)
   }
@@ -220,7 +220,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
       )
     )
     result.size shouldEqual 4
-    result.map(_.key.labelValues) sameElements(expectedLabels)
+    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
 
     result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
     result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
@@ -253,7 +253,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
     ))
 
     result.size shouldEqual 1
-    result.map(_.key.labelValues) sameElements(expectedLabels)
+    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
     result.foreach(_.rows.size shouldEqual(1))
     result(0).rows.map(_.getDouble(1)).foreach(_ shouldEqual(2))
   }
@@ -299,11 +299,46 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
       )
     )
     result.size shouldEqual 4
-    result.map(_.key.labelValues) sameElements(expectedLabels)
+    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
 
     result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
     result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
     result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
     result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+  }
+
+  it("should return metric name when operator is not MathOperator") {
+
+    val samplesRhs2 = scala.util.Random.shuffle(sampleNodeRole.toList) // they may come out of order
+
+    val execPlan = BinaryJoinExec("someID", dummyDispatcher,
+      Array(dummyPlan), // cannot be empty as some compose's rely on the schema
+      new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
+      BinaryOperator.ADD,
+      Cardinality.ManyToOne,
+      Seq("instance"), Nil, Seq("role"), "__name__")
+
+    // scalastyle:off
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializableRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializableRangeVector(rv, schema)))
+    // scalastyle:on
+    val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, queryConfig)
+      .toListL.runAsync.futureValue
+
+    val expectedLabels = List(Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
+      ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
+      ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("idle"),
+      ZeroCopyUTF8String("role") -> ZeroCopyUTF8String("prometheus"),
+      ZeroCopyUTF8String("__name__") -> ZeroCopyUTF8String("node_cpu")
+    ),
+      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
+        ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
+        ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("user"),
+        ZeroCopyUTF8String("role") -> ZeroCopyUTF8String("prometheus"),
+        ZeroCopyUTF8String("__name__") -> ZeroCopyUTF8String("node_cpu"))
+    )
+
+    result.size shouldEqual 2
+    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
   }
 }

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -307,14 +307,14 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
     result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
   }
 
-  it("should return metric name when operator is not MathOperator") {
+  it("should have metric name when operator is not MathOperator") {
 
     val samplesRhs2 = scala.util.Random.shuffle(sampleNodeRole.toList) // they may come out of order
 
     val execPlan = BinaryJoinExec("someID", dummyDispatcher,
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
-      BinaryOperator.ADD,
+      BinaryOperator.LTE,
       Cardinality.ManyToOne,
       Seq("instance"), Nil, Seq("role"), "__name__")
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -308,9 +308,7 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
   }
 
   it("should have metric name when operator is not MathOperator") {
-
-    val samplesRhs2 = scala.util.Random.shuffle(sampleNodeRole.toList) // they may come out of order
-
+    
     val sampleLhs: Array[RangeVector] = Array(
       new RangeVector {
         val key: RangeVectorKey = CustomRangeVectorKey(
@@ -348,7 +346,6 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
           new TransientRow(1L, 1)).iterator
       }
     )
-
 
     val execPlan = BinaryJoinExec("someID", dummyDispatcher,
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Metric column is not part of Binary Join result. Prometheus has it when the operator is non-arithmetic.

**New behavior :**
Add metric column for non-arithmatic operator