### PR TITLE
fix(query): Rename all DoubleColumns in output ResultSchema pos 1 to "value"

### DIFF
--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -155,7 +155,7 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
     expectMsgPF(10.seconds.dilated) {
       case QueryResult(_, schema, vectors) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn),
-                                       ColumnInfo("AvgTone", ColumnType.DoubleColumn))
+                                       ColumnInfo("value", ColumnType.DoubleColumn))
         // query is counting each partition....
         vectors should have length (59 * 2)
         // vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(575.24)

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -119,6 +119,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
   val timeMinSchema = ResultSchema(Seq(ColumnInfo("timestamp", LongColumn), ColumnInfo("min", DoubleColumn)), 1)
   val countSchema = ResultSchema(Seq(ColumnInfo("timestamp", LongColumn), ColumnInfo("count", DoubleColumn)), 1)
+  val valueSchema = ResultSchema(Seq(ColumnInfo("timestamp", LongColumn), ColumnInfo("value", DoubleColumn)), 1)
   val qOpt = QueryOptions(shardOverrides = Some(Seq(0)))
 
   describe("QueryActor commands and responses") {
@@ -202,7 +203,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
         case QueryResult(_, schema, vectors) =>
-          schema.columns shouldEqual timeMinSchema.columns
+          schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
       }
@@ -216,7 +217,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, q3)
       probe.expectMsgPF() {
         case QueryResult(_, schema, vectors) =>
-          schema.columns shouldEqual countSchema.columns
+          schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(98.0, 108.0)
       }
@@ -256,7 +257,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       (0 until numQueries).foreach { _ =>
         probe.expectMsgPF() {
           case QueryResult(_, schema, vectors) =>
-            schema.columns shouldEqual timeMinSchema.columns
+            schema.columns shouldEqual valueSchema.columns
             vectors should have length (1)
             vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
         }
@@ -286,7 +287,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
         case QueryResult(_, schema, vectors) =>
-          schema.columns shouldEqual timeMinSchema.columns
+          schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0, 14.0)
       }
@@ -384,7 +385,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     probe.expectMsgPF() {
       case QueryResult(_, schema, vectors) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", LongColumn),
-                                       ColumnInfo("AvgTone", DoubleColumn))
+                                       ColumnInfo("value", DoubleColumn))
         vectors should have length (1)
         // vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(575.24)
         // TODO:  verify if the expected results are right.  They are something....

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -100,9 +100,14 @@ final case class PeriodicSamplesMapper(start: Long,
       source.copy(columns = source.columns.zipWithIndex.map {
         // Transform if its not a row key column
         case (ColumnInfo(name, ColumnType.LongColumn), i) if i >= source.numRowKeyColumns =>
-          ColumnInfo(name, ColumnType.DoubleColumn)
+          ColumnInfo("value", ColumnType.DoubleColumn)
         case (ColumnInfo(name, ColumnType.IntColumn), i) if i >= source.numRowKeyColumns =>
           ColumnInfo(name, ColumnType.DoubleColumn)
+        // For double columns, just rename the output so that it's the same no matter source schema.
+        // After all after applying a range function, source column doesn't matter anymore
+        // NOTE: we only rename if i is 1 or second column.  If its 2 it might be max which cannot be renamed
+        case (ColumnInfo(name, ColumnType.DoubleColumn), i) if i == 1 =>
+          ColumnInfo("value", ColumnType.DoubleColumn)
         case (c: ColumnInfo, _) => c
       }, fixedVectorLen = Some(((end - start) / step).toInt + 1))
     }

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -192,6 +192,8 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
     val resp = execPlan.execute(memStore, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
     result.resultSchema.columns.map(_.colType) shouldEqual Seq(TimestampColumn, DoubleColumn)
+    // PSM should rename the double column to value always
+    result.resultSchema.columns.map(_.name) shouldEqual Seq("timestamp", "value")
     result.result.size shouldEqual 1
     val partKeyRead = result.result(0).key.labelValues.map(lv => (lv._1.asNewString, lv._2.asNewString))
     partKeyRead shouldEqual partKeyKVWithMetric
@@ -294,7 +296,6 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
     // Check that the "inner" SelectRawPartitionsExec has the right schema/columnIDs
     execPlan.finalPlan shouldBe a[SelectRawPartitionsExec]
     execPlan.finalPlan.asInstanceOf[SelectRawPartitionsExec].colIds shouldEqual Seq(0, 4, 3)
-
     val result = resp.asInstanceOf[QueryResult]
     result.resultSchema.columns.map(_.colType) shouldEqual Seq(TimestampColumn, HistogramColumn, DoubleColumn)
     result.result.size shouldEqual 1


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

When doing binary joins of a gauge and a counter, the query returns with SchemaMismatch error.

**New behavior :**

The above is caused by two ResultSchemas which are slightly different: LHS one has "count" and RHS one has "value".   The change causes ResultSchemas of DoubleColumns in position 1 (the normal value or result column) to always be named "value" so that anything going through PSM will be named consistently, regardless of the source schema.
