### PR TITLE
bug(sparkJobs): Workaround spire linbrary conflict with spark

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
@@ -39,8 +39,8 @@ trait DownsamplePeriodMarker {
   def inputColId: Int
 
   /**
-    * Places sorted collection of row numbers for the given chunkset which marks the
-    * periods to downsample into the result buffer param
+    * Returns sorted collection of row numbers for the given chunkset that mark the
+    * periods to downsample
     */
   def periods(part: ReadablePartition,
               chunkset: ChunkSetInfoReader,
@@ -130,7 +130,7 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
 
     val res = result.toArray()
     util.Arrays.sort(res)
-    debox.Buffer(res: _*)
+    debox.Buffer.fromArray(res)
   }
 }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
@@ -2,6 +2,7 @@ package filodb.core.downsample
 
 import debox.Buffer
 import enumeratum.{Enum, EnumEntry}
+import java.util
 import scalaxy.loops._
 
 import filodb.core.metadata.DataSchema
@@ -38,7 +39,7 @@ trait DownsamplePeriodMarker {
   def inputColId: Int
 
   /**
-    * Places row numbers for the given chunkset which marks the
+    * Places sorted collection of row numbers for the given chunkset which marks the
     * periods to downsample into the result buffer param
     */
   def periods(part: ReadablePartition,
@@ -121,8 +122,15 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
       case _ =>
         throw new IllegalStateException("Did not get a double column - cannot apply counter period marking strategy")
     }
-    import spire.std.int._
-    result.toSortedBuffer
+
+    // It would have been nice to use this piece of code which is more efficient, but
+    // it results in spire library version conflicts with Spark. :(
+//    import spire.std.int._
+//    result.toSortedBuffer
+
+    val res = result.toArray()
+    util.Arrays.sort(res)
+    debox.Buffer(res: _*)
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

debox.Set.toSortedBuffer and debox.Buffer.sort result in `spire` library conflicts when executed in spark. Hence resorting to the approach of removing spire runtime dependency.