### PR TITLE
feat(prometheus): Use ::col for column selection in PromQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,11 +427,11 @@ FiloDB can be queried using the [Prometheus Query Language](https://prometheus.i
 
 ### FiloDB PromQL Extensions
 
-Since FiloDB supports multiple schemas, with possibly more than one value column per schema, there needs to be a way to specify the target column to query.  This is done using the special `__col__` tag filter, like this request which pulls out the "min" column:
+Since FiloDB supports multiple schemas, with possibly more than one value column per schema, there needs to be a way to specify the target column to query.  This is done using a `::columnName` suffix in the metric name, like this request which pulls out the "min" column:
 
-    http_req_timer{_ws_="demo", _ns_="foo",__col__="min"}
+    http_req_timer::min{_ws_="demo", _ns_="foo"}
 
-By default if `__col__` is not specified then the `value-column` option of each data schema is used.
+By default if `::col` suffix is not specified then the `value-column` option of each data schema is used.
 
 Some special functions exist to aid debugging and for other purposes:
 
@@ -450,11 +450,10 @@ Example of debugging chunk metadata using the CLI:
 One major difference FiloDB has from the Prometheus data model is that FiloDB supports histograms as a first-class entity.  In Prometheus, histograms are stored with each bucket in its own time series differentiated by the `le` tag.  In FiloDB, there is a `HistogramColumn` which stores all the buckets together for significantly improved compression, especially over the wire during ingestion, as well as significantly faster query speeds (up to two orders of magnitude).  There is no "le" tag or individual time series for each bucket.  Here are the differences users need to be aware of when using `HistogramColumn`:
 
 * There is no need to append `_bucket` to the metric name.
-* However, you need to select the histogram column like `__col__="hist"`
-* To compute quantiles:  `histogram_quantile(0.7, sum_over_time(http_req_latency{app="foo",__col__="hist"}[5m]))`
-* To extract a bucket: `histogram_bucket(100.0, http_req_latency{app="foo",__col__="hist"})`
-* Sum over multiple Histogram time series:  `sum(sum_over_time(http_req_latency{app="foo",__col__="hist"}[5m]))` - you could then compute quantile over the sum.
-  - NOTE: Do NOT use `group by (le)` when summing `HistogramColumns`.  This is not appropriate as the "le" tag is not used.  FiloDB knows how to sum multiple histograms together correctly without grouping tricks.
+* To compute quantiles:  `histogram_quantile(0.7, sum(rate(http_req_latency{app="foo"}[5m])))`
+* To extract a bucket: `histogram_bucket(100.0, http_req_latency{app="foo"})`
+* Sum over multiple Histogram time series:  `sum(rate(http_req_latency{app="foo"}[5m]))` - you could then compute quantile over the sum.
+  - NOTE: Do NOT use `by (le)` when summing `HistogramColumns`.  This is not appropriate as the "le" tag is not used.  FiloDB knows how to sum multiple histograms together correctly without grouping tricks.
   - FiloDB prevents many incorrect histogram aggregations in Prometheus when using `HistogramColumn`, such as handling of multiple histogram schemas across time series and across time.
 
 FiloDB offers an improved accuracy `histogram_max_quantile` function designed to work with a max column from the source.  If clients are able to send the max value captured during a window, then we can report more accurate upper quantiles (ie 99%, 99.9%, etc.) that do not suffer from clipping.

--- a/doc/downsampling.md
+++ b/doc/downsampling.md
@@ -120,11 +120,8 @@ downsampler on the downsampled dataset.
 
 ## Querying of Downsample Data
  
-Downsampled data for individual time series can be queried from the downsampled dataset. The PromQL
-filters in the query needs to include the `__col__` tag with the value of the downsample column name
-chosen in the downsample dataset. For example `heap_usage{_ws_="demo",_ns_="myApp" __col__="avg"}`
-
-Coming soon in subsequent PR: Automatic selection of column based on the time window function applied in the query.
+Downsampled data for individual time series can be queried from the downsampled dataset. The downsampled dataset schema varies by schema type.  For gauges, the min, max, sum, count, and avergage are computed and stored in separate columns in the `ds-gauge` schema. The FiloDB Query Engine automatically translates queries to select the right column under the hood.
+For example `min(heap_usage{_ws_="demo",_ns_="myApp"})` is translated to something like `heap_usage::min{_ws_="demo",_ns_="myApp"}`.
 
 ## Validation of Downsample Results
 
@@ -132,13 +129,14 @@ Run main class [filodb.prom.downsample.GaugeDownsampleValidator](../http/src/tes
 
 ```
 -Dquery-endpoint=https://myFiloDbEndpoint.com
--Draw-data-promql=jvm_threads{_ws_=\"demo\",_ns_=\"myApplication\",measure=\"daemon\",__col__=\"value\"}[@@@@s]
+-Draw-data-promql=jvm_threads::value{_ws_=\"demo\",_ns_=\"myApplication\",measure=\"daemon\"}[@@@@s]
 -Dflush-interval=12h
 -Dquery-range=6h
 ```
 
 Notes:
-* `raw-data-promql` system property value should end with `,__col__="value"}[@@@@s]`.
+* `raw-data-promql` system property value should end with `[@@@@s]`.
+* `raw-data-promql` needs to have `::value` column selector suffix at end of metric name as it gets replaced with diff column names
 * The lookback window `@@@@` is replaced with downsample period by validation tool when running the query.
 
 This will perform validation of min, max, sum and count downsamplers by issuing same query to both datasets

--- a/doc/downsampling.md
+++ b/doc/downsampling.md
@@ -121,7 +121,7 @@ downsampler on the downsampled dataset.
 ## Querying of Downsample Data
  
 Downsampled data for individual time series can be queried from the downsampled dataset. The downsampled dataset schema varies by schema type.  For gauges, the min, max, sum, count, and avergage are computed and stored in separate columns in the `ds-gauge` schema. The FiloDB Query Engine automatically translates queries to select the right column under the hood.
-For example `min(heap_usage{_ws_="demo",_ns_="myApp"})` is translated to something like `heap_usage::min{_ws_="demo",_ns_="myApp"}`.
+For example `min_over_time(heap_usage{_ws_="demo",_ns_="myApp"})` is roughly converted to something like `heap_usage::min{_ws_="demo",_ns_="myApp"}`.
 
 ## Validation of Downsample Results
 

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -82,7 +82,7 @@ object TestTimeseriesProducer extends StrictLogging {
     val rawSamplesUrl = s"http://localhost:8080/promql/prometheus/api/v1/query?query=$rawSamplesQ&time=$endQuery"
     logger.info(s"Raw Samples query URL: \n$rawSamplesUrl")
 
-    val downsampledQ = URLEncoder.encode("""heap_usage{dc="DC0",_ws_="demo",_ns_="App-0",__col__="sum"}[2m]""",
+    val downsampledQ = URLEncoder.encode("""heap_usage::sum{dc="DC0",_ws_="demo",_ns_="App-0"}[2m]""",
       StandardCharsets.UTF_8.toString)
     val downsampledSamplesUrl = s"http://localhost:8080/promql/prometheus_ds_1m/api/v1/query?" +
       s"query=$downsampledQ&time=$endQuery"

--- a/http/src/test/scala/filodb/prom/downsample/GaugeDownsampleValidator.scala
+++ b/http/src/test/scala/filodb/prom/downsample/GaugeDownsampleValidator.scala
@@ -24,11 +24,11 @@ import filodb.query.SuccessResponse
   * Run as main class with following system properties:
   *
   * -Dquery-endpoint=https://myFiloDbEndpoint.com
-  * -Draw-data-promql=jvm_threads{_ns=\"myApplication\",measure=\"daemon\",__col__=\"value\"}[@@@@s]
+  * -Draw-data-promql=jvm_threads::value{_ns=\"myApplication\",measure=\"daemon\"}[@@@@s]
   * -Dflush-interval=12h
   * -Dquery-range=6h
   *
-  * raw-data-promql property value should end with ',__col__="value"}[@@@@s]'.
+  * raw-data-promql property value should end with '}[@@@@s]'.
   * The lookback window is replaced by validation tool when running the query.
   *
   */
@@ -49,8 +49,8 @@ object GaugeDownsampleValidator extends App with StrictLogging {
   val flushIntervalHours = config.getDuration("flush-interval")
   val queryRange = config.getDuration("query-range")
 
-  require((rawPromql.endsWith(""",__col__="value"}[@@@@s]""")),
-    """Raw Data PromQL should end with ,__col__="value"}[@@@@s]""")
+  require((rawPromql.endsWith("""}[@@@@s]""")),
+    """Raw Data PromQL should end with }[@@@@s]""")
 
   // List of validations to perform
   val validations = Seq (

--- a/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
@@ -83,7 +83,7 @@ class HistogramQueryBenchmark {
   val pEngine = new QueryEngine(promDataset.ref, promSchemas, shardMapper, EmptyFailureProvider)
   val startTime = 100000L + 100*1000  // 100 samples in.  Look back 30 samples, which normally would be 5min
 
-  val histQuery = """histogram_quantile(0.9, sum_over_time(http_requests_total{job="prometheus",__col__="h"}[30s]))"""
+  val histQuery = """histogram_quantile(0.9, sum_over_time(http_requests_total::h{job="prometheus"}[30s]))"""
   val promQuery = """histogram_quantile(0.9, sum_over_time(http_requests_total_bucket{job="prometheus"}[30s]))"""
 
   // Single-threaded query test

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -72,14 +72,13 @@ trait Functions extends Base with Operators with Vectors {
         } else if (filoFunctionIdOpt.isDefined) {
           // No lookback needed as we are looking at chunk metadata only, not raw samples
           val rangeSelector = timeParamToSelector(timeParams, 0)
-          val (filters, columns) = seriesParam match {
-            case i: InstantExpression => (i.columnFilters, i.columns)
-            case r: RangeExpression   => (r.columnFilters, r.columns)
+          val (filters, column) = seriesParam match {
+            case i: InstantExpression => (i.columnFilters, i.column)
+            case r: RangeExpression   => (r.columnFilters, r.column)
           }
           filoFunctionIdOpt.get match {
-            case FiloFunctionId.ChunkMetaAll => // Just get the raw chunk metadata
-              RawChunkMeta(rangeSelector, filters, columns.headOption.getOrElse(""))
-          }
+            case FiloFunctionId.ChunkMetaAll =>   // Just get the raw chunk metadata
+              RawChunkMeta(rangeSelector, filters, column.getOrElse(""))
         } else if (miscellaneousFunctionIdOpt.isDefined) {
           val miscellaneousFunctionId = miscellaneousFunctionIdOpt.get
           val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -73,8 +73,8 @@ trait Functions extends Base with Operators with Vectors {
           // No lookback needed as we are looking at chunk metadata only, not raw samples
           val rangeSelector = timeParamToSelector(timeParams, 0)
           val (filters, columns) = seriesParam match {
-            case i: InstantExpression => (i.columnFilters :+ i.nameFilter, i.columns)
-            case r: RangeExpression => (r.columnFilters :+ r.nameFilter, r.columns)
+            case i: InstantExpression => (i.columnFilters, i.columns)
+            case r: RangeExpression   => (r.columnFilters, r.columns)
           }
           filoFunctionIdOpt.get match {
             case FiloFunctionId.ChunkMetaAll => // Just get the raw chunk metadata

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -27,19 +27,15 @@ trait Functions extends Base with Operators with Vectors {
       name.equalsIgnoreCase("scalar") ||
       name.equalsIgnoreCase("time")
 
-    // scalastyle:off
     def toPeriodicSeriesPlan(timeParams: TimeRangeParams): PeriodicSeriesPlan = {
-
       val vectorFn = VectorFunctionId.withNameInsensitiveOption(name)
       val instantFunctionIdOpt = InstantFunctionId.withNameInsensitiveOption(name)
       val filoFunctionIdOpt = FiloFunctionId.withNameInsensitiveOption(name)
-      val miscellaneousFunctionIdOpt = MiscellaneousFunctionId.withNameInsensitiveOption(name)
       val scalarFunctionIdOpt = ScalarFunctionId.withNameInsensitiveOption(name)
-      val sortFunctionIdOpt = SortFunctionId.withNameInsensitiveOption(name)
-
       if (vectorFn.isDefined) {
         allParams.head match {
-          case num: ScalarExpression => VectorPlan(ScalarFixedDoublePlan(num.toScalar, RangeParams(timeParams.start, timeParams.step, timeParams.end)))
+          case num: ScalarExpression => val params = RangeParams(timeParams.start, timeParams.step, timeParams.end)
+                                        VectorPlan(ScalarFixedDoublePlan(num.toScalar, params))
           case function: Function    => val nestedPlan = function.toPeriodicSeriesPlan(timeParams)
                                         nestedPlan match {
                                           case scalarPlan: ScalarPlan => VectorPlan(scalarPlan)
@@ -48,25 +44,23 @@ trait Functions extends Base with Operators with Vectors {
         }
       } else if (allParams.isEmpty) {
         ScalarTimeBasedPlan(scalarFunctionIdOpt.get, RangeParams(timeParams.start, timeParams.step, timeParams.end) )
-      }  else {
+      } else {
         val seriesParam = allParams.filter(_.isInstanceOf[Series]).head.asInstanceOf[Series]
-
-        // Get parameters other than  series like label names. Parameters can be quoted so remove special characters
-        val stringParam = allParams.filter(!_.equals(seriesParam)).
-                          filter(_.isInstanceOf[InstantExpression]).
-                          map(_.asInstanceOf[InstantExpression].realMetricName.replaceAll("^\"|\"$", ""))
-        val otherParams : Seq[FunctionArgsPlan] = allParams.filter(!_.equals(seriesParam)).
-          filter(!_.isInstanceOf[InstantExpression]).map {
-          case num: ScalarExpression => ScalarFixedDoublePlan(num.toScalar,RangeParams(timeParams.start, timeParams.step, timeParams.end))
-          case function: Function  if (function.name.equalsIgnoreCase("scalar")) =>
-            function.toPeriodicSeriesPlan(timeParams).asInstanceOf[ScalarVaryingDoublePlan]
-          case _ => throw new IllegalArgumentException("Parameters can be a string, number or scalar function")
-        }
-
+        val otherParams: Seq[FunctionArgsPlan] =
+          allParams.filter(!_.equals(seriesParam))
+                   .filter(!_.isInstanceOf[InstantExpression])
+                   .map {
+                     case num: ScalarExpression =>
+                       val params = RangeParams(timeParams.start, timeParams.step, timeParams.end)
+                       ScalarFixedDoublePlan(num.toScalar, params)
+                     case function: Function if (function.name.equalsIgnoreCase("scalar")) =>
+                       function.toPeriodicSeriesPlan(timeParams).asInstanceOf[ScalarVaryingDoublePlan]
+                     case _ =>
+                       throw new IllegalArgumentException("Parameters can be a string, number or scalar function")
+                   }
         if (instantFunctionIdOpt.isDefined) {
           val instantFunctionId = instantFunctionIdOpt.get
           val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)
-
           ApplyInstantFunction(periodicSeriesPlan, instantFunctionId, otherParams)
           // Special FiloDB functions to extract things like chunk metadata
         } else if (filoFunctionIdOpt.isDefined) {
@@ -79,33 +73,44 @@ trait Functions extends Base with Operators with Vectors {
           filoFunctionIdOpt.get match {
             case FiloFunctionId.ChunkMetaAll =>   // Just get the raw chunk metadata
               RawChunkMeta(rangeSelector, filters, column.getOrElse(""))
-        } else if (miscellaneousFunctionIdOpt.isDefined) {
-          val miscellaneousFunctionId = miscellaneousFunctionIdOpt.get
-          val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)
-          ApplyMiscellaneousFunction(periodicSeriesPlan, miscellaneousFunctionId, stringParam)
-        } else if (scalarFunctionIdOpt.isDefined) {
-          val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)
-          ScalarVaryingDoublePlan(periodicSeriesPlan, scalarFunctionIdOpt.get, RangeParams(timeParams.start, timeParams.step, timeParams.end))
-        }
-        else if (sortFunctionIdOpt.isDefined) {
-          val sortFunctionId = sortFunctionIdOpt.get
-          val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)
-          ApplySortFunction(periodicSeriesPlan, sortFunctionId)
-        } else {
-          val rangeFunctionId = RangeFunctionId.withNameInsensitiveOption(name).get
-          val rangeExpression = seriesParam.asInstanceOf[RangeExpression]
-
-          PeriodicSeriesWithWindowing(
-            rangeExpression.toRawSeriesPlan(timeParams, isRoot = false).asInstanceOf[RawSeries],
-            timeParams.start * 1000, timeParams.step * 1000, timeParams.end * 1000,
-            rangeExpression.window.millis,
-            rangeFunctionId, otherParams)
-
-        }
+          }
+        } else toPeriodicSeriesPlanMisc(seriesParam, otherParams, timeParams)
       }
-
     }
 
-  }
+    def toPeriodicSeriesPlanMisc(seriesParam: Series,
+                                 otherParams: Seq[FunctionArgsPlan],
+                                 timeParams: TimeRangeParams): PeriodicSeriesPlan = {
+      val miscellaneousFunctionIdOpt = MiscellaneousFunctionId.withNameInsensitiveOption(name)
+      val scalarFunctionIdOpt = ScalarFunctionId.withNameInsensitiveOption(name)
+      val sortFunctionIdOpt = SortFunctionId.withNameInsensitiveOption(name)
+      // Get parameters other than  series like label names. Parameters can be quoted so remove special characters
+      val stringParam = allParams.filter(!_.equals(seriesParam)).
+                        filter(_.isInstanceOf[InstantExpression]).
+                        map(_.asInstanceOf[InstantExpression].realMetricName.replaceAll("^\"|\"$", ""))
 
+      if (miscellaneousFunctionIdOpt.isDefined) {
+        val miscellaneousFunctionId = miscellaneousFunctionIdOpt.get
+        val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)
+        ApplyMiscellaneousFunction(periodicSeriesPlan, miscellaneousFunctionId, stringParam)
+      } else if (scalarFunctionIdOpt.isDefined) {
+        val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)
+        val params = RangeParams(timeParams.start, timeParams.step, timeParams.end)
+        ScalarVaryingDoublePlan(periodicSeriesPlan, scalarFunctionIdOpt.get, params)
+      }
+      else if (sortFunctionIdOpt.isDefined) {
+        val sortFunctionId = sortFunctionIdOpt.get
+        val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toPeriodicSeriesPlan(timeParams)
+        ApplySortFunction(periodicSeriesPlan, sortFunctionId)
+      } else {
+        val rangeFunctionId = RangeFunctionId.withNameInsensitiveOption(name).get
+        val rangeExpression = seriesParam.asInstanceOf[RangeExpression]
+        PeriodicSeriesWithWindowing(
+          rangeExpression.toRawSeriesPlan(timeParams, isRoot = false).asInstanceOf[RawSeries],
+          timeParams.start * 1000, timeParams.step * 1000, timeParams.end * 1000,
+          rangeExpression.window.millis,
+          rangeFunctionId, otherParams)
+      }
+    }
+  }
 }

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -5,9 +5,6 @@ import filodb.core.query.ColumnFilter
 import filodb.query._
 
 object Vectors {
-  // The "tag" or key used to indicate the column to query to FiloDB.  A non-standard Prom extension.
-  val ColumnSelectorLabel = "__col__"
-
   val PromMetricLabel = "__name__"
 }
 
@@ -84,41 +81,58 @@ trait Vectors extends Scalars with TimeUnits with Base {
   }
 
   sealed trait Vector extends Expression {
-
     def metricName: Option[String]
     def labelSelection: Seq[LabelMatch]
 
-    def realMetricName: String = {
-      val nameLabelValue = labelSelection.find(_.label == PromMetricLabel).map(_.value)
-      if (nameLabelValue.nonEmpty && metricName.nonEmpty) {
-        throw new IllegalArgumentException("Metric name should not be set twice")
+    // Convert metricName{labels} -> {labels, __name__="metricName"} so it's uniform
+    lazy val mergeNameToLabels: Seq[LabelMatch] = {
+      val nameLabel = labelSelection.find(_.label == PromMetricLabel)
+      if (nameLabel.isEmpty && metricName.isEmpty)
+        throw new IllegalArgumentException("Metric name is not present")
+      if (metricName.nonEmpty) {
+        if (nameLabel.nonEmpty) throw new IllegalArgumentException("Metric name should not be set twice")
+        // metric name specified but no __name__ label.  Add it
+        labelSelection :+ LabelMatch(PromMetricLabel, EqualMatch, metricName.get)
+      } else {
+        labelSelection
       }
-      metricName.orElse(nameLabelValue)
-        .getOrElse(throw new IllegalArgumentException("Metric name is not present"))
     }
 
-    protected def labelMatchesToFilters(labels: Seq[LabelMatch]) =
-      labels.map { labelMatch =>
-        val labelValue = labelMatch.value.replace("\\\\", "\\")
+    def realMetricName: String = mergeNameToLabels.find(_.label == PromMetricLabel).get.value
+
+    // Returns (trimmedMetricName, column) after stripping ::columnName
+    private def extractStripColumn(metricName: String): (String, Option[String]) = {
+      val parts = metricName.split("::", 2)
+      if (parts.size > 1) (parts(0), Some(parts(1))) else (metricName, None)
+    }
+
+    /**
+     * Converts LabelMatches to ColumnFilters.  Along the way:
+     * - extracts ::col column name expressions in metric names to columns
+     * - removes ::col in __name__ label matches as needed
+     */
+    protected def labelMatchesToFilters(labels: Seq[LabelMatch]) = {
+      var columns: List[String] = Nil
+      val filters = labels.map { labelMatch =>
+        val labelVal = labelMatch.value.replace("\\\\", "\\")
                                          .replace("\\\"", "\"")
                                          .replace("\\n", "\n")
                                          .replace("\\t", "\t")
-          labelMatch.labelMatchOp match {
+        val labelValue = if (labelMatch.label == PromMetricLabel) {
+          val (newValue, colNameOpt) = extractStripColumn(labelVal)
+          colNameOpt.foreach { col => columns = col :: columns }
+          newValue
+        } else { labelVal }
+        labelMatch.labelMatchOp match {
           case EqualMatch      => ColumnFilter(labelMatch.label, query.Filter.Equals(labelValue))
           case NotRegexMatch   => ColumnFilter(labelMatch.label, query.Filter.NotEqualsRegex(labelValue))
           case RegexMatch      => ColumnFilter(labelMatch.label, query.Filter.EqualsRegex(labelValue))
           case NotEqual(false) => ColumnFilter(labelMatch.label, query.Filter.NotEquals(labelValue))
           case other: Any      => throw new IllegalArgumentException(s"Unknown match operator $other")
         }
-      // Remove the column selector as that is not a real time series filter
-      }.filterNot(_.column == ColumnSelectorLabel)
-
-    protected def labelMatchesToColumnName(labels: Seq[LabelMatch]): Seq[String] =
-      labels.collect {
-        // TODO: We may support multiple columns with the regex filter or some other
-        //       custom "in" operator that we can specify in PromQL
-        case LabelMatch(ColumnSelectorLabel, EqualMatch, col) => col
       }
+      (filters, columns)
+    }
   }
 
   /**
@@ -130,17 +144,13 @@ trait Vectors extends Scalars with TimeUnits with Base {
     * It is possible to filter these time series further by
     * appending a set of labels to match in curly braces ({}).
     */
-
-  case class InstantExpression(override val metricName: Option[String],
-                               override val labelSelection: Seq[LabelMatch],
+  case class InstantExpression(val metricName: Option[String],
+                               val labelSelection: Seq[LabelMatch],
                                offset: Option[Duration]) extends Vector with PeriodicSeries {
 
     val staleDataLookbackSeconds = 5 * 60 // 5 minutes
 
-    private[prometheus] val columnFilters = labelMatchesToFilters(labelSelection)
-    private[prometheus] val columns = labelMatchesToColumnName(labelSelection)
-    private[prometheus] val nameFilter = ColumnFilter(PromMetricLabel, query.Filter.Equals(realMetricName))
-    def getColFilters: Seq[ColumnFilter] = if (metricName.isDefined) columnFilters :+ nameFilter else columnFilters
+    private[prometheus] val (columnFilters, columns) = labelMatchesToFilters(mergeNameToLabels)
 
     def toPeriodicSeriesPlan(timeParams: TimeRangeParams): PeriodicSeriesPlan = {
 
@@ -148,13 +158,13 @@ trait Vectors extends Scalars with TimeUnits with Base {
       // start timestamp. Prometheus goes back unto 5 minutes to get sample before declaring as stale
       PeriodicSeries(
         RawSeries(timeParamToSelector(timeParams, staleDataLookbackSeconds * 1000),
-          getColFilters, columns),
+          columnFilters, columns),
         timeParams.start * 1000, timeParams.step * 1000, timeParams.end * 1000
       )
     }
 
     def toMetadataPlan(timeParams: TimeRangeParams): SeriesKeysByFilters = {
-      SeriesKeysByFilters(getColFilters, timeParams.start * 1000, timeParams.end * 1000)
+      SeriesKeysByFilters(columnFilters, timeParams.start * 1000, timeParams.end * 1000)
     }
   }
 
@@ -165,23 +175,19 @@ trait Vectors extends Scalars with TimeUnits with Base {
     * at the end of a vector selector to specify how far back in time values
     * should be fetched for each resulting range vector element.
     */
-  case class RangeExpression(override val metricName: Option[String],
-                             override val labelSelection: Seq[LabelMatch],
+  case class RangeExpression(val metricName: Option[String],
+                             val labelSelection: Seq[LabelMatch],
                              window: Duration,
                              offset: Option[Duration]) extends Vector with SimpleSeries {
 
-    private[prometheus] val columnFilters = labelMatchesToFilters(labelSelection)
-    private[prometheus] val columns = labelMatchesToColumnName(labelSelection)
-    private[prometheus] val nameFilter = ColumnFilter(PromMetricLabel, query.Filter.Equals(realMetricName))
-
-    val allFilters: Seq[ColumnFilter] = if (metricName.isDefined) columnFilters :+ nameFilter else columnFilters
+    private[prometheus] val (columnFilters, columns) = labelMatchesToFilters(mergeNameToLabels)
 
     def toRawSeriesPlan(timeParams: TimeRangeParams, isRoot: Boolean): RawSeriesPlan = {
       if (isRoot && timeParams.start != timeParams.end) {
         throw new UnsupportedOperationException("Range expression is not allowed in query_range")
       }
       // multiply by 1000 to convert unix timestamp in seconds to millis
-      RawSeries(timeParamToSelector(timeParams, window.millis), allFilters, columns)
+      RawSeries(timeParamToSelector(timeParams, window.millis), columnFilters, columns)
     }
 
   }

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -103,7 +103,10 @@ trait Vectors extends Scalars with TimeUnits with Base {
     // Returns (trimmedMetricName, column) after stripping ::columnName
     private def extractStripColumn(metricName: String): (String, Option[String]) = {
       val parts = metricName.split("::", 2)
-      if (parts.size > 1) (parts(0), Some(parts(1))) else (metricName, None)
+      if (parts.size > 1) {
+        require(parts(1).nonEmpty, "cannot use empty column name")
+        (parts(0), Some(parts(1)))
+      } else (metricName, None)
     }
 
     /**

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -145,7 +145,7 @@ class ParserSpec extends FunSpec with Matchers {
     parseError("foo{a*\"b\"}")
     parseError("foo{a>=\"b\"}")
 
-    parseError("foo{gibberish}")
+    parseError("foo::b{gibberish}")
     parseError("foo{1}")
     parseError("{}")
     parseError("{x=\"\"}")
@@ -261,6 +261,8 @@ class ParserSpec extends FunSpec with Matchers {
         "ScalarVectorBinaryOperation(MUL,ScalarFixedDoublePlan(5.0,RangeParams(1524855988,1000,1524855988)),ScalarVectorBinaryOperation(ADD,ScalarFixedDoublePlan(10.0,RangeParams(1524855988,1000,1524855988)),PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),true),false)",
       "topk(5, http_requests_total)" ->
         "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(5.0),List(),List())",
+      "topk(5, http_requests_total::foo)" ->
+        "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List(foo)),1524855988000,1000000,1524855988000),List(5.0),List(),List())",
       "stdvar(http_requests_total)" ->
         "Aggregate(Stdvar,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000),List(),List(),List())",
       "irate(http_requests_total{job=\"api-server\"}[5m])" ->
@@ -275,6 +277,8 @@ class ParserSpec extends FunSpec with Matchers {
         "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Rate,List())",
       "http_requests_total{job=\"prometheus\"}[5m]" ->
         "RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List())",
+      "http_requests_total::sum{job=\"prometheus\"}[5m]" ->
+        "RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(sum))",
       "http_requests_total offset 5m" ->
         "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000)",
       "http_requests_total{environment=~\"staging|testing|development\",method!=\"GET\"}" ->


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

To select the non-default column in a query, one uses a label: `__col__="min"` for example.
This is a magic filter which does not work like normal label filters.

**New behavior :**

This change switches the syntax to select a column to a `::col` suffix in either the metric name or the `__name__` label filter value.   
The thought is that this makes the transition easier for some histogram use cases, ie

`rate(my_histogram_count{....}[5m])` => `rate(my_histogram::count{...}[5m])`

**BREAKING CHANGES**

Existing queries that specify `__col__` filter would need to be rewritten.