### PR TITLE
bug(sparkJobs): Ensure downsample marker rows are within chunk length

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
@@ -40,7 +40,7 @@ trait DownsamplePeriodMarker {
 
   /**
     * Returns sorted collection of row numbers for the given chunkset that mark the
-    * periods to downsample
+    * periods to downsample. startRow and endRow are inclusive
     */
   def periods(part: ReadablePartition,
               chunkset: ChunkSetInfoReader,
@@ -115,8 +115,10 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
         if (PrimitiveVectorReader.dropped(ctrVecAcc, ctrVecPtr)) { // counter dip detected
           val drops = r.asInstanceOf[CorrectingDoubleVectorReader].dropPositions(ctrVecAcc, ctrVecPtr)
           for {i <- 0 until drops.length optimized} {
-            result += drops(i) - 1
-            result += drops(i)
+            if (drops(i) <= endRow) {
+              result += drops(i) - 1
+              result += drops(i)
+            }
           }
         }
       case _ =>

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfoReader.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfoReader.scala
@@ -3,6 +3,7 @@ package filodb.core.store
 import java.nio.ByteBuffer
 
 import filodb.core.Types.ChunkID
+import filodb.core.metadata.Schema
 import filodb.memory.format.{BinaryVector, MemoryReader, VectorDataReader}
 import filodb.memory.format.MemoryReader._
 import filodb.memory.format.vectors.LongVectorDataReader
@@ -63,6 +64,15 @@ trait ChunkSetInfoReader {
   def getValueVectorAddr: BinaryVector.BinaryVectorPtr = valueVectorAddr
   def getTsReader: LongVectorDataReader = tsReader
   def getValueReader: VectorDataReader = valueReader
+
+  def debugString(schema: Schema): String = {
+    val vectors = (0 until schema.data.columns.length).map { c =>
+      schema.dataReader(c, vectorAccessor(c), vectorAddress(c))
+        .toHexString(vectorAccessor(c), vectorAddress(c))
+    }
+    s"${getClass.getSimpleName}(id=$id numRows=$numRows startTime=$startTime endTime=$endTime) " +
+      s"vectors=$vectors"
+  }
 }
 
 /**

--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -138,6 +138,9 @@ trait VectorDataReader extends AvailableReader {
     bytes
   }
 
+  def toHexString(acc: MemoryReader, vector: BinaryVectorPtr): String =
+    s"0x${toBytes(acc, vector).map("%02X" format _).mkString}"
+
   def asIntReader: vectors.IntVectorDataReader = this.asInstanceOf[vectors.IntVectorDataReader]
   def asLongReader: vectors.LongVectorDataReader = this.asInstanceOf[vectors.LongVectorDataReader]
   def asDoubleReader: vectors.DoubleVectorDataReader = this.asInstanceOf[vectors.DoubleVectorDataReader]


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Downsample period markers are purely calculated based on vector length.
However it is possible for some vectors to be longer due to ingestion buffer limits.

**New behavior :**

* Incorporate chunk length in marker calculations.
* Also add copious debugging information when vector processing goes astray during downsampling
