### PR TITLE
Disabling optional regex in Lucene since RE2 does not support it.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -435,13 +435,13 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     filter match {
       case EqualsRegex(value) =>
         val term = new Term(column, value.toString)
-        new RegexpQuery(term, RegExp.ALL)
+        new RegexpQuery(term, RegExp.NONE)
       case NotEqualsRegex(value) =>
         val term = new Term(column, value.toString)
         val allDocs = new MatchAllDocsQuery
         val booleanQuery = new BooleanQuery.Builder
         booleanQuery.add(allDocs, Occur.FILTER)
-        booleanQuery.add(new RegexpQuery(term, RegExp.ALL), Occur.MUST_NOT)
+        booleanQuery.add(new RegexpQuery(term, RegExp.NONE), Occur.MUST_NOT)
         booleanQuery.build()
       case Equals(value) =>
         val term = new Term(column, value.toString)

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -19,6 +19,7 @@ import org.apache.lucene.search._
 import org.apache.lucene.search.BooleanClause.Occur
 import org.apache.lucene.store.MMapDirectory
 import org.apache.lucene.util.{BytesRef, InfoStream}
+import org.apache.lucene.util.automaton.RegExp
 import scalaxy.loops._
 
 import filodb.core.{concurrentCache, DatasetRef}
@@ -434,13 +435,13 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     filter match {
       case EqualsRegex(value) =>
         val term = new Term(column, value.toString)
-        new RegexpQuery(term)
+        new RegexpQuery(term, RegExp.ALL)
       case NotEqualsRegex(value) =>
         val term = new Term(column, value.toString)
         val allDocs = new MatchAllDocsQuery
         val booleanQuery = new BooleanQuery.Builder
         booleanQuery.add(allDocs, Occur.FILTER)
-        booleanQuery.add(new RegexpQuery(term), Occur.MUST_NOT)
+        booleanQuery.add(new RegexpQuery(term, RegExp.ALL), Occur.MUST_NOT)
         booleanQuery.build()
       case Equals(value) =>
         val term = new Term(column, value.toString)


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
TSDB regex label filters with `&` in value are ignored.
**New behavior :**
Optional regex in Lucene are disabled.


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: