### PR TITLE
add function "last" for supporting last sample in a time window

### DIFF
--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -206,6 +206,7 @@ class ParserSpec extends FunSpec with Matchers {
     parseSuccessfully("time()")
     parseSuccessfully("floor(some_metric{foo!=\"bar\"})")
     parseSuccessfully("rate(some_metric[5m])")
+    parseSuccessfully("last(some_metric[5m])")
     parseSuccessfully("round(some_metric)")
     parseSuccessfully("round(some_metric, 5)")
 
@@ -261,6 +262,8 @@ class ParserSpec extends FunSpec with Matchers {
         "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Deriv,List())",
       "rate(http_requests_total{job=\"api-server\"}[5m])" ->
         "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,300000,Rate,List())",
+      "last(jvm_memory{job=\"api-server\"}[5m])" ->
+        "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(api-server)), ColumnFilter(__name__,Equals(jvm_memory))),List()),1524855988000,1000000,1524855988000,300000,Last,List())",
       "http_requests_total{job=\"prometheus\"}[5m]" ->
         "RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List())",
       "http_requests_total offset 5m" ->

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -74,6 +74,8 @@ object RangeFunctionId extends Enum[RangeFunctionId] {
 
   case object Rate extends RangeFunctionId("rate")
 
+  case object Last extends RangeFunctionId("last")
+
   case object Resets extends RangeFunctionId("resets")
 
   case object StdDevOverTime extends RangeFunctionId("stddev_over_time")

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -149,7 +149,7 @@ extends Iterator[R] with StrictLogging {
       val nextInfo = ChunkSetInfo(queryInfo.infoPtr)
       try {
         rangeFunction.addChunks(queryInfo.tsVector, queryInfo.tsReader, queryInfo.valueVector, queryInfo.valueReader,
-                                wit.curWindowStart, wit.curWindowEnd, nextInfo, queryConfig)
+                                wit.curWindowStart, wit.curWindowEnd, window, nextInfo, queryConfig)
       } catch {
         case e: Exception =>
           val timestampVector = nextInfo.vectorPtr(rv.timestampColID)
@@ -255,7 +255,7 @@ class SlidingWindowIterator(raw: Iterator[RowReader],
       windowSamplesPool.putBack(removed)
     }
     // apply function on window samples
-    rangeFunction.apply(curWindowStart, curWindowEnd, windowSamples, sampleToEmit, queryConfig)
+    rangeFunction.apply(curWindowStart, curWindowEnd, window, windowSamples, sampleToEmit, queryConfig)
     curWindowEnd = curWindowEnd + step
     sampleToEmit
   }

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -149,7 +149,7 @@ extends Iterator[R] with StrictLogging {
       val nextInfo = ChunkSetInfo(queryInfo.infoPtr)
       try {
         rangeFunction.addChunks(queryInfo.tsVector, queryInfo.tsReader, queryInfo.valueVector, queryInfo.valueReader,
-                                wit.curWindowStart, wit.curWindowEnd, window, nextInfo, queryConfig)
+                                wit.curWindowStart, wit.curWindowEnd, nextInfo, queryConfig)
       } catch {
         case e: Exception =>
           val timestampVector = nextInfo.vectorPtr(rv.timestampColID)
@@ -255,7 +255,7 @@ class SlidingWindowIterator(raw: Iterator[RowReader],
       windowSamplesPool.putBack(removed)
     }
     // apply function on window samples
-    rangeFunction.apply(curWindowStart, curWindowEnd, window, windowSamples, sampleToEmit, queryConfig)
+    rangeFunction.apply(curWindowStart, curWindowEnd, windowSamples, sampleToEmit, queryConfig)
     curWindowEnd = curWindowEnd + step
     sampleToEmit
   }

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -77,7 +77,6 @@ trait RangeFunction extends BaseRangeFunction {
             window: Window,
             sampleToEmit: TransientRow,
             queryConfig: QueryConfig): Unit
-
 }
 
 /**
@@ -227,10 +226,10 @@ trait ChunkedLongRangeFunction extends TimeRangeFunction[TransientRow] {
 object RangeFunction {
   type RangeFunctionGenerator = () => BaseRangeFunction
 
-
+  // scalastyle:off cyclomatic.complexity
   def downsampleColsFromRangeFunction(dataset: Dataset, f: Option[RangeFunctionId]): Seq[String] = {
     f match {
-      case None | Some(Last)      => Seq("avg")
+      case None                   => Seq("avg")
       case Some(Rate)             => Seq(dataset.options.valueColumn)
       case Some(Irate)            => Seq(dataset.options.valueColumn)
       case Some(Increase)         => Seq(dataset.options.valueColumn)
@@ -249,6 +248,7 @@ object RangeFunction {
       case Some(QuantileOverTime) => Seq("avg")
       case Some(MinOverTime)      => Seq("min")
       case Some(MaxOverTime)      => Seq("max")
+      case Some(Last)             => Seq("avg")
     }
   }
   /**

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -292,6 +292,7 @@ object RangeFunction {
                           funcParams: Seq[Any] = Nil): RangeFunctionGenerator = {
     func match {
       case None                 => () => new LastSampleChunkedFunctionL
+      case Some(Last)           => () => new LastSampleInWindowChunkedFunctionL
       case Some(CountOverTime)  => () => if (dataset.options.hasDownsampledData) new SumOverTimeChunkedFunctionL
                                          else new CountOverTimeChunkedFunction()
       case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionL
@@ -344,6 +345,8 @@ object RangeFunction {
                           maxCol: Option[Int] = None): RangeFunctionGenerator = func match {
     case None if maxCol.isDefined => () => new LastSampleChunkedFunctionHMax(maxCol.get)
     case None                 => () => new LastSampleChunkedFunctionH
+    case Some(Last) if maxCol.isDefined => () => new LastSampleInWindowChunkedFunctionHMax(maxCol.get)
+    case Some(Last)           => () => new LastSampleInWindowChunkedFunctionH
     case Some(SumOverTime) if maxCol.isDefined => () => new SumAndMaxOverTimeFuncHD(maxCol.get)
     case Some(SumOverTime)    => () => new SumOverTimeChunkedFunctionH
     case Some(Rate)           => () => new HistRateFunction

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -78,7 +78,6 @@ trait RangeFunction extends BaseRangeFunction {
             sampleToEmit: TransientRow,
             queryConfig: QueryConfig): Unit
 
-
 }
 
 /**
@@ -426,7 +425,7 @@ object LastSampleInWindowFunction extends RangeFunction {
 abstract class LastSampleChunkedFunction[R <: MutableRowReader](var timestamp: Long = -1L)
 extends ChunkedRangeFunction[R] {
   // Add each chunk and update timestamp and value such that latest sample wins
-  def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
+  final def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
                       valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
                       startTime: Long, endTime: Long, info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
     // Just in case timestamp vectors are a bit longer than others.
@@ -521,15 +520,23 @@ class LastSampleChunkedFunctionD extends LastSampleChunkedFuncDblVal() {
   }
 }
 
-// Return the last sample within the window
-class LastSampleInWindowChunkedFunctionD extends LastSampleChunkedFunctionD {
+class LastSampleChunkedFunctionL extends LastSampleChunkedFuncDblVal() {
+  final def updateValue(ts: Long, valVector: BinaryVectorPtr, valReader: VectorDataReader, endRowNum: Int): Unit = {
+    val longReader = valReader.asLongReader
+    timestamp = ts
+    value = longReader(valVector, endRowNum).toDouble
+  }
+}
 
+// Below classes are for supporting Last Sample function in a time-window. This implementation is in contract to the
+// above stack where sample is included if the time is within stale sample period
 
+abstract class LastSampleInWindowChunkedFunction[R <: MutableRowReader](var timestamp: Long = -1L)
+  extends ChunkedRangeFunction[R] {
   // Add each chunk and update timestamp and value such that latest sample wins
-  final override def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
-                               valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
-                               startTime: Long, endTime: Long,
-                               info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
+  final def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
+                      valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
+                      startTime: Long, endTime: Long, info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
     // Just in case timestamp vectors are a bit longer than others.
     val endRowNum = Math.min(tsReader.ceilingIndex(tsVector, endTime), info.numRows - 1)
 
@@ -543,12 +550,90 @@ class LastSampleInWindowChunkedFunctionD extends LastSampleChunkedFunctionD {
         updateValue(ts, valueVector, valueReader, endRowNum)
     }
   }
+
+  def updateValue(ts: Long, valVector: BinaryVectorPtr, valReader: VectorDataReader, endRowNum: Int): Unit
 }
 
-class LastSampleChunkedFunctionL extends LastSampleChunkedFuncDblVal() {
+// LastSample functions with double value, based on TransientRow
+abstract class LastSampleInWindowChunkedFuncDblVal(var value: Double = Double.NaN)
+  extends LastSampleInWindowChunkedFunction[TransientRow] {
+  override final def reset(): Unit = { timestamp = -1L; value = Double.NaN }
+  final def apply(endTimestamp: Long, sampleToEmit: TransientRow): Unit = {
+    sampleToEmit.setValues(endTimestamp, value)
+  }
+}
+
+// LastSample function for Histogram columns
+class LastSampleInWindowChunkedFunctionH(var value: bv.HistogramWithBuckets = bv.Histogram.empty)
+  extends LastSampleInWindowChunkedFunction[TransientHistRow] {
+  override final def reset(): Unit = { timestamp = -1L; value = bv.Histogram.empty }
+  final def apply(endTimestamp: Long, sampleToEmit: TransientHistRow): Unit = {
+    sampleToEmit.setValues(endTimestamp, value)
+  }
+  final def updateValue(ts: Long, valVector: BinaryVectorPtr, valReader: VectorDataReader, endRowNum: Int): Unit = {
+    timestamp = ts
+    value = valReader.asHistReader(endRowNum)
+  }
+}
+
+class LastSampleInWindowChunkedFunctionHMax(maxColID: Int,
+                                    var timestamp: Long = -1L,
+                                    var value: bv.HistogramWithBuckets = bv.Histogram.empty,
+                                    var max: Double = Double.NaN) extends ChunkedRangeFunction[TransientHistMaxRow] {
+  override final def reset(): Unit = { timestamp = -1L; value = bv.Histogram.empty; max = Double.NaN }
+  final def apply(endTimestamp: Long, sampleToEmit: TransientHistMaxRow): Unit = {
+    sampleToEmit.setValues(endTimestamp, value)
+    sampleToEmit.setDouble(2, max)
+  }
+
+  // Add each chunk and update timestamp and value such that latest sample wins
+  final def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
+                      valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
+                      startTime: Long, endTime: Long, info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
+    // Just in case timestamp vectors are a bit longer than others.
+    val endRowNum = Math.min(tsReader.ceilingIndex(tsVector, endTime), info.numRows - 1)
+
+    // update timestamp only if
+    //   1) endRowNum >= 0 (timestamp within chunk)
+    //   2) timestamp is within window; AND
+    //   3) timestamp is greater than current timestamp (for multiple chunk scenarios)
+    if (endRowNum >= 0) {
+      val ts = tsReader(tsVector, endRowNum)
+      if (ts >= startTime && ts > timestamp) {
+        val maxVect = info.vectorPtr(maxColID)
+        timestamp = ts
+        value = valueReader.asHistReader(endRowNum)
+        max = bv.DoubleVector(maxVect)(maxVect, endRowNum)
+      }
+    }
+  }
+}
+
+class LastSampleInWindowChunkedFunctionD extends LastSampleInWindowChunkedFuncDblVal() {
+  final def updateValue(ts: Long, valVector: BinaryVectorPtr, valReader: VectorDataReader, endRowNum: Int): Unit = {
+    val dblReader = valReader.asDoubleReader
+    val doubleVal = dblReader(valVector, endRowNum)
+    // If the last value is NaN, that may be Prometheus end of time series marker.
+    // In that case try to get the sample before last.
+    // If endRowNum==0, we are at beginning of chunk, and if the window included the last chunk, then
+    // the call to addChunks to the last chunk would have gotten the last sample value anyways.
+    if (java.lang.Double.isNaN(doubleVal)) {
+      if (endRowNum > 0) {
+        timestamp = ts
+        value = dblReader(valVector, endRowNum - 1)
+      }
+    } else {
+      timestamp = ts
+      value = doubleVal
+    }
+  }
+}
+
+class LastSampleInWindowChunkedFunctionL extends LastSampleInWindowChunkedFuncDblVal() {
   final def updateValue(ts: Long, valVector: BinaryVectorPtr, valReader: VectorDataReader, endRowNum: Int): Unit = {
     val longReader = valReader.asLongReader
     timestamp = ts
     value = longReader(valVector, endRowNum).toDouble
   }
 }
+

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -392,7 +392,7 @@ object LastSampleFunction extends RangeFunction {
             queryConfig: QueryConfig): Unit = {
     if (window.size > 1)
       throw new IllegalStateException(s"Window had more than 1 sample. Possible out of order samples. Window: $window")
-    if (window.size == 0 || startTimestamp > window.head.getLong(0)) {
+    if (window.size == 0 || (endTimestamp - window.head.getLong(0)) > queryConfig.staleSampleAfterMs) {
       sampleToEmit.setValues(endTimestamp, Double.NaN)
     } else {
       sampleToEmit.setValues(endTimestamp, window.head.getDouble(1))

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -78,14 +78,7 @@ trait RangeFunction extends BaseRangeFunction {
             sampleToEmit: TransientRow,
             queryConfig: QueryConfig): Unit
 
-  def apply(startTimestamp: Long,
-            endTimestamp: Long,
-            windowSize: Long,
-            window: Window,
-            sampleToEmit: TransientRow,
-            queryConfig: QueryConfig): Unit = {
-    this.apply(startTimestamp, endTimestamp, window, sampleToEmit, queryConfig)
-  }
+
 }
 
 /**
@@ -111,28 +104,6 @@ trait ChunkedRangeFunction[R <: MutableRowReader] extends BaseRangeFunction {
   def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
                 valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
                 startTime: Long, endTime: Long, info: ChunkSetInfo, queryConfig: QueryConfig): Unit
-
-  /**
-    * This is a modified version of above method, adds windowSize parameter
-    * @param tsVector raw pointer to the timestamp BinaryVector
-    * @param tsReader a LongVectorDataReader for parsing the tsVector
-    * @param valueVector a raw pointer to the value BinaryVector
-    * @param valueReader a VectorDataReader for the value BinaryVector. Method must cast to appropriate type.
-    * @param startTime starting timestamp in millis since Epoch for time window, inclusive
-    * @param endTime ending timestamp in millis since Epoch for time window, inclusive
-    * @param windowSize window size in milliseconds
-    * @param info chunk info
-    * @param queryConfig query execution configuration
-    */
-  // scalastyle:off parameter.number
-  def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
-                valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
-                startTime: Long, endTime: Long, windowSize: Long,
-                info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
-    addChunks(tsVector, tsReader, valueVector, valueReader, startTime, endTime, info, queryConfig)
-  }
-
-
 
   /**
    * Return the computed result in sampleToEmit for the given window.
@@ -389,7 +360,7 @@ object RangeFunction {
                         funcParams: Seq[Any] = Nil): RangeFunctionGenerator = func match {
     // when no window function is asked, use last sample for instant
     case None                   => () => LastSampleFunction
-    case Some(Last)             => () => LastSampleWindowedFunction
+    case Some(Last)             => () => LastSampleInWindowFunction
     case Some(Rate)             => () => RateFunction
     case Some(Increase)         => () => IncreaseFunction
     case Some(Delta)            => () => DeltaFunction
@@ -427,29 +398,20 @@ object LastSampleFunction extends RangeFunction {
   }
 }
 
-object LastSampleWindowedFunction extends RangeFunction {
+object LastSampleInWindowFunction extends RangeFunction {
   override def needsLastSample: Boolean = true
   def addedToWindow(row: TransientRow, window: Window): Unit = {}
   def removedFromWindow(row: TransientRow, window: Window): Unit = {}
-  def apply(startTimestamp: Long,
-            endTimestamp: Long,
-            window: Window,
-            sampleToEmit: TransientRow,
-            queryConfig: QueryConfig): Unit = {
-    this.apply(startTimestamp, endTimestamp, queryConfig.staleSampleAfterMs, window, sampleToEmit, queryConfig)
-  }
 
   override def apply(startTimestamp: Long,
             endTimestamp: Long,
-            windowSize: Long,
             window: Window,
             sampleToEmit: TransientRow,
             queryConfig: QueryConfig): Unit = {
-
     if (window.size > 1)
       throw new IllegalStateException(s"Window had more than 1 sample. Possible out of order samples. Window: $window")
     // if no sample found in the window, set the value to NaN
-    if (window.size == 0 || (endTimestamp - window.head.getLong(0)) > windowSize) {
+    if (window.size == 0 || startTimestamp > window.head.getLong(0)) {
       sampleToEmit.setValues(endTimestamp, Double.NaN)
     } else {
       sampleToEmit.setValues(endTimestamp, window.head.getDouble(1))
@@ -464,7 +426,7 @@ object LastSampleWindowedFunction extends RangeFunction {
 abstract class LastSampleChunkedFunction[R <: MutableRowReader](var timestamp: Long = -1L)
 extends ChunkedRangeFunction[R] {
   // Add each chunk and update timestamp and value such that latest sample wins
-  final def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
+  def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
                       valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
                       startTime: Long, endTime: Long, info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
     // Just in case timestamp vectors are a bit longer than others.
@@ -559,58 +521,26 @@ class LastSampleChunkedFunctionD extends LastSampleChunkedFuncDblVal() {
   }
 }
 
-class LastSampleInWindowChunkedFunctionD[R <: MutableRowReader](var value: Double = Double.NaN,
-                                                                var timestamp: Long = -1L)
-  extends ChunkedRangeFunction[TransientRow] {
+// Return the last sample within the window
+class LastSampleInWindowChunkedFunctionD extends LastSampleChunkedFunctionD {
 
-  final def apply(endTimestamp: Long, sampleToEmit: TransientRow): Unit = {
-    sampleToEmit.setValues(endTimestamp, value)
-  }
-
-  // Add each chunk and update timestamp and value such that latest sample wins
-  final def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
-                      valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
-                      startTime: Long, endTime: Long, info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
-    addChunks(tsVector, tsReader, valueVector, valueReader, startTime,
-      endTime, queryConfig.staleSampleAfterMs, info, queryConfig)
-  }
 
   // Add each chunk and update timestamp and value such that latest sample wins
   final override def addChunks(tsVector: BinaryVectorPtr, tsReader: bv.LongVectorDataReader,
                                valueVector: BinaryVectorPtr, valueReader: VectorDataReader,
-                               startTime: Long, endTime: Long, windowSize: Long,
+                               startTime: Long, endTime: Long,
                                info: ChunkSetInfo, queryConfig: QueryConfig): Unit = {
     // Just in case timestamp vectors are a bit longer than others.
     val endRowNum = Math.min(tsReader.ceilingIndex(tsVector, endTime), info.numRows - 1)
 
     // update timestamp only if
     //   1) endRowNum >= 0 (timestamp within chunk)
-    //   2) timestamp is within stale window; AND
+    //   2) timestamp is within window; AND
     //   3) timestamp is greater than current timestamp (for multiple chunk scenarios)
     if (endRowNum >= 0) {
       val ts = tsReader(tsVector, endRowNum)
-      if ((endTime - ts) <= windowSize && ts > timestamp)
+      if (ts >= startTime && ts > timestamp)
         updateValue(ts, valueVector, valueReader, endRowNum)
-    }
-  }
-
-  override final def reset(): Unit = { timestamp = -1L; value = Double.NaN }
-
-  final def updateValue(ts: Long, valVector: BinaryVectorPtr, valReader: VectorDataReader, endRowNum: Int): Unit = {
-    val dblReader = valReader.asDoubleReader
-    val doubleVal = dblReader(valVector, endRowNum)
-    // If the last value is NaN, that may be Prometheus end of time series marker.
-    // In that case try to get the sample before last.
-    // If endRowNum==0, we are at beginning of chunk, and if the window included the last chunk, then
-    // the call to addChunks to the last chunk would have gotten the last sample value anyways.
-    if (java.lang.Double.isNaN(doubleVal)) {
-      if (endRowNum > 0) {
-        timestamp = ts
-        value = dblReader(valVector, endRowNum - 1)
-      }
-    } else {
-      timestamp = ts
-      value = doubleVal
     }
   }
 }

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -273,7 +273,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
       1540846875000L->237,
       1540846890000L->237,
       1540846905000L->237,
-      1540846920000L->237, // note that value 237 becomes stale at this point (older than 3 minutes). No samples with 237 anymore.
+      1540846920000L->237, // note that value 237 becomes stale at this point. No samples with 237 anymore.
       1540850355000L->330,
       1540850370000L->330,
       1540850385000L->330,

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -3,8 +3,8 @@ package filodb.query.exec
 import filodb.core.MetricsTestData
 import filodb.core.metadata.Column.ColumnType
 import filodb.query.RangeFunctionId
-import filodb.query.exec.rangefn.{RangeFunction, RawDataWindowingSpec}
 import filodb.query.RangeFunctionId.Last
+import filodb.query.exec.rangefn.{RangeFunction, RawDataWindowingSpec}
 
 /**
  * Tests both the SlidingWindowIterator and the ChunkedWindowIterator

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -250,7 +250,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
 
   }
 
-  it ("should calculate lastSampleInWindow when ingested samples are more than 3 minutes apart") {
+  it ("should calculate last sample when ingested samples are more than 3 minutes apart") {
     val samples = Seq(
       1540832354000L->1d,
       1540835954000L->2d,
@@ -286,13 +286,6 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
       1540850490000L->330,
       1540850505000L->330,
       1540850520000L->330) // 330 becomes stale now.
-
-    val slidingWinIterator = new SlidingWindowIterator(rv.rows, 1540845090000L,
-      15000, 1540855905000L, 180000,
-      RangeFunction(MetricsTestData.timeseriesDataset,
-        Some(Last), ColumnType.DoubleColumn, queryConfig, useChunked = false).asSliding,
-      queryConfig)
-    slidingWinIterator.map(r => (r.getLong(0), r.getDouble(1))).toList.filter(!_._2.isNaN) shouldEqual windowResults
 
     val chunkedWinIt = new ChunkedWindowIteratorD(rv, 1540845090000L,
       15000, 1540855905000L, 180000,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

add `last` function for supporting last sample in a time window. This implementation ensures that timestamp of last sample is after start-time and before end-time of the window.