### PR TITLE
feat(gateway): Convert ILP lines to new gauge, counter, histogram schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,18 @@ The following will scrape metrics from FiloDB using its Prometheus metrics endpo
 
 Now, metrics from the application having a Prom endpoint at port 9095 will be streamed into Kafka and FiloDB.
 
+Querying the total number of ingesting time series for the last 5 minutes, every 10 seconds:
+
+    ./filo-cli  --host 127.0.0.1 --dataset prometheus --promql 'sum(num_ingesting_partitions{_ws_="local_test",_ns_="filodb"})' --minutes 5
+
+Note that histograms are ingested using FiloDB's optimized histogram format, which leads to very large savings in space.  For example, querying the 90%-tile for the size of chunks written to Cassandra, last 5 minutes:
+
+    ./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus --promql 'histogram_quantile(0.9, sum(rate(chunk_bytes_per_call{_ws_="local_test",_ns_="filodb"}[3m])))' --minutes 5
+
+Here is how you display the raw histogram data for the same:
+
+    ./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus --promql 'chunk_bytes_per_call{_ws_="local_test",_ns_="filodb"}' --minutes 5
+
 #### Multiple Servers using Consul
 
 The original example used a static IP to form a cluster, but a more realistic example is to use a registration service like Consul.

--- a/conf/telegraf.conf
+++ b/conf/telegraf.conf
@@ -18,6 +18,8 @@
 [global_tags]
   # dc = "us-east-1" # will tag all metrics with dc=us-east-1
   app = "filodb"
+  _ns_ = "filodb"
+  _ws_ = "local_test"
   ## Environment variables can be used as tags, and throughout the config file
   # user = "$USER"
 

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
@@ -24,7 +24,7 @@ class StringKVVisitor extends KVVisitor {
  * A KVVisitor that parses Influx format field values into the right types and invokes the right callback
  * based on the type of the detected field.
  */
-trait InfluxFieldVisitor extends KVVisitor {
+trait InfluxFieldVisitor extends KVVisitor with StrictLogging {
   def doubleValue(bytes: Array[Byte], keyIndex: Int, keyLen: Int, value: Double): Unit
   def stringValue(bytes: Array[Byte], keyIndex: Int, keyLen: Int, valueOffset: Int, valueLen: Int): Unit
   final def apply(bytes: Array[Byte], keyIndex: Int, keyLen: Int, valueIndex: Int, valueLen: Int): Unit = {
@@ -42,6 +42,7 @@ trait InfluxFieldVisitor extends KVVisitor {
         doubleValue(bytes, keyIndex, keyLen, InfluxProtocolParser.parseDouble(bytes, valueIndex, numBytesToParse))
       } catch {
         case e: Exception =>
+          logger.error(s"Could not parse [${new String(bytes, valueIndex, numBytesToParse)}] as number!", e)
           stringValue(bytes, keyIndex, keyLen, valueIndex, valueLen)
       }
     }

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
@@ -7,6 +7,7 @@ import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.{Schema, Schemas}
 import filodb.memory.BinaryRegion
 import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.vectors.{CustomBuckets, LongHistogram}
 
 /**
  * Base trait for common shard calculation and debug logic for all Influx Line Protocol based records for FiloDB
@@ -85,8 +86,7 @@ class SimpleDoubleAdder(builder: RecordBuilder) extends InfluxFieldVisitor {
  * A Prom counter or gauge outputted using Telegraf Influx format with just one field
  * NOTE: Telegraf always sorts the tags so we don't need to do this
  *
- * These are not histograms/summaries so no stripping of metric name and separate calculation
- * of shard hash is needed.
+ * We deduce counter or gauge based on the field name.  Counters will have "counter" as the field name.
  *
  * @param bytes unescaped(parsed) bytes from raw text bytes
  * @param kpiLen the number of bytes taken by the KPI or Influx "measurement" field
@@ -104,7 +104,7 @@ final case class InfluxPromSingleRecord(bytes: Array[Byte],
   require(fieldDelims.length == 1, s"Cannot use ${getClass.getName} with fieldDelims of length ${fieldDelims.length}")
   final def addToBuilder(builder: RecordBuilder): Unit = {
     // Add the timestamp and value first
-    builder.startNewRecord(Schemas.promCounter)
+    builder.startNewRecord(schema)
     builder.addLong(ts)
     InfluxProtocolParser.parseKeyValues(bytes, fieldDelims, fieldEnd, new SimpleDoubleAdder(builder))
 
@@ -114,16 +114,20 @@ final case class InfluxPromSingleRecord(bytes: Array[Byte],
     InfluxProtocolParser.parseKeyValues(bytes, tagDelims, endOfTags, new MapBuilderVisitor(builder))
     builder.updatePartitionHash(partitionKeyHash)
 
-    builder.endMap()
+    builder.endMap(false)
     builder.endRecord()
   }
 
-  def schema: Schema = Schemas.promCounter
+  lazy val schema = {
+    val counter = InfluxProtocolParser.firstKeyEquals(bytes, fieldDelims, InfluxProtocolParser.CounterKey)
+    if (counter) Schemas.promCounter else Schemas.gauge
+  }
 }
 
-object InfluxPromHistogramRecord extends StrictLogging {
-  val sumSuffix = "sum".getBytes
-  val countSuffix = "count".getBytes
+object InfluxHistogramRecord extends StrictLogging {
+  val sumLabel = "sum".getBytes
+  val countLabel = "count".getBytes
+  val infLabel = "+Inf".getBytes
   val leKey = "le".getBytes
   val leHash = BinaryRegion.hash32(leKey)
   val bucketSuffix = "bucket".getBytes
@@ -162,44 +166,46 @@ object InfluxPromHistogramRecord extends StrictLogging {
   }
 }
 
-// For each field in a histogram / multi field Influx record, create a separate BinaryRecord
-// Assumes the base metric name has been copied to the thread local metricBuffer
-// Add prometheus style time series with le= the bucket name.
-class HistogramPromFieldVisitor(builder: RecordBuilder,
-                                ts: Long,
-                                baseMetricLen: Int,
-                                tagDelims: Buffer[Int],
-                                endOfTags: Int,
-                                partKeyHash: Int) extends InfluxFieldVisitor {
-  import InfluxPromHistogramRecord._
+// Parses and sorts fields assuming they are buckets for histograms, to prepare for histogram
+// encoding and writing to BinaryRecord.  The sum and count are also extracted.
+// To conserve memory, we keep arrays and do sorted insertion in place
+class HistogramFieldVisitor(numFields: Int) extends InfluxFieldVisitor {
+  import InfluxHistogramRecord._
 
-  val tagsBuilderVisitor = new MapBuilderVisitor(builder)
+  require(numFields >= 3, s"Not enough fields ($numFields) for histogram schema")
+
+  var gotInf = false
+  var sum = Double.NaN
+  var count = Double.NaN
+  val bucketTops = Array.fill(numFields - 2)(Double.PositiveInfinity)  // to ensure binarySearch works
+  val bucketVals = new Array[Long](numFields - 2)
+  var numBuckets = 0
 
   def doubleValue(bytes: Array[Byte], keyIndex: Int, keyLen: Int, value: Double): Unit = {
-    builder.startNewRecord(Schemas.promCounter)
-    builder.addLong(ts)
-    builder.addDouble(value)
-
-    // Is the key sum or count?  If so, append that to metric name
-    if (BinaryRegion.equalBytes(bytes, keyIndex, keyLen, sumSuffix)) {
-      addSuffixToMetricAndBuild(builder, baseMetricLen, sumSuffix)
-      builder.startMap()
-    } else if (BinaryRegion.equalBytes(bytes, keyIndex, keyLen, countSuffix)) {
-      addSuffixToMetricAndBuild(builder, baseMetricLen, countSuffix)
-      builder.startMap()
-    // Otherwise, add _bucket to metric name and add le= with the key
+    if (BinaryRegion.equalBytes(bytes, keyIndex, keyLen, sumLabel)) {
+      sum = value
+    } else if (BinaryRegion.equalBytes(bytes, keyIndex, keyLen, countLabel)) {
+      count = value
     } else {
-      addSuffixToMetricAndBuild(builder, baseMetricLen, bucketSuffix)
-      builder.startMap()
-      builder.addMapKeyValueHash(leKey, leHash, bytes, keyIndex, keyLen)
+      // Assume it is a bucket.  Convert the field bytes to a number
+      val top = if (BinaryRegion.equalBytes(bytes, keyIndex, keyLen, infLabel)) {
+                  gotInf = true
+                  Double.PositiveInfinity
+                } else { InfluxProtocolParser.parseDouble(bytes, keyIndex, keyLen) }
+      // Find position to insert top and value in bucket.  Buckets must be sorted
+      val pos = if (numBuckets == 0) 0
+                else {
+                  val binSearchRes = java.util.Arrays.binarySearch(bucketTops, top)
+                  if (binSearchRes < 0) (-binSearchRes - 1) else binSearchRes
+                }
+      // insert/shift over array elements and insert
+      assert(numBuckets < (numFields - 2))
+      System.arraycopy(bucketTops, pos, bucketTops, pos + 1, numBuckets - pos)
+      bucketTops(pos) = top
+      System.arraycopy(bucketVals, pos, bucketVals, pos + 1, numBuckets - pos)
+      bucketVals(pos) = value.toLong
+      numBuckets += 1
     }
-
-    // Add original tags....  TODO: somehow make this more efficient
-    InfluxProtocolParser.parseKeyValues(bytes, tagDelims, endOfTags, tagsBuilderVisitor)
-    builder.updatePartitionHash(partKeyHash)
-
-    builder.endMap()
-    builder.endRecord()
   }
 
   def stringValue(bytes: Array[Byte], keyIndex: Int, keyLen: Int, valueOffset: Int, valueLen: Int): Unit = {
@@ -209,26 +215,48 @@ class HistogramPromFieldVisitor(builder: RecordBuilder,
 }
 
 /**
- * A Prom histogram outputted using Influx Line Protocol.  One record contains multiple fileds, one for each bucket
+ * A histogram outputted using Influx Line Protocol.  One record contains multiple fields, one for each bucket
  * plus sum and count.
  * Much more efficient than Prom WriteRequest since it only has to compute shard hashes once.
- * For now we have to translate each field to its own BinaryRecord.
- * In the future make this more efficient by encoding as just one record.
+ * Will be encoded as a single efficient BinaryRecord using FiloDB histogram schema.
  */
-final case class InfluxPromHistogramRecord(bytes: Array[Byte],
-                                           kpiLen: Int,
-                                           tagDelims: Buffer[Int],
-                                           fieldDelims: Buffer[Int],
-                                           fieldEnd: Int,
-                                           ts: Long) extends InfluxRecord {
+final case class InfluxHistogramRecord(bytes: Array[Byte],
+                                       kpiLen: Int,
+                                       tagDelims: Buffer[Int],
+                                       fieldDelims: Buffer[Int],
+                                       fieldEnd: Int,
+                                       ts: Long) extends InfluxRecord {
   final def addToBuilder(builder: RecordBuilder): Unit = {
     // do some preprocessing: copy metric name to the thread local buffer
-    InfluxPromHistogramRecord.copyMetricToBuffer(bytes, kpiLen)
+    // TODO: this would be needed in case it is not a histogram and we need to write a summary
+    // InfluxPromHistogramRecord.copyMetricToBuffer(bytes, kpiLen)
 
-    // For each field, append one BinaryRecord
-    val visitor = new HistogramPromFieldVisitor(builder, ts, kpiLen, tagDelims, endOfTags, partitionKeyHash)
+    // Parse sorted buckets, sum, count from fields
+    val visitor = new HistogramFieldVisitor(fieldDelims.length)
     InfluxProtocolParser.parseKeyValues(bytes, fieldDelims, fieldEnd, visitor)
+
+    // Only create histogram record if we are able to parse above and it contains +Inf bucket
+    if (visitor.gotInf) {
+      val buckets = CustomBuckets(visitor.bucketTops)
+      val hist = LongHistogram(buckets, visitor.bucketVals)
+
+      // Now, write out histogram
+      builder.startNewRecord(Schemas.promHistogram)
+      builder.addLong(ts)
+      builder.addDouble(visitor.sum)
+      builder.addDouble(visitor.count)
+      builder.addBlob(hist.serialize())
+
+      // Add metric name, then the map/tags
+      builder.addBlob(bytes, UnsafeUtils.arayOffset, kpiLen)
+      builder.startMap()
+      InfluxProtocolParser.parseKeyValues(bytes, tagDelims, endOfTags, new MapBuilderVisitor(builder))
+      builder.updatePartitionHash(partitionKeyHash)
+
+      builder.endMap(false)
+      builder.endRecord()
+    }
   }
 
-  def schema: Schema = Schemas.promCounter
+  def schema: Schema = Schemas.promHistogram
 }

--- a/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InfluxRecordSpec.scala
@@ -3,7 +3,7 @@ package filodb.gateway.conversion
 import org.jboss.netty.buffer.ChannelBuffers
 import org.scalatest.{FunSpec, Matchers}
 
-import filodb.core.binaryrecord2.{RecordBuilder, StringifyMapItemConsumer}
+import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema, StringifyMapItemConsumer}
 import filodb.core.metadata.Schemas
 import filodb.memory.MemFactory
 
@@ -16,7 +16,7 @@ class InfluxRecordSpec extends FunSpec with Matchers {
     "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1 counter=0 1536790212000000000",
     "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=0,_ws_=demo,_ns_=filodb counter=0 1536790212000000000",
     "num_partitions,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,_ws_=demo,_ns_=filodb counter=0 1536790212000000000",
-    "memstore_flushes_success_total,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,url=http://localhost:9095 counter=0 1536628260000000000",
+    "memstore_flushes_success_total,dataset=timeseries,host=MacBook-Pro-229.local,shard=1,url=http://localhost:9095 gauge=5 1536628260000000000",
     "span_processing_time_seconds,error=false,host=MacBook-Pro-229.local,operation=memstore-recover-index-latency +Inf=2,0.005=0,0.01=0,0.025=0,0.05=0,0.075=0,0.1=1,0.25=2,0.5=2,0.75=2,1=2,10=2,2.5=2,5=2,7.5=2,count=2,sum=0.230162432 1536790212000000000"
   )
 
@@ -44,10 +44,12 @@ class InfluxRecordSpec extends FunSpec with Matchers {
       val recordOpts = convertToRecords(rawInfluxLPs take 2)
       recordOpts(0).isDefined shouldEqual true
       recordOpts(0).get.nonMetricShardValues shouldEqual Seq("filodb")
+      recordOpts(0).get.schema shouldEqual Schemas.promCounter
 
       // app not in tags, return nothing
       recordOpts(1).isDefined shouldEqual true
       recordOpts(1).get.nonMetricShardValues shouldEqual Nil
+      recordOpts(1).get.schema shouldEqual Schemas.promCounter
     }
 
     it("should return varying results for shard key and partition hashes") {
@@ -76,6 +78,7 @@ class InfluxRecordSpec extends FunSpec with Matchers {
       // println(recordOpts(0).get)
       recordOpts(0).get.addToBuilder(builder)
       builder.allContainers.head.foreach { case (base, offset) =>
+        RecordSchema.schemaID(base, offset) shouldEqual Schemas.promCounter.schemaHash
         schema.ingestionSchema.partitionHash(base, offset) should not equal (7)
         schema.ingestionSchema.getLong(base, offset, 0) shouldEqual 1536790212000L
         schema.ingestionSchema.getDouble(base, offset, 1) shouldEqual 0.0
@@ -89,32 +92,65 @@ class InfluxRecordSpec extends FunSpec with Matchers {
                                                    "_ws_" -> "demo",
                                                    "_ns_" -> "filodb")
       }
+
+      builder.reset()
+      val recordOpts2 = convertToRecords(rawInfluxLPs drop 4 take 1)
+      recordOpts2(0).get.addToBuilder(builder)
+      builder.allContainers.head.foreach { case (base, offset) =>
+        RecordSchema.schemaID(base, offset) shouldEqual Schemas.gauge.schemaHash
+        schema.ingestionSchema.partitionHash(base, offset) should not equal (7)
+        schema.ingestionSchema.getLong(base, offset, 0) shouldEqual 1536628260000L
+        schema.ingestionSchema.getDouble(base, offset, 1) shouldEqual 5.0
+
+        schema.ingestionSchema.asJavaString(base, offset, 2) shouldEqual "memstore_flushes_success_total"
+
+        val consumer = new StringifyMapItemConsumer()
+        schema.ingestionSchema.consumeMapItems(base, offset, 3, consumer)
+        consumer.stringPairs.toMap shouldEqual Map("dataset" -> "timeseries",
+                                                   "host" -> "MacBook-Pro-229.local",
+                                                   "shard" -> "1",
+                                                   "url" -> "http://localhost:9095")
+      }
     }
   }
 
-  describe("InfluxPromHistogramRecord") {
-    it("should create multiple BinaryRecordV2s with addToBuilder, one for each bucket") {
+  describe("InfluxHistogramRecord") {
+    it("should create single BinaryRecordV2s with addToBuilder with FiloDB histogram") {
       val recordOpts = convertToRecords(rawInfluxLPs drop 5)
       val builder = new RecordBuilder(MemFactory.onHeapFactory)
       println(recordOpts(0).get)
       recordOpts(0).get.addToBuilder(builder)
-      builder.allContainers.head.countRecords shouldEqual 17
+      builder.allContainers.head.countRecords shouldEqual 1
+
+      val ingSchema = Schemas.promHistogram.ingestionSchema
       builder.allContainers.head.foreach { case (base, offset) =>
-        schema.ingestionSchema.partitionHash(base, offset) should not equal (7)
-        schema.ingestionSchema.getLong(base, offset, 0) shouldEqual 1536790212000L
+        RecordSchema.schemaID(base, offset) shouldEqual Schemas.promHistogram.schemaHash
+        ingSchema.partitionHash(base, offset) should not equal (7)
+
         val consumer = new StringifyMapItemConsumer()
-        schema.ingestionSchema.consumeMapItems(base, offset, 3, consumer)
+        ingSchema.consumeMapItems(base, offset, 5, consumer)
         val map = consumer.stringPairs.toMap
         map("operation") shouldEqual "memstore-recover-index-latency"
-        (map.keySet - "le") shouldEqual Set("operation", "host", "error")
+        map.keySet shouldEqual Set("operation", "host", "error")
+      }
 
-        val metric = schema.ingestionSchema.asJavaString(base, offset, 2)
-        metric should startWith ("span_processing_time_seconds")
-        metric.drop("span_processing_time_seconds".length) match {
-          case "_sum"    => schema.ingestionSchema.getDouble(base, offset, 1) shouldEqual 0.230162432 +- 0.00000001
-          case "_count"  => schema.ingestionSchema.getDouble(base, offset, 1) shouldEqual 2
-          case "_bucket" => map.contains("le") shouldEqual true
-        }
+      builder.allContainers.head.iterate(ingSchema).foreach { reader =>
+        reader.getLong(0) shouldEqual 1536790212000L
+
+        val metric = reader.getString(4)
+        metric shouldEqual "span_processing_time_seconds"
+
+        // sum
+        reader.getDouble(1) shouldEqual 0.230162432 +- 0.00000001
+        // count
+        reader.getDouble(2) shouldEqual 2
+
+        val hist = reader.getHistogram(3)
+        hist.numBuckets shouldEqual 15
+        hist.bucketTop(0) shouldEqual 0.005 +- 0.000001
+        hist.bucketValue(0) shouldEqual 0
+        hist.bucketTop(5) shouldEqual 0.1 +- 0.000001
+        hist.bucketValue(5) shouldEqual 1
       }
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

In the gateway, Influx Line Protocol input was being converted to all "promCounter" schema, and histograms were being written using old Prom-style individual time series per bucket.

**New behavior :**

Influx Line Protocol inputs are now converted to gauge, counter, and histogram schemas.
summaries are not supported yet.

**BREAKING CHANGES**

Existing Prom-style histogram queries will need to be changed.