### PR TITLE
feat(core): Prometheus Counter and Histogram downsampling

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -127,10 +127,6 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
             listRegisteredDatasets(Client.standaloneClient(system, server, args.port))
           }
 
-        case Some("truncate") =>
-          client.truncateDataset(getRef(args), timeout)
-          println(s"Truncated data for ${getRef(args)} with no errors")
-
         case Some("indexnames") =>
           val (remote, ref) = getClientAndRef(args)
           val names = remote.getIndexNames(ref)

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -127,6 +127,10 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
             listRegisteredDatasets(Client.standaloneClient(system, server, args.port))
           }
 
+        case Some("truncate") =>
+          client.truncateDataset(getRef(args), timeout)
+          println(s"Truncated data for ${getRef(args)} with no errors")
+
         case Some("indexnames") =>
           val (remote, ref) = getClientAndRef(args)
           val names = remote.getIndexNames(ref)

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -65,12 +65,12 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
 
   def printHelp(): Unit = {
     println("filo-cli help:")
-    println("  commands: init create importcsv list truncate clearMetadata")
+    println("  commands: init create importcsv list clearMetadata")
     println("  dataColumns/partitionColumns: <colName1>:<type1>,<colName2>:<type2>,... ")
     println("  types:  int,long,double,string,bitmap,ts,map")
     println("  common options:  --dataset --database")
     println("  OR:  --select col1, col2  [--limit <n>]  [--outfile /tmp/out.csv]")
-    println("\n  NOTE: truncate and clearMetadata should NOT be used while FiloDB instances are up\n")
+    println("\n  NOTE: clearMetadata should NOT be used while FiloDB instances are up\n")
     println("\nStandalone client commands:")
     println("  --host <hostname/IP> [--port ...] --command indexnames --dataset <dataset>")
     println("  --host <hostname/IP> [--port ...] --command indexvalues --indexname <index> --dataset <dataset> --shards SS")

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -107,7 +107,7 @@
         # Retention of downsampled data for the corresponding resolution
         ttls = [ 30 days, 183 days ]
         # Raw schemas from which to downsample
-        raw-schema-names = [ "gauge", "untyped" ]
+        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram"]
         # class implementing the dispatch of downsample metrics to another dataset
         publisher-class = "filodb.kafka.KafkaDownsamplePublisher"
         publisher-config {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -91,7 +91,7 @@ filodb {
                  "count:double:detectDrops=true",
                  "h:hist:counter=true"]
       value-column = "h"
-      downsamplers = ["tTime(0)", "cLast(1)", "cLast(2 )", "hLast(3)"]
+      downsamplers = ["tTime(0)", "dLast(1)", "dLast(2)", "hLast(3)"]
       # Downsample periods are determined by counter dips of the count column
       downsample-period-marker = "counter(2)"
       downsample-schema = "prom-histogram"

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -60,6 +60,9 @@ filodb {
       # Downsampling configuration.  See doc/downsampling.md
       downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
 
+      # The marker implemention that determines row numbers at which to downsample
+      downsample-period-marker = "default"
+
       # If downsamplers are defined, then the downsample schema must also be defined
       downsample-schema = "ds-gauge"
     }
@@ -76,7 +79,10 @@ filodb {
     prom-counter {
       columns = ["timestamp:ts", "count:double:detectDrops=true"]
       value-column = "count"
-      downsamplers = []
+      downsamplers = ["tTime(0)", "dLast(1)"]
+      # Downsample periods are determined by counter dips of the counter column
+      downsample-period-marker = "counter(1)"
+      downsample-schema = "prom-counter"
     }
 
     prom-histogram {
@@ -85,7 +91,10 @@ filodb {
                  "count:double:detectDrops=true",
                  "h:hist:counter=true"]
       value-column = "h"
-      downsamplers = []
+      downsamplers = ["tTime(0)", "cLast(1)", "cLast(2 )", "hLast(3)"]
+      # Downsample periods are determined by counter dips of the count column
+      downsample-period-marker = "counter(2)"
+      downsample-schema = "prom-histogram"
     }
 
     # Used for downsampled gauge data

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -61,7 +61,7 @@ filodb {
       downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
 
       # The marker implemention that determines row numbers at which to downsample
-      downsample-period-marker = "default"
+      downsample-period-marker = "time(0)"
 
       # If downsamplers are defined, then the downsample schema must also be defined
       downsample-schema = "ds-gauge"

--- a/core/src/main/scala/filodb.core/downsample/ChunkDownsampler.scala
+++ b/core/src/main/scala/filodb.core/downsample/ChunkDownsampler.scala
@@ -147,7 +147,7 @@ class CounterDownsamplePeriodMarker(val inputColIds: Seq[Int]) extends Downsampl
         if (PrimitiveVectorReader.dropped(ctrVecAcc, ctrVecPtr)) { // counter dip detected
           val drops = r.asInstanceOf[CorrectingDoubleVectorReader].dropPositions(ctrVecAcc, ctrVecPtr)
           for {i <- 0 until drops.length optimized} {
-            result += drops(i - 1)
+            result += drops(i) - 1
             result += drops(i)
           }
         }

--- a/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
@@ -1,0 +1,148 @@
+package filodb.core.downsample
+
+import debox.Buffer
+import enumeratum.{Enum, EnumEntry}
+import scalaxy.loops._
+
+import filodb.core.metadata.DataSchema
+import filodb.core.store.{ChunkSetInfoReader, ReadablePartition}
+import filodb.memory.format.PrimitiveVectorReader
+import filodb.memory.format.vectors.{CorrectingDoubleVectorReader, DoubleVectorDataReader}
+
+/**
+  * Enum of supported downsample period marker names
+  * @param entryName name of the marker
+  * @param periodMarkerClass its corresponding marker class used for instance construction
+  */
+sealed abstract class PeriodMarkerName(override val entryName: String, val periodMarkerClass: Class[_])
+  extends EnumEntry
+
+object PeriodMarkerName extends Enum[PeriodMarkerName] {
+  val values = findValues
+  case object Time extends PeriodMarkerName("time", classOf[TimeDownsamplePeriodMarker])
+  case object Counter extends PeriodMarkerName("counter", classOf[CounterDownsamplePeriodMarker])
+}
+
+/**
+  * Implementations of the trait identify row numbers that
+  * demark the boundaries of downsampling periods
+  */
+trait DownsamplePeriodMarker {
+
+  def name: PeriodMarkerName
+
+  /**
+    * Ids of Data Columns the marker works on.
+    * The column id values are fed in via downsampling configuration of the dataset
+    */
+  def inputColId: Int
+
+  /**
+    * Places row numbers for the given chunkset which marks the
+    * periods to downsample into the result buffer param
+    */
+  def getPeriods(part: ReadablePartition,
+                 chunkset: ChunkSetInfoReader,
+                 resMillis: Long,
+                 startRow: Int,
+                 endRow: Int): Buffer[Int]
+}
+
+/**
+  * Time based downsample period marker, which returns row numbers of the last sample for each downsample period
+  * @param inputColId requires the timestamp column 0
+  */
+class TimeDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePeriodMarker {
+  require(inputColId == DataSchema.timestampColID)
+  override def getPeriods(part: ReadablePartition,
+                          chunkset: ChunkSetInfoReader,
+                          resMillis: Long,
+                          startRow: Int,
+                          endRow: Int): Buffer[Int] = {
+    val tsAcc = chunkset.vectorAccessor(DataSchema.timestampColID)
+    val tsPtr = chunkset.vectorAddress(DataSchema.timestampColID)
+    val tsReader = part.chunkReader(DataSchema.timestampColID, tsAcc, tsPtr).asLongReader
+
+    val startTime = tsReader.apply(tsAcc, tsPtr, startRow)
+    val endTime = tsReader.apply(tsAcc, tsPtr, endRow)
+
+    val result = debox.Buffer.empty[Int]
+    // A sample exactly for 5pm downsampled 5-minutely should fall in the period 4:55:00:001pm to 5:00:00:000pm.
+    // Hence subtract - 1 below from chunk startTime to find the first downsample period.
+    // + 1 is needed since the startTime is inclusive. We don't want pStart to be 4:55:00:000;
+    // instead we want 4:55:00:001
+    var pStart = ((startTime - 1) / resMillis) * resMillis + 1
+    var pEnd = pStart + resMillis // end is inclusive
+    // for each downsample period
+    while (pStart <= endTime) {
+      // fix the boundary row numbers for the downsample period by looking up the timestamp column
+      val endRowNum = Math.min(tsReader.ceilingIndex(tsAcc, tsPtr, pEnd), chunkset.numRows - 1)
+      result += endRowNum
+      pStart += resMillis
+      pEnd += resMillis
+    }
+    result
+  }
+  override def name: PeriodMarkerName = PeriodMarkerName.Time
+}
+
+/**
+  * Returns union of the following:
+  * (a) the results from TimeDownsamplePeriodMarker.
+  * (b) row number when counter drops
+  * (c) last row number before counter drops
+  * @param inputColId requires the counter column id
+  */
+class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePeriodMarker {
+  override def name: PeriodMarkerName = PeriodMarkerName.Counter
+  override def getPeriods(part: ReadablePartition,
+                          chunkset: ChunkSetInfoReader,
+                          resMillis: Long,
+                          startRow: Int,
+                          endRow: Int): Buffer[Int] = {
+    val result = debox.Set.empty[Int]
+    result += startRow // need to add start of every chunk
+    result ++= DownsamplePeriodMarker.timeDownsamplePeriodMarker
+      .getPeriods(part, chunkset, resMillis, startRow + 1, endRow)
+    val ctrVecAcc = chunkset.vectorAccessor(inputColId)
+    val ctrVecPtr = chunkset.vectorAddress(inputColId)
+    val ctrReader = part.chunkReader(inputColId, ctrVecAcc, ctrVecPtr)
+    ctrReader match {
+      case r: DoubleVectorDataReader =>
+        if (PrimitiveVectorReader.dropped(ctrVecAcc, ctrVecPtr)) { // counter dip detected
+          val drops = r.asInstanceOf[CorrectingDoubleVectorReader].dropPositions(ctrVecAcc, ctrVecPtr)
+          for {i <- 0 until drops.length optimized} {
+            result += drops(i) - 1
+            result += drops(i)
+          }
+        }
+      case _ =>
+        throw new IllegalStateException("Did not get a double column - cannot apply counter period marking strategy")
+    }
+    import spire.std.int._
+    result.toSortedBuffer
+  }
+}
+
+
+object DownsamplePeriodMarker {
+
+  /**
+    * Parses single downsampler from string notation such as
+    * "counter(2)" where "counter" is the downsample period marker name, 2 is the column IDs to be used by the function
+    */
+  def downsamplePeriodMarker(strNotation: String): DownsamplePeriodMarker = {
+    val parts = strNotation.split("[()]")
+    // TODO possibly better validation of string notation
+    require(parts.length == 2, s"DownsamplePeriodMarker '$strNotation' needs a name and a column id")
+    val name = parts(0)
+    val colId = parts(1).toInt
+    PeriodMarkerName.withNameOption(name) match {
+      case None    => throw new IllegalArgumentException(s"Unsupported downsample period marker $name")
+      case Some(d) => d.periodMarkerClass.getConstructor(classOf[Int])
+        .newInstance(Integer.valueOf(colId)).asInstanceOf[DownsamplePeriodMarker]
+    }
+  }
+
+  val timeDownsamplePeriodMarker = new TimeDownsamplePeriodMarker(DataSchema.timestampColID)
+}

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -174,6 +174,7 @@ object Dataset {
 
   sealed trait BadSchema
   case class BadDownsampler(msg: String) extends BadSchema
+  case class BadDownsamplerPeriodMarker(msg: String) extends BadSchema
   case class BadColumnType(colType: String) extends BadSchema
   case class BadColumnName(colName: String, reason: String) extends BadSchema
   case class NotNameColonType(nameTypeString: String) extends BadSchema
@@ -239,10 +240,12 @@ object Dataset {
   def validatedDownsamplerPeriodMarker(marker: Option[String]): DownsamplePeriodMarker Or BadSchema = {
     try {
       val v = marker.map(m => DownsamplePeriodMarker.downsamplePeriodMarker(m))
-            .getOrElse(DownsamplePeriodMarker.defaultDownsamplePeriodMarker)
+            .getOrElse(DownsamplePeriodMarker.timeDownsamplePeriodMarker)
       Good(v)
     } catch {
-      case e: IllegalArgumentException => Bad(BadDownsampler(e.getMessage))
+      case e: IllegalArgumentException =>
+        e.printStackTrace()
+        Bad(BadDownsamplerPeriodMarker(e.getMessage))
     }
   }
 

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -90,7 +90,7 @@ object DataSchema {
           _            <- validateTimeSeries(dataColumns, Seq(0)) }
     yield {
       DataSchema(name, dataColumns, downsamplers, Schemas.genHash(dataColumns),
-        valueColID, downsampleSchema, periodMarker)
+                 valueColID, downsampleSchema, periodMarker)
     }
   }
 

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfoReader.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfoReader.scala
@@ -57,7 +57,6 @@ trait ChunkSetInfoReader {
   private[store] var tsReader: LongVectorDataReader = _
   private[store] var valueReader: VectorDataReader = _
 
-
   def getTsVectorAccessor: MemoryReader = tsVectorAccessor
   def getTsVectorAddr: BinaryVector.BinaryVectorPtr = tsVectorAddr
   def getValueVectorAccessor: MemoryReader = valueVectorAccessor

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -430,6 +430,7 @@ object CustomMetricsData {
                         partitionColumns,
                         columns,
                         Seq.empty,
+                        None,
                         DatasetOptions(Seq("metric", "_ns_", "_ws_"), "metric", true)).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
   val defaultPartKey = partKeyBuilder.partKeyFromObjects(metricdataset.schema, "metric1", "app1")
@@ -440,6 +441,7 @@ object CustomMetricsData {
                         partitionColumns2,
                         columns,
                         Seq.empty,
+                        None,
                         DatasetOptions(Seq("__name__"), "__name__", true)).get
   val partKeyBuilder2 = new RecordBuilder(TestData.nativeMem, 2048)
   val defaultPartKey2 = partKeyBuilder2.partKeyFromObjects(metricdataset2.schema,
@@ -452,6 +454,7 @@ object MetricsTestData {
                                   Seq("tags:map"),
                                   Seq("timestamp:ts", "value:double:detectDrops=true"),
                                   Seq.empty,
+                                  None,
                                   DatasetOptions(Seq("__name__", "job"), "__name__")).get
   val timeseriesSchema = timeseriesDataset.schema
   val timeseriesSchemas = Schemas(timeseriesSchema)

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -492,8 +492,8 @@ object MetricsTestData {
     MachineMetricsData.linearHistSeries(startTs, numSeries, timeStep, numBuckets)
       .flatMap { record =>
         val timestamp = record(0)
-        val tags = record(4).asInstanceOf[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
-        val metricName = tags("__name__".utf8).toString
+        val tags = record(5).asInstanceOf[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
+        val metricName = record(4).toString
         val countRec = Seq(timestamp, record(1).asInstanceOf[Long].toDouble,
                            tags + ("__name__".utf8 -> (metricName + "_count").utf8))
         val sumRec = Seq(timestamp, record(2).asInstanceOf[Long].toDouble,

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -631,6 +631,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
       Seq("tags:map"),
       Seq("timestamp:ts", "value:double"),
       Seq.empty,
+      None,
       DatasetOptions(Seq("__name__", "job"), "__name__", false, Map("dummy" -> Seq("_bucket")))).get
     val metricName4 = RecordBuilder.trimShardColumn(timeseriesDataset.options, "__name__", "heap_usage_bucket")
     metricName4 shouldEqual "heap_usage_bucket"

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -252,7 +252,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
 
     partKeysWritten shouldEqual numPartKeysWritten + 10 // 10 set1 series started
     0.until(10).foreach{i => tsShard.partitions.get(i).ingesting shouldEqual true}
-    0.until(10).foreach{i => tsShard.activelyIngesting.get(i) shouldEqual true}
+    0.until(10).foreach{i => tsShard.activelyIngesting(i) shouldEqual true}
 
     val startTime2 = startTime1 + 1000 * numSamples
 
@@ -268,9 +268,9 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     // 10 Set1 series started + 10 Set1 series ended + 10 Set2 series started
     partKeysWritten shouldEqual numPartKeysWritten + 30
     0.until(10).foreach {i => tsShard.partitions.get(i).ingesting shouldEqual false}
-    0.until(10).foreach {i => tsShard.activelyIngesting.get(i) shouldEqual false}
+    0.until(10).foreach {i => tsShard.activelyIngesting(i) shouldEqual false}
     10.until(20).foreach {i => tsShard.partitions.get(i).ingesting shouldEqual true}
-    10.until(20).foreach {i => tsShard.activelyIngesting.get(i) shouldEqual true}
+    10.until(20).foreach {i => tsShard.activelyIngesting(i) shouldEqual true}
 
     val startTime3 = startTime2 + 1000 * numSamples
 
@@ -287,9 +287,9 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     // 10 set1 series restarted
     partKeysWritten shouldEqual numPartKeysWritten + 50
     0.until(10).foreach {i => tsShard.partitions.get(i).ingesting shouldEqual true}
-    0.until(10).foreach {i => tsShard.activelyIngesting.get(i) shouldEqual true}
+    0.until(10).foreach {i => tsShard.activelyIngesting(i) shouldEqual true}
     10.until(20).foreach {i => tsShard.partitions.get(i).ingesting shouldEqual false}
-    10.until(20).foreach {i => tsShard.activelyIngesting.get(i) shouldEqual false}
+    10.until(20).foreach {i => tsShard.activelyIngesting(i) shouldEqual false}
   }
 
   it("should recover index data from col store correctly") {

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -1,6 +1,6 @@
 package filodb.core.metadata
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{FunSpec, Matchers}
 
 import filodb.core._
@@ -13,13 +13,13 @@ class SchemasSpec extends FunSpec with Matchers {
 
   describe("DataSchema") {
     it("should return NotNameColonType if column specifiers not name:type format") {
-      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "column2", Nil, "first")
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "column2", Nil, None, "first")
       resp1.isBad shouldEqual true
       resp1.swap.get shouldEqual ColumnErrors(Seq(NotNameColonType("column2")))
     }
 
     it("should return BadColumnParams if name:type:params portion not valid key=value pairs") {
-      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "column2:a:b", Nil, "first")
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "column2:a:b", Nil, None, "first")
       resp1.isBad shouldEqual true
       resp1.swap.get shouldBe a[ColumnErrors]
       val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
@@ -28,14 +28,14 @@ class SchemasSpec extends FunSpec with Matchers {
     }
 
     it("should return BadColumnParams if required param config not specified") {
-      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "h:hist:foo=bar", Nil, "first")
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "h:hist:foo=bar", Nil, None, "first")
       resp1.isBad shouldEqual true
       resp1.swap.get shouldBe a[ColumnErrors]
       val errors = resp1.swap.get.asInstanceOf[ColumnErrors].errs
       errors should have length 1
       errors.head shouldBe a[BadColumnParams]
 
-      val resp2 = DataSchema.make("dataset", dataColSpecs :+ "h:hist:counter=bar", Nil, "first")
+      val resp2 = DataSchema.make("dataset", dataColSpecs :+ "h:hist:counter=bar", Nil, None, "first")
       resp2.isBad shouldEqual true
       resp2.swap.get shouldBe a[ColumnErrors]
       val errors2 = resp2.swap.get.asInstanceOf[ColumnErrors].errs
@@ -44,7 +44,7 @@ class SchemasSpec extends FunSpec with Matchers {
     }
 
     it("should return BadColumnName if illegal chars in column name") {
-      val resp1 = DataSchema.make("dataset", Seq("col, umn1:string"), Nil, "first")
+      val resp1 = DataSchema.make("dataset", Seq("col, umn1:string"), Nil, None, "first")
       resp1.isBad shouldEqual true
       val errors = resp1.swap.get match {
         case ColumnErrors(errs) => errs
@@ -55,7 +55,7 @@ class SchemasSpec extends FunSpec with Matchers {
     }
 
     it("should return BadColumnType if unsupported type specified in column spec") {
-      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "part:linkedlist", Nil, "first")
+      val resp1 = DataSchema.make("dataset", dataColSpecs :+ "part:linkedlist", Nil, None, "first")
       resp1.isBad shouldEqual true
       val errors = resp1.swap.get match {
         case ColumnErrors(errs) => errs
@@ -78,7 +78,7 @@ class SchemasSpec extends FunSpec with Matchers {
     }
 
     it("should return multiple column spec errors") {
-      val resp1 = DataSchema.make("dataset", Seq("first:str", "age:long", "la(st):int"), Nil, "first")
+      val resp1 = DataSchema.make("dataset", Seq("first:str", "age:long", "la(st):int"), Nil, None, "first")
       resp1.isBad shouldEqual true
       val errors = resp1.swap.get match {
         case ColumnErrors(errs) => errs
@@ -101,7 +101,7 @@ class SchemasSpec extends FunSpec with Matchers {
     }
 
     it("should return NoTimestampRowKey if non timestamp used for row key / first column") {
-      val ds1 = DataSchema.make("dataset", Seq("first:string", "age:long"), Nil, "first")
+      val ds1 = DataSchema.make("dataset", Seq("first:string", "age:long"), Nil, None, "first")
       ds1.isBad shouldEqual true
       ds1.swap.get shouldBe a[NoTimestampRowKey]
     }
@@ -272,7 +272,7 @@ class SchemasSpec extends FunSpec with Matchers {
       errors.map(_._1) shouldEqual Seq("prom")
     }
 
-    def schemasFromString(partConf: String) = ConfigFactory.parseString(s"""
+    def schemasFromString(partConf: String): Config = ConfigFactory.parseString(s"""
                   {
                     partition-schema $partConf
                     schemas {

--- a/doc/query-engine.md
+++ b/doc/query-engine.md
@@ -250,20 +250,31 @@ Look here for examples of [RangeFunctions](../query/exec/rangefn/RangeFunction.s
 
 ### ChunkedWindowIterator Details
 
-The `ChunkedWindowIterator` applies `ChunkedRangeFunctions` to each time window, outputting a computed value for each window.  It works as follows:
+The `ChunkedWindowIterator` applies `ChunkedRangeFunctions` to each time window, outputting a computed value for each 
+window.  It works as follows:
 
 ![](mermaid/chunked-iteration.png)
 
 1. `ChunkedWindowIterator` advances to the next window
 2. it first calls `reset` on the `ChunkedRangeFunction`
-2. It then loops through each relevant chunk within the window, calling the `addChunk` method of the range function to update its result for each chunk.  The range function is free to use any method from the raw chunk data, usually this is pretty fast compared to row-wise iteration.
-3. Finally, the `apply` method is called on the range function to present result for that time window from all the intermediate results from the chunks.
+2. It then loops through each relevant chunk within the window, calling the `addChunk` method of the range function to 
+update its result for each chunk.  The range function is free to use any method from the raw chunk data, usually this 
+is pretty fast compared to row-wise iteration.
+3. Finally, the `apply` method is called on the range function to present result for that time window from all the 
+intermediate results from the chunks.
 
-Note that `ChunkedWindowIterator` support different types of `RowReader` outputs for different types of output columns.  One version is for `TransientRow` which has Double values, and another is for `TransientHistRow` which supports Histogram values as output.
+Note that `ChunkedWindowIterator` support different types of `RowReader` outputs for different types of output columns.
+One version is for `TransientRow` which has Double values, and another is for `TransientHistRow` which supports 
+Histogram values as output.
 
 ### Efficient Counter Correction and Rate Calculation
 
-The naive way to do counter correction would be to iterate through each sample of the entire time series data covering all windows, and detect and correct the samples one by one.  This however costs O(n) with every query.  We take an alternative approach where we detect any corrections or resets at ingestion time and store some metadata with each chunk of data.  Then, at query time, a quick check is done on the chunk to see if it needs correction or not.  Corrections are carried over and adjusted from chunk to chunk.  This allows us to do corrections at query time only for chunks that actually need correction.
+The naive way to do counter correction would be to iterate through each sample of the entire time series data 
+covering all windows, and detect and correct the samples one by one.  This however costs O(n) with every query.  
+We take an alternative approach where we detect any corrections or resets at ingestion time and store some metadata 
+with each chunk of data.  Then, at query time, a quick check is done on the chunk to see if it needs correction or 
+not.  Corrections are carried over and adjusted from chunk to chunk.  This allows us to do corrections at query time 
+only for chunks that actually need correction.
 In addition, the rate is calculated quickly by examining the start and end of the time window within each chunk.
 
 ### Aggregation across Range Vectors

--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -176,6 +176,11 @@ trait CounterVectorReader extends VectorDataReader {
    * @param meta CorrectionMeta with total running correction info.  lastValue is ignored
    */
   def updateCorrection(acc: MemoryReader, vector: BinaryVectorPtr, meta: CorrectionMeta): CorrectionMeta
+
+  /**
+    * Identifies row numbers at which histogram or counter has dropped
+    */
+  def dropPositions(acc2: MemoryReader, vector: BinaryVectorPtr): debox.Buffer[Int]
 }
 
 // An efficient iterator for the bitmap mask, rotating a mask as we go

--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -131,7 +131,7 @@ trait VectorDataReader extends AvailableReader {
     * Used only for testing. When using in production be careful of unnecessary allocation
     * when backing memory is already on heap.
     */
-  def toBytes(acc: MemoryAccessor, vector: BinaryVectorPtr): Array[Byte] = {
+  def toBytes(acc: MemoryReader, vector: BinaryVectorPtr): Array[Byte] = {
     val numByts = numBytes(acc, vector) + 4
     val bytes = new Array[Byte](numByts)
     acc.copy(vector, MemoryAccessor.fromArray(bytes), 0, numByts)

--- a/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
@@ -148,6 +148,7 @@ class OnHeapByteBufferAccessor(buf: ByteBuffer) extends MemoryAccessor {
   var base: Array[Byte] = _
   var baseOffset: Long = _
   var length: Int = _
+  val origBufPos = buf.position()
 
   // TODO check bounds of array before accessing
   require (!buf.isDirect, "buf arg cannot be a DirectBuffer")
@@ -163,7 +164,7 @@ class OnHeapByteBufferAccessor(buf: ByteBuffer) extends MemoryAccessor {
   }
 
   override def wrapInto(dBuf: DirectBuffer, addr: Long, length: Int): Unit = {
-    dBuf.wrap(buf, addr.toInt, length)
+    dBuf.wrap(buf, origBufPos + addr.toInt, length)
   }
 
 }

--- a/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
@@ -60,6 +60,8 @@ sealed trait MemoryReader {
   final def getLongVolatile(addr: Long): Long = unsafe.getLongVolatile(base, baseOffset + addr)
   final def getDouble(addr: Long): Double = unsafe.getDouble(base, baseOffset + addr)
   final def getFloat(addr: Long): Double = unsafe.getFloat(base, baseOffset + addr)
+  final def copy(fromAddr: Long, toAcc: MemoryAccessor, toAddr: Long, numBytes: Int): Unit =
+    UnsafeUtils.copy(base, baseOffset + fromAddr, toAcc.base, toAcc.baseOffset + toAddr, numBytes)
 }
 
 /**
@@ -100,8 +102,6 @@ sealed trait MemoryAccessor extends MemoryReader {
   final def setLong(addr: Long, l: Long): Unit = unsafe.putLong(base, baseOffset + addr, l)
   final def setDouble(addr: Long, d: Double): Unit = unsafe.putDouble(base, baseOffset + addr, d)
   final def setFloat(addr: Long, f: Float): Unit = unsafe.putFloat(base, baseOffset + addr, f)
-  final def copy(fromAddr: Long, toAcc: MemoryAccessor, toAddr: Long, numBytes: Int): Unit =
-    UnsafeUtils.copy(base, baseOffset + fromAddr, toAcc.base, toAcc.baseOffset + toAddr, numBytes)
   //  def wordCompare(thisOffset: Long, destObj: MemoryBase, destOffset: Long, n: Int): Int
   //  def compareTo(offset1: Long, numBytes1: Int, base2: MemoryBase, offset2: Long, numBytes2: Int): Int
 }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -540,7 +540,6 @@ class SectDeltaHistogramReader(acc2: MemoryReader, histVect: Ptr.U8)
       } else { meta }
   }
 
-  private val _drops = debox.Buffer.empty[Int] // to track counter drop positions
   // code to go through and build a list of corrections and corresponding index values.. (dropIndex, correction)
   private lazy val corrections = {
     var index = 0
@@ -552,7 +551,11 @@ class SectDeltaHistogramReader(acc2: MemoryReader, histVect: Ptr.U8)
   }
 
   def dropPositions(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr): debox.Buffer[Int] = {
-    ??? // implement later when needed
+    val res = debox.Buffer.empty[Int]
+    corrections.foreach { case (dropPos, hist) =>
+      res += dropPos
+    }
+    res
   }
 
   def updateCorrection(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr,

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -552,7 +552,7 @@ class SectDeltaHistogramReader(acc2: MemoryReader, histVect: Ptr.U8)
   }
 
   def dropPositions(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr): debox.Buffer[Int] = {
-    ???
+    ??? // implement later when needed
   }
 
   def updateCorrection(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr,

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -540,14 +540,19 @@ class SectDeltaHistogramReader(acc2: MemoryReader, histVect: Ptr.U8)
       } else { meta }
   }
 
+  private val _drops = debox.Buffer.empty[Int] // to track counter drop positions
   // code to go through and build a list of corrections and corresponding index values.. (dropIndex, correction)
-  lazy val corrections = {
+  private lazy val corrections = {
     var index = 0
     // Step 1: build an iterator of (starting-index, section) for each section
     iterateSections.map { case (s) => val o = (index, s); index += s.numElements(acc); o }.collect {
       case (i, s) if i > 0 && s.sectionType(acc) == Section.TypeDrop =>
         (i, apply(i - 1).asInstanceOf[LongHistogram].copy)
     }.toBuffer
+  }
+
+  def dropPositions(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr): debox.Buffer[Int] = {
+    ???
   }
 
   def updateCorrection(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr,

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -25,8 +25,7 @@ class HistogramVectorTest extends NativeVectorTest {
 
   def verifyHistogram(h: Histogram, itemNo: Int,
                       rawBuckets: Seq[Array[Double]] = rawHistBuckets,
-                      bucketScheme: HistogramBuckets = bucketScheme
-                     ): Unit = {
+                      bucketScheme: HistogramBuckets = bucketScheme ): Unit = {
     h.numBuckets shouldEqual bucketScheme.numBuckets
     for { i <- 0 until bucketScheme.numBuckets } {
       h.bucketTop(i) shouldEqual bucketScheme.bucketTop(i)

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -23,7 +23,10 @@ class HistogramVectorTest extends NativeVectorTest {
 
   val buffer = new UnsafeBuffer(new Array[Byte](4096))
 
-  def verifyHistogram(h: Histogram, itemNo: Int, rawBuckets: Seq[Array[Double]] = rawHistBuckets): Unit = {
+  def verifyHistogram(h: Histogram, itemNo: Int,
+                      rawBuckets: Seq[Array[Double]] = rawHistBuckets,
+                      bucketScheme: HistogramBuckets = bucketScheme
+                     ): Unit = {
     h.numBuckets shouldEqual bucketScheme.numBuckets
     for { i <- 0 until bucketScheme.numBuckets } {
       h.bucketTop(i) shouldEqual bucketScheme.bucketTop(i)
@@ -102,7 +105,6 @@ class HistogramVectorTest extends NativeVectorTest {
     appender.length shouldEqual 0
   }
 
-
   it("should be able to read from on-heap Histogram Vector") {
     val appender = HistogramVector.appending(memFactory, 1024)
     rawLongBuckets.foreach { rawBuckets =>
@@ -138,7 +140,6 @@ class HistogramVectorTest extends NativeVectorTest {
     }
   }
 
-
   val lastIncrHist = LongHistogram(bucketScheme, incrHistBuckets.last.map(_.toLong))
 
   it("should append, optimize, and query SectDelta histograms") {
@@ -171,6 +172,64 @@ class HistogramVectorTest extends NativeVectorTest {
       HistogramCorrection(lastIncrHist, LongHistogram.empty(bucketScheme))
     oReader2.updateCorrection(acc, optimized, HistogramCorrection(lastIncrHist, correction1.copy)) shouldEqual
       HistogramCorrection(lastIncrHist, correction1)
+  }
+
+  it("should work for the downsampling round trip of a histogram vector") {
+
+    val myBucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
+    // time, sum, count, histogram
+    val bucketData = Seq(
+      Array(0d, 0d, 1d),
+      Array(0d, 2d, 3d),
+      Array(2d, 5d, 6d),
+      Array(2d, 5d, 9d),
+      Array(2d, 5d, 10d),
+      Array(2d, 8d, 14d),
+      Array(0d, 0d, 2d),
+      Array(1d, 7d, 9d),
+      Array(1d, 15d, 19d),
+      Array(2d, 16d, 21d),
+      Array(0d, 1d, 1d),
+      Array(0d, 15d, 15d),
+      Array(1d, 16d, 19d),
+      Array(4d, 20d, 25d)
+    )
+
+    val appender = HistogramVector.appendingSect(memFactory, 1024)
+    bucketData.foreach { rawBuckets =>
+      BinaryHistogram.writeDelta(myBucketScheme, rawBuckets.map(_.toLong), buffer)
+      appender.addData(buffer) shouldEqual Ack
+    }
+
+    appender.length shouldEqual bucketData.length
+
+    val reader = appender.reader.asInstanceOf[SectDeltaHistogramReader]
+    reader.length shouldEqual bucketData.length
+
+    reader.dropPositions(MemoryAccessor.nativePtrAccessor, appender.addr) shouldEqual debox.Buffer(6, 10)
+
+    (0 until bucketData.length).foreach { i =>
+      verifyHistogram(reader(i), i, bucketData, myBucketScheme)
+    }
+
+    val optimized = appender.optimize(memFactory)
+
+    val optReader = HistogramVector(BinaryVector.asBuffer(optimized))
+
+    val bytes = optReader.toBytes(acc, optimized)
+
+    val onHeapAcc = Seq(MemoryReader.fromArray(bytes),
+      MemoryReader.fromByteBuffer(BinaryVector.asBuffer(optimized)),
+      MemoryReader.fromByteBuffer(ByteBuffer.wrap(bytes)))
+
+    onHeapAcc.foreach { a =>
+      val readerH = HistogramVector(a, 0).asInstanceOf[SectDeltaHistogramReader]
+      readerH.dropPositions(a, 0) shouldEqual debox.Buffer(6, 10)
+      (0 until bucketData.length).foreach { i =>
+        val h = readerH(i)
+        verifyHistogram(h, i, bucketData, myBucketScheme)
+      }
+    }
   }
 
   it("SectDelta vectors should detect and handle drops correctly") {

--- a/scripts/schema-create.sh
+++ b/scripts/schema-create.sh
@@ -3,7 +3,7 @@
 if [[ $# -ne 4 ]]; then
     echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <DATASET> <NUM_SHARDS>"
     echo "First Run: $0 filodb_admin filodb prometheus 4 > ddl.cql"
-    echo "Then Run: cql -f ddl.cql"
+    echo "Then Run: cql --request-timeout 3000 -f ddl.cql"
     exit 1
 fi
 

--- a/scripts/schema-truncate.sh
+++ b/scripts/schema-truncate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [[ $# -ne 4 ]]; then
+    echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <DATASET> <NUM_SHARDS>"
+    echo "First Run: $0 filodb_admin filodb prometheus 4 > ddl.cql"
+    echo "Then Run: cql --request-timeout 3000 -f ddl.cql"
+    exit 1
+fi
+
+FILO_ADMIN_KEYSPACE=$1
+FILO_KEYSPACE=$2
+DATASET=$3
+NUM_SHARDS=$4
+
+cat << EOF
+TRUNCATE ${FILO_ADMIN_KEYSPACE}.checkpoints;
+TRUNCATE ${FILO_KEYSPACE}.${DATASET}_tschunks;
+TRUNCATE ${FILO_KEYSPACE}.${DATASET}_ingestion_time_index;
+EOF
+
+for SHARD in $(seq 0 $((NUM_SHARDS - 1))); do
+
+cat << EOF
+TRUNCATE ${FILO_KEYSPACE}.${DATASET}_partitionkeys_$SHARD;
+EOF
+
+done

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -68,6 +68,9 @@ object BatchDownsampler extends StrictLogging with Instance {
   private val chunkDownsamplersByRawSchemaId = debox.Map.empty[Int, scala.Seq[ChunkDownsampler]]
   rawSchemas.foreach { s => chunkDownsamplersByRawSchemaId += s.schemaHash -> s.data.downsamplers }
 
+  private val downsamplePeriodMarkersByRawSchemaId = debox.Map.empty[Int, DownsamplePeriodMarker]
+  rawSchemas.foreach { s => downsamplePeriodMarkersByRawSchemaId += s.schemaHash -> s.data.downsamplePeriodMarker }
+
   /**
     * Raw dataset from which we downsample data
     */
@@ -158,6 +161,7 @@ object BatchDownsampler extends StrictLogging with Instance {
         val rawReadablePart = new PagedReadablePartition(rawPartSchema, 0, 0, rawPart)
         val bufferPool = offHeapMem.bufferPools(rawPartSchema.downsample.get.schemaHash)
         val downsamplers = chunkDownsamplersByRawSchemaId(rawSchemaId)
+        val periodMarker = downsamplePeriodMarkersByRawSchemaId(rawSchemaId)
         val (_, partKeyPtr, _) = BinaryRegionLarge.allocateAndCopy(rawReadablePart.partKeyBase,
                                                    rawReadablePart.partKeyOffset,
                                                    offHeapMem.nativeMemoryManager)
@@ -168,7 +172,8 @@ object BatchDownsampler extends StrictLogging with Instance {
           res -> part
         }.toMap
 
-        downsampleChunks(offHeapMem, rawReadablePart, downsamplers, downsampledParts, userTimeStart, userTimeEnd)
+        downsampleChunks(offHeapMem, rawReadablePart, downsamplers, periodMarker,
+                         downsampledParts, userTimeStart, userTimeEnd)
 
         pagedPartsToFree += rawReadablePart
         downsampledPartsToFree ++= downsampledParts.values
@@ -195,6 +200,7 @@ object BatchDownsampler extends StrictLogging with Instance {
   private def downsampleChunks(offHeapMem: OffHeapMemory,
                                rawPartToDownsample: ReadablePartition,
                                downsamplers: Seq[ChunkDownsampler],
+                               periodMarker: DownsamplePeriodMarker,
                                downsampledParts: Map[FiniteDuration, TimeSeriesPartition],
                                userTimeStart: Long,
                                userTimeEnd: Long) = {
@@ -207,114 +213,44 @@ object BatchDownsampler extends StrictLogging with Instance {
 
     while (rawChunksets.hasNext) {
       val chunkset = rawChunksets.nextInfoReader
-      val startTime = chunkset.startTime
-      val endTime = chunkset.endTime
-      val vecPtr = chunkset.vectorAddress(timestampCol)
-      val vecAcc = chunkset.vectorAccessor(timestampCol)
-      val tsReader = rawPartToDownsample.chunkReader(timestampCol, vecAcc, vecPtr).asLongReader
+      val tsPtr = chunkset.vectorAddress(timestampCol)
+      val tsAcc = chunkset.vectorAccessor(timestampCol)
+      val tsReader = rawPartToDownsample.chunkReader(timestampCol, tsAcc, tsPtr).asLongReader
 
       // for each downsample resolution
       downsampledParts.foreach { case (resolution, part) =>
         val resMillis = resolution.toMillis
-        // A sample exactly for 5pm downsampled 5-minutely should fall in the period 4:55:00:001pm to 5:00:00:000pm.
-        // Hence subtract - 1 below from chunk startTime to find the first downsample period.
-        // + 1 is needed since the startTime is inclusive. We don't want pStart to be 4:55:00:000;
-        // instead we want 4:55:00:001
-        var pStart = ((startTime - 1) / resMillis) * resMillis + 1
-        var pEnd = pStart + resMillis // end is inclusive
-        // for each downsample period
-        while (pStart <= endTime) {
-          if (pEnd >= userTimeStart && pEnd <= userTimeEnd) {
-            // fix the boundary row numbers for the downsample period by looking up the timestamp column
-            val startRowNum = tsReader.binarySearch(vecAcc, vecPtr, pStart) & 0x7fffffff
-            val endRowNum = Math.min(tsReader.ceilingIndex(vecAcc, vecPtr, pEnd), chunkset.numRows - 1)
 
-            // for each downsampler, add downsample column value
-            for {col <- downsamplers.indices optimized} {
-              val downsampler = downsamplers(col)
-              downsampler match {
-                case d: TimeChunkDownsampler =>
-                  downsampleRow(col) = d.downsampleChunk(rawPartToDownsample, chunkset, startRowNum, endRowNum)
-                case d: DoubleChunkDownsampler =>
-                  downsampleRow(col) = d.downsampleChunk(rawPartToDownsample, chunkset, startRowNum, endRowNum)
-                case h: HistChunkDownsampler =>
-                  downsampleRow(col) = h.downsampleChunk(rawPartToDownsample, chunkset, startRowNum, endRowNum)
-                    .serialize()
-              }
+        val startRow = tsReader.binarySearch(tsAcc, tsPtr, userTimeStart) & 0x7fffffff
+        val endRow = Math.min(tsReader.ceilingIndex(tsAcc, tsPtr, userTimeEnd), chunkset.numRows - 1)
+        val downsamplePeriods = periodMarker.getPeriods(rawPartToDownsample, chunkset, resMillis, startRow, endRow)
+
+        var first = startRow
+        for { i <- 0 until downsamplePeriods.length optimized } {
+          val last = downsamplePeriods(i)
+          // for each downsampler, add downsample column value
+          for {col <- downsamplers.indices optimized} {
+            val downsampler = downsamplers(col)
+            downsampler match {
+              case d: TimeChunkDownsampler =>
+                downsampleRow(col) = d.downsampleChunk(rawPartToDownsample, chunkset, first, last)
+              case d: DoubleChunkDownsampler =>
+                downsampleRow(col) = d.downsampleChunk(rawPartToDownsample, chunkset, first, last)
+              case h: HistChunkDownsampler =>
+                downsampleRow(col) = h.downsampleChunk(rawPartToDownsample, chunkset, first, last)
+                  .serialize()
             }
-            logger.trace(s"Ingesting into part=${part.hashCode}: $downsampleRow")
-            //use the userTimeStart as ingestionTime
-            part.ingest(userTimeStart, downsampleRowReader, offHeapMem.blockMemFactory)
           }
-          pStart += resMillis
-          pEnd += resMillis
+          logger.trace(s"Ingesting into part=${part.hashCode}: $downsampleRow")
+          //use the userTimeStart as ingestionTime
+          part.ingest(userTimeStart, downsampleRowReader, offHeapMem.blockMemFactory)
+
+          first = last + 1 // first row for next downsample period is last + 1
         }
+
       }
     }
   }
-
-  private def rowBasedDownsampleChunks(offHeapMem: OffHeapMemory,
-                                       rawPartToDownsample: ReadablePartition,
-                                       downsamplers: Seq[ChunkDownsampler],
-                                       downsampledParts: Map[FiniteDuration, TimeSeriesPartition],
-                                       userTimeStart: Long,
-                                       userTimeEnd: Long) = {
-    val timestampCol = 0
-    val rawChunksets = rawPartToDownsample.infos(AllChunkScan)
-
-    // TODO create a rowReader that will not box the vals below
-    val downsampleRow = new Array[Any](downsamplers.size)
-    val downsampleRowReader = SeqRowReader(downsampleRow)
-
-    while (rawChunksets.hasNext) {
-      val chunkset = rawChunksets.nextInfoReader
-      val startTime = chunkset.startTime
-      val endTime = chunkset.endTime
-      val vecPtr = chunkset.vectorAddress(timestampCol)
-      val vecAcc = chunkset.vectorAccessor(timestampCol)
-      val tsReader = rawPartToDownsample.chunkReader(timestampCol, vecAcc, vecPtr).asLongReader
-
-      // for each downsample resolution
-      downsampledParts.foreach { case (resolution, part) =>
-        val resMillis = resolution.toMillis
-        // A sample exactly for 5pm downsampled 5-minutely should fall in the period 4:55:00:001pm to 5:00:00:000pm.
-        // Hence subtract - 1 below from chunk startTime to find the first downsample period.
-        // + 1 is needed since the startTime is inclusive. We don't want pStart to be 4:55:00:000;
-        // instead we want 4:55:00:001
-        var pStart = ((startTime - 1) / resMillis) * resMillis + 1
-        var pEnd = pStart + resMillis // end is inclusive
-        // for each downsample period
-        while (pStart <= endTime) {
-          if (pEnd >= userTimeStart && pEnd <= userTimeEnd) {
-            // fix the boundary row numbers for the downsample period by looking up the timestamp column
-            val startRowNum = tsReader.binarySearch(vecAcc, vecPtr, pStart) & 0x7fffffff
-            val endRowNum = Math.min(tsReader.ceilingIndex(vecAcc, vecPtr, pEnd), chunkset.numRows - 1)
-
-            // for each downsampler, add downsample column value
-            for {col <- downsamplers.indices optimized} {
-              val downsampler = downsamplers(col)
-              downsampler match {
-                case d: TimeChunkDownsampler =>
-                  downsampleRow(col) = d.downsampleChunk(rawPartToDownsample, chunkset, startRowNum, endRowNum)
-                case d: DoubleChunkDownsampler =>
-                  downsampleRow(col) = d.downsampleChunk(rawPartToDownsample, chunkset, startRowNum, endRowNum)
-                case h: HistChunkDownsampler =>
-                  downsampleRow(col) = h.downsampleChunk(rawPartToDownsample, chunkset, startRowNum, endRowNum)
-                    .serialize()
-              }
-            }
-            logger.trace(s"Ingesting into part=${part.hashCode}: $downsampleRow")
-            //use the userTimeStart as ingestionTime
-            part.ingest(userTimeStart, downsampleRowReader, offHeapMem.blockMemFactory)
-          }
-          pStart += resMillis
-          pEnd += resMillis
-        }
-      }
-    }
-  }
-
-
 
   /**
     * Persist chunks in `downsampledChunksToPersist` to Cassandra.

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -221,7 +221,7 @@ object BatchDownsampler extends StrictLogging with Instance {
 
         val startRow = tsReader.binarySearch(tsAcc, tsPtr, userTimeStart) & 0x7fffffff
         val endRow = Math.min(tsReader.ceilingIndex(tsAcc, tsPtr, userTimeEnd), chunkset.numRows - 1)
-        val downsamplePeriods = periodMarker.getPeriods(rawPartToDownsample, chunkset, resMillis, startRow, endRow)
+        val downsamplePeriods = periodMarker.periods(rawPartToDownsample, chunkset, resMillis, startRow, endRow)
 
         // for each downsample period
         var first = startRow

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -297,26 +297,29 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3))
 
+    val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
     val downsampledData1 = rv1.rows.map { r =>
-      (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getHistogram(3))
+      val h = r.getHistogram(3)
+      h.numBuckets shouldEqual 3
+      (0 until h.numBuckets).map(i => h.bucketTop(i)) shouldEqual bucketScheme
+      (r.getLong(0), r.getDouble(1), r.getDouble(2), (0 until h.numBuckets).map(i => h.bucketValue(i)))
     }.toList
 
-    val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
     // time, sum, count, histogram
     downsampledData1 shouldEqual Seq(
-      Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d))),
-      Seq(1574272802000L, 5d, 6d, MutableHistogram(bucketScheme, Array(2d, 5d, 6d))),
+      (1574272801000L, 0d, 1d, Seq(0d, 0d, 1d)),
+      (1574272802000L, 5d, 6d, Seq(2d, 5d, 6d)),
 
-      Seq(1574272862000L, 11d, 14d, MutableHistogram(bucketScheme, Array(2d, 8d, 14d))),
+      (1574272862000L, 11d, 14d, Seq(2d, 8d, 14d)),
 
-      Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d))),
-      Seq(1574272922000L, 15d, 19d, MutableHistogram(bucketScheme, Array(1d, 15d, 19d))),
+      (1574272921000L, 2d, 2d, Seq(0d, 0d, 2d)),
+      (1574272922000L, 15d, 19d, Seq(1d, 15d, 19d)),
 
-      Seq(1574272981000L, 17d, 21d, MutableHistogram(bucketScheme, Array(2d, 16d, 21d))),
-      Seq(1574272981500L, 1d, 1d, MutableHistogram(bucketScheme, Array(0d, 1d, 1d))),
-      Seq(1574272982000L, 15d, 15d, MutableHistogram(bucketScheme, Array(0d, 15d, 15d))),
+      (1574272981000L, 17d, 21d, Seq(2d, 16d, 21d)),
+      (1574272981500L, 1d, 1d, Seq(0d, 1d, 1d)),
+      (1574272982000L, 15d, 15d, Seq(0d, 15d, 15d)),
 
-      Seq(1574273042000L, 20d, 25d, MutableHistogram(bucketScheme, Array(4d, 20d, 25d)))
+      (1574273042000L, 20d, 25d, Seq(4d, 20d, 25d))
     )
   }
 
@@ -398,20 +401,24 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3))
 
+    val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
     val downsampledData1 = rv1.rows.map { r =>
-      (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getHistogram(3))
+      val h = r.getHistogram(3)
+      h.numBuckets shouldEqual 3
+      (0 until h.numBuckets).map(i => h.bucketTop(i)) shouldEqual bucketScheme
+      (r.getLong(0), r.getDouble(1), r.getDouble(2), (0 until h.numBuckets).map(i => h.bucketValue(i)))
     }.toList
 
-    val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
     // time, sum, count, histogram
     downsampledData1 shouldEqual Seq(
-      Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d))),
-      Seq(1574272862000L, 11d, 14d, MutableHistogram(bucketScheme, Array(2d, 8d, 14d))),
-      Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d))),
-      Seq(1574272981000L, 17d, 21d, MutableHistogram(bucketScheme, Array(2d, 16d, 21d))),
-      Seq(1574272981500L, 1d, 1d, MutableHistogram(bucketScheme, Array(0d, 1d, 1d))),
-      Seq(1574273042000L, 20d, 25d, MutableHistogram(bucketScheme, Array(4d, 20d, 25d)))
+      (1574272801000L, 0d, 1d, Seq(0d, 0d, 1d)),
+      (1574272862000L, 11d, 14d, Seq(2d, 8d, 14d)),
+      (1574272921000L, 2d, 2d, Seq(0d, 0d, 2d)),
+      (1574272981000L, 17d, 21d, Seq(2d, 16d, 21d)),
+      (1574272981500L, 1d, 1d, Seq(0d, 1d, 1d)),
+      (1574273042000L, 20d, 25d, Seq(4d, 20d, 25d))
     )
+
   }
 
   it("should read and verify part key migration in cassandra for 5-min downsampled data") {

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -37,7 +37,8 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
                   |shard-mem-size = 1MB
                 """.stripMargin))
 
-  val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter), Map.empty, 100, storeConfig)
+  val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram),
+                                     Map.empty, 100, storeConfig)
   var gaugePartKeyBytes: Array[Byte] = _
   var counterPartKeyBytes: Array[Byte] = _
   val lastSampleTime = 1574273042000L
@@ -144,6 +145,52 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     colStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
+  }
+
+  it ("should write prom histogram data to cassandra") {
+
+//    val rawDataset = Dataset("prometheus", Schemas.promCounter)
+//
+//    val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
+//    val seriesName = "myCounter"
+//    val seriesTags = Map("k".utf8 -> "v".utf8)
+//    val partKey = partBuilder.partKeyFromObjects(Schemas.promHistogram, seriesName, seriesTags)
+//
+//    val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey,
+//      0, offheapMem.bufferPools(Schemas.promHistogram.schemaHash), shardStats,
+//      offheapMem.nativeMemoryManager, 1)
+//
+//    counterPartKeyBytes = part.partKeyBytes
+//
+//    val rawSamples = Stream(
+//      Seq(1574272801000L, 3d, seriesName, seriesTags),
+//      Seq(1574272801500L, 4d, seriesName, seriesTags),
+//      Seq(1574272802000L, 5d, seriesName, seriesTags),
+//
+//      Seq(1574272861000L, 9d, seriesName, seriesTags),
+//      Seq(1574272861500L, 10d, seriesName, seriesTags),
+//      Seq(1574272862000L, 11d, seriesName, seriesTags),
+//
+//      Seq(1574272921000L, 2d, seriesName, seriesTags),
+//      Seq(1574272921500L, 7d, seriesName, seriesTags),
+//      Seq(1574272922000L, 15d, seriesName, seriesTags),
+//
+//      Seq(1574272981000L, 17d, seriesName, seriesTags),
+//      Seq(1574272981500L, 1d, seriesName, seriesTags),
+//      Seq(1574272982000L, 15d, seriesName, seriesTags),
+//
+//      Seq(1574273041000L, 18d, seriesName, seriesTags),
+//      Seq(1574273042000L, 20d, seriesName, seriesTags)
+//    )
+//
+//    MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
+//      val rr = new BinaryRecordRowReader(Schemas.promCounter.ingestionSchema, base, offset)
+//      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+//    }
+//    part.switchBuffers(offheapMem.blockMemFactory, true)
+//    val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
+//
+//    colStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
   }
 
   it ("should downsample raw data into the downsample dataset tables in cassandra using spark job") {

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -167,23 +167,23 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
     val rawSamples = Stream( // time, sum, count, hist, name, tags
       Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d)), seriesName, seriesTags),
-      Seq(1574272801500L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 2d, 2d)), seriesName, seriesTags),
-      Seq(1574272802000L, 5d, 5d, MutableHistogram(bucketScheme, Array(2d, 3d, 5d)), seriesName, seriesTags),
+      Seq(1574272801500L, 2d, 3d, MutableHistogram(bucketScheme, Array(0d, 2d, 3d)), seriesName, seriesTags),
+      Seq(1574272802000L, 5d, 6d, MutableHistogram(bucketScheme, Array(2d, 5d, 6d)), seriesName, seriesTags),
 
       Seq(1574272861000L, 9d, 9d, MutableHistogram(bucketScheme, Array(2d, 5d, 9d)), seriesName, seriesTags),
       Seq(1574272861500L, 10d, 10d, MutableHistogram(bucketScheme, Array(2d, 5d, 10d)), seriesName, seriesTags),
-      Seq(1574272862000L, 11d, 11d, MutableHistogram(bucketScheme, Array(2d, 8d, 11d)), seriesName, seriesTags),
+      Seq(1574272862000L, 11d, 14d, MutableHistogram(bucketScheme, Array(2d, 8d, 14d)), seriesName, seriesTags),
 
       Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d)), seriesName, seriesTags),
-      Seq(1574272921500L, 7d, 7d, MutableHistogram(bucketScheme, Array(1d, 7d, 7d)), seriesName, seriesTags),
-      Seq(1574272922000L, 15d, 15d, MutableHistogram(bucketScheme, Array(1d, 15d, 15d)), seriesName, seriesTags),
+      Seq(1574272921500L, 7d, 9d, MutableHistogram(bucketScheme, Array(1d, 7d, 9d)), seriesName, seriesTags),
+      Seq(1574272922000L, 15d, 19d, MutableHistogram(bucketScheme, Array(1d, 15d, 19d)), seriesName, seriesTags),
 
-      Seq(1574272981000L, 17d, 17d, MutableHistogram(bucketScheme, Array(2d, 15d, 17d)), seriesName, seriesTags),
+      Seq(1574272981000L, 17d, 21d, MutableHistogram(bucketScheme, Array(2d, 16d, 21d)), seriesName, seriesTags),
       Seq(1574272981500L, 1d, 1d, MutableHistogram(bucketScheme, Array(0d, 1d, 1d)), seriesName, seriesTags),
       Seq(1574272982000L, 15d, 15d, MutableHistogram(bucketScheme, Array(0d, 15d, 15d)), seriesName, seriesTags),
 
-      Seq(1574273041000L, 18d, 18d, MutableHistogram(bucketScheme, Array(1d, 15d, 18d)), seriesName, seriesTags),
-      Seq(1574273042000L, 20d, 20d, MutableHistogram(bucketScheme, Array(4d, 20d, 20d)), seriesName, seriesTags)
+      Seq(1574273041000L, 18d, 19d, MutableHistogram(bucketScheme, Array(1d, 16d, 19d)), seriesName, seriesTags),
+      Seq(1574273042000L, 20d, 25d, MutableHistogram(bucketScheme, Array(4d, 20d, 25d)), seriesName, seriesTags)
     )
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
@@ -305,18 +305,18 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     // time, sum, count, histogram
     downsampledData1 shouldEqual Seq(
       Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d))),
-      Seq(1574272802000L, 5d, 5d, MutableHistogram(bucketScheme, Array(2d, 3d, 5d))),
+      Seq(1574272802000L, 5d, 6d, MutableHistogram(bucketScheme, Array(2d, 5d, 6d))),
 
-      Seq(1574272862000L, 11d, 11d, MutableHistogram(bucketScheme, Array(2d, 8d, 11d))),
+      Seq(1574272862000L, 11d, 14d, MutableHistogram(bucketScheme, Array(2d, 8d, 14d))),
 
       Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d))),
-      Seq(1574272922000L, 15d, 15d, MutableHistogram(bucketScheme, Array(1d, 15d, 15d))),
+      Seq(1574272922000L, 15d, 19d, MutableHistogram(bucketScheme, Array(1d, 15d, 19d))),
 
-      Seq(1574272981000L, 17d, 17d, MutableHistogram(bucketScheme, Array(2d, 15d, 17d))),
+      Seq(1574272981000L, 17d, 21d, MutableHistogram(bucketScheme, Array(2d, 16d, 21d))),
       Seq(1574272981500L, 1d, 1d, MutableHistogram(bucketScheme, Array(0d, 1d, 1d))),
       Seq(1574272982000L, 15d, 15d, MutableHistogram(bucketScheme, Array(0d, 15d, 15d))),
 
-      Seq(1574273042000L, 20d, 20d, MutableHistogram(bucketScheme, Array(4d, 20d, 20d)))
+      Seq(1574273042000L, 20d, 25d, MutableHistogram(bucketScheme, Array(4d, 20d, 25d)))
     )
   }
 
@@ -406,11 +406,11 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     // time, sum, count, histogram
     downsampledData1 shouldEqual Seq(
       Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d))),
-      Seq(1574272862000L, 11d, 11d, MutableHistogram(bucketScheme, Array(2d, 8d, 11d))),
+      Seq(1574272862000L, 11d, 14d, MutableHistogram(bucketScheme, Array(2d, 8d, 14d))),
       Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d))),
-      Seq(1574272981000L, 17d, 17d, MutableHistogram(bucketScheme, Array(2d, 15d, 17d))),
+      Seq(1574272981000L, 17d, 21d, MutableHistogram(bucketScheme, Array(2d, 16d, 21d))),
       Seq(1574272981500L, 1d, 1d, MutableHistogram(bucketScheme, Array(0d, 1d, 1d))),
-      Seq(1574273042000L, 20d, 20d, MutableHistogram(bucketScheme, Array(4d, 20d, 20d)))
+      Seq(1574273042000L, 20d, 25d, MutableHistogram(bucketScheme, Array(4d, 20d, 25d)))
     )
   }
 

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -282,7 +282,6 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
       (1574272981500L, 1d),
 
       (1574273042000L, 20d)
-
     )
   }
 

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -166,7 +166,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
     val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
     val rawSamples = Stream( // time, sum, count, hist, name, tags
-      Seq(1574272801000L, 0d, 0d, MutableHistogram(bucketScheme, Array(0d, 0d, 0d)), seriesName, seriesTags),
+      Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d)), seriesName, seriesTags),
       Seq(1574272801500L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 2d, 2d)), seriesName, seriesTags),
       Seq(1574272802000L, 5d, 5d, MutableHistogram(bucketScheme, Array(2d, 3d, 5d)), seriesName, seriesTags),
 
@@ -194,6 +194,10 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     colStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
+  }
+
+  it ("should free all offheap memory") {
+    offheapMem.free()
   }
 
   it ("should downsample raw data into the downsample dataset tables in cassandra using spark job") {
@@ -291,7 +295,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val ctrChunkInfo = downsampledPart1.infos(AllChunkScan).nextInfoReader
     PrimitiveVectorReader.dropped(ctrChunkInfo.vectorAccessor(2), ctrChunkInfo.vectorAddress(2)) shouldEqual true
 
-    val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1))
+    val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3))
 
     val downsampledData1 = rv1.rows.map { r =>
       (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getHistogram(3))
@@ -300,7 +304,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
     // time, sum, count, histogram
     downsampledData1 shouldEqual Seq(
-      Seq(1574272801000L, 0d, 0d, MutableHistogram(bucketScheme, Array(0d, 0d, 0d))),
+      Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d))),
       Seq(1574272802000L, 5d, 5d, MutableHistogram(bucketScheme, Array(2d, 3d, 5d))),
 
       Seq(1574272862000L, 11d, 11d, MutableHistogram(bucketScheme, Array(2d, 8d, 11d))),
@@ -392,7 +396,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val ctrChunkInfo = downsampledPart1.infos(AllChunkScan).nextInfoReader
     PrimitiveVectorReader.dropped(ctrChunkInfo.vectorAccessor(2), ctrChunkInfo.vectorAddress(2)) shouldEqual true
 
-    val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1))
+    val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3))
 
     val downsampledData1 = rv1.rows.map { r =>
       (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getHistogram(3))
@@ -401,7 +405,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
     // time, sum, count, histogram
     downsampledData1 shouldEqual Seq(
-      Seq(1574272801000L, 0d, 0d, MutableHistogram(bucketScheme, Array(0d, 0d, 0d))),
+      Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d))),
       Seq(1574272862000L, 11d, 11d, MutableHistogram(bucketScheme, Array(2d, 8d, 11d))),
       Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d))),
       Seq(1574272981000L, 17d, 17d, MutableHistogram(bucketScheme, Array(2d, 15d, 17d))),


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Capability to downsample Prometheus Counters and Histograms.

Simple strategy:
* Last value of counter or histogram used for every downsample period
* If there is a drop, then the last value before drop and the first value after drop are also included.
* Case of gauges and counters in same schema is handled using downsampler-period-marker which is an abstraction which identifies the row numbers at which downsampling should be done by looking at timestamps of rows or counter values. The period marker is configurable for schemas.
