### PR TITLE
feat(query, coord): _type_ schema filter and metadata results label

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ Example of debugging chunk metadata using the CLI:
 
     ./filo-cli --host 127.0.0.1 --dataset prometheus --promql '_filodb_chunkmeta_all(heap_usage{_ws_="demo",_ns_="App-0"})' --start XX --end YY
 
+There is also a special filter, `_type_="gauge"`, to filter on only a particular type of metric or schema.  Normally, this is not necessary unless a user changes the type of metric in their application, for example from a gauge to a histogram.  The types are found in the configuration `schemas` section, and by default are `gauge`, `prom-counter`, `prom-histogram`, and `untyped`.
+
 ### First-Class Histogram Support
 
 One major difference FiloDB has from the Prometheus data model is that FiloDB supports histograms as a first-class entity.  In Prometheus, histograms are stored with each bucket in its own time series differentiated by the `le` tag.  In FiloDB, there is a `HistogramColumn` which stores all the buckets together for significantly improved compression, especially over the wire during ingestion, as well as significantly faster query speeds (up to two orders of magnitude).  There is no "le" tag or individual time series for each bucket.  Here are the differences users need to be aware of when using `HistogramColumn`:

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine2/QueryEngine.scala
@@ -20,7 +20,7 @@ import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.SpreadProvider
 import filodb.core.store._
-import filodb.prometheus.ast.Vectors.PromMetricLabel
+import filodb.prometheus.ast.Vectors.{PromMetricLabel, TypeLabel}
 import filodb.query.{exec, _}
 import filodb.query.exec._
 
@@ -372,9 +372,8 @@ class QueryEngine(dsRef: DatasetRef,
                                    options: QueryOptions,
                                    lp: RawSeries, spreadProvider : SpreadProvider): PlanResult = {
     val colName = lp.columns.headOption
-    val renamedFilters = renameMetricFilter(lp.filters)
+    val (renamedFilters, schemaOpt) = extractSchemaFilter(renameMetricFilter(lp.filters))
     val spreadChanges = spreadProvider.spreadFunc(renamedFilters)
-    val schemaOpt = None
     val needsStitch = lp.rangeSelector match {
       case IntervalSelector(from, to) => spreadChanges.exists(c => c.time >= from && c.time <= to)
       case _                          => false
@@ -419,7 +418,8 @@ class QueryEngine(dsRef: DatasetRef,
                                      submitTime: Long,
                                      options: QueryOptions,
                                      lp: SeriesKeysByFilters, spreadProvider : SpreadProvider): PlanResult = {
-    val renamedFilters = renameMetricFilter(lp.filters)
+    // NOTE: _type_ filter support currently isn't there in series keys queries
+    val (renamedFilters, schemaOpt) = extractSchemaFilter(renameMetricFilter(lp.filters))
     val filterCols = lp.filters.map(_.column).toSet
     val shardsToHit = if (shardColumns.toSet.subsetOf(filterCols)) {
                         shardsFromFilters(lp.filters, options, spreadProvider)
@@ -442,8 +442,7 @@ class QueryEngine(dsRef: DatasetRef,
                                       spreadProvider: SpreadProvider): PlanResult = {
     // Translate column name to ID and validate here
     val colName = if (lp.column.isEmpty) None else Some(lp.column)
-    val schemaOpt = None
-    val renamedFilters = renameMetricFilter(lp.filters)
+    val (renamedFilters, schemaOpt) = extractSchemaFilter(renameMetricFilter(lp.filters))
     val metaExec = shardsFromFilters(renamedFilters, options, spreadProvider).map { shard =>
       val dispatcher = dispatcherForShard(shard)
       SelectChunkInfosExec(queryId, submitTime, options.sampleLimit, dispatcher, dsRef, shard,
@@ -544,7 +543,7 @@ class QueryEngine(dsRef: DatasetRef,
     PlanResult(Seq(scalarFixedDoubleExec), false)
   }
 
-    /**
+  /**
    * Renames Prom AST __name__ metric name filters to one based on the actual metric column of the dataset,
    * if it is not the prometheus standard
    */
@@ -557,6 +556,23 @@ class QueryEngine(dsRef: DatasetRef,
     } else {
       filters
     }
+
+  /**
+   * If there is a _type_ filter, remove it and populate the schema name string.  This is because while
+   * the _type_ filter is a real filter on time series, we don't index it using Lucene at the moment.
+   */
+  private def extractSchemaFilter(filters: Seq[ColumnFilter]): (Seq[ColumnFilter], Option[String]) = {
+    var schemaOpt: Option[String] = None
+    val newFilters = filters.filterNot { case ColumnFilter(label, filt) =>
+      val isTypeFilt = label == TypeLabel
+      if (isTypeFilt) filt match {
+        case Filter.Equals(schema) => schemaOpt = Some(schema.asInstanceOf[String])
+        case x: Any                 => throw new IllegalArgumentException(s"Illegal filter $x on _type_")
+      }
+      isTypeFilt
+    }
+    (newFilters, schemaOpt)
+  }
 
   private def toChunkScanMethod(rangeSelector: RangeSelector): ChunkScanMethod = {
     rangeSelector match {

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -236,7 +236,9 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
       case (MapColumn, i)    => val consumer = new StringifyMapItemConsumer
                                 consumeMapItems(base, offset, i, consumer)
                                 resultMap ++= consumer.stringPairs
-      case (BinaryRecordColumn, i)  => resultMap ++= brSchema(i).toStringPairs(base, offset)
+      case (BinaryRecordColumn, i) => resultMap ++= brSchema(i).toStringPairs(base, offset)
+                                resultMap += ("_type_" ->
+                                              Schemas.global.schemaName(RecordSchema.schemaID(base, offset)))
       case (HistogramColumn, i) =>
         resultMap += ((colNames(i), bv.BinaryHistogram.BinHistogram(blobAsBuffer(base, offset, i)).toString))
     }

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -270,7 +270,7 @@ final case class Schemas(part: PartitionSchema,
    */
   final def schemaName(id: Int): String = {
     val sch = apply(id)
-    if (sch == Schemas.UnknownSchema) "<unknown>" else sch.name
+    if (sch == Schemas.UnknownSchema) s"schemaID:$id" else sch.name
   }
 }
 

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -6,6 +6,7 @@ import filodb.query._
 
 object Vectors {
   val PromMetricLabel = "__name__"
+  val TypeLabel       = "_type_"
 }
 
 trait Vectors extends Scalars with TimeUnits with Base {

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -32,8 +32,8 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
 
   val partKeyLabelValues = Seq(
-    Map("__name__"->"http_req_total", "instance"->"someHost:8787", "job"->"myCoolService"),
-    Map("__name__"->"http_resp_time", "instance"->"someHost:8787", "job"->"myCoolService")
+    Map("__name__"->"http_req_total", "instance"->"someHost:8787", "job"->"myCoolService", "_type_"->"schemaID:35859"),
+    Map("__name__"->"http_resp_time", "instance"->"someHost:8787", "job"->"myCoolService", "_type_"->"schemaID:35859")
   )
 
   val jobQueryResult1 = ArrayBuffer(("job", "myCoolService"))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

The only way to discover the schema of time series is by using the `filo-cli` querying capability.
There is no way to filter time series by specific schema.  This becomes an issue if a user changes the type of a metric.

**New behavior :**

Metadata queries using `PartKeysExec` (ie /api/v1/series) will return `_type_` labels for all matching time series.

The `_type_` filter can be added to queries to restrict queries to only a specific schema.
