### PR TITLE
bug(core): EWAH bitmap in query is very CPU intensive

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -94,6 +94,10 @@
         # trace-filters = {
         #   metric = "bad-metric-to-log"
         # }
+
+        # Maximum number of partitions per shard scanned per query. This is necessary
+        # to ensure no run-away query hogs memory and destabilizes the server.
+        # max-query-matches = 250000
       }
       downsample {
         # can be disabled by setting this flag to false

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -148,12 +148,12 @@ class DownsampledTimeSeriesShard(ref: DatasetRef,
   case class LabelValueResultIterator(partIds: debox.Buffer[Int], labelNames: Seq[String], limit: Int)
     extends Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] {
     var currVal: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = _
-    var resIndex = 0
+    var numResultsReturned = 0
     var partIndex = 0
 
     override def hasNext: Boolean = {
       var foundValue = false
-      while(partIndex < partIds.length && resIndex < limit && !foundValue) {
+      while(partIndex < partIds.length && numResultsReturned < limit && !foundValue) {
         val partId = partIds(partIndex)
 
         import ZeroCopyUTF8String._
@@ -174,7 +174,7 @@ class DownsampledTimeSeriesShard(ref: DatasetRef,
     }
 
     override def next(): Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = {
-      resIndex += 1
+      numResultsReturned += 1
       currVal
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -89,7 +89,7 @@ TimeSeriesShard(ref, schemas, storeConfig, shardNum, bufferMemoryManager, rawSto
       s"and full ODP of partIds ${partLookupRes.partIdsNotInMemory}")
 
     // partitions that do not need ODP are those that are not in the inMemOdp collection
-    val inMemParts = InMemPartitionIterator(partLookupRes.partsInMemory.intIterator())
+    val inMemParts = InMemPartitionIterator2(partLookupRes.partsInMemory)
     val noOdpPartitions = inMemParts.filterNot(p => inMemOdp(p.partID))
 
     // NOTE: multiPartitionODP mode does not work with AllChunkScan and unit tests; namely missing partitions will not

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -607,12 +607,6 @@ class TopKPartIdsCollector(limit: Int) extends Collector with StrictLogging {
 
   def needsScores(): Boolean = false
 
-  def topKPartIdsSet(): debox.Set[Int] = {
-    val result = debox.Set.empty[Int]
-    topkResults.iterator().asScala.foreach { p => result += p._1 }
-    result
-  }
-
   def topKPartIds(): IntIterator = {
     val result = new EWAHCompressedBitmap()
     topkResults.iterator().asScala.foreach { p => result.set(p._1) }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1434,12 +1434,12 @@ class TimeSeriesShard(val ref: DatasetRef,
 
       if (matches.length > storeConfig.maxQueryMatches)
         throw new IllegalArgumentException(s"Seeing ${matches.length} matching time series per shard. Try " +
-          s"to narrow your query by adding more filters so there is less than  matches " +
-          s"or request for increasing number of shards this metric lives in")
+          s"to narrow your query by adding more filters so there is less than ${storeConfig.maxQueryMatches} matches " +
+          s"or request that number of shards for the metric be increased")
 
       // first find out which partitions are being queried for data not in memory
       val firstPartId = if (matches.isEmpty) None else Some(matches(0))
-      val _schema = firstPartId.filter(_ >= 0).map(schemaIDFromPartID)
+      val _schema = firstPartId.map(schemaIDFromPartID)
       val it1 = InMemPartitionIterator2(matches)
       val partIdsToPage = it1.filter(_.earliestTime > chunkMethod.startTime).map(_.partID)
       val partIdsNotInMem = it1.skippedPartIDs

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -667,7 +667,10 @@ class TimeSeriesShard(val ref: DatasetRef,
                           startTime: Long,
                           limit: Int): Iterator[PartKey] = {
     val partIds = partKeyIndex.partIdsFromFilters(filter, startTime, endTime)
-    InMemPartitionIterator2(partIds).take(limit).map { p => PartKey(p.partKeyBase, p.partKeyOffset) }
+    val inMem = InMemPartitionIterator2(partIds)
+    val inMemPartKeys = inMem.map { p => PartKey(p.partKeyBase, p.partKeyOffset) }
+    val skippedPartKeys = inMem.skippedPartIDs.iterator().map(partKeyFromPartId)
+    (inMemPartKeys ++ skippedPartKeys).take(limit)
   }
 
   /**

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -34,7 +34,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              demandPagingEnabled: Boolean,
                              evictedPkBfCapacity: Int,
                              // filters on ingested records to log in detail
-                             traceFilters: Map[String, String]) {
+                             traceFilters: Map[String, String],
+                             maxQueryMatches: Int) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -56,6 +57,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "multi-partition-odp" -> multiPartitionODP,
                                "demand-paging-parallelism" -> demandPagingParallelism,
                                "demand-paging-enabled" -> demandPagingEnabled,
+                               "max-query-matches" -> maxQueryMatches,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity).asJava)
 }
 
@@ -69,6 +71,7 @@ object StoreConfig {
                                            |disk-time-to-live = 3 days
                                            |demand-paged-chunk-retention-period = 72 hours
                                            |max-chunks-size = 400
+                                           |max-query-matches = 250000
                                            |max-blob-buffer-size = 15000
                                            |ingestion-buffer-mem-size = 10M
                                            |max-buffer-pool-size = 10000
@@ -113,7 +116,8 @@ object StoreConfig {
                 config.getInt("demand-paging-parallelism"),
                 config.getBoolean("demand-paging-enabled"),
                 config.getInt("evicted-pk-bloom-filter-capacity"),
-                config.as[Map[String, String]]("trace-filters"))
+                config.as[Map[String, String]]("trace-filters"),
+                config.getInt("max-query-matches"))
   }
 }
 

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -228,37 +228,37 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
     allValues.drop(2).toSet shouldEqual infos.toSet
   }
 
-//  it("should be able to AND multiple filters together") {
-//    // Add the first ten keys and row numbers
-//    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-//      .zipWithIndex.foreach { case (addr, i) =>
-//      keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
-//    }
-//
-//    keyIndex.refreshReadersBlocking()
-//
-//    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-//      ColumnFilter("Actor2Name", Equals("REGIME".utf8)))
-//    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
-//    partNums1.toSeq should equal (Seq(8, 9))
-//
-//    val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-//      ColumnFilter("Actor2Name", Equals("CHINA".utf8)))
-//    val partNums2 = keyIndex.partIdsFromFilters(filters2, 0, Long.MaxValue)
-//    partNums2.toSeq shouldEqual Nil
-//  }
-//
-//  it("should ignore unsupported columns and return empty filter") {
-//    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, 0, 1.hour)
-//    partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
-//      index2.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
-//    }
-//    keyIndex.refreshReadersBlocking()
-//
-//    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)), ColumnFilter("Year", Equals(1979)))
-//    val partNums1 = index2.partIdsFromFilters(filters1, 0, Long.MaxValue)
-//    partNums1.toSeq shouldEqual Seq.empty
-//  }
+  it("should be able to AND multiple filters together") {
+    // Add the first ten keys and row numbers
+    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+      .zipWithIndex.foreach { case (addr, i) =>
+      keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
+    }
+
+    keyIndex.refreshReadersBlocking()
+
+    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+      ColumnFilter("Actor2Name", Equals("REGIME".utf8)))
+    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+    partNums1 shouldEqual debox.Buffer(8, 9)
+
+    val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+      ColumnFilter("Actor2Name", Equals("CHINA".utf8)))
+    val partNums2 = keyIndex.partIdsFromFilters(filters2, 0, Long.MaxValue)
+    partNums2 shouldEqual debox.Buffer.empty[Int]
+  }
+
+  it("should ignore unsupported columns and return empty filter") {
+    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, 0, 1.hour)
+    partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
+      index2.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
+    }
+    keyIndex.refreshReadersBlocking()
+
+    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)), ColumnFilter("Year", Equals(1979)))
+    val partNums1 = index2.partIdsFromFilters(filters1, 0, Long.MaxValue)
+    partNums1 shouldEqual debox.Buffer.empty[Int]
+  }
 
   it("should be able to fetch partKey from partId and partId from partKey") {
     // Add the first ten keys and row numbers

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -55,31 +55,31 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
 
     // Should get empty iterator when passing no filters
     val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
-    partNums1.toSeq shouldEqual Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    partNums1 shouldEqual debox.Buffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
     val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
     val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), start, end)
-    partNums2.toSeq shouldEqual Seq(7, 8, 9)
+    partNums2 shouldEqual debox.Buffer(7, 8, 9)
 
     val filter3 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), start, end)
-    partNums3.toSeq shouldEqual Seq(8, 9)
+    partNums3 shouldEqual debox.Buffer(8, 9)
 
     val filter4 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums4 = keyIndex.partIdsFromFilters(Seq(filter4), 10, start-1)
-    partNums4.toSeq shouldEqual Seq.empty
+    partNums4 shouldEqual debox.Buffer.empty[Int]
 
     val filter5 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums5 = keyIndex.partIdsFromFilters(Seq(filter5), end + 100, end + 100000)
-    partNums5.toSeq should not equal (Seq.empty)
+    partNums5 should not equal debox.Buffer.empty[Int]
 
     val filter6 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums6 = keyIndex.partIdsFromFilters(Seq(filter6), start - 10000, end )
-    partNums6.toSeq should not equal (Seq.empty)
+    partNums6 should not equal debox.Buffer.empty[Int]
 
     val filter7 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums7 = keyIndex.partIdsFromFilters(Seq(filter7), (start + end)/2, end + 1000 )
-    partNums7.toSeq should not equal (Seq.empty)
+    partNums7 should not equal debox.Buffer.empty[Int]
 
   }
 
@@ -133,8 +133,9 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
     keyIndex.refreshReadersBlocking()
 
     val pIds = keyIndex.partIdsEndedBefore(start + 200)
+    val pIdsList = pIds.toList()
     for { i <- 0 until numPartIds} {
-      pIds.get(i) shouldEqual (if (i <= 100) true else false)
+      pIdsList.contains(i) shouldEqual (if (i <= 100) true else false)
     }
 
     keyIndex.removePartKeys(pIds)
@@ -161,31 +162,31 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
 
     // Should get empty iterator when passing no filters
     val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
-    partNums1.toSeq shouldEqual Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    partNums1 shouldEqual debox.Buffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
     val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
     val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), start, end)
-    partNums2.toSeq shouldEqual Seq(7, 8, 9)
+    partNums2 shouldEqual debox.Buffer(7, 8, 9)
 
     val filter3 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), start, end)
-    partNums3.toSeq shouldEqual Seq(8, 9)
+    partNums3 shouldEqual debox.Buffer(8, 9)
 
     val filter4 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums4 = keyIndex.partIdsFromFilters(Seq(filter4), 10, start-1)
-    partNums4.toSeq shouldEqual Seq.empty
+    partNums4 shouldEqual debox.Buffer.empty[Int]
 
     val filter5 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums5 = keyIndex.partIdsFromFilters(Seq(filter5), end + 20000, end + 100000)
-    partNums5.toSeq should equal (Seq.empty)
+    partNums5 shouldEqual debox.Buffer.empty[Int]
 
     val filter6 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums6 = keyIndex.partIdsFromFilters(Seq(filter6), start - 10000, end-1 )
-    partNums6.toSeq should not equal (Seq.empty)
+    partNums6 should not equal debox.Buffer.empty[Int]
 
     val filter7 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
     val partNums7 = keyIndex.partIdsFromFilters(Seq(filter7), (start + end)/2, end + 1000 )
-    partNums7.toSeq should not equal (Seq.empty)
+    partNums7 should not equal debox.Buffer.empty[Int]
   }
 
   it("should parse filters with UTF8Wrapper and string correctly") {
@@ -199,11 +200,11 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
 
     val filter2 = ColumnFilter("Actor2Name", Equals(UTF8Wrapper("REGIME".utf8)))
     val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), 0, Long.MaxValue)
-    partNums2.toSeq shouldEqual Seq(8, 9)
+    partNums2 shouldEqual debox.Buffer(8, 9)
 
     val filter3 = ColumnFilter("Actor2Name", Equals("REGIME"))
     val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), 0, Long.MaxValue)
-    partNums3.toSeq shouldEqual Seq(8, 9)
+    partNums3 shouldEqual debox.Buffer(8, 9)
   }
 
   it("should obtain indexed names and values") {
@@ -227,37 +228,37 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
     allValues.drop(2).toSet shouldEqual infos.toSet
   }
 
-  it("should be able to AND multiple filters together") {
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-
-    keyIndex.refreshReadersBlocking()
-
-    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-      ColumnFilter("Actor2Name", Equals("REGIME".utf8)))
-    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1.toSeq should equal (Seq(8, 9))
-
-    val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-      ColumnFilter("Actor2Name", Equals("CHINA".utf8)))
-    val partNums2 = keyIndex.partIdsFromFilters(filters2, 0, Long.MaxValue)
-    partNums2.toSeq shouldEqual Nil
-  }
-
-  it("should ignore unsupported columns and return empty filter") {
-    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, 0, 1.hour)
-    partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
-      index2.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)), ColumnFilter("Year", Equals(1979)))
-    val partNums1 = index2.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1.toSeq shouldEqual Seq.empty
-  }
+//  it("should be able to AND multiple filters together") {
+//    // Add the first ten keys and row numbers
+//    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+//      .zipWithIndex.foreach { case (addr, i) =>
+//      keyIndex.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
+//    }
+//
+//    keyIndex.refreshReadersBlocking()
+//
+//    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+//      ColumnFilter("Actor2Name", Equals("REGIME".utf8)))
+//    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+//    partNums1.toSeq should equal (Seq(8, 9))
+//
+//    val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+//      ColumnFilter("Actor2Name", Equals("CHINA".utf8)))
+//    val partNums2 = keyIndex.partIdsFromFilters(filters2, 0, Long.MaxValue)
+//    partNums2.toSeq shouldEqual Nil
+//  }
+//
+//  it("should ignore unsupported columns and return empty filter") {
+//    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, 0, 1.hour)
+//    partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
+//      index2.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
+//    }
+//    keyIndex.refreshReadersBlocking()
+//
+//    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)), ColumnFilter("Year", Equals(1979)))
+//    val partNums1 = index2.partIdsFromFilters(filters1, 0, Long.MaxValue)
+//    partNums1.toSeq shouldEqual Seq.empty
+//  }
 
   it("should be able to fetch partKey from partId and partId from partKey") {
     // Add the first ten keys and row numbers

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -347,7 +347,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val range = TimeRangeChunkScan(105000L, 2000000L)
     val res = memStore.lookupPartitions(dataset2.ref, FilteredPartitionScan(split, Seq(filter)), range)
     res.firstSchemaId shouldEqual Some(schema2.schemaHash)
-    res.partsInMemory.cardinality() shouldEqual 2   // two partitions should match
+    res.partsInMemory.length shouldEqual 2   // two partitions should match
     res.shard shouldEqual 0
     res.chunkMethod shouldEqual range
     res.partIdsMemTimeGap shouldEqual debox.Map(7 -> 107000L)
@@ -402,6 +402,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
   private def partKeysWritten = memStore.store.sinkStats.partKeysWritten.get()
 
   // returns the "endTime" or last sample time of evicted partitions
+  // used for testing only
   def markPartitionsForEviction(partIDs: Seq[Int]): Long = {
     val shard = memStore.getShardE(dataset1.ref, 0)
     val blockFactory = shard.overflowBlockFactory
@@ -420,7 +421,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.setup(dataset1.ref, schemas1, 0, TestData.storeConf)
 
     // Ingest normal multi series data with 10 partitions.  Should have 10 partitions.
-    val data = records(dataset1, linearMultiSeries().take(10))
+    val data = records(dataset1, linearMultiSeries(numSeries = 10).take(10))
     memStore.ingest(dataset1.ref, 0, data)
 
     memStore.refreshIndexForTesting(dataset1.ref)
@@ -440,14 +441,21 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 20
     memStore.getShardE(dataset1.ref, 0).evictionWatermark shouldEqual endTime + 1
     memStore.getShardE(dataset1.ref, 0).addPartitionsDisabled() shouldEqual false
+    import collection.JavaConverters._
 
     memStore.refreshIndexForTesting(dataset1.ref)
+
+    // 0 and 1 are evicted
+    memStore.getShardE(dataset1.ref, 0).partitions.keySet().asScala shouldEqual (2 to 21).toSet
+    // but they should still stay in the index
+    memStore.getShardE(dataset1.ref, 0).partKeyIndex.indexNumEntries shouldEqual 22
+
     val split = memStore.getScanSplits(dataset1.ref, 1).head
     val parts = memStore.scanPartitions(dataset1.ref, Seq(0, 1), FilteredPartitionScan(split))
                         .toListL.runAsync
                         .futureValue
                         .asInstanceOf[Seq[TimeSeriesPartition]]
-    parts.map(_.partID).toSet shouldEqual (2 to 21).toSet  ++ Set(0)
+    parts.map(_.partID).toSet shouldEqual (2 to 21).toSet ++ Set(0)
     // Above query will ODP evicted partition 0 back in, but there is no space for evicted part 1,
     // so it will not be returned as part of query :(
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We use EWAH bitmap in queries. When matching partitions are very high, constructing the bitmap is VERY cpu intensive since the set is O(n) complexity on a bitmap. 

**New behavior :**

Replace bitmap with debox buffers.

Also limiting the maximum number of partition matches per shard in queries to be defensive. Extremely large queries can hog memory and destabilize the server.
