### PR TITLE
feat(core): Place downsampled data in its own keyspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,13 @@ Subsequent servers. Change log file suffix with the `-l` option for each server.
 ./filodb-dev-start.sh -c conf/timeseries-filodb-server-ds.conf -l 2 -p
 ```
 
+If you had run the unit test `DownsamplerMainSpec` which populates data into the downsample
+dataset, you can query downsample results by visiting the following URL: 
+
+```
+curl "http://localhost:8080/promql/prometheus/api/v1/query_range?query=myGuage\{_ws_='myWs',_ns_='myNs'\}&start=1574272801&end=1574273042&step=10&verbose=true&spread=2"
+```
+
 #### Local Scale Testing
 
 Follow the same steps as in original setup, but do this first to clear out existing metadata:

--- a/README.md
+++ b/README.md
@@ -158,9 +158,10 @@ sbt standalone/assembly cli/assembly gateway/assembly
 
 First initialize the keyspaces and tables in Cassandra. 
 ```
-./filo-cli -Dconfig.file=conf/timeseries-filodb-server.conf  --command init
+./scripts/schema-create.sh filodb_admin filodb filodb_downsample prometheus 4 1,5 > /tmp/ddl.cql
+cqlsh -f /tmp/ddl.cql
 ```
-Verify that tables were created in `filodb` and `filodb-admin` keyspaces using `cqlsh`:
+Verify that tables were created in `filodb`, `filodb_downsample` and `filodb-admin` keyspaces using `cqlsh`:
 First type `cqlsh` to start the cassandra cli. Then check the keyspaces by entering `DESCRIBE keyspaces`.
 
 
@@ -173,7 +174,6 @@ The script below brings up the FiloDB Dev Standalone server, and then sets up th
 Note that the above script starts the server with configuration at `conf/timeseries-filodb-server.conf`. This config
 file refers to the following datasets that will be loaded on bootstrap:
 * `conf/timeseries-dev-source.conf`
-* `conf/timeseries-ds-1m-dev-source.conf`
 
 For queries to work properly you'll want to start a second server to serve all the shards:
 
@@ -319,10 +319,21 @@ Start first FiloDB server
 ```
 ./filodb-dev-start.sh -c conf/timeseries-filodb-server-consul.conf -l 1
 ```
-And subsequent FiloDB servers. Change log file suffix with the `-l` option for each server. Add the `-s` option to 
-the last server, so data setup is initiated after all servers come up.
+And subsequent FiloDB servers. Change log file suffix with the `-l` option for each server. 
 ```
-./filodb-dev-start.sh -c conf/timeseries-filodb-server-consul.conf -l 2 -p -s
+./filodb-dev-start.sh -c conf/timeseries-filodb-server-consul.conf -l 2 -p
+```
+
+### Downsample Filo Cluster
+
+To bring up local cluster for serving downsampled data
+
+```
+./filodb-dev-start.sh -c conf/timeseries-filodb-server-ds.conf -l 1
+```
+Subsequent servers. Change log file suffix with the `-l` option for each server.
+```
+./filodb-dev-start.sh -c conf/timeseries-filodb-server-ds.conf -l 2 -p
 ```
 
 #### Local Scale Testing

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ If you had run the unit test `DownsamplerMainSpec` which populates data into the
 dataset, you can query downsample results by visiting the following URL: 
 
 ```
-curl "http://localhost:8080/promql/prometheus/api/v1/query_range?query=myGuage\{_ws_='myWs',_ns_='myNs'\}&start=1574272801&end=1574273042&step=10&verbose=true&spread=2"
+curl "http://localhost:8080/promql/prometheus/api/v1/query_range?query=my_counter\{_ws_='my_ws',_ns_='my_ns'\}&start=1574272801&end=1574273042&step=10&verbose=true&spread=2"
 ```
 
 #### Local Scale Testing

--- a/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
@@ -24,7 +24,7 @@ class CassandraTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFa
 }
 
 class DownsampledTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFactory {
-  val colStore = new CassandraColumnStore(config, ioPool)(ioPool)
+  val colStore = new CassandraColumnStore(config, ioPool, None, true)(ioPool)
   val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(ioPool)
   val memStore = new DownsampledTimeSeriesStore(colStore, metaStore, config)(ioPool)
 }

--- a/cassandra/src/main/scala/filodb.cassandra/FiloCassandraConnector.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/FiloCassandraConnector.scala
@@ -35,9 +35,7 @@ trait FiloCassandraConnector extends StrictLogging {
 
   implicit def ec: ExecutionContext
 
-  lazy val defaultKeySpace = config.getString("keyspace")
-
-  def keySpaceName(ref: DatasetRef): String = ref.database.getOrElse(defaultKeySpace)
+  def keyspace: String
 
   def createKeyspace(keyspace: String): Unit = {
     val replOptions = config.getString("keyspace-replication-options")

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
@@ -11,7 +11,7 @@ trait BaseDatasetTable extends StrictLogging {
   // The suffix for the dataset table, ie chunks, index, filter, etc.
   def dataset: DatasetRef
   def suffix: String
-  lazy val keyspace = dataset.database.getOrElse(connector.keyspace)
+  lazy val keyspace = connector.keyspace
   lazy val tableString = s"${keyspace}.${dataset.dataset + s"_$suffix"}"
   lazy val session = connector.session
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
@@ -11,7 +11,7 @@ trait BaseDatasetTable extends StrictLogging {
   // The suffix for the dataset table, ie chunks, index, filter, etc.
   def dataset: DatasetRef
   def suffix: String
-  lazy val keyspace = dataset.database.getOrElse(connector.defaultKeySpace)
+  lazy val keyspace = dataset.database.getOrElse(connector.keyspace)
   lazy val tableString = s"${keyspace}.${dataset.dataset + s"_$suffix"}"
   lazy val session = connector.session
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -259,7 +259,8 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   }
 
   def writePartKeys(ref: DatasetRef, shard: Int,
-                    partKeys: Observable[PartKeyRecord], diskTTLSeconds: Int): Future[Response] = {
+                    partKeys: Observable[PartKeyRecord],
+                    diskTTLSeconds: Int): Future[Response] = {
     val table = getOrCreatePartitionKeysTable(ref, shard)
     val span = Kamon.buildSpan("write-part-keys").start()
     val ret = partKeys.mapAsync(writeParallelism) { pk =>

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -46,7 +46,8 @@ import filodb.memory.BinaryRegionLarge
  * @param sched A Scheduler for writes
  */
 class CassandraColumnStore(val config: Config, val readEc: Scheduler,
-                           val filoSessionProvider: Option[FiloSessionProvider] = None)
+                           val filoSessionProvider: Option[FiloSessionProvider] = None,
+                           val downsampledData: Boolean = false)
                           (implicit val sched: Scheduler)
 extends ColumnStore with CassandraChunkSource with StrictLogging {
   import collection.JavaConverters._
@@ -206,7 +207,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
    * @return each split will have token_start, token_end, replicas filled in
    */
   def getScanSplits(dataset: DatasetRef, splitsPerNode: Int = 1): Seq[ScanSplit] = {
-    val keyspace = clusterConnector.keySpaceName(dataset)
+    val keyspace = clusterConnector.keyspace
     require(splitsPerNode >= 1, s"Must specify at least 1 splits_per_node, got $splitsPerNode")
 
     val tokenRanges = unwrapTokenRanges(clusterMeta.getTokenRanges.asScala.toSeq)
@@ -289,6 +290,8 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
 
   val stats = new ChunkSourceStats
 
+  def downsampledData: Boolean
+
   val cassandraConfig = config.getConfig("cassandra")
   val ingestionConsistencyLevel = ConsistencyLevel.valueOf(cassandraConfig.getString("ingestion-consistency-level"))
   val tableCacheSize = config.getInt("columnstore.tablecache-size")
@@ -302,7 +305,10 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
     def config: Config = cassandraConfig
     def ec: ExecutionContext = readEc
     val sessionProvider = filoSessionProvider.getOrElse(new DefaultFiloSessionProvider(cassandraConfig))
-  }
+
+    val keyspace: String = if (!downsampledData) config.getString("keyspace")
+                           else config.getString("downsample-keyspace")
+}
 
   val partParallelism = 4
 
@@ -356,7 +362,6 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
                                     { dataset: DatasetRef =>
                                       new IngestionTimeIndexTable(dataset, clusterConnector)(readEc) })
   }
-
 
   def getOrCreatePartitionKeysTable(dataset: DatasetRef, shard: Int): PartitionKeysTable = {
     val map = partitionKeysTableCache.getOrElseUpdate(dataset, { _ =>

--- a/conf/timeseries-filodb-server-ds.conf
+++ b/conf/timeseries-filodb-server-ds.conf
@@ -1,0 +1,5 @@
+include "timeseries-filodb-server.conf"
+
+filodb {
+  store-factory = "filodb.cassandra.DownsampledTSStoreFactory"
+}

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -13,6 +13,7 @@ import akka.event.LoggingReceive
 import kamon.Kamon
 import monix.eval.Task
 import monix.execution.{CancelableFuture, Scheduler, UncaughtExceptionReporter}
+import monix.reactive.Observable
 import net.ceedubs.ficus.Ficus._
 
 import filodb.core.{DatasetRef, Iterators}
@@ -174,6 +175,7 @@ private[filodb] final class IngestionActor(ref: DatasetRef,
         _ <- memStore.recoverIndex(ref, shard)
       } yield {
         streamSubscriptions(shard) = CancelableFuture.never // simulate ingestion happens continuously
+        streams(shard) = IngestionStream(Observable.never)
       }
     } else {
       for {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -270,10 +270,14 @@ filodb {
     ]
 
     # Partition will be downsampled only if it does not match every blacklist filter.
-    # If whitelist is non-empty, this list can be used to temporarily block downsampling of items in whitelist.
+    # If whitelist is non-empty, this list can be used to further filter out items in whitelist
     # If whitelist is empty, this list flags data not eligible foe downsampling
     blacklist-filters = [
-
+      #{
+      #  tagB1 = value1
+      #  tagB2 = value2
+      #  tagB3 = value3
+      #}
     ]
   }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -257,6 +257,24 @@ filodb {
       ingestion-buffer-mem-size = 400 MB
     }
 
+    # If non-empty, partition will be downsampled only if it matches one of the whitelist filters
+    whitelist-filters = [
+      # {
+      #  tagA1 = value1
+      #  tagA2 = value2
+      #},
+      #{
+      #  tagB1 = value1
+      #  tagB2 = value2
+      #}
+    ]
+
+    # Partition will be downsampled only if it does not match every blacklist filter.
+    # If whitelist is non-empty, this list can be used to temporarily block downsampling of items in whitelist.
+    # If whitelist is empty, this list flags data not eligible foe downsampling
+    blacklist-filters = [
+
+    ]
   }
 
   spark {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -174,6 +174,7 @@ filodb {
     hosts = ["localhost"]
     port = 9042
     keyspace = "filodb"
+    downsample-keyspace = "filodb_downsample"
     admin-keyspace = "filodb_admin"
     # username = "abc"
     # password = "xyz"

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -226,23 +226,23 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
     */
   def toStringPairs(base: Any, offset: Long): Seq[(String, String)] = {
     import Column.ColumnType._
-    val resultMap = new collection.mutable.ArrayBuffer[(String, String)]()
+    val result = new collection.mutable.ArrayBuffer[(String, String)]()
     columnTypes.zipWithIndex.map {
-      case (IntColumn, i)    => resultMap += ((colNames(i), getInt(base, offset, i).toString))
-      case (LongColumn, i)   => resultMap += ((colNames(i), getLong(base, offset, i).toString))
-      case (DoubleColumn, i) => resultMap += ((colNames(i), getDouble(base, offset, i).toString))
-      case (StringColumn, i) => resultMap += ((colNames(i), asJavaString(base, offset, i).toString))
-      case (TimestampColumn, i) => resultMap += ((colNames(i), getLong(base, offset, i).toString))
+      case (IntColumn, i)    => result += ((colNames(i), getInt(base, offset, i).toString))
+      case (LongColumn, i)   => result += ((colNames(i), getLong(base, offset, i).toString))
+      case (DoubleColumn, i) => result += ((colNames(i), getDouble(base, offset, i).toString))
+      case (StringColumn, i) => result += ((colNames(i), asJavaString(base, offset, i).toString))
+      case (TimestampColumn, i) => result += ((colNames(i), getLong(base, offset, i).toString))
       case (MapColumn, i)    => val consumer = new StringifyMapItemConsumer
                                 consumeMapItems(base, offset, i, consumer)
-                                resultMap ++= consumer.stringPairs
-      case (BinaryRecordColumn, i) => resultMap ++= brSchema(i).toStringPairs(base, offset)
-                                resultMap += ("_type_" ->
+                                result ++= consumer.stringPairs
+      case (BinaryRecordColumn, i) => result ++= brSchema(i).toStringPairs(base, offset)
+                                result += ("_type_" ->
                                               Schemas.global.schemaName(RecordSchema.schemaID(base, offset)))
       case (HistogramColumn, i) =>
-        resultMap += ((colNames(i), bv.BinaryHistogram.BinHistogram(blobAsBuffer(base, offset, i)).toString))
+        result += ((colNames(i), bv.BinaryHistogram.BinHistogram(blobAsBuffer(base, offset, i)).toString))
     }
-    resultMap
+    result
   }
 
   /**

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -20,6 +20,8 @@ final case class DownsampleConfig(config: Config) {
   val ttls = if (config.hasPath ("ttls")) config.as[Seq[FiniteDuration]]("ttls")
              else Seq.empty
   require(resolutions.length == ttls.length)
+  require(ttls.sorted == ttls, "Downsample TTLs are not sorted")
+  require(resolutions.sorted == resolutions, "Downsample Resolutions are not sorted")
 
   /**
     * Schemas to downsample

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -17,7 +17,7 @@ final case class DownsampleConfig(config: Config) {
   /**
     * TTL for downsampled data for the resolutions in same order
     */
-  val ttls = if (config.hasPath ("ttls")) config.as[Seq[FiniteDuration]]("ttls").map(_.toSeconds.toInt)
+  val ttls = if (config.hasPath ("ttls")) config.as[Seq[FiniteDuration]]("ttls")
              else Seq.empty
   require(resolutions.length == ttls.length)
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -5,6 +5,8 @@ import scala.concurrent.duration.FiniteDuration
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 
+import filodb.core.DatasetRef
+
 final case class DownsampleConfig(config: Config) {
   val enabled = config.hasPath("enabled") && config.getBoolean("enabled")
 
@@ -19,15 +21,21 @@ final case class DownsampleConfig(config: Config) {
     */
   val ttls = if (config.hasPath ("ttls")) config.as[Seq[FiniteDuration]]("ttls")
              else Seq.empty
-  require(resolutions.length == ttls.length)
+  require(resolutions.length == ttls.length, "Downsample TTLs and resolutions are not same length")
   require(ttls.sorted == ttls, "Downsample TTLs are not sorted")
-  require(resolutions.sorted == resolutions, "Downsample Resolutions are not sorted")
+  require(resolutions.sorted == resolutions, "Downsample resolutions are not sorted")
 
   /**
     * Schemas to downsample
     */
   val schemas = if (config.hasPath ("raw-schema-names")) config.as[Seq[String]]("raw-schema-names")
                 else Seq.empty
+
+  def downsampleDatasetRefs(rawDataset: String): Seq[DatasetRef] = {
+    resolutions.map { res =>
+      DatasetRef(s"${rawDataset}_ds_${res.toMinutes}")
+    }
+  }
 
   def makePublisher(): DownsamplePublisher = {
     if (!enabled) {

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -27,18 +27,18 @@ class DownsampledTimeSeriesShard(ref: DatasetRef,
 
   val downsampleResolutions = downsampleConfig.resolutions
   val downsampleTtls = downsampleConfig.ttls
-  val downsampledDatasetRefs = downsampleResolutions.map { res =>
-    DownsampledTimeSeriesStore.downsampleDatasetRef(ref, res)
-  }
+  val downsampledDatasetRefs = downsampleConfig.downsampleDatasetRefs(ref.dataset)
+
   val indexResolution = downsampleResolutions.last
   val indexDataset = downsampledDatasetRefs.last
+  val indexTtl = downsampleTtls.last
 
   // since all partitions are paged from store, this would be much lower than what is configured for raw data
   val maxQueryMatches = storeConfig.maxQueryMatches * 0.5 // TODO configure if really necessary
 
   private var nextPartitionID = 0
 
-  private final val partKeyIndex = new PartKeyLuceneIndex(ref, schemas.part, shardNum, downsampleTtls.max)
+  private final val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, shardNum, indexTtl)
 
   def indexNames(limit: Int): Seq[String] = Seq.empty
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -19,11 +19,9 @@ import filodb.core.store._
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 
 object DownsampledTimeSeriesStore {
-  def downsampleDatasetRefs(rawDatasetRef: DatasetRef,
-                            downsampleResolutions: Seq[FiniteDuration]): Map[FiniteDuration, DatasetRef] = {
-    downsampleResolutions.map { res =>
-      res -> DatasetRef(s"${rawDatasetRef}_ds_${res.toMinutes}")
-    }.toMap
+  def downsampleDatasetRef(rawDatasetRef: DatasetRef,
+                           res: FiniteDuration): DatasetRef = {
+    DatasetRef(s"${rawDatasetRef}_ds_${res.toMinutes}")
   }
 }
 
@@ -124,7 +122,8 @@ extends MemStore with StrictLogging {
   def getScanSplits(dataset: DatasetRef, splitsPerNode: Int = 1): Seq[ScanSplit] =
     activeShards(dataset).map(ShardSplit)
 
-  def groupsInDataset(ref: DatasetRef): Int = throw new UnsupportedOperationException()
+  def groupsInDataset(ref: DatasetRef): Int =
+    datasets.get(ref).map(_.values.asScala.head.storeConfig.groupsPerShard).getOrElse(1)
 
   def analyzeAndLogCorruptPtr(ref: DatasetRef, cve: CorruptVectorException): Unit =
     throw new UnsupportedOperationException()

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -2,7 +2,6 @@ package filodb.core.downsample
 
 import scala.collection.mutable.HashMap
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.FiniteDuration
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
@@ -17,13 +16,6 @@ import filodb.core.metadata.Schemas
 import filodb.core.query.ColumnFilter
 import filodb.core.store._
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
-
-object DownsampledTimeSeriesStore {
-  def downsampleDatasetRef(rawDatasetRef: DatasetRef,
-                           res: FiniteDuration): DatasetRef = {
-    DatasetRef(s"${rawDatasetRef}_ds_${res.toMinutes}")
-  }
-}
 
 class DownsampledTimeSeriesStore(val store: ColumnStore,
                                  val metastore: MetaStore,

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -47,7 +47,7 @@ extends MemStore with StrictLogging {
     if (shards.containsKey(shard)) {
       throw ShardAlreadySetup(ref, shard)
     } else {
-      val tsdb = new DownsampledTimeSeriesShard(ref, storeConf, schemas, store, shard, filodbConfig)
+      val tsdb = new DownsampledTimeSeriesShard(ref, storeConf, schemas, store, shard, filodbConfig, downsample)
       shards.put(shard, tsdb)
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -527,9 +527,9 @@ class TimeSeriesShard(val ref: DatasetRef,
   def recoverIndex(): Future[Unit] = {
     val indexBootstrapper = new ColStoreIndexBootstrapper(colStore)
     indexBootstrapper.bootstrapIndex(partKeyIndex, shardNum, ref, ingestSched)(bootstrapPartKey)
-                     .map { _ =>
+                     .map { count =>
                         startFlushingIndex()
-                        logger.info(s"Bootstrapped index for dataset=$ref shard=$shardNum")
+                       logger.info(s"Bootstrapped index for dataset=$ref shard=$shardNum with $count records")
                      }
   }
 

--- a/filodb-dev-start.sh
+++ b/filodb-dev-start.sh
@@ -14,7 +14,7 @@ CONFIG=conf/timeseries-filodb-server.conf
 LOG_SUFFIX=1
 AKKA_PORT_ARG=""
 
-while getopts "hc:l:ps" opt; do
+while getopts "hc:l:p" opt; do
     case "$opt" in
     h|\?) showHelp
         exit 1

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -126,7 +126,7 @@ final case class SelectRawPartitionsExec(id: String,
                 queryConfig: QueryConfig)
                (implicit sched: Scheduler,
                 timeout: FiniteDuration): ExecResult = {
-    Query.qLogger.debug(s"queryId=$id on dataset=$datasetRef shard=${lookupRes.map(_.shard).getOrElse("")}" +
+    Query.qLogger.debug(s"queryId=$id on dataset=$datasetRef shard=${lookupRes.map(_.shard).getOrElse("")} " +
       s"schema=${dataSchema.map(_.name)} is configured to use columnIDs=$colIds")
     val rvs = dataSchema.map { sch =>
       source.rangeVectors(datasetRef, lookupRes.get, colIds, sch, filterSchemas)

--- a/scripts/schema-create.sh
+++ b/scripts/schema-create.sh
@@ -1,19 +1,78 @@
 #!/usr/bin/env bash
 
-if [[ $# -ne 4 ]]; then
-    echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <DATASET> <NUM_SHARDS>"
-    echo "First Run: $0 filodb_admin filodb prometheus 4 > ddl.cql"
+if [[ $# -ne 6 ]]; then
+    echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <FILO_DOWNSAMPLE_KEYSPACE> <DATASET> <NUM_SHARDS> <RESOLUTIONS>"
+    echo "First Run: $0 filodb_admin filodb filodb_downsample prometheus 4 1,5 > ddl.cql"
     echo "Then Run: cql --request-timeout 3000 -f ddl.cql"
     exit 1
 fi
 
 FILO_ADMIN_KEYSPACE=$1
 FILO_KEYSPACE=$2
-DATASET=$3
-NUM_SHARDS=$4
+FILO_DOWNSAMPLE_KEYSPACE=$3
+DATASET=$4
+NUM_SHARDS=$5
+IFS=',' read -r -a RESOLUTIONS <<< "$6"
+
+
+function create_keyspaces() {
+
+local KEYSP=$1
 
 cat << EOF
-CREATE TABLE  IF NOT EXISTS ${FILO_ADMIN_KEYSPACE}.checkpoints (
+CREATE KEYSPACE IF NOT EXISTS ${KEYSP} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
+EOF
+
+}
+
+function create_chunk_tables() {
+
+local KEYSP=$1
+local DSET=$2
+
+cat << EOF
+CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_tschunks (
+    partition blob,
+    chunkid bigint,
+    chunks frozen<list<blob>>,
+    info blob,
+    PRIMARY KEY (partition, chunkid)
+) WITH compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+EOF
+
+cat << EOF
+CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_ingestion_time_index (
+    partition blob,
+    ingestion_time bigint,
+    start_time bigint,
+    info blob,
+    PRIMARY KEY (partition, ingestion_time, start_time)
+) WITH compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+EOF
+}
+
+function create_partkey_tables() {
+local KEYSP=$1
+local DSET=$2
+
+for SHARD in $(seq 0 $((NUM_SHARDS - 1))); do
+
+cat << EOF
+CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_$SHARD (
+    partKey blob,
+    startTime bigint,
+    endTime bigint,
+    PRIMARY KEY (partKey)
+) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+EOF
+
+done
+}
+
+function create_admin_tables() {
+
+cat << EOF
+CREATE TABLE IF NOT EXISTS ${FILO_ADMIN_KEYSPACE}.checkpoints (
     databasename text,
     datasetname text,
     shardnum int,
@@ -24,35 +83,21 @@ CREATE TABLE  IF NOT EXISTS ${FILO_ADMIN_KEYSPACE}.checkpoints (
 
 EOF
 
-cat << EOF
-CREATE TABLE  IF NOT EXISTS ${FILO_KEYSPACE}.${DATASET}_tschunks (
-    partition blob,
-    chunkid bigint,
-    chunks frozen<list<blob>>,
-    info blob,
-    PRIMARY KEY (partition, chunkid)
-) WITH compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
-EOF
+}
 
-cat << EOF
-CREATE TABLE IF NOT EXISTS ${FILO_KEYSPACE}.${DATASET}_ingestion_time_index (
-    partition blob,
-    ingestion_time bigint,
-    start_time bigint,
-    info blob,
-    PRIMARY KEY (partition, ingestion_time, start_time)
-) WITH compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
-EOF
+create_keyspaces ${FILO_ADMIN_KEYSPACE}
+create_keyspaces ${FILO_KEYSPACE}
+create_keyspaces ${FILO_DOWNSAMPLE_KEYSPACE}
 
-for SHARD in $(seq 0 $((NUM_SHARDS - 1))); do
+create_admin_tables
 
-cat << EOF
-CREATE TABLE IF NOT EXISTS ${FILO_KEYSPACE}.${DATASET}_partitionkeys_$SHARD (
-    partKey blob,
-    startTime bigint,
-    endTime bigint,
-    PRIMARY KEY (partKey)
-) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
-EOF
+create_chunk_tables ${FILO_KEYSPACE} ${DATASET}
+create_partkey_tables ${FILO_KEYSPACE} ${DATASET}
 
+for RES in "${RESOLUTIONS[@]}"
+do
+    create_chunk_tables ${FILO_DOWNSAMPLE_KEYSPACE} "${DATASET}_ds_${RES}"
 done
+
+create_partkey_tables ${FILO_DOWNSAMPLE_KEYSPACE} "${DATASET}_ds_${RESOLUTIONS[-1]}"
+

--- a/scripts/schema-truncate.sh
+++ b/scripts/schema-truncate.sh
@@ -1,27 +1,59 @@
 #!/usr/bin/env bash
 
-if [[ $# -ne 4 ]]; then
-    echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <DATASET> <NUM_SHARDS>"
-    echo "First Run: $0 filodb_admin filodb prometheus 4 > ddl.cql"
+if [[ $# -ne 6 ]]; then
+    echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <FILO_DOWNSAMPLE_KEYSPACE> <DATASET> <NUM_SHARDS> <RESOLUTIONS>"
+    echo "First Run: $0 filodb_admin filodb filodb_downsample prometheus 4 1,5 > ddl.cql"
     echo "Then Run: cql --request-timeout 3000 -f ddl.cql"
     exit 1
 fi
 
 FILO_ADMIN_KEYSPACE=$1
 FILO_KEYSPACE=$2
-DATASET=$3
-NUM_SHARDS=$4
+FILO_DOWNSAMPLE_KEYSPACE=$3
+DATASET=$4
+NUM_SHARDS=$5
+IFS=',' read -r -a RESOLUTIONS <<< "$6"
+
+function truncate_chunk_tables() {
+
+local KEYSP=$1
+local DSET=$2
 
 cat << EOF
-TRUNCATE ${FILO_ADMIN_KEYSPACE}.checkpoints;
-TRUNCATE ${FILO_KEYSPACE}.${DATASET}_tschunks;
-TRUNCATE ${FILO_KEYSPACE}.${DATASET}_ingestion_time_index;
+TRUNCATE ${KEYSP}.${DSET}_tschunks;
+TRUNCATE ${KEYSP}.${DSET}_ingestion_time_index;
 EOF
+}
+
+function truncate_partkey_tables() {
+
+local KEYSP=$1
+local DSET=$2
 
 for SHARD in $(seq 0 $((NUM_SHARDS - 1))); do
-
 cat << EOF
-TRUNCATE ${FILO_KEYSPACE}.${DATASET}_partitionkeys_$SHARD;
+TRUNCATE ${KEYSP}.${DSET}_partitionkeys_$SHARD;
 EOF
 
 done
+}
+
+function truncate_admin_tables() {
+
+cat << EOF
+TRUNCATE ${FILO_ADMIN_KEYSPACE}.checkpoints;
+EOF
+
+}
+
+truncate_admin_tables
+
+truncate_chunk_tables ${FILO_KEYSPACE} ${DATASET}
+truncate_partkey_tables ${FILO_KEYSPACE} ${DATASET}
+
+for RES in "${RESOLUTIONS[@]}"
+do
+    truncate_chunk_tables ${FILO_DOWNSAMPLE_KEYSPACE} "${DATASET}_ds_${RES}"
+done
+
+truncate_partkey_tables ${FILO_DOWNSAMPLE_KEYSPACE} "${DATASET}_ds_${RESOLUTIONS[-1]}"

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -87,8 +87,9 @@ object BatchDownsampler extends StrictLogging with Instance {
     * Datasets to which we write downsampled data. Keyed by Downsample resolution.
     */
   private[downsampler] val downsampleDatasetRefs =
-    DownsampledTimeSeriesStore.downsampleDatasetRefs(rawDatasetRef, settings.downsampleResolutions)
-
+    settings.downsampleResolutions.map { res =>
+      res -> DownsampledTimeSeriesStore.downsampleDatasetRef(rawDatasetRef, res)
+    }.toMap
 
   private[downsampler] val shardStats = new TimeSeriesShardStats(rawDatasetRef, -1) // TODO fix
 

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -86,10 +86,8 @@ object BatchDownsampler extends StrictLogging with Instance {
   /**
     * Datasets to which we write downsampled data. Keyed by Downsample resolution.
     */
-  private[downsampler] val downsampleDatasetRefs =
-    settings.downsampleResolutions.map { res =>
-      res -> DownsampledTimeSeriesStore.downsampleDatasetRef(rawDatasetRef, res)
-    }.toMap
+  private[downsampler] val downsampleRefsByRes = settings.downsampleResolutions
+                .zip(settings.downsampledDatasetRefs).toMap
 
   private[downsampler] val shardStats = new TimeSeriesShardStats(rawDatasetRef, -1) // TODO fix
 
@@ -285,7 +283,7 @@ object BatchDownsampler extends StrictLogging with Instance {
         numChunks += 1
         c.copy(listener = _ => {})
       }
-      downsampleCassandraColStore.write(downsampleDatasetRefs(res),
+      downsampleCassandraColStore.write(downsampleRefsByRes(res),
         Observable.fromIterator(chunksToPersist), settings.ttlByResolution(res))
     }
 

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -47,8 +47,11 @@ object BatchDownsampler extends StrictLogging with Instance {
                                               createInstance[FiloSessionProvider](clazz, args).get
                                             }
 
-  private[downsampler] val cassandraColStore =
-    new CassandraColumnStore(settings.filodbConfig, readSched, sessionProvider)(writeSched)
+  private[downsampler] val downsampleCassandraColStore =
+    new CassandraColumnStore(settings.filodbConfig, readSched, sessionProvider, true)(writeSched)
+
+  private[downsampler] val rawCassandraColStore =
+    new CassandraColumnStore(settings.filodbConfig, readSched, sessionProvider, false)(writeSched)
 
   private val kamonTags = Map( "rawDataset" -> settings.rawDatasetName,
                                "owner" -> "BatchDownsampler")
@@ -271,7 +274,7 @@ object BatchDownsampler extends StrictLogging with Instance {
         numChunks += 1
         c.copy(listener = _ => {})
       }
-      cassandraColStore.write(downsampleDatasetRefs(res),
+      downsampleCassandraColStore.write(downsampleDatasetRefs(res),
         Observable.fromIterator(chunksToPersist), settings.ttlByResolution(res))
     }
 

--- a/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
@@ -40,7 +40,7 @@ object DownsamplerSettings extends StrictLogging {
 
   val downsampleResolutions = rawDatasetIngestionConfig.downsampleConfig.resolutions
 
-  val downsampleTtls = rawDatasetIngestionConfig.downsampleConfig.ttls
+  val downsampleTtls = rawDatasetIngestionConfig.downsampleConfig.ttls.map(_.toSeconds.toInt)
 
   val downsampleStoreConfig = StoreConfig(downsamplerConfig.getConfig("downsample-store-config"))
 

--- a/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
@@ -42,6 +42,8 @@ object DownsamplerSettings extends StrictLogging {
 
   val downsampleTtls = rawDatasetIngestionConfig.downsampleConfig.ttls.map(_.toSeconds.toInt)
 
+  val downsampledDatasetRefs = rawDatasetIngestionConfig.downsampleConfig.downsampleDatasetRefs(rawDatasetName)
+
   val downsampleStoreConfig = StoreConfig(downsamplerConfig.getConfig("downsample-store-config"))
 
   val ttlByResolution = downsampleResolutions.zip(downsampleTtls).toMap

--- a/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/DownsamplerSettings.scala
@@ -58,5 +58,9 @@ object DownsamplerSettings extends StrictLogging {
 
   val downsampleChunkDuration = downsampleStoreConfig.flushInterval.toMillis
 
+  val whitelist = downsamplerConfig.as[Seq[Map[String, String]]]("whitelist-filters").map(_.toSeq)
+
+  val blacklist = downsamplerConfig.as[Seq[Map[String, String]]]("blacklist-filters").map(_.toSeq)
+
 }
 

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -48,7 +48,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   val downsampler = new Downsampler
 
   override def beforeAll(): Unit = {
-    BatchDownsampler.downsampleDatasetRefs.values.foreach { ds =>
+    BatchDownsampler.downsampleRefsByRes.values.foreach { ds =>
       downsampleColStore.initialize(ds, 4).futureValue
       downsampleColStore.truncate(ds, 4).futureValue
     }
@@ -223,7 +223,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   it("should read and verify gauge data in cassandra using PagedReadablePartition for 1-min downsampled data") {
 
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
-      BatchDownsampler.downsampleDatasetRefs(FiniteDuration(1, "min")),
+      BatchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
       0,
       SinglePartitionScan(gaugePartKeyBytes))
       .toListL.runAsync.futureValue.head
@@ -251,7 +251,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   it("should read and verify prom counter data in cassandra using PagedReadablePartition for 1-min downsampled data") {
 
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
-      BatchDownsampler.downsampleDatasetRefs(FiniteDuration(1, "min")),
+      BatchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
       0,
       SinglePartitionScan(counterPartKeyBytes))
       .toListL.runAsync.futureValue.head
@@ -292,7 +292,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     "PagedReadablePartition for 1-min downsampled data") {
 
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
-      BatchDownsampler.downsampleDatasetRefs(FiniteDuration(1, "min")),
+      BatchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
       0,
       SinglePartitionScan(histPartKeyBytes))
       .toListL.runAsync.futureValue.head
@@ -334,7 +334,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
   it("should read and verify gauge data in cassandra using PagedReadablePartition for 5-min downsampled data") {
     val downsampledPartData2 = downsampleColStore.readRawPartitions(
-      BatchDownsampler.downsampleDatasetRefs(FiniteDuration(5, "min")),
+      BatchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
       0,
       SinglePartitionScan(gaugePartKeyBytes))
       .toListL.runAsync.futureValue.head
@@ -359,7 +359,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   it("should read and verify prom counter data in cassandra using PagedReadablePartition for 5-min downsampled data") {
 
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
-      BatchDownsampler.downsampleDatasetRefs(FiniteDuration(5, "min")),
+      BatchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
       0,
       SinglePartitionScan(counterPartKeyBytes))
       .toListL.runAsync.futureValue.head
@@ -396,7 +396,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     "PagedReadablePartition for 5-min downsampled data") {
 
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
-      BatchDownsampler.downsampleDatasetRefs(FiniteDuration(5, "min")),
+      BatchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
       0,
       SinglePartitionScan(histPartKeyBytes))
       .toListL.runAsync.futureValue.head

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -66,9 +66,9 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val rawDataset = Dataset("prometheus", Schemas.gauge)
 
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
-    val seriesName = "myGauge"
-    val seriesTags = Map("_ws_".utf8 -> "myWs".utf8,
-                         "_ns_".utf8 -> "myNs".utf8)
+    val seriesName = "my_gauge"
+    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+                         "_ns_".utf8 -> "my_ns".utf8)
     val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, seriesName, seriesTags)
 
     val part = new TimeSeriesPartition(0, Schemas.gauge, partKey,
@@ -111,9 +111,9 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val rawDataset = Dataset("prometheus", Schemas.promCounter)
 
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
-    val seriesName = "myCounter"
-    val seriesTags = Map("_ws_".utf8 -> "myWs".utf8,
-                         "_ns_".utf8 -> "myNs".utf8)
+    val seriesName = "my_counter"
+    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+                         "_ns_".utf8 -> "my_ns".utf8)
     val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, seriesName, seriesTags)
 
     val part = new TimeSeriesPartition(0, Schemas.promCounter, partKey,
@@ -160,9 +160,9 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val rawDataset = Dataset("prometheus", Schemas.promHistogram)
 
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
-    val seriesName = "myHistogram"
-    val seriesTags = Map("_ws_".utf8 -> "myWs".utf8,
-                         "_ns_".utf8 -> "myNs".utf8)
+    val seriesName = "my_histogram"
+    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+                         "_ns_".utf8 -> "my_ns".utf8)
     val partKey = partBuilder.partKeyFromObjects(Schemas.promHistogram, seriesName, seriesTags)
 
     val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey,
@@ -432,5 +432,9 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
   it("should read and verify part key migration in cassandra for 5-min downsampled data") {
     // TODO in future PR
+  }
+
+  it("should bring up DownsampledTimeSeriesShard and be able to read data using SelectRawPartitionsExec") {
+    // TODO in future PR when index migration is done
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Downsampled data and raw data are in same keyspaces (but different tables)

**New behavior :**

1. Downsampled data is moved to another keyspace. Reasons:
* We may want different replication settings for downsampled data
* PartKey tables per shard may result in too many tables in one keyspace

2. manual testing of Downsample Filo Cluster is done with this PR. Fixed all issues so we can serve downsampled data queries.

3. Downsampling White/Black Listing
