### PR TITLE
bug(core): Fix/change predefined keys hashing algorithm for keys < 4 bytes

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -424,7 +424,7 @@ object RecordSchema {
   private def eightBytesToLong(bytes: Array[Byte], index: Int, len: Int): Long = {
     var num = 0L
     for { i <- 0 until len optimized } {
-      num = (num << 8) | bytes(index + i)
+      num = (num << 8) ^ (bytes(index + i) & 0x00ff)
     }
     num
   }

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -380,6 +380,9 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
 
       val data = withMap(linearMultiSeries(), extraTags=extraTags).take(3)
       addToBuilder(builder, data, dataset3.schema)
+      builder.currentContainer.get.foreach { case (base, offset) =>
+        println(schemaWithPredefKeys.debugString(base, offset))
+      }
 
       val containers = builder.allContainers
       containers should have length (1)
@@ -553,10 +556,7 @@ class BinaryRecordSpec extends FunSpec with Matchers with BeforeAndAfter with Be
     it("should copy ingest BRs to partition key BRs correctly when data columns have a blob/histogram") {
       val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory)
       val data = linearHistSeries().take(3)
-      data.foreach { row =>
-        val offset = ingestBuilder.addFromReader(SeqRowReader(row), histDataset.schema)
-        println(histDataset.schema.ingestionSchema.debugString(ingestBuilder.curContainerBase, offset))
-      }
+      data.foreach { row => ingestBuilder.addFromReader(SeqRowReader(row), histDataset.schema) }
 
       records.clear()
       ingestBuilder.allContainers.head.consumeRecords(consumer)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

When `RecordBuilder` adds map key values to a BinaryRecord, it makes an assumption that keys are at least 4 bytes long in the `makeKeyKey` hashing code, reading an Int from a byte array.  If the keys are less than 4 bytes long this can result in undefined behavior.

**New behavior :**

The algorithm is changed to the following:
* If the key is <= 8 bytes long, the entire key is converted to a Long and used as a hash.
* If the key is > 8 bytes long, then XXHash 64-bit hash generator is used.
