### PR TITLE
feat(core): Rate Limiting Number of Time Series Ingested into TSDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 dist: trusty
 env:
   global:
-   _JAVA_OPTIONS="-Dakka.test.timefactor=3 -XX:MaxMetaspaceSize=256m"
+   _JAVA_OPTIONS="-Dakka.test.timefactor=3 -XX:MaxMetaspaceSize=512m"
 scala:
   - 2.11.12
 jdk:

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -97,6 +97,9 @@
 
         # Limits maximum amount of data a single leaf query can scan
         max-data-per-shard-query = 50 MB
+
+        # Set to true to enable metering of time series. Used for rate-limiting
+        metering-enabled = true
       }
       downsample {
         # Resolutions for downsampled data ** in ascending order **

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -11,6 +11,22 @@ filodb {
     "conf/timeseries-dev-source.conf"
   ]
 
+  quotas {
+    prometheus {
+      defaults = [100, 500, 10000, 100000]
+      custom = [
+        {
+          shardKeyPrefix = ["demo", "App-0", "heap_usage"]
+          quota = 100
+        },
+        {
+          shardKeyPrefix = ["demo"]
+          quota = 10
+        }
+      ]
+    }
+  }
+
   spread-default = 1
 
   # Override default spread for application using override block which will have non metric shard keys and spread.

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -202,6 +202,11 @@ final class QueryActor(memStore: MemStore,
     }
   }
 
+  private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
+    val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k)
+    sender ! ret
+  }
+
   def checkTimeout(queryContext: QueryContext, replyTo: ActorRef): Boolean = {
     // timeout can occur here if there is a build up in actor mailbox queue and delayed delivery
     val queryTimeElapsed = System.currentTimeMillis() - queryContext.submitTime
@@ -218,6 +223,7 @@ final class QueryActor(memStore: MemStore,
     case q: ExplainPlan2Query      => val replyTo = sender()
                                       processExplainPlanQuery(q, replyTo)
     case q: ExecPlan              =>  execPhysicalPlan2(q, sender())
+    case q: GetTopkCardinality     => execTopkCardinalityQuery(q, sender())
 
     case GetIndexNames(ref, limit, _) =>
       sender() ! memStore.indexNames(ref, limit).map(_._1).toBuffer

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -203,8 +203,12 @@ final class QueryActor(memStore: MemStore,
   }
 
   private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
-    val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k)
-    sender ! ret
+    try {
+      val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k)
+      sender ! ret
+    } catch { case e: Exception =>
+      sender ! QueryError(s"Error Occurred", e)
+    }
   }
 
   def checkTimeout(queryContext: QueryContext, replyTo: ActorRef): Boolean = {

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -32,9 +32,11 @@ object QueryCommands {
                                   limit: Int = 100,
                                   submitTime: Long = System.currentTimeMillis()) extends QueryCommand
 
-
-
-
+  final case class GetTopkCardinality(dataset: DatasetRef,
+                                      shards: Seq[Int],
+                                      shardKeyPrefix: Seq[String],
+                                      k: Int,
+                                      submitTime: Long = System.currentTimeMillis()) extends QueryCommand
 
   final case class StaticSpreadProvider(spreadChange: SpreadChange = SpreadChange()) extends SpreadProvider {
     def spreadFunc(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
@@ -5,6 +5,7 @@ import scala.concurrent.duration._
 import com.typesafe.scalalogging.StrictLogging
 
 import filodb.core._
+import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.query.QueryContext
 import filodb.query.{LogicalPlan => LogicalPlan2, QueryResponse => QueryResponse2}
 
@@ -42,6 +43,15 @@ trait QueryOps extends ClientBase with StrictLogging {
                      timeout: FiniteDuration = 15.seconds): Seq[(String, Int)] =
     askCoordinator(GetIndexValues(dataset, indexName, shard, limit, System.currentTimeMillis()), timeout) {
       case s: Seq[(String, Int)] @unchecked => s
+    }
+
+  def getTopkCardinality(dataset: DatasetRef,
+                     shards: Seq[Int],
+                     shardKeyPrefix: Seq[String],
+                     k: Int,
+                     timeout: FiniteDuration = 15.seconds): Seq[CardinalityRecord] =
+    askCoordinator(GetTopkCardinality(dataset, shards, shardKeyPrefix, k), timeout) {
+      case s: Seq[CardinalityRecord] @unchecked => s
     }
 
   /**

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import filodb.core._
 import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.query.QueryContext
-import filodb.query.{QueryError, LogicalPlan => LogicalPlan2, QueryResponse => QueryResponse2}
+import filodb.query.{LogicalPlan => LogicalPlan2, QueryError, QueryResponse => QueryResponse2}
 
 trait QueryOps extends ClientBase with StrictLogging {
   import QueryCommands._

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import filodb.core._
 import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.query.QueryContext
-import filodb.query.{LogicalPlan => LogicalPlan2, QueryResponse => QueryResponse2}
+import filodb.query.{QueryError, LogicalPlan => LogicalPlan2, QueryResponse => QueryResponse2}
 
 trait QueryOps extends ClientBase with StrictLogging {
   import QueryCommands._
@@ -52,6 +52,7 @@ trait QueryOps extends ClientBase with StrictLogging {
                      timeout: FiniteDuration = 15.seconds): Seq[CardinalityRecord] =
     askCoordinator(GetTopkCardinality(dataset, shards, shardKeyPrefix, k), timeout) {
       case s: Seq[CardinalityRecord] @unchecked => s
+      case e: QueryError => throw e.t
     }
 
   /**

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -44,7 +44,8 @@ filodb {
       ignoreShardKeyColumnSuffixes = { "_metric_" = ["_bucket", "_count", "_sum"] }
       ignoreTagsOnPartitionKeyHash = ["le"]
       metricColumn = "_metric_"
-      shardKeyColumns = [ "_metric_", "_ws_", "_ns_" ]
+      # shard key columns should be in hierarchical order
+      shardKeyColumns = ["_ws_", "_ns_", "_metric_"]
     }
   }
 
@@ -107,6 +108,20 @@ filodb {
       value-column = "avg"
       downsamplers = []
     }
+  }
+
+  quotas {
+    # if one is not defined for data source, this number is used for all limits
+    default = 1000000
+    # prometheus {
+    #   defaults = [100, 500, 10000, 100000]
+    #   custom = [
+    #     {
+    #       shardKeyPrefix = ["myWs", "myNs", "myMetricName"]
+    #       quota = 10000
+    #     }
+    #   ]
+    # }
   }
 
   tasks {

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -13,6 +13,7 @@ import org.jctools.maps.NonBlockingHashMapLong
 
 import filodb.core.{DatasetRef, Response, Types}
 import filodb.core.memstore._
+import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, QuerySession}
 import filodb.core.store._
@@ -169,4 +170,10 @@ extends MemStore with StrictLogging {
   override def readRawPartitions(ref: DatasetRef, maxChunkTime: Long,
                                  partMethod: PartitionScanMethod,
                                  chunkMethod: ChunkScanMethod): Observable[RawPartData] = ???
+
+  // TODO we need breakdown for downsample store too, but in a less memory intensive way
+  override def topKCardinality(ref: DatasetRef,
+                               shards: Seq[Int],
+                               shardKeyPrefix: scala.Seq[String],
+                               k: Int): scala.Seq[CardinalityRecord] = ???
 }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -13,6 +13,7 @@ import monix.reactive.{Observable, OverflowStrategy}
 
 import filodb.core.{DatasetRef, Types}
 import filodb.core.binaryrecord2.RecordSchema
+import filodb.core.memstore.ratelimit.QuotaSource
 import filodb.core.metadata.Schemas
 import filodb.core.query.QuerySession
 import filodb.core.store._
@@ -25,13 +26,15 @@ import filodb.memory.NativeMemoryManager
 class OnDemandPagingShard(ref: DatasetRef,
                           schemas: Schemas,
                           storeConfig: StoreConfig,
+                          quotaSource: QuotaSource,
                           shardNum: Int,
                           bufferMemoryManager: NativeMemoryManager,
                           rawStore: ColumnStore,
                           metastore: MetaStore,
                           evictionPolicy: PartitionEvictionPolicy)
                          (implicit ec: ExecutionContext) extends
-TimeSeriesShard(ref, schemas, storeConfig, shardNum, bufferMemoryManager, rawStore, metastore, evictionPolicy)(ec) {
+TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryManager, rawStore,
+                metastore, evictionPolicy)(ec) {
   import TimeSeriesShard._
   import FiloSchedulers._
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -210,7 +210,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
 
   /**
     * Fetch values/terms for a specific column/key/field, in order from most frequent on down.
-    * Note that it iterates through all docs up to a certain limit only, so if there are too many terms
+   * Note that it iterates through all docs up to a certain limit only, so if there are too many terms
     * it will not report an accurate top k in exchange for not running too long.
     * @param fieldName the name of the column/field/key to get terms for
     * @param topK the number of top k results to fetch

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -25,6 +25,7 @@ import spire.syntax.cfor._
 
 import filodb.core.{ErrorResponse, _}
 import filodb.core.binaryrecord2._
+import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityTracker, QuotaSource, RocksDbCardinalityStore}
 import filodb.core.metadata.{Schema, Schemas}
 import filodb.core.query.{ColumnFilter, QuerySession}
 import filodb.core.store._
@@ -220,6 +221,7 @@ object SchemaMismatch {
 class TimeSeriesShard(val ref: DatasetRef,
                       val schemas: Schemas,
                       val storeConfig: StoreConfig,
+                      quotaSource: QuotaSource,
                       val shardNum: Int,
                       val bufferMemoryManager: NativeMemoryManager,
                       colStore: ColumnStore,
@@ -250,6 +252,19 @@ class TimeSeriesShard(val ref: DatasetRef,
     */
   private[memstore] final val partKeyIndex = new PartKeyLuceneIndex(ref, schemas.part, shardNum,
     storeConfig.demandPagedRetentionPeriod)
+
+  private val cardTracker: CardinalityTracker = if (storeConfig.meteringEnabled) {
+    // FIXME switch this to some local-disk based store when we graduate out of POC mode
+    val cardStore = new RocksDbCardinalityStore(ref, shardNum)
+
+    val defaultQuota = quotaSource.getDefaults(ref)
+    val tracker = new CardinalityTracker(ref, shardNum, schemas.part.options.shardKeyColumns.length,
+                                                     defaultQuota, cardStore)
+    quotaSource.getQuotas(ref).foreach { q =>
+      tracker.setQuota(q.shardKeyPrefix, q.quota)
+    }
+    tracker
+  } else UnsafeUtils.ZeroPointer.asInstanceOf[CardinalityTracker]
 
   /**
     * Keeps track of count of rows ingested into memstore, not necessarily flushed.
@@ -532,6 +547,11 @@ class TimeSeriesShard(val ref: DatasetRef,
     _offset
   }
 
+  def topKCardinality(k: Int, shardKeyPrefix: Seq[String]): Seq[CardinalityRecord] = {
+    if (storeConfig.meteringEnabled) cardTracker.topk(k, shardKeyPrefix)
+    else throw new IllegalArgumentException("Metering is not enabled")
+  }
+
   def startFlushingIndex(): Unit =
     partKeyIndex.startFlushThread(storeConfig.partIndexFlushMinDelaySeconds, storeConfig.partIndexFlushMaxDelaySeconds)
 
@@ -555,11 +575,11 @@ class TimeSeriesShard(val ref: DatasetRef,
   // scalastyle:off method.length
   private[memstore] def bootstrapPartKey(pk: PartKeyRecord): Int = {
     assertThreadName(IngestSchedName)
+    val schemaId = RecordSchema.schemaID(pk.partKey, UnsafeUtils.arayOffset)
+    val schema = schemas(schemaId)
     val partId = if (pk.endTime == Long.MaxValue) {
       // this is an actively ingesting partition
       val group = partKeyGroup(schemas.part.binSchema, pk.partKey, UnsafeUtils.arayOffset, numGroups)
-      val schemaId = RecordSchema.schemaID(pk.partKey, UnsafeUtils.arayOffset)
-      val schema = schemas(schemaId)
       if (schema != Schemas.UnknownSchema) {
         val part = createNewPartition(pk.partKey, UnsafeUtils.arayOffset, group, CREATE_NEW_PARTID, schema, 4)
         // In theory, we should not get an OutOfMemPartition here since
@@ -600,6 +620,10 @@ class TimeSeriesShard(val ref: DatasetRef,
       else activelyIngesting -= partId
     }
     shardStats.indexRecoveryNumRecordsProcessed.increment()
+    if (storeConfig.meteringEnabled) {
+      val shardKey = schema.partKeySchema.colValues(pk.partKey, UnsafeUtils.arayOffset, schema.options.shardKeyColumns)
+      cardTracker.incrementCount(shardKey)
+    }
     partId
   }
 
@@ -715,8 +739,6 @@ class TimeSeriesShard(val ref: DatasetRef,
     */
   def refreshPartKeyIndexBlocking(): Unit = partKeyIndex.refreshReadersBlocking()
 
-  def closePartKeyIndex(): Unit = partKeyIndex.closeIndex()
-
   def numRowsIngested: Long = ingested
 
   def numActivePartitions: Int = partSet.size
@@ -767,6 +789,11 @@ class TimeSeriesShard(val ref: DatasetRef,
       if (!p.ingesting) {
         logger.debug(s"Purging partition with partId=${p.partID}  ${p.stringPartition} from " +
           s"memory in dataset=$ref shard=$shardNum")
+        val schema = p.schema
+        if (storeConfig.meteringEnabled) {
+          val shardKey = schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset, schema.options.shardKeyColumns)
+          cardTracker.decrementCount(shardKey)
+        }
         removePartition(p)
         removedParts += p.partID
         numDeleted += 1
@@ -1098,11 +1125,11 @@ class TimeSeriesShard(val ref: DatasetRef,
   private def addPartitionForIngestion(recordBase: Any, recordOff: Long, schema: Schema, group: Int) = {
     assertThreadName(IngestSchedName)
     // TODO: remove when no longer needed - or figure out how to log only for tracing partitions
-    logger.debug(s"Adding ingestion record details: ${schema.ingestionSchema.debugString(recordBase, recordOff)}")
+//    logger.debug(s"Adding ingestion record details: ${schema.ingestionSchema.debugString(recordBase, recordOff)}")
     val partKeyOffset = schema.comparator.buildPartKeyFromIngest(recordBase, recordOff, partKeyBuilder)
     val previousPartId = lookupPreviouslyAssignedPartId(partKeyArray, partKeyOffset)
     // TODO: remove when no longer needed
-    logger.debug(s"Adding part key details: ${schema.partKeySchema.debugString(partKeyArray, partKeyOffset)}")
+//    logger.debug(s"Adding part key details: ${schema.partKeySchema.debugString(partKeyArray, partKeyOffset)}")
     val newPart = createNewPartition(partKeyArray, partKeyOffset, group, previousPartId, schema)
     if (newPart != OutOfMemPartition) {
       val partId = newPart.partID
@@ -1111,6 +1138,11 @@ class TimeSeriesShard(val ref: DatasetRef,
         // add new lucene entry if this partKey was never seen before
         // causes endTime to be set to Long.MaxValue
         partKeyIndex.addPartKey(newPart.partKeyBytes, partId, startTime)()
+        if (storeConfig.meteringEnabled) {
+          val shardKey = schema.partKeySchema.colValues(newPart.partKeyBase, newPart.partKeyOffset,
+            schema.options.shardKeyColumns)
+          cardTracker.incrementCount(shardKey)
+        }
       } else {
         // newly created partition is re-ingesting now, so update endTime
         updatePartEndTimeInIndex(newPart, Long.MaxValue)
@@ -1499,7 +1531,6 @@ class TimeSeriesShard(val ref: DatasetRef,
     ingestSched.executeTrampolined { () =>
       partitions.values.asScala.foreach(removePartition)
     }
-    partKeyIndex.reset()
     // TODO unable to reset/clear bloom filter
     ingested = 0L
     for { group <- 0 until numGroups } {
@@ -1509,6 +1540,10 @@ class TimeSeriesShard(val ref: DatasetRef,
   }
 
   def shutdown(): Unit = {
+    if (storeConfig.meteringEnabled) {
+      cardTracker.close()
+    }
+    partKeyIndex.closeIndex()
     evictedPartKeys.synchronized {
       if (!evictedPartKeysDisposed) {
         evictedPartKeysDisposed = true

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -1,0 +1,71 @@
+package filodb.core.memstore.ratelimit
+
+case class Cardinality(name: String, timeSeriesCount: Int, childrenCount: Int, childrenQuota: Int)
+
+/**
+ *
+ * Abstracts storage of cardinality for each shard prefix.
+ *
+ * Data model needs to represent a trie like data structure.
+ * For the Ws/Ns/Name shard key example, here is the trie structure:
+ *
+ * <pre>
+ * Root
+ * * myWs1
+ * ** myNs11
+ * *** myMetric111
+ * *** myMetric112
+ * ** myNs12
+ * *** myMetric121
+ * *** myMetric122
+ * * myWs2
+ * ** myNs21
+ * *** myMetric211
+ * *** myMetric212
+ * ** myNs22
+ * *** myMetric221
+ * *** myMetric222
+ * </pre>
+ *
+ * The root to leaf path forms a full shard key. At each level in that path, we store
+ * the cardinality under that shard key prefix.
+ *
+ * The store also needs to be able to fetch immediate children of any node quickly.
+ * There can potentially be numerous nodes in the trie, so exhaustive tree-wide searches would
+ * be inefficient. So it is important that the store chosen is an implementation of some kind of tree
+ * like data structure and provides prefix search capability.
+ *
+ * Amount of memory used should be configurable. So it does not affect rest of the system.
+ *
+ * Implementations need to be local, fast and should not involve network I/O.
+ */
+trait CardinalityStore {
+
+  /**
+   * This method will be called for each shard key prefix when a new time series is added
+   * to the index.
+   */
+  def store(shardKeyPrefix: Seq[String], card: Cardinality): Unit
+
+  /**
+   * Read existing cardinality value, if one does not exist return the zero value
+   * indicated
+   */
+  def getOrZero(shardKeyPrefix: Seq[String], zero: Cardinality): Cardinality
+
+  /**
+   * Remove entry from store. Need to call for each shard key prefix to fully remove shard key.
+   * Called when a time series is purged from the index.
+   */
+  def remove(shardKeyPrefix: Seq[String]): Unit
+
+  /**
+   * Fetch immediate children of the node for the given shard key prefix
+   */
+  def scanChildren(shardKeyPrefix: Seq[String]): Seq[Cardinality]
+
+  /**
+   * Close store. Data will be thrown away
+   */
+  def close(): Unit
+}

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -1,0 +1,185 @@
+package filodb.core.memstore.ratelimit
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import com.typesafe.scalalogging.StrictLogging
+
+import filodb.core.DatasetRef
+
+case class QuotaReachedException(cannotSetShardKey: Seq[String], prefix: Seq[String], quota: Int)
+  extends RuntimeException
+
+case class CardinalityRecord(shard: Int, childName: String, timeSeriesCount: Int,
+                             childrenCount: Int, childrenQuota: Int)
+
+/**
+  * Tracks cardinality (number of time series) under each shard key prefix. The shard key
+  * essentially comprises of the part key key/value pairs that determine which shard a time
+  * series goes into.
+  *
+  * For example if shard Key is Seq("myWs", "myNs", "myMetric") then cardinality of each prefix
+  * Seq(), Seq("myWs"), Seq("myWs, "myNs"), Seq("myWs", "myNs", "myMetric") would be tracked.
+  *
+  * Thus, the cardinality store can be represented as a Trie of shard key elements. For the above example,
+  * the trie would have 4 levels. Cardinality is tracked at each node of the trie. Both count of number
+  * of immediate children as well as number of time series under that level are tracked.
+  *
+  * This Cardinality Tracker can also enforce quotas. Quotas are set by invoking the setQuota method.
+  * While this tracker tracks both immediate children as well as total number of time series under each node,
+  * quota enforcement is for immediate children only.
+  *
+  * @param ref the dataset for which we track the cardinality
+  * @param shard the shard number
+  * @param shardKeyLen number of elements in the shard key
+  * @param defaultChildrenQuota the default quota at each level if no explicit quota is set
+  * @param store fast memory or disk based store where cardinality and quota can be read and written
+  * @param quotaExceededProtocol action to be taken when quota is breached
+  */
+class CardinalityTracker(ref: DatasetRef,
+                         shard: Int,
+                         shardKeyLen: Int,
+                         defaultChildrenQuota: Seq[Int],
+                         val store: CardinalityStore,
+                         quotaExceededProtocol: QuotaExceededProtocol = NoActionQuotaProtocol) extends StrictLogging {
+
+  require(defaultChildrenQuota.length == shardKeyLen + 1)
+  require(defaultChildrenQuota.forall(q => q > 0 && q < 2000000))
+  logger.info(s"Initializing Cardinality Tracker for shard $shard with $defaultChildrenQuota")
+
+  /**
+   * Call when a new time series with the given shard key has been added to the system.
+   * This will update the cardinality at each level within the trie. If quota is breached,
+   * QuotaReachedException will be thrown and quotaExceededProtocol will be invoked
+   *
+   * @param shardKey elements in the shard key of time series. For example: (ws, ns, name). Full shard key needed.
+   * @return current cardinality for each shard key prefix. There
+   *         will be shardKeyLen + 1 items in the return value
+   */
+  def incrementCount(shardKey: Seq[String]): Seq[Cardinality] = {
+    require(shardKey.length == shardKeyLen, "full shard key is needed")
+
+    val toStore = ArrayBuffer[(Seq[String], Cardinality)]()
+    // first make sure there is no breach for any prefix
+    (0 to shardKey.length).foreach { i =>
+      val prefix = shardKey.take(i)
+      val name = if (prefix.isEmpty) "" else prefix.last
+      val old = store.getOrZero(prefix, Cardinality(name, 0, 0, defaultChildrenQuota(i)))
+      val neu = old.copy(timeSeriesCount = old.timeSeriesCount + 1,
+                         childrenCount = if (i == shardKeyLen) old.childrenCount + 1 else old.childrenCount)
+      if (i == shardKeyLen && neu.timeSeriesCount > neu.childrenQuota) {
+        quotaExceededProtocol.quotaExceeded(ref, shard, prefix, neu.childrenQuota)
+        throw QuotaReachedException(shardKey, prefix, neu.childrenQuota)
+      }
+      if (i > 0 && neu.timeSeriesCount == 1) { // parent's new child
+        val parent = toStore(i-1)
+        val neuParent = parent._2.copy(childrenCount = parent._2.childrenCount + 1)
+        toStore(i-1) = (parent._1, neuParent)
+        if (neuParent.childrenCount > neuParent.childrenQuota) {
+          quotaExceededProtocol.quotaExceeded(ref, shard, parent._1, neuParent.childrenQuota)
+          throw QuotaReachedException(shardKey, parent._1, neuParent.childrenQuota)
+        }
+      }
+      toStore += (prefix -> neu)
+    }
+
+    toStore.map { case (prefix, neu) =>
+      store.store(prefix, neu)
+      neu
+    }
+  }
+
+  /**
+   * Fetch cardinality for given shard key or shard key prefix
+   *
+   * @param shardKeyPrefix zero or more elements that form a valid shard key prefix
+   */
+  def getCardinality(shardKeyPrefix: Seq[String]): Cardinality = {
+    require(shardKeyPrefix.length <= shardKeyLen, s"Too many shard keys in $shardKeyPrefix - max $shardKeyLen")
+    val name = if (shardKeyPrefix.isEmpty) "" else shardKeyPrefix.last
+    store.getOrZero(shardKeyPrefix, Cardinality(name, 0, 0, defaultChildrenQuota(shardKeyPrefix.length)))
+  }
+
+  /**
+   * Set quota for given shard key or shard key prefix
+   *
+   * @param shardKeyPrefix zero or more elements that form a valid shard key prefix
+   * @param childrenQuota maximum number of time series for this prefix
+   * @return current Cardinality for the prefix
+   */
+  def setQuota(shardKeyPrefix: Seq[String], childrenQuota: Int): Cardinality = {
+    require(shardKeyPrefix.length <= shardKeyLen, s"Too many shard keys in $shardKeyPrefix - max $shardKeyLen")
+    require(childrenQuota > 0 && childrenQuota < 2000000, "Children quota invalid. Provide [1, 2000000)")
+
+    logger.debug(s"Setting children quota for $shardKeyPrefix as $childrenQuota")
+    val name = if (shardKeyPrefix.isEmpty) "" else shardKeyPrefix.last
+    val old = store.getOrZero(shardKeyPrefix, Cardinality(name, 0, 0, defaultChildrenQuota(shardKeyPrefix.length)))
+    val neu = old.copy(childrenQuota = childrenQuota)
+    store.store(shardKeyPrefix, neu)
+    neu
+  }
+
+  /**
+   * Call when an existing time series with the given shard key has been removed from the system.
+   * This will reduce the cardinality at each level within the trie.
+   *
+   * If cardinality reduces to 0, and the quota is the default quota, record will be removed from the store
+   *
+   * @param shardKey elements in the shard key of time series.
+   *                 For example: (ws, ns, name). Full shard key is needed.
+   * @return current cardinality for each shard key prefix. There
+   *         will be shardKeyLen + 1 items in the return value
+   */
+  def decrementCount(shardKey: Seq[String]): Seq[Cardinality] = {
+    require(shardKey.length == shardKeyLen, "full shard key is needed")
+    val toStore = (0 to shardKey.length).map { i =>
+      val prefix = shardKey.take(i)
+      val old = store.getOrZero(prefix, Cardinality("", 0, 0, defaultChildrenQuota(i)))
+      if (old.timeSeriesCount == 0)
+        throw new IllegalArgumentException(s"$prefix count is already zero - cannot reduce further")
+      val neu = old.copy(timeSeriesCount = old.timeSeriesCount - 1)
+      (prefix, neu)
+    }
+    toStore.map { case (prefix, neu) =>
+      val name = if (prefix.isEmpty) "" else prefix.last
+      if (neu == Cardinality(name, 0, 0, defaultChildrenQuota(prefix.length))) {
+        // node can be removed
+        store.remove(prefix)
+      } else {
+        store.store(prefix, neu)
+      }
+      neu
+    }
+  }
+
+  /**
+   * Use this method to query the top-k cardinality consumers immediately
+   * under a provided shard key prefix
+   *
+   * @param k
+   * @param shardKeyPrefix zero or more elements that form a valid shard key prefix
+   * @return Top-K records, can the less than K if fewer children
+   */
+  def topk(k: Int, shardKeyPrefix: Seq[String]): Seq[CardinalityRecord] = {
+    require(shardKeyPrefix.length <= shardKeyLen, s"Too many shard keys in $shardKeyPrefix - max $shardKeyLen")
+    implicit val ord = new Ordering[CardinalityRecord]() {
+      override def compare(x: CardinalityRecord, y: CardinalityRecord): Int = {
+        x.timeSeriesCount - y.timeSeriesCount
+      }
+    }.reverse
+    val heap = mutable.PriorityQueue[CardinalityRecord]()
+    store.scanChildren(shardKeyPrefix).foreach { card =>
+      heap.enqueue(
+        CardinalityRecord(shard, card.name,
+                 card.timeSeriesCount,
+                 if (shardKeyPrefix.length == shardKeyLen - 1) card.timeSeriesCount else card.childrenCount,
+                 card.childrenQuota))
+      if (heap.size > k) heap.dequeue()
+    }
+    heap.toSeq
+  }
+
+  def close(): Unit = {
+    store.close()
+  }
+}

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaExceededProtocol.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaExceededProtocol.scala
@@ -1,0 +1,33 @@
+package filodb.core.memstore.ratelimit
+
+import filodb.core.DatasetRef
+
+/**
+ * Allows for action to be taken when quota is breached
+ */
+trait QuotaExceededProtocol {
+  /**
+   * Invoked when quota is breached.
+   *
+   * Example actions that could be taken:
+   * 1. Send message to gateway to block ingestion of this shardKeyPrefix
+   * 2. Automatically increase quota if reasonable
+   * 3. Send a notification/alert to customers or operations
+   *
+   * Note that this can be invoked multiple times until either ingestion of invalid data stops
+   * or if quota is fixed. So implementations should ensure that actions are idempotent.
+   *
+   * @param ref dataset
+   * @param shardNum the shardNumber that breached the quota
+   * @param shardKeyPrefix the shardKeyPrefix for which quota was breached
+   * @param quota the actual quota number that was breached
+   */
+  def quotaExceeded(ref: DatasetRef, shardNum: Int, shardKeyPrefix: Seq[String], quota: Int): Unit
+}
+
+/**
+ * Default implementation which takes no action.
+ */
+object NoActionQuotaProtocol extends QuotaExceededProtocol {
+  def quotaExceeded(ref: DatasetRef, shardNum: Int, shardKeyPrefix: Seq[String], quota: Int): Unit = {}
+}

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaSource.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaSource.scala
@@ -1,0 +1,60 @@
+package filodb.core.memstore.ratelimit
+
+import com.typesafe.config.Config
+import net.ceedubs.ficus.Ficus._
+import net.ceedubs.ficus.readers.ValueReader
+
+import filodb.core.DatasetRef
+
+case class QuotaRecord(shardKeyPrefix: Seq[String], quota: Int)
+
+/**
+ * Source of quotas for shard key prefixes.
+ */
+trait QuotaSource {
+
+  /**
+   * Fetch all configured quotas. Invoked when a new Time Series Shard is bootstrapped.
+   *
+   * The quota represents number of immediate children allowed for the given
+   * shard key prefix within each shard.
+   */
+  def getQuotas(dataset: DatasetRef): Iterator[QuotaRecord]
+
+  /**
+   * Quota to use in case explicit quota record is not present.
+   * Return value is one item for each level of the tree.
+   * Hence number of items in the returned sequence should be
+   * shardKeyLen + 1
+   */
+  def getDefaults(dataset: DatasetRef): Seq[Int]
+}
+
+/**
+ * QuotaSource implementation where static quota definitions are loaded from server configuration.
+ */
+class ConfigQuotaSource(filodbConfig: Config, shardKeyLen: Int) extends QuotaSource {
+  implicit val quotaReader: ValueReader[QuotaRecord] = ValueReader.relative { quotaConfig =>
+    QuotaRecord(quotaConfig.as[Seq[String]]("shardKeyPrefix"),
+                quotaConfig.as[Int]("quota"))
+  }
+
+  def getQuotas(dataset: DatasetRef): Iterator[QuotaRecord] = {
+    if (filodbConfig.hasPath(s"quotas.$dataset.custom")) {
+      filodbConfig.as[Seq[QuotaRecord]](s"quotas.$dataset.custom").iterator
+    } else {
+      Iterator.empty
+    }
+  }
+
+  def getDefaults(dataset: DatasetRef): Seq[Int] = {
+    if (filodbConfig.hasPath(s"quotas.$dataset.custom")) {
+      val defaults = filodbConfig.as[Seq[Int]](s"quotas.$dataset.defaults")
+      require(defaults.length == shardKeyLen + 1, s"Quota defaults $defaults was not of length ${shardKeyLen + 1}")
+      defaults
+    } else {
+      val default = filodbConfig.as[Int]("quotas.default")
+      Seq.fill(shardKeyLen + 1)(default)
+    }
+  }
+}

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
@@ -1,0 +1,207 @@
+package filodb.core.memstore.ratelimit
+
+import java.io.File
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+import scala.reflect.io.Directory
+
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
+import kamon.metric.MeasurementUnit
+import kamon.tag.TagSet
+import monix.reactive.Observable
+import org.rocksdb._
+import spire.syntax.cfor._
+
+import filodb.core.{DatasetRef, GlobalScheduler}
+import filodb.memory.format.UnsafeUtils
+
+class CardinalitySerializer extends Serializer[Cardinality] {
+  def write(kryo: Kryo, output: Output, card: Cardinality): Unit = {
+    output.writeString(card.name)
+    output.writeInt(card.timeSeriesCount, true)
+    output.writeInt(card.childrenCount, true)
+    output.writeInt(card.childrenQuota, true)
+  }
+
+  def read(kryo: Kryo, input: Input, t: Class[Cardinality]): Cardinality = {
+    Cardinality(input.readString(), input.readInt(true), input.readInt(true), input.readInt(true))
+  }
+}
+
+object RocksDbCardinalityStore {
+  private val LastKeySeparator: Char = 0x1E
+  private val NotLastKeySeparator: Char = 0x1D
+}
+
+class RocksDbCardinalityStore(ref: DatasetRef, shard: Int) extends CardinalityStore with StrictLogging {
+
+  val tags = Map("shard" -> shard.toString, "dataset" -> ref.toString)
+  val diskSpaceUsed = Kamon.gauge("card-store-disk-space-used", MeasurementUnit.information.bytes)
+    .withTags(TagSet.from(tags))
+  val memoryUsed = Kamon.gauge("card-store-offheap-mem-used")
+    .withTags(TagSet.from(tags))
+  val compactionBytesPending = Kamon.gauge("card-store-compaction-pending", MeasurementUnit.information.bytes)
+    .withTags(TagSet.from(tags))
+  val numRunningCompactions = Kamon.gauge("card-store-num-running-compactions")
+    .withTags(TagSet.from(tags))
+  val numKeys = Kamon.gauge("card-store-est-num-keys")
+    .withTags(TagSet.from(tags))
+
+  private val options = new Options().setCreateIfMissing(true) // TODO fine tune options
+  private val baseDir = new File(System.getProperty("java.io.tmpdir"))
+  private val baseName = s"cardStore-$ref-$shard-${System.currentTimeMillis()}"
+  private val dbDirInTmp = new File(baseDir, baseName)
+
+  private val metricsReporter = Observable.interval(1.minute)
+    .onErrorRestart(Int.MaxValue)
+    .foreach(_ => updateStats())(GlobalScheduler.globalImplicitScheduler)
+
+  private val db = RocksDB.open(options, dbDirInTmp.getAbsolutePath)
+  logger.info(s"Opening new Cardinality DB at ${dbDirInTmp.getAbsolutePath}")
+
+  private val kryo = new ThreadLocal[Kryo]() {
+    override def initialValue(): Kryo = {
+      val k = new Kryo()
+      k.addDefaultSerializer(classOf[Cardinality], classOf[CardinalitySerializer])
+      k
+    }
+  }
+
+  private val NotFound = UnsafeUtils.ZeroPointer.asInstanceOf[Array[Byte]]
+
+  def updateStats(): Unit = {
+
+    //  List of all RocksDB properties at https://github.com/facebook/rocksdb/blob/6.12.fb/include/rocksdb/db.h#L720
+
+    // Returns the total size, in bytes, of all the SST files.
+    // WAL files are not included in the calculation.
+    diskSpaceUsed.update(db.getLongProperty("rocksdb.total-sst-files-size"))
+    numKeys.update(db.getLongProperty("rocksdb.estimate-num-keys"))
+
+    val memTableSize = db.getLongProperty("rocksdb.size-all-mem-tables")
+    val blockCacheSize = db.getLongProperty("rocksdb.block-cache-usage")
+    val tableReadersSize = db.getLongProperty("rocksdb.estimate-table-readers-mem")
+    memoryUsed.update(memTableSize + blockCacheSize + tableReadersSize)
+
+    compactionBytesPending.update(db.getLongProperty("rocksdb.estimate-pending-compaction-bytes"))
+    numRunningCompactions.update(db.getLongProperty("rocksdb.num-running-compactions"))
+    // consider compaction-pending yes/no
+  }
+
+  /**
+   * In order to enable quick prefix search, we formulate string based keys to the RocksDB
+   * key-value store.
+   *
+   * For example, here is the list of rocksDb keys for a few shard keys. {LastKeySeparator} and
+   * {NotLastKeySeparator} are special characters chosen as separator char between shard key elements.
+   * {LastKeySeparator} is used just prior to last shard key element. {NotLastKeySeparator} is used otherwise.
+   * This model helps with fast prefix searches to do top-k scans.
+   *
+   * BTW, Remove quote chars from actual string key.
+   * They are there just to emphasize the shard key element in the string. "" represents the root.
+   *
+   * <pre>
+   * ""
+   * ""{LastKeySeparator}"myWs1"
+   * ""{LastKeySeparator}"myWs2"
+   * ""{NotLastKeySeparator}"myWs1"{LastKeySeparator}"myNs11"
+   * ""{NotLastKeySeparator}"myWs1"{LastKeySeparator}"myNs12"
+   * ""{NotLastKeySeparator}"myWs2"{LastKeySeparator}"myNs21"
+   * ""{NotLastKeySeparator}"myWs2"{LastKeySeparator}"myNs22"
+   * ""{NotLastKeySeparator}"myWs1"{NotLastKeySeparator}"myNs11"{LastKeySeparator}"heap_usage"
+   * ""{NotLastKeySeparator}"myWs1"{NotLastKeySeparator}"myNs11"{LastKeySeparator}"cpu_usage"
+   * ""{NotLastKeySeparator}"myWs1"{NotLastKeySeparator}"myNs11"{LastKeySeparator}"network_usage"
+   * </pre>
+   *
+   * In the above tree, we simply do a prefix search on <pre> ""{NotLastKeySeparator}"myWs1"{LastKeySeparator} </pre>
+   * to get namespaces under workspace myWs1.
+   *
+   * @param shardKeyPrefix Zero or more elements that make up shard key prefix
+   * @param prefixSearch If true, returns key that can be used to perform prefix search to
+   *                     fetch immediate children in trie. Use false to fetch one specific node.
+   * @return string key to use to perform reads and writes of entries into RocksDB
+   */
+  private def toStringKey(shardKeyPrefix: Seq[String], prefixSearch: Boolean): String = {
+    import RocksDbCardinalityStore._
+    if (shardKeyPrefix.isEmpty) {
+      if (prefixSearch) LastKeySeparator.toString else ""
+    } else {
+      val b = new StringBuilder
+      cforRange { 0 until shardKeyPrefix.length - 1 } { i =>
+        b.append(NotLastKeySeparator)
+        b.append(shardKeyPrefix(i))
+      }
+      if (prefixSearch) {
+        b.append(NotLastKeySeparator)
+        b.append(shardKeyPrefix.last)
+        b.append(LastKeySeparator)
+      } else {
+        b.append(LastKeySeparator)
+        b.append(shardKeyPrefix.last)
+      }
+      b.toString()
+    }
+  }
+
+  private def cardinalityToBytes(card: Cardinality): Array[Byte] = {
+    val out = new Output(500)
+    kryo.get().writeObject(out, card)
+    out.close()
+    out.toBytes
+  }
+
+  private def bytesToCardinality(bytes: Array[Byte]): Cardinality = {
+    val inp = new Input(bytes)
+    val c = kryo.get().readObject(inp, classOf[Cardinality])
+    inp.close()
+    c
+  }
+
+  override def store(shardKeyPrefix: Seq[String], card: Cardinality): Unit = {
+    val key = toStringKey(shardKeyPrefix, false).getBytes()
+    logger.debug(s"Storing ${new String(key)} with $card")
+    db.put(key, cardinalityToBytes(card))
+  }
+
+  def getOrZero(shardKeyPrefix: Seq[String], zero: Cardinality): Cardinality = {
+    val value = db.get(toStringKey(shardKeyPrefix, false).getBytes())
+    if (value == NotFound) zero else bytesToCardinality(value)
+  }
+
+  override def remove(shardKeyPrefix: Seq[String]): Unit = {
+    db.delete(toStringKey(shardKeyPrefix, false).getBytes())
+  }
+
+  override def scanChildren(shardKeyPrefix: Seq[String]): Seq[Cardinality] = {
+    val it = db.newIterator()
+    val searchPrefix = toStringKey(shardKeyPrefix, true)
+    logger.debug(s"Scanning ${new String(searchPrefix)}")
+    it.seek(searchPrefix.getBytes())
+    val buf = ArrayBuffer[Cardinality]()
+    import scala.util.control.Breaks._
+
+    breakable {
+      while (it.isValid()) {
+        val key = new String(it.key())
+        if (key.startsWith(searchPrefix)) {
+          buf += bytesToCardinality(it.value())
+        } else break // dont continue beyond valid results
+        it.next()
+      }
+    }
+    buf
+  }
+
+  def close(): Unit = {
+    db.cancelAllBackgroundWork(true)
+    db.close()
+    options.close()
+    val directory = new Directory(dbDirInTmp)
+    directory.deleteRecursively()
+    metricsReporter.cancel()
+  }
+}

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -9,6 +9,7 @@ import monix.reactive.Observable
 
 import filodb.core._
 import filodb.core.memstore.{PartLookupResult, SchemaMismatch, TimeSeriesShard}
+import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.{Schema, Schemas}
 import filodb.core.query._
 
@@ -167,6 +168,9 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       RawDataRangeVector(key, partition, lookupRes.chunkMethod, ids)
     }
   }
+
+  def topKCardinality(ref: DatasetRef, shard: Seq[Int], shardKeyPrefix: Seq[String], k: Int): Seq[CardinalityRecord]
+
 }
 
 /**

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -37,7 +37,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              ensureHeadroomPercent: Double,
                              // filters on ingested records to log in detail
                              traceFilters: Map[String, String],
-                             maxDataPerShardQuery: Long) {
+                             maxDataPerShardQuery: Long,
+                             meteringEnabled: Boolean) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -61,7 +62,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "demand-paging-enabled" -> demandPagingEnabled,
                                "max-data-per-shard-query" -> maxDataPerShardQuery,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
-                               "ensure-headroom-percent" -> ensureHeadroomPercent).asJava)
+                               "ensure-headroom-percent" -> ensureHeadroomPercent,
+                               "metering-enabled" -> meteringEnabled).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -97,6 +99,7 @@ object StoreConfig {
                                            |evicted-pk-bloom-filter-capacity = 5000000
                                            |ensure-headroom-percent = 5.0
                                            |trace-filters = {}
+                                           |metering-enabled = true
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -128,7 +131,8 @@ object StoreConfig {
                 config.getInt("evicted-pk-bloom-filter-capacity"),
                 config.getDouble("ensure-headroom-percent"),
                 config.as[Map[String, String]]("trace-filters"),
-                config.getMemorySize("max-data-per-shard-query").toBytes)
+                config.getMemorySize("max-data-per-shard-query").toBytes,
+                config.getBoolean("metering-enabled"))
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -99,7 +99,7 @@ object StoreConfig {
                                            |evicted-pk-bloom-filter-capacity = 5000000
                                            |ensure-headroom-percent = 5.0
                                            |trace-filters = {}
-                                           |metering-enabled = true
+                                           |metering-enabled = false
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -30,6 +30,11 @@ filodb {
     shardmap-publish-frequency = 1s
   }
 
+  quotas {
+    default = 1000000
+  }
+
+
   columnstore {
     # Number of cache entries for the table cache
     tablecache-size = 50

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -320,7 +320,8 @@ object MachineMetricsData {
     }
   }
 
-  val dataset2 = Dataset("metrics2", Seq("series:string", "tags:map"), columns)
+  val dataset2 = Dataset("metrics2", Seq("series:string", "tags:map"), columns,
+    options = DatasetOptions(shardKeyColumns = Seq("_ws_", "_ns_", "_metric_"), "_metric_"))
   val schema2 = dataset2.schema
 
   def withMap(data: Stream[Seq[Any]], n: Int = 5, extraTags: UTF8Map = Map.empty): Stream[Seq[Any]] =
@@ -339,7 +340,7 @@ object MachineMetricsData {
 
   val histDataset = Dataset("histogram", Seq("metric:string", "tags:map"),
                             Seq("timestamp:ts", "count:long", "sum:long", "h:hist:counter=false"),
-                            DatasetOptions.DefaultOptions.copy(metricColumn = "metric"))
+                            options = DatasetOptions(shardKeyColumns = Seq("_ws_", "_ns_", "metric"), "metric"))
 
   var histBucketScheme: bv.HistogramBuckets = _
   def linearHistSeries(startTs: Long = 100000L, numSeries: Int = 10, timeStep: Int = 1000, numBuckets: Int = 8,

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -1,0 +1,249 @@
+package filodb.core.memstore.ratelimit
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.{DatasetRef, MachineMetricsData}
+
+class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
+
+  val ref = MachineMetricsData.dataset2.ref
+
+  private def newCardStore = {
+    new RocksDbCardinalityStore(DatasetRef("test"), 0)
+  }
+
+  it("should enforce quota when set explicitly for all levels") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
+    t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual Cardinality("aaa", 0, 0, 1)
+    t.setQuota(Seq("a", "aa"), 2) shouldEqual Cardinality("aa", 0, 0, 2)
+    t.setQuota(Seq("a"), 1) shouldEqual Cardinality("a",0, 0, 1)
+    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
+      Seq(Cardinality("", 1, 1, 4),
+        Cardinality("a", 1, 1, 1),
+        Cardinality("aa", 1, 1, 2),
+        Cardinality("aaa", 1, 1, 1))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 2, 1, 4),
+        Cardinality("a", 2, 1, 1),
+        Cardinality("aa", 2, 2, 2),
+        Cardinality("aab", 1, 1, 4))
+
+    val ex = intercept[QuotaReachedException] {
+      t.incrementCount(Seq("a", "aa", "aac"))
+    }
+    ex.prefix shouldEqual (Seq("a", "aa"))
+
+    // increment should not have been applied for any prefix
+    t.getCardinality(Seq("a")) shouldEqual Cardinality("a", 2, 1, 1)
+    t.getCardinality(Seq("a", "aa")) shouldEqual Cardinality("aa", 2, 2, 2)
+    t.getCardinality(Seq("a", "aa", "aac")) shouldEqual Cardinality("aac", 0, 0, 4)
+    t.close()
+  }
+
+  it("should invoke quota exceeded protocol when breach occurs") {
+
+    class MyQEP extends QuotaExceededProtocol {
+      var breachedPrefix: Seq[String] = Nil
+      var breachedQuota = -1
+      def quotaExceeded(ref: DatasetRef, shard: Int, shardKeyPrefix: Seq[String], quota: Int): Unit = {
+        breachedPrefix = shardKeyPrefix
+        breachedQuota = quota
+      }
+    }
+
+    val qp = new MyQEP
+    val t = new CardinalityTracker(ref, 0, 3, Seq(1, 1, 1, 1), newCardStore, qp)
+    t.incrementCount(Seq("a", "aa", "aaa"))
+    val ex = intercept[QuotaReachedException] {
+      t.incrementCount(Seq("a", "aa", "aaa"))
+    }
+    qp.breachedQuota shouldEqual 1
+    qp.breachedPrefix shouldEqual Seq("a", "aa", "aaa")
+    t.close()
+  }
+
+  it("should enforce quota when not set for any level") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
+    t.incrementCount(Seq("a", "ab", "aba")) shouldEqual
+      Seq(Cardinality("", 1, 1, 4),
+        Cardinality("a", 1, 1, 4),
+        Cardinality("ab", 1, 1, 4),
+        Cardinality("aba", 1, 1, 4))
+    t.close()
+  }
+
+  it("should be able to enforce for top 2 levels always, and enforce for 3rd level only in some cases") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 10)
+    // enforce for 3rd level only for aaa
+    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 2)
+    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
+      Seq(Cardinality("", 1, 1, 20),
+        Cardinality("a", 1, 1, 10),
+        Cardinality("aa", 1, 1, 10),
+        Cardinality("aaa", 1, 1, 2))
+    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
+      Seq(Cardinality("", 2, 1, 20),
+        Cardinality("a", 2, 1, 10),
+        Cardinality("aa", 2, 1, 10),
+        Cardinality("aaa", 2, 2, 2))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 3, 1, 20),
+        Cardinality("a", 3, 1, 10),
+        Cardinality("aa", 3, 2, 10),
+        Cardinality("aab", 1, 1, 20))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 4, 1, 20),
+        Cardinality("a", 4, 1, 10),
+        Cardinality("aa", 4, 2, 10),
+        Cardinality("aab", 2, 2, 20))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 5, 1, 20),
+        Cardinality("a", 5, 1, 10),
+        Cardinality("aa", 5, 2, 10),
+        Cardinality("aab", 3, 3, 20))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 6, 1, 20),
+        Cardinality("a", 6, 1, 10),
+        Cardinality("aa", 6, 2, 10),
+        Cardinality("aab", 4, 4, 20))
+
+    val ex = intercept[QuotaReachedException] {
+      t.incrementCount(Seq("a", "aa", "aaa"))
+    }
+     ex.prefix shouldEqual Seq("a", "aa", "aaa")
+    t.close()
+
+  }
+
+  it("should be able to increase and decrease quota after it has been set before") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 10)
+    // enforce for 3rd level only for aaa
+    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 2)
+    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
+      Seq(Cardinality("", 1, 1, 20),
+        Cardinality("a", 1, 1, 10),
+        Cardinality("aa", 1, 1, 10),
+        Cardinality("aaa", 1, 1, 2))
+    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
+      Seq(Cardinality("", 2, 1, 20),
+        Cardinality("a", 2, 1, 10),
+        Cardinality("aa", 2, 1, 10),
+        Cardinality("aaa", 2, 2, 2))
+
+    val ex = intercept[QuotaReachedException] {
+      t.incrementCount(Seq("a", "aa", "aaa"))
+    }
+    ex.prefix shouldEqual (Seq("a", "aa", "aaa"))
+
+    // increase quota
+    t.setQuota(Seq("a", "aa", "aaa"), 5) shouldEqual Cardinality("aaa", 2, 2, 5)
+    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
+      Seq(Cardinality("", 3, 1, 20),
+        Cardinality("a", 3, 1, 10),
+        Cardinality("aa", 3, 1, 10),
+        Cardinality("aaa", 3, 3, 5))
+
+    // decrease quota
+    t.setQuota(Seq("a", "aa", "aaa"), 4) shouldEqual Cardinality("aaa", 3, 3, 4)
+    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
+      Seq(Cardinality("", 4, 1, 20),
+        Cardinality("a", 4, 1, 10),
+        Cardinality("aa", 4, 1, 10),
+        Cardinality("aaa", 4, 4, 4))
+    val ex2 = intercept[QuotaReachedException] {
+      t.incrementCount(Seq("a", "aa", "aaa"))
+    }
+    ex2.prefix shouldEqual Seq("a", "aa", "aaa")
+    t.close()
+  }
+
+  it("should be able to decrease quota if count is higher than new quota") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 10)
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 1, 1, 20),
+        Cardinality("a", 1, 1, 10),
+        Cardinality("aa", 1, 1, 10),
+        Cardinality("aab", 1, 1, 20))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 2, 1, 20),
+        Cardinality("a", 2, 1, 10),
+        Cardinality("aa", 2, 1, 10),
+        Cardinality("aab", 2, 2, 20))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 3, 1, 20),
+        Cardinality("a", 3, 1, 10),
+        Cardinality("aa", 3, 1, 10),
+        Cardinality("aab", 3, 3, 20))
+    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 4, 1, 20),
+        Cardinality("a", 4, 1, 10),
+        Cardinality("aa", 4, 1, 10),
+        Cardinality("aab", 4, 4, 20))
+
+    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 4, 20)
+
+    t.setQuota(Seq("a", "aa", "aab"), 3)
+    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 4, 3)
+    val ex2 = intercept[QuotaReachedException] {
+      t.incrementCount(Seq("a", "aa", "aab"))
+    }
+    ex2.prefix shouldEqual Seq("a", "aa", "aab")
+    t.close()
+  }
+
+  it ("should be able to do topk") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
+    (1 to 10).foreach(_ => t.incrementCount(Seq("a", "ac", "aca")))
+    (1 to 20).foreach(_ => t.incrementCount(Seq("a", "ac", "acb")))
+    (1 to 11).foreach(_ => t.incrementCount(Seq("a", "ac", "acc")))
+    (1 to 6).foreach(_ => t.incrementCount(Seq("a", "ac", "acd")))
+    (1 to 1).foreach(_ => t.incrementCount(Seq("a", "ac", "ace")))
+    (1 to 9).foreach(_ => t.incrementCount(Seq("a", "ac", "acf")))
+    (1 to 15).foreach(_ => t.incrementCount(Seq("a", "ac", "acg")))
+
+    (1 to 15).foreach(_ => t.incrementCount(Seq("b", "bc", "bcg")))
+    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bc", "bch")))
+    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bd", "bdh")))
+
+    (1 to 3).foreach(_ => t.incrementCount(Seq("c", "cc", "ccg")))
+    (1 to 2).foreach(_ => t.incrementCount(Seq("c", "cc", "cch")))
+
+    t.incrementCount(Seq("a", "aa", "aaa"))
+    t.incrementCount(Seq("a", "aa", "aab"))
+    t.incrementCount(Seq("a", "aa", "aac"))
+    t.incrementCount(Seq("a", "aa", "aad"))
+    t.incrementCount(Seq("b", "ba", "baa"))
+    t.incrementCount(Seq("b", "bb", "bba"))
+    t.incrementCount(Seq("a", "ab", "aba"))
+    t.incrementCount(Seq("a", "ab", "abb"))
+    t.incrementCount(Seq("a", "ab", "abc"))
+    t.incrementCount(Seq("a", "ab", "abd"))
+    t.incrementCount(Seq("a", "ab", "abe"))
+
+    t.topk(3, Seq("a", "ac")) shouldEqual Seq(
+      CardinalityRecord(0, "acc", 11, 11, 100),
+      CardinalityRecord(0, "acg", 15, 15, 100),
+      CardinalityRecord(0, "acb", 20, 20, 100)
+    )
+
+    t.topk(3, Seq("a")) shouldEqual Seq(
+      CardinalityRecord(0, "aa", 4, 4, 100),
+      CardinalityRecord(0, "ab", 5, 5, 100),
+      CardinalityRecord(0, "ac", 72, 7, 100)
+    )
+
+    t.topk(3, Nil) shouldEqual Seq(
+      CardinalityRecord(0, "c", 5, 1, 100),
+      CardinalityRecord(0, "a", 81, 3, 100),
+      CardinalityRecord(0, "b", 35, 4, 100)
+    )
+    t.close()
+  }
+}

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
@@ -1,0 +1,53 @@
+package filodb.core.memstore.ratelimit
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.MachineMetricsData
+import filodb.core.memstore.ratelimit.RocksDbCardinalityStore._
+
+class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
+
+  val ref = MachineMetricsData.dataset2.ref
+
+  val db = new RocksDbCardinalityStore(ref, 0)
+  val tracker = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 1000, 1000), db)
+
+  it("should be able to write keys and cap memory") {
+
+    def dumpStats() = {
+      println(db.statsAsString)
+      println(s"memTablesSize=${db.memTablesSize}")
+      println(s"blockCacheSize=${db.blockCacheSize}")
+      println(s"diskSpaceUsed=${db.diskSpaceUsed}")
+      println(s"estimatedNumKeys=${db.estimatedNumKeys}")
+      println()
+    }
+
+    def assertStats() = {
+      db.blockCacheSize should be < LRU_CACHE_SIZE
+      (db.memTablesSize + db.blockCacheSize) should be < TOTAL_OFF_HEAP_SIZE
+      db.diskSpaceUsed should be < (100L << 20)
+    }
+
+    val start = System.nanoTime()
+    for { ws <- 0 until 5
+          ns <- 0 until 20
+          name <- 0 until 100
+          ts <- 0 until 50 } {
+      val mName = s"name_really_really_really_really_very_really_long_metric_name_$name"
+      tracker.incrementCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName))
+      if (name == 0 && ts ==0 ) assertStats()
+    }
+    val end = System.nanoTime()
+
+    assertStats()
+    dumpStats()
+    val numTimeSeries = 5 * 20 * 100 * 50
+    val timePerIncrement = (end-start) / numTimeSeries / 1000
+    println(s"Was able to increment $numTimeSeries time series, $timePerIncrement microseconds each increment")
+    timePerIncrement should be < 100L
+
+  }
+
+}

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
@@ -48,7 +48,7 @@ class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
     val timePerIncrementMicroSecs = (end-start) / numTimeSeries / 1000
     println(s"Was able to increment $numTimeSeries time series, $timePerIncrementMicroSecs" +
       s"us each increment total of ${totalTimeSecs}s")
-    timePerIncrementMicroSecs should be < 100L
+    timePerIncrementMicroSecs should be < 200L
 
   }
 

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
@@ -13,7 +13,7 @@ class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
   val db = new RocksDbCardinalityStore(ref, 0)
   val tracker = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 1000, 1000), db)
 
-  it("should be able to write keys and cap memory") {
+  it("should be able to write keys quickly and cap memory usage") {
 
     def dumpStats() = {
       println(db.statsAsString)
@@ -33,8 +33,8 @@ class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
     val start = System.nanoTime()
     for { ws <- 0 until 5
           ns <- 0 until 20
-          name <- 0 until 100
-          ts <- 0 until 50 } {
+          name <- 0 until 50
+          ts <- 0 until 100 } {
       val mName = s"name_really_really_really_really_very_really_long_metric_name_$name"
       tracker.incrementCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName))
       if (name == 0 && ts ==0 ) assertStats()
@@ -44,9 +44,11 @@ class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
     assertStats()
     dumpStats()
     val numTimeSeries = 5 * 20 * 100 * 50
-    val timePerIncrement = (end-start) / numTimeSeries / 1000
-    println(s"Was able to increment $numTimeSeries time series, $timePerIncrement microseconds each increment")
-    timePerIncrement should be < 100L
+    val totalTimeSecs = (end-start) / 1000000000L
+    val timePerIncrementMicroSecs = (end-start) / numTimeSeries / 1000
+    println(s"Was able to increment $numTimeSeries time series, $timePerIncrementMicroSecs" +
+      s"us each increment total of ${totalTimeSecs}s")
+    timePerIncrementMicroSecs should be < 100L
 
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,10 @@ object Dependencies {
     "com.github.rholder.fauxflake" % "fauxflake-core"     % "1.1.0",
     "org.scalactic"                %% "scalactic"         % "3.2.0" withJavadoc(),
     "org.apache.lucene"            % "lucene-core"        % "7.3.0" withJavadoc(),
-    "com.github.alexandrnikitin"   %% "bloom-filter"      % "0.11.0"
+    "com.github.alexandrnikitin"   %% "bloom-filter"      % "0.11.0",
+    "org.rocksdb"                  % "rocksdbjni"         % "6.11.4",
+    "com.esotericsoftware"         % "kryo"               % "4.0.0" excludeAll(excludeMinlog),
+    "com.dorkbox"            % "MinLog-SLF4J"                 % "1.12"
   )
 
   lazy val sparkJobsDeps = commonDeps ++ Seq(

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -41,7 +41,8 @@ object Submodules {
       libraryDependencies ++= coordDeps,
       libraryDependencies +=
       "com.typesafe.akka" %% "akka-contrib" % akkaVersion exclude(
-        "com.typesafe.akka", s"akka-persistence-experimental_${scalaBinaryVersion.value}")
+        "com.typesafe.akka", s"akka-persistence-experimental_${scalaBinaryVersion.value}"),
+      allExcludeDependencies ++= Seq(excludeMinlog)
     )
 
   lazy val prometheus = (project in file("prometheus"))

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -7,6 +7,7 @@ import monix.reactive.Observable
 
 import filodb.core.{DatasetRef, Types}
 import filodb.core.memstore.PartLookupResult
+import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
 import filodb.core.query.{EmptyQueryConfig, QueryConfig, QuerySession}
 import filodb.core.store._
@@ -70,10 +71,13 @@ case class UnsupportedChunkSource() extends ChunkSource {
                                  chunkMethod: ChunkScanMethod): Observable[RawPartData] =
     throw new UnsupportedOperationException("This operation is not supported")
 
-  /**
-    * True if this store is in the mode of serving downsampled data.
-    * This is used to switch ingestion and query behaviors for downsample cluster.
-    */
   override def isDownsampleStore: Boolean = false
+
+  override def topKCardinality(ref: DatasetRef,
+                               shards: Seq[Int],
+                               shardKeyPrefix: scala.Seq[String],
+                               k: Int): scala.Seq[CardinalityRecord] =
+    throw new UnsupportedOperationException("This operation is not supported")
+
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Use RocksDB to store cardinality information on disk at the shard level. Can add caching configuration to make it faster.
* RocksDB can be replaced with anything else. We are not married to it in any way.
* Cardinality Tracker can enforce quotas. Quotas are read from static configuration file for starters
* When Quotas are breached, actions can be taken. For this PR, no action is taken except that the data is dropped.
* Cardinality tracked and quotas are enforced per shard. Currently, not possible at the global level.
* Filo CLI can query current cardinality at any shard level.


Quotas are configured for Shard Key Prefixes, and limits number of immediate children.

For example, the following static quota configuration limits number of time series under `heap_usage{_ws_="demo", _ns_="App-0"}` to 100. It also limits the number of namespaces under the workspace "demo" to 10.

```
  quotas {
    prometheus {
      defaults = [100, 500, 10000, 100000]
      custom = [
        {
          shardKeyPrefix = ["demo", "App-0", "heap_usage"]
          quota = 100
        },
        {
          shardKeyPrefix = ["demo"]
          quota = 10
        }
      ]
    }
  }
```


CLI Tool to query top-k cardinality statistics. The `--shardKeyPrefix` argument is used to indicate the shard key prefix under which the top-k query applies.
```
❯ ./filo-cli --host 127.0.0.1 --dataset prometheus --command topkcard --k 10
ShardKeyPrefix: List()
Shard: 1
                                   Child  Descendants   Children   Children
                                    Name        Count      Count      Quota
===================================================================================
                                   demo1           17          2        500
                                    demo           78          2         10
Shard: 0
                                   Child  Descendants   Children   Children
                                    Name        Count      Count      Quota
===================================================================================
                                   demo1           28          2        500
                                    demo           77          2         10
❯ ./filo-cli --host 127.0.0.1 --dataset prometheus --command topkcard --k 10 --shardkeyprefix demo
ShardKeyPrefix: List(demo)
Shard: 1
                                   Child  Descendants   Children   Children
                                    Name        Count      Count      Quota
===================================================================================
                                   App-1           34          2      10000
                                   App-2           44          2      10000
Shard: 0
                                   Child  Descendants   Children   Children
                                    Name        Count      Count      Quota
===================================================================================
                                   App-3           32          2      10000
                                   App-0           45          2      10000
❯ ./filo-cli --host 127.0.0.1 --dataset prometheus --command topkcard --k 10 --shardkeyprefix demo App-1
ShardKeyPrefix: List(demo, App-1)
Shard: 1
                                   Child  Descendants   Children   Children
                                    Name        Count      Count      Quota
===================================================================================
                              heap_usage            9          9     100000
                             heap_usage1           25         25     100000
```
