### PR TITLE
config: Change metric partition column to _metric_ to avoid clashes with "metric" labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ The number of shards in each dataset is preconfigured in the source config.  Ple
 
 Metrics are routed to shards based on factors:
 
-1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency. Currently `_ws_`, `_ns_`, `metric` labels are mandatory to calculate shard key along with `metric` column.
+1. Shard keys, which can be for example an application and the metric name, which define a group of shards to use for that application.  This allows limiting queries to a subset of shards for lower latency. Currently `_ws_`, `_ns_` labels are mandatory to calculate shard key along with `_metric_` column.
 2. The rest of the tags or components of a partition key are then used to compute which shard within the group of shards to assign to.
 
 ## Querying FiloDB

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -21,7 +21,8 @@ filodb {
   # to the exact definitions.
   partition-schema {
     # Typical column types used: map, string.  Also possible: ts,long,double
-    columns = ["metric:string", "tags:map"]
+    # NOTE: the metric column needs underscores to escape conflicts with tag labels named the same.
+    columns = ["_metric_:string", "tags:map"]
 
     # Predefined keys allow space to be saved for over the wire tags with the given keys
     # WARN: It is suggested to only ADD to predefined keys.
@@ -38,8 +39,8 @@ filodb {
       }
       ignoreShardKeyColumnSuffixes = { "__name__" = ["_bucket", "_count", "_sum"] }
       ignoreTagsOnPartitionKeyHash = ["le"]
-      metricColumn = "metric"
-      shardKeyColumns = [ "metric", "_ws_", "_ns_" ]
+      metricColumn = "_metric_"
+      shardKeyColumns = [ "_metric_", "_ws_", "_ns_" ]
     }
   }
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -425,13 +425,13 @@ object CustomMetricsData {
   val columns = Seq("timestamp:ts", "min:double", "avg:double", "max:double", "count:long")
 
   //Partition Key with multiple string columns
-  val partitionColumns = Seq("metric:string", "app:string")
+  val partitionColumns = Seq("_metric_:string", "app:string")
   val metricdataset = Dataset.make("tsdbdata",
                         partitionColumns,
                         columns,
                         Seq.empty,
                         None,
-                        DatasetOptions(Seq("metric", "_ns_", "_ws_"), "metric", true)).get
+                        DatasetOptions(Seq("_metric_", "_ns_", "_ws_"), "_metric_", true)).get
   val partKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
   val defaultPartKey = partKeyBuilder.partKeyFromObjects(metricdataset.schema, "metric1", "app1")
 

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -314,14 +314,14 @@ class SchemasSpec extends FunSpec with Matchers {
     }
 
     val partSchemaStr2 = """{
-                        columns = ["metric:string", "tags:map"]
+                        columns = ["_metric_:string", "tags:map"]
                         predefined-keys = ["_ns", "app", "__name__", "instance", "dc"]
                         options {
                           copyTags = {}
                           ignoreShardKeyColumnSuffixes = {}
                           ignoreTagsOnPartitionKeyHash = ["le"]
-                          metricColumn = "metric"
-                          shardKeyColumns = ["metric", "_ns"]
+                          metricColumn = "_metric_"
+                          shardKeyColumns = ["_metric_", "_ns"]
                         }
                       }"""
 

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -38,7 +38,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
 
   val typeLabel = "_type_" -> "prom-counter"
   val expectedLabelValues = partKeyLabelValues.map { case (metric, tags) =>
-    tags + typeLabel + ("metric" -> metric)
+    tags + typeLabel + ("_metric_" -> metric)
   }
 
   val jobQueryResult1 = ArrayBuffer(("job", "myCoolService"))
@@ -81,7 +81,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
 
   it ("should read the job names from timeseriesindex matching the columnfilters") {
     import ZeroCopyUTF8String._
-    val filters = Seq (ColumnFilter("metric", Filter.Equals("http_req_total".utf8)),
+    val filters = Seq (ColumnFilter("_metric_", Filter.Equals("http_req_total".utf8)),
                        ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
     val execPlan = LabelValuesExec("someQueryId", now, limit, dummyDispatcher,

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -48,7 +48,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
   val metric = "http_req_total"
   val partKeyLabelValues = Map("job" -> "myCoolService", "instance" -> "someHost:8787")
-  val partKeyKVWithMetric = partKeyLabelValues ++ Map("metric" -> metric)
+  val partKeyKVWithMetric = partKeyLabelValues ++ Map("_metric_" -> metric)
   val partTagsUTF8 = partKeyLabelValues.map { case (k, v) => (k.utf8, v.utf8) }
   val now = System.currentTimeMillis()
   val numRawSamples = 1000
@@ -97,7 +97,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
   it ("should read raw samples from Memstore using AllChunksSelector") {
     import ZeroCopyUTF8String._
-    val filters = Seq (ColumnFilter("metric", Filter.Equals("http_req_total".utf8)),
+    val filters = Seq (ColumnFilter("_metric_", Filter.Equals("http_req_total".utf8)),
                        ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = MultiSchemaPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher,
       dsRef, 0, filters, AllChunkScan)
@@ -114,7 +114,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
   it ("should read raw samples from Memstore using IntervalSelector") {
     import ZeroCopyUTF8String._
-    val filters = Seq (ColumnFilter("metric", Filter.Equals("http_req_total".utf8)),
+    val filters = Seq (ColumnFilter("_metric_", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     // read from an interval of 100000ms, resulting in 11 samples
     val startTime = now - numRawSamples * reportingInterval
@@ -134,7 +134,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
   it("should get empty schema if query returns no results") {
     import ZeroCopyUTF8String._
-    val filters = Seq (ColumnFilter("metric", Filter.Equals("not_a_metric!".utf8)),
+    val filters = Seq (ColumnFilter("_metric_", Filter.Equals("not_a_metric!".utf8)),
                        ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = MultiSchemaPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher,
       dsRef, 0, filters, AllChunkScan)
@@ -165,7 +165,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
     import ZeroCopyUTF8String._
 
     val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)),
-                      ColumnFilter("metric", Filter.Equals("request-latency".utf8)))
+                      ColumnFilter("_metric_", Filter.Equals("request-latency".utf8)))
     val execPlan = MultiSchemaPartitionsExec("id1", now, numRawSamples, dummyDispatcher, dsRef, 0,
                                              filters, TimeRangeChunkScan(100000L, 150000L), colName=Some("h"))
 
@@ -180,7 +180,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
   it ("should read periodic samples from Memstore") {
     import ZeroCopyUTF8String._
-    val filters = Seq (ColumnFilter("metric", Filter.Equals("http_req_total".utf8)),
+    val filters = Seq (ColumnFilter("_metric_", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = MultiSchemaPartitionsExec("someQueryId", now, numRawSamples, dummyDispatcher,
                                              dsRef, 0, filters, AllChunkScan)
@@ -237,7 +237,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
   it ("should read periodic Histogram samples from Memstore") {
     import ZeroCopyUTF8String._
     val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)),
-                      ColumnFilter("metric", Filter.Equals("request-latency".utf8)))
+                      ColumnFilter("_metric_", Filter.Equals("request-latency".utf8)))
     val execPlan = MultiSchemaPartitionsExec("id1", now, numRawSamples, dummyDispatcher, dsRef, 0,
                                              filters, AllChunkScan)   // should default to h column
 
@@ -354,7 +354,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
   }
 
   it("should return chunk metadata from MemStore") {
-    val filters = Seq (ColumnFilter("metric", Filter.Equals("http_req_total".utf8)),
+    val filters = Seq (ColumnFilter("_metric_", Filter.Equals("http_req_total".utf8)),
                        ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     // TODO: SelectChunkInfos should not require a raw schema
     val execPlan = SelectChunkInfosExec("someQueryId", now, numRawSamples, dummyDispatcher,
@@ -383,7 +383,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
   it ("should fail with exception BadQueryException") {
     import ZeroCopyUTF8String._
-    val filters = Seq (ColumnFilter("metric", Filter.Equals("http_req_total".utf8)),
+    val filters = Seq (ColumnFilter("_metric_", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
     // Query returns n ("numRawSamples") samples - Applying Limit (n-1) to fail the query execution


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

If users send time series data with a tag labeled "metric", it clashes with the built-in "metric" column used in the partition key.  Users are not able to properly query those time series.

**New behavior :**

The internal metric column is renamed `_metric_`, since underscores are internal labels, so it no longer conflicts.

**BREAKING CHANGES**

Data on disk does not change and does not need to be wiped.  
However, any queries which explicitly used `metric` would need to be rewritten to use `_metric_`.