### PR TITLE
debug(sparkJobs): Skip/Debug startRow > endRow during downsampling

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
@@ -60,7 +60,8 @@ class TimeDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePeriodMa
                        resMillis: Long,
                        startRow: Int,
                        endRow: Int): Buffer[Int] = {
-    require(startRow <= endRow)
+    require(startRow <= endRow, s"startRow $startRow > endRow $endRow, " +
+      s"chunkset: ${chunkset.debugString(part.schema)}")
     val tsAcc = chunkset.vectorAccessor(DataSchema.timestampColID)
     val tsPtr = chunkset.vectorAddress(DataSchema.timestampColID)
     val tsReader = part.chunkReader(DataSchema.timestampColID, tsAcc, tsPtr).asLongReader
@@ -104,7 +105,8 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
                        resMillis: Long,
                        startRow: Int,
                        endRow: Int): Buffer[Int] = {
-    require(startRow <= endRow)
+    require(startRow <= endRow, s"startRow $startRow > endRow $endRow, " +
+      s"chunkset: ${chunkset.debugString(part.schema)}")
     val result = debox.Set.empty[Int]
     result += startRow // need to add start of every chunk
     result ++= DownsamplePeriodMarker.timeDownsamplePeriodMarker
@@ -127,8 +129,7 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
         throw new IllegalStateException("Did not get a double column - cannot apply counter period marking strategy")
     }
 
-    // It would have been nice to use this piece of code which is more efficient, but
-    // it results in spire library version conflicts with Spark. :(
+    // Note: following alternative avoids copies, but results in spire library version conflicts with Spark. :(
 //    import spire.std.int._
 //    result.toSortedBuffer
 
@@ -137,7 +138,6 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
     debox.Buffer.fromArray(res)
   }
 }
-
 
 object DownsamplePeriodMarker {
 

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfoReader.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfoReader.scala
@@ -71,7 +71,7 @@ trait ChunkSetInfoReader {
         .toHexString(vectorAccessor(c), vectorAddress(c))
     }
     s"${getClass.getSimpleName}(id=$id numRows=$numRows startTime=$startTime endTime=$endTime) " +
-      s"vectors=$vectors"
+      s"vectors: $vectors EOM"
   }
 }
 

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -234,51 +234,59 @@ object BatchDownsampler extends StrictLogging with Instance {
         // userTimeEndExclusive-1 since ceilingIndex does an inclusive check
         val endRow = Math.min(tsReader.ceilingIndex(tsAcc, tsPtr, userTimeEndExclusive - 1), chunkset.numRows - 1)
 
-        // for each downsample resolution
-        downsampleResToPart.foreach { case (resolution, part) =>
-          val resMillis = resolution.toMillis
+        if (startRow <= endRow) {
+          // for each downsample resolution
+          downsampleResToPart.foreach { case (resolution, part) =>
+            val resMillis = resolution.toMillis
 
-          val downsamplePeriods = periodMarker.periods(rawPartToDownsample, chunkset, resMillis, startRow, endRow)
+            val downsamplePeriods = periodMarker.periods(rawPartToDownsample, chunkset, resMillis, startRow, endRow)
+            try {
+              // for each downsample period
+              var first = startRow
+              for {i <- 0 until downsamplePeriods.length optimized} {
+                val last = downsamplePeriods(i)
 
-          try {
-            // for each downsample period
-            var first = startRow
-            for {i <- 0 until downsamplePeriods.length optimized} {
-              val last = downsamplePeriods(i)
-
-              dsRecordBuilder.startNewRecord(part.schema)
-              // for each column, add downsample column value
-              for {col <- 0 until downsamplers.length optimized} {
-                val downsampler = downsamplers(col)
-                downsampler match {
-                  case t: TimeChunkDownsampler =>
-                    dsRecordBuilder.addLong(t.downsampleChunk(rawPartToDownsample, chunkset, first, last))
-                  case d: DoubleChunkDownsampler =>
-                    dsRecordBuilder.addDouble(d.downsampleChunk(rawPartToDownsample, chunkset, first, last))
-                  case h: HistChunkDownsampler =>
-                    dsRecordBuilder.addBlob(h.downsampleChunk(rawPartToDownsample, chunkset, first, last).serialize())
+                dsRecordBuilder.startNewRecord(part.schema)
+                // for each column, add downsample column value
+                for {col <- 0 until downsamplers.length optimized} {
+                  val downsampler = downsamplers(col)
+                  downsampler match {
+                    case t: TimeChunkDownsampler =>
+                      dsRecordBuilder.addLong(t.downsampleChunk(rawPartToDownsample, chunkset, first, last))
+                    case d: DoubleChunkDownsampler =>
+                      dsRecordBuilder.addDouble(d.downsampleChunk(rawPartToDownsample, chunkset, first, last))
+                    case h: HistChunkDownsampler =>
+                      dsRecordBuilder.addBlob(h.downsampleChunk(rawPartToDownsample, chunkset, first, last).serialize())
+                  }
                 }
+                dsRecordBuilder.endRecord(false)
+                first = last + 1 // first row for next downsample period is last + 1
               }
-              dsRecordBuilder.endRecord(false)
-              first = last + 1 // first row for next downsample period is last + 1
-            }
 
-            for {c <- dsRecordBuilder.allContainers
-                 row <- c.iterate(part.schema.ingestionSchema)
-            } {
-              part.ingest(userTimeEndExclusive, row, offHeapMem.blockMemFactory)
+              for {c <- dsRecordBuilder.allContainers
+                   row <- c.iterate(part.schema.ingestionSchema)
+              } {
+                part.ingest(userTimeEndExclusive, row, offHeapMem.blockMemFactory)
+              }
+            } catch {
+              case e: Exception =>
+                logger.error(s"Error downsampling partition ${rawPartToDownsample.stringPartition} " +
+                  s"resolution=$resolution " +
+                  s"startRow=$startRow " +
+                  s"endRow=$endRow " +
+                  s"downsamplePeriods=$downsamplePeriods " +
+                  s"chunkset: ${chunkset.debugString(rawPartToDownsample.schema)}", e)
+                // log debugging information and re-throw
+                throw e
             }
-          } catch { case e: Exception =>
-              logger.error(s"Error downsampling partition ${rawPartToDownsample.stringPartition} " +
-                s"resolution=$resolution " +
-                s"startRow=$startRow " +
-                s"endRow=$endRow " +
-                s"downsamplePeriods=$downsamplePeriods " +
-                s"chunkset=${chunkset.debugString(rawPartToDownsample.schema)}", e)
-              // log debugging information and re-throw
-              throw e
+            dsRecordBuilder.removeAndFreeContainers(dsRecordBuilder.allContainers.size)
           }
-          dsRecordBuilder.removeAndFreeContainers(dsRecordBuilder.allContainers.size)
+        } else {
+          logger.warn(s"Skipping since startRow lessThan endRow when downsampling " +
+            s"partition ${rawPartToDownsample.stringPartition} " +
+            s"startRow=$startRow " +
+            s"endRow=$endRow " +
+            s"chunkset: ${chunkset.debugString(rawPartToDownsample.schema)}")
         }
       }
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

There seems to be more cases where startRow still is less than endRow. Add debug information 