### PR TITLE
fix(gateway): Skip empty histogram records in gateway

### DIFF
--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
@@ -238,6 +238,7 @@ final case class InfluxHistogramRecord(bytes: Array[Byte],
     InfluxProtocolParser.parseKeyValues(bytes, fieldDelims, fieldEnd, visitor)
 
     // Only create histogram record if we are able to parse above and it contains +Inf bucket
+    // This also ensures that it's not a blank histogram, which cannot be ingested
     if (visitor.gotInf) {
       val buckets = CustomBuckets(visitor.bucketTops)
       val hist = LongHistogram(buckets, visitor.bucketVals)

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -106,20 +106,22 @@ object InputRecord {
       case (k, v) =>      (k.toDouble, v.toLong)
     }.sorted
 
-    // Built up custom histogram objects and scheme, then encode
-    val buckets = CustomBuckets(sortedBuckets.map(_._1).toArray)
-    val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
+    if (sortedBuckets.nonEmpty) {
+      // Built up custom histogram objects and scheme, then encode
+      val buckets = CustomBuckets(sortedBuckets.map(_._1).toArray)
+      val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
 
-    // Now, write out histogram
-    builder.startNewRecord(promHistogram)
-    builder.addLong(timestamp)
-    builder.addDouble(sum)
-    builder.addDouble(count)
-    builder.addBlob(hist.serialize())
+      // Now, write out histogram
+      builder.startNewRecord(promHistogram)
+      builder.addLong(timestamp)
+      builder.addDouble(sum)
+      builder.addDouble(count)
+      builder.addBlob(hist.serialize())
 
-    builder.addString(metric)
-    builder.addMap(tags.map { case (k, v) => (k.utf8, v.utf8) })
-    builder.endRecord()
+      builder.addString(metric)
+      builder.addMap(tags.map { case (k, v) => (k.utf8, v.utf8) })
+      builder.endRecord()
+    }
   }
 }
 

--- a/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
@@ -15,19 +15,19 @@ class InputRecordBuilderSpec extends FunSpec with Matchers {
                      "shard" -> "0")
   val metric = "my_hist"
 
+  val counts  = Array(10L, 20L, 25, 38, 50, 66)
+  val sum = counts.sum.toDouble
+  val count = 50.0
+  val sumCountKVs = Seq("sum" -> sum, "count" -> count)
+
   it("should writePromHistRecord to BR and be able to deserialize it") {
     val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
-    val counts  = Array(10L, 20L, 25, 38, 50, 66)
     val expected = LongHistogram(CustomBuckets(buckets), counts)
 
-    val sum = counts.sum.toDouble
-    val count = 50.0
     val bucketKVs = buckets.zip(counts).map {
       case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
       case (b, c)                       => b.toString -> c.toDouble
     }.toSeq
-    val sumCountKVs = Seq("sum" -> sum, "count" -> count)
-
     // 1 - sum/count at end
     InputRecord.writePromHistRecord(builder, metric, baseTags, 100000L, bucketKVs ++ sumCountKVs)
     builder.allContainers.head.iterate(Schemas.promHistogram.ingestionSchema).foreach { row =>
@@ -35,5 +35,14 @@ class InputRecordBuilderSpec extends FunSpec with Matchers {
       row.getDouble(2) shouldEqual count
       row.getHistogram(3) shouldEqual expected
     }
+  }
+
+  it("should skip empty histograms via writePromHistRecord, and write subsequent records") {
+    builder.reset()
+    InputRecord.writePromHistRecord(builder, metric, baseTags, 100000L, sumCountKVs)
+    InputRecord.writeGaugeRecord(builder, metric, baseTags, 100000L, 5.5)
+
+    // The empty histogram should have been skipped, so we should have only one record
+    builder.allContainers.head.countRecords shouldEqual 1
   }
 }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -139,13 +139,16 @@ object BinaryHistogram extends StrictLogging {
     val formatCode = buckets match {
       case g: GeometricBuckets if g.minusOne => HistFormat_Geometric1_Delta
       case g: GeometricBuckets               => HistFormat_Geometric_Delta
+      case c: CustomBuckets if c.numBuckets == 0 => HistFormat_Null
       case c: CustomBuckets                  => HistFormat_Custom_Delta
     }
 
     buf.putByte(2, formatCode)
-    val valuesIndex = buckets.serialize(buf, 3)
-    val finalPos = NibblePack.packDelta(values, buf, valuesIndex)
-
+    val finalPos = if (formatCode == HistFormat_Null) { 3 }
+                   else {
+                     val valuesIndex = buckets.serialize(buf, 3)
+                     NibblePack.packDelta(values, buf, valuesIndex)
+                   }
     require(finalPos <= 65535, s"Histogram data is too large: $finalPos bytes needed")
     buf.putShort(0, (finalPos - 2).toShort)
     finalPos


### PR DESCRIPTION
Empty histograms cannot be ingested and queried properly as they don't have a schema.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

When an empty histogram is pushed into the gateway, it corrupts the state of the RecordBuilder, as empty histograms cannot really be encoded.  

**New behavior :**

Empty histograms are checked in `InputRecord` and skipped, thus encoding is not attempted.
