### PR TITLE
feat(core): Downsample Cluster Index Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,29 @@ You may also configure CLI logging by copying `cli/src/main/resources/logback.xm
 
 You can also change the logging directory by setting the FILO_LOG_DIR environment variable before calling the CLI.
 
+### Debugging Binary Vectors and Binary Records
+
+Following command can be used to formulate BR for a partKey using Prometheus filter. Use this to formulate CQL to issue a cassandra query
+
+    > ./filo-cli --command promFilterToPartKeyBR --promql "myMetricName{_ws_='myWs',_ns_='myNs'}" --schema prom-counter
+    0x2c0000000f1712000000200000004b8b36940c006d794d65747269634e616d650e00c104006d794e73c004006d795773
+    
+Following command can be used to decode partKey BR into tag/value pairs
+
+    > ./filo-cli --command partKeyBrAsString --hexPk 0x2C0000000F1712000000200000004B8B36940C006D794D65747269634E616D650E00C104006D794E73C004006D795773
+    b2[schema=prom-counter  _metric_=myMetricName,tags={_ns_: myNs, _ws_: myWs}]
+
+Following command can be used to decode a ChunkSetInfo read from Cassandra
+
+    > ./filo-cli  --command decodeChunkInfo --hexChunkInfo 0x12e8253a267ea2db060000005046fc896e0100005046fc896e010000
+    ChunkSetInfo id=-2620393330526787566 numRows=6 startTime=1574272801000 endTime=1574273042000
+    
+Following command can be used to decode a Binary Vector. Valid vector types are `d` for double, `i` for integer `l` for long, `h` for histogram and `s` for string
+     
+    > ./filo-cli  --command decodeVector  --vectorType d --hexVector 0x1b000000080800000300000000000000010000000700000006080400109836
+    DoubleLongWrapDataReader$
+    3.0,5.0,13.0,15.0,13.0,11.0,9.0
+ 
 ## Current Status
 
 | Component | Status     |

--- a/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
@@ -24,9 +24,10 @@ class CassandraTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFa
 }
 
 class DownsampledTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFactory {
-  val colStore = new CassandraColumnStore(config, ioPool, None, true)(ioPool)
+  val downsampleColStore = new CassandraColumnStore(config, ioPool, None, true)(ioPool)
+  val rawColStore = new CassandraColumnStore(config, ioPool, None, false)(ioPool)
   val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(ioPool)
-  val memStore = new DownsampledTimeSeriesStore(colStore, metaStore, config)(ioPool)
+  val memStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore, metaStore, config)(ioPool)
 }
 
 /**

--- a/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/CassandraTSStoreFactory.scala
@@ -8,7 +8,7 @@ import filodb.cassandra.metastore.CassandraMetaStore
 import filodb.coordinator.StoreFactory
 import filodb.core.downsample.DownsampledTimeSeriesStore
 import filodb.core.memstore.TimeSeriesMemStore
-import filodb.core.store.NullColumnStore
+import filodb.core.store.{MetaStore, NullColumnStore}
 
 /**
  * A StoreFactory for a TimeSeriesMemStore backed by a Cassandra ChunkSink for on-demand recovery/persistence
@@ -26,8 +26,8 @@ class CassandraTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFa
 class DownsampledTSStoreFactory(config: Config, ioPool: Scheduler) extends StoreFactory {
   val downsampleColStore = new CassandraColumnStore(config, ioPool, None, true)(ioPool)
   val rawColStore = new CassandraColumnStore(config, ioPool, None, false)(ioPool)
-  val metaStore = new CassandraMetaStore(config.getConfig("cassandra"))(ioPool)
-  val memStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore, metaStore, config)(ioPool)
+  def metaStore: MetaStore = ??? // not used
+  val memStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore, config)(ioPool)
 }
 
 /**

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -59,6 +59,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
 
   private val writeParallelism = cassandraConfig.getInt("write-parallelism")
   private val pkByUTNumSplits = cassandraConfig.getInt("pk-by-updated-time-table-num-splits")
+  private val pkByUTTtl = cassandraConfig.getDuration("pk-by-updated-time-table-num-ttl").toSeconds.toInt
 
   val sinkStats = new ChunkSinkStats
 
@@ -119,14 +120,14 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   // Future optimization: group by token range and batch?
   def write(ref: DatasetRef,
             chunksets: Observable[ChunkSet],
-            diskTimeToLive: Int = 259200): Future[Response] = {
+            diskTimeToLiveSeconds: Int = 259200): Future[Response] = {
     chunksets.mapAsync(writeParallelism) { chunkset =>
                val span = Kamon.buildSpan("write-chunkset").start()
                val partBytes = BinaryRegionLarge.asNewByteArray(chunkset.partition)
                val future =
-                 for { writeChunksResp   <- writeChunks(ref, partBytes, chunkset, diskTimeToLive)
+                 for { writeChunksResp   <- writeChunks(ref, partBytes, chunkset, diskTimeToLiveSeconds)
                        if writeChunksResp == Success
-                       writeIndicesResp  <- writeIndices(ref, partBytes, chunkset, diskTimeToLive)
+                       writeIndicesResp  <- writeIndices(ref, partBytes, chunkset, diskTimeToLiveSeconds)
                        if writeIndicesResp == Success
                  } yield {
                    span.finish()
@@ -144,10 +145,10 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   private def writeChunks(ref: DatasetRef,
                           partition: Array[Byte],
                           chunkset: ChunkSet,
-                          diskTimeToLive: Int): Future[Response] = {
+                          diskTimeToLiveSeconds: Int): Future[Response] = {
     asyncSubtrace("write-chunks", "ingestion") {
       val chunkTable = getOrCreateChunkTable(ref)
-      chunkTable.writeChunks(partition, chunkset.info, chunkset.chunks, sinkStats, diskTimeToLive)
+      chunkTable.writeChunks(partition, chunkset.info, chunkset.chunks, sinkStats, diskTimeToLiveSeconds)
         .collect {
           case Success => chunkset.invokeFlushListener(); Success
         }
@@ -157,12 +158,12 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   private def writeIndices(ref: DatasetRef,
                            partition: Array[Byte],
                            chunkset: ChunkSet,
-                           diskTimeToLive: Int): Future[Response] = {
+                           diskTimeToLiveSeconds: Int): Future[Response] = {
     asyncSubtrace("write-index", "ingestion") {
       val indexTable = getOrCreateIngestionTimeIndexTable(ref)
       val info = chunkset.info
       val infos = Seq((info.ingestionTime, info.startTime, ChunkSetInfo.toBytes(info)))
-      indexTable.writeIndices(partition, infos, sinkStats, diskTimeToLive)
+      indexTable.writeIndices(partition, infos, sinkStats, diskTimeToLiveSeconds)
     }
   }
 
@@ -283,7 +284,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       val ttl = if (pk.endTime == Long.MaxValue) -1 else diskTTLSeconds
       val split = pk.hash.get % pkByUTNumSplits // caller needs to supply hash for partKey - cannot be None
       val writePkFut = pkTable.writePartKey(pk, ttl).flatMap {
-        case resp if resp == Success => pkByUTTable.writePartKey(shard, updateHour, split, pk)
+        case resp if resp == Success => pkByUTTable.writePartKey(shard, updateHour, split, pk, pkByUTTtl)
         case resp                    => Future.successful(resp)
       }
       Task.fromFuture(writePkFut).map{ resp =>

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -103,7 +103,7 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
   def writeIndices(partition: Array[Byte],
                    infos: Seq[(Long, Long, Array[Byte])],
                    stats: ChunkSinkStats,
-                   diskTimeToLive: Int): Future[Response] = {
+                   diskTimeToLiveSeconds: Int): Future[Response] = {
     var infoBytes = 0
     val partitionBuf = toBuffer(partition)
     val statements = infos.map { case (ingestionTime, startTime, info) =>
@@ -112,7 +112,7 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
                          ingestionTime: java.lang.Long,
                          startTime: java.lang.Long,
                          ByteBuffer.wrap(info),
-                         diskTimeToLive: java.lang.Integer)
+                         diskTimeToLiveSeconds: java.lang.Integer)
     }
     stats.addIndexWriteStats(infoBytes)
     connector.execStmtWithRetries(unloggedBatch(statements).setConsistencyLevel(ConsistencyLevel.ONE))

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
@@ -48,10 +48,9 @@ sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
   lazy val readCql = session.prepare(s"SELECT * FROM $tableString " +
     s"WHERE shard = ? AND updateHour = ? AND split = ? ")
   def scanPartKeys(shard: Int, updateHour: Long, split: Int): Observable[PartKeyRecord] = {
-    val fut: Future[Iterator[PartKeyRecord]] =
-      session.executeAsync(readCql.bind(shard: JInt, updateHour: JLong, split: JInt)).toIterator.handleErrors
-             .map { rowIt => rowIt.map(PartitionKeysTable.rowToPartKeyRecord) }
-    Observable.fromFuture(fut).flatMap(it => Observable.fromIterator(it))
+    session.executeAsync(readCql.bind(shard: JInt, updateHour: JLong, split: JInt))
+      .toObservable.handleObservableErrors
+      .map(PartitionKeysTable.rowToPartKeyRecord)
   }
 
 }

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
@@ -1,0 +1,57 @@
+package filodb.cassandra.columnstore
+
+import java.lang.{Integer => JInt, Long => JLong}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+import com.datastax.driver.core.ConsistencyLevel
+import monix.reactive.Observable
+
+import filodb.cassandra.FiloCassandraConnector
+import filodb.core.{DatasetRef, Response}
+import filodb.core.store.PartKeyRecord
+
+sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
+                                            val connector: FiloCassandraConnector)
+                                           (implicit ec: ExecutionContext) extends BaseDatasetTable {
+
+  import filodb.cassandra.Util._
+
+  val suffix = s"_partitionKeysByUpdateTime"
+
+  val createCql =
+    s"""
+       |CREATE TABLE IF NOT EXISTS $tableString (
+       |    shard int,
+       |    epochHour bigint,
+       |    split int,
+       |    partKey blob,
+       |    startTime bigint,
+       |    endTime bigint,
+       |    PRIMARY KEY ((shard, epochHour, split), partKey)
+       |    WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': '$sstableCompression'}""".stripMargin
+      // TODO time window compaction since we have time component in the primary key
+
+  lazy val writePartitionKeyCql =
+    session.prepare(
+      s"INSERT INTO ${tableString} (shard, epochHour, split, partKey, startTime, endTime) " +
+        s"VALUES (?, ?, ?) USING TTL ?")
+      .setConsistencyLevel(ConsistencyLevel.ONE)
+
+  def writePartKey(shard: Int, updateHour: Long, split: Int, pk: PartKeyRecord): Future[Response] = {
+    connector.execStmtWithRetries(writePartitionKeyCql.bind(
+      shard: JInt, updateHour: JLong,
+      toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong))
+  }
+
+  def scanPartKeys(shard: Int, updateHour: Long, split: Int): Observable[PartKeyRecord] = {
+    val cql = s"SELECT * FROM ${tableString} " +
+              s"WHERE shard = $shard AND updateHour = $updateHour AND split = $split "
+    val it = session.execute(cql).iterator.asScala
+        .map(PartitionKeysTable.rowToPartKeyRecord)
+    Observable.fromIterator(it).handleObservableErrors
+  }
+
+}
+

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
@@ -40,13 +40,13 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
       s"INSERT INTO ${tableString} (partKey, startTime, endTime) VALUES (?, ?, ?)")
       .setConsistencyLevel(writeConsistencyLevel)
 
-  def writePartKey(pk: PartKeyRecord, diskTimeToLive: Int): Future[Response] = {
-    if (diskTimeToLive <= 0) {
+  def writePartKey(pk: PartKeyRecord, diskTimeToLiveSeconds: Int): Future[Response] = {
+    if (diskTimeToLiveSeconds <= 0) {
       connector.execStmtWithRetries(writePartitionCqlNoTtl.bind(
         toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong))
     } else {
       connector.execStmtWithRetries(writePartitionCql.bind(
-        toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong, diskTimeToLive: JInt))
+        toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong, diskTimeToLiveSeconds: JInt))
     }
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
@@ -50,7 +50,7 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
     }
   }
 
-  lazy val scanCql = session.prepare(s"SELECT * FROM ${tableString} " +
+  lazy val scanCql = session.prepare(s"SELECT * FROM $tableString " +
                                       s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ?")
   def scanPartKeys(tokens: Seq[(String, String)], shard: Int): Observable[PartKeyRecord] = {
     val res: Observable[Iterator[PartKeyRecord]] = Observable.fromIterable(tokens)

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -323,7 +323,7 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
     }
 
     val vecReader = BinaryVector.reader(clazz, memReader, 0)
-    val str = vecReader.toHumanReadable(memReader, 0)
+    val str = vecReader.debugString(memReader, 0)
     println(vecReader.getClass.getSimpleName)
     println(str)
   }

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -233,7 +233,7 @@ private[filodb] final class IngestionActor(ref: DatasetRef,
 
       // Define a cancel task to run when ingestion is stopped.
       val onCancel = Task {
-        logger.info(s"Ingstion cancel task invoked for dataset=$ref shard=$shard")
+        logger.info(s"Ingestion cancel task invoked for dataset=$ref shard=$shard")
         val stopped = IngestionStopped(ref, shard)
         self ! stopped
         statusActor ! stopped

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -214,6 +214,8 @@ filodb {
     //      = 5000 keys per split * 1000 bytes per pk
     //      = 5MB per cass partition. Goal is to keep it under 10MB.
     pk-by-updated-time-table-num-splits = 200
+
+    pk-by-updated-time-table-num-ttl = 1 day
   }
 
   downsampler {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -208,6 +208,12 @@ filodb {
     retry-interval-max-jitter = 10s
 
     ingestion-consistency-level = "ONE"
+
+    # Number of splits in the partitionKeysByUpdateTime table to keep cassandra partition size under control
+    // 1mil max pks per shard per hour / 200 splits
+    //      = 5000 keys per split * 1000 bytes per pk
+    //      = 5MB per cass partition. Goal is to keep it under 10MB.
+    pk-by-updated-time-table-num-splits = 200
   }
 
   downsampler {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -210,9 +210,9 @@ filodb {
     ingestion-consistency-level = "ONE"
 
     # Number of splits in the partitionKeysByUpdateTime table to keep cassandra partition size under control
-    // 1mil max pks per shard per hour / 200 splits
-    //      = 5000 keys per split * 1000 bytes per pk
-    //      = 5MB per cass partition. Goal is to keep it under 10MB.
+    #  1mil max pks per shard per hour / 200 splits
+    #      = 5000 keys per split * 1000 bytes per pk
+    #      = 5MB per cass partition. Goal is to keep it under 10MB.
     pk-by-updated-time-table-num-splits = 200
 
     pk-by-updated-time-table-num-ttl = 1 day

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -336,6 +336,10 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
   }
   def asByteArray(address: NativePointer): Array[Byte] = asByteArray(UnsafeUtils.ZeroPointer, address)
 
+
+  def toHexString(base: Any, offset: Long): String =
+    s"0x${asByteArray(base, offset).map("%02X" format _).mkString}"
+
   /**
    * Allows us to compare two RecordSchemas against each other
    */

--- a/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
@@ -1,8 +1,6 @@
 package filodb.core.downsample
 
-import debox.Buffer
 import enumeratum.{Enum, EnumEntry}
-import java.util
 import scalaxy.loops._
 
 import filodb.core.metadata.DataSchema
@@ -46,7 +44,7 @@ trait DownsamplePeriodMarker {
               chunkset: ChunkSetInfoReader,
               resMillis: Long,
               startRow: Int,
-              endRow: Int): Buffer[Int]
+              endRow: Int): debox.Set[Int]
 }
 
 /**
@@ -59,7 +57,7 @@ class TimeDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePeriodMa
                        chunkset: ChunkSetInfoReader,
                        resMillis: Long,
                        startRow: Int,
-                       endRow: Int): Buffer[Int] = {
+                       endRow: Int): debox.Set[Int] = {
     require(startRow <= endRow, s"startRow $startRow > endRow $endRow, " +
       s"chunkset: ${chunkset.debugString(part.schema)}")
     val tsAcc = chunkset.vectorAccessor(DataSchema.timestampColID)
@@ -69,7 +67,8 @@ class TimeDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePeriodMa
     val startTime = tsReader.apply(tsAcc, tsPtr, startRow)
     val endTime = tsReader.apply(tsAcc, tsPtr, endRow)
 
-    val result = debox.Buffer.empty[Int]
+    // set to remove duplicates - it is possible for dupes in case there are no samples in the period
+    val result = debox.Set.empty[Int]
     // A sample exactly for 5pm downsampled 5-minutely should fall in the period 4:55:00:001pm to 5:00:00:000pm.
     // Hence subtract - 1 below from chunk startTime to find the first downsample period.
     // + 1 is needed since the startTime is inclusive. We don't want pStart to be 4:55:00:000;
@@ -104,14 +103,15 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
                        chunkset: ChunkSetInfoReader,
                        resMillis: Long,
                        startRow: Int,
-                       endRow: Int): Buffer[Int] = {
+                       endRow: Int): debox.Set[Int] = {
     require(startRow <= endRow, s"startRow $startRow > endRow $endRow, " +
       s"chunkset: ${chunkset.debugString(part.schema)}")
     val result = debox.Set.empty[Int]
     result += startRow // need to add start of every chunk
     if (startRow < endRow) { // there is more than 1 row
-      result ++= DownsamplePeriodMarker.timeDownsamplePeriodMarker
-        .periods(part, chunkset, resMillis, startRow + 1, endRow)
+      DownsamplePeriodMarker.timeDownsamplePeriodMarker.periods(part, chunkset, resMillis, startRow + 1, endRow)
+                            .foreach(result += _)
+
       val ctrVecAcc = chunkset.vectorAccessor(inputColId)
       val ctrVecPtr = chunkset.vectorAddress(inputColId)
       val ctrReader = part.chunkReader(inputColId, ctrVecAcc, ctrVecPtr)
@@ -130,14 +130,7 @@ class CounterDownsamplePeriodMarker(val inputColId: Int) extends DownsamplePerio
           throw new IllegalStateException("Did not get a double column - cannot apply counter period marking strategy")
       }
     }
-
-    // Note: following alternative avoids copies, but results in spire library version conflicts with Spark. :(
-//    import spire.std.int._
-//    result.toSortedBuffer
-
-    val res = result.toArray()
-    util.Arrays.sort(res)
-    debox.Buffer.fromArray(res)
+    result
   }
 }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -45,8 +45,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   private val indexUpdatedHour = new AtomicLong(0)
 
-  val indexBootstrapper = new IndexBootstrapper(store)
-  val indexRefresher = new IndexBootstrapper(rawColStore)
+  val indexBootstrapper = new IndexBootstrapper(store) // used for initial index loading
+  val indexRefresher = new IndexBootstrapper(rawColStore) // used for periodic refresh of index, happens from raw tables
 
   var indexUpdateFuture: CancelableFuture[Unit] = _
 
@@ -260,6 +260,10 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   def cleanup(): Unit = {
     Option(indexUpdateFuture).foreach(_.cancel())
+  }
+
+  override protected def finalize(): Unit = {
+    cleanup()
   }
 
 }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -101,6 +101,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       // records with same part key
       indexRefresher.refreshIndex(partKeyIndex, shardNum, rawDatasetRef,
                                   fromHour, toHour)(lookupOrCreatePartId)
+        .map( _ => indexUpdatedHour.set(toHour))
         .onErrorHandle { e =>
           logger.error(s"Error occurred when refreshing downsample index " +
             s"dataset=$rawDatasetRef shard=$shardNum fromHour=$fromHour toHour=$toHour", e)

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -19,7 +19,6 @@ import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 
 class DownsampledTimeSeriesStore(val store: ColumnStore,
                                  rawColStore: ColumnStore,
-                                 val metastore: MetaStore,
                                  val filodbConfig: Config)
                                 (implicit val ioPool: ExecutionContext)
 extends MemStore with StrictLogging {
@@ -30,6 +29,8 @@ extends MemStore with StrictLogging {
   val stats = new ChunkSourceStats
 
   override def isReadOnly: Boolean = true
+
+  override def metastore: MetaStore = ??? // Not needed
 
   // TODO: Change the API to return Unit Or ShardAlreadySetup, instead of throwing.  Make idempotent.
   def setup(ref: DatasetRef, schemas: Schemas, shard: Int, storeConf: StoreConfig,

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -1,15 +1,14 @@
 package filodb.core.memstore
 
-import scala.concurrent.Future
-
 import kamon.Kamon
-import monix.execution.Scheduler
+import monix.eval.Task
 import monix.reactive.{Observable, OverflowStrategy}
 
 import filodb.core.DatasetRef
 import filodb.core.store.{ColumnStore, PartKeyRecord}
 
-trait IndexBootstrapper {
+class IndexBootstrapper(colStore: ColumnStore) {
+
   /**
     * Bootstrap the lucene index for the shard
     * using PartKeyRecord objects read from some persistent source.
@@ -20,50 +19,54 @@ trait IndexBootstrapper {
     * @param index the lucene index to populate
     * @param shardNum shard number
     * @param ref dataset ref
-    * @param ingestSched the thread on which to get the partitionId to be used to populate the index record
-    * @param addPartKey the function to invoke to get the partitionId to be used to populate the index record
+    * @param assignPartId the function to invoke to get the partitionId to be used to populate the index record
     * @return
     */
   def bootstrapIndex(index: PartKeyLuceneIndex,
                      shardNum: Int,
-                     ref: DatasetRef,
-                     ingestSched: Scheduler)
-                     (addPartKey: PartKeyRecord => Int): Future[Long] = {
+                     ref: DatasetRef)
+                     (assignPartId: PartKeyRecord => Int): Task[Long] = {
     val tracer = Kamon.buildSpan("memstore-recover-index-latency")
       .withTag("dataset", ref.dataset)
       .withTag("shard", shardNum).start()
 
-    fetchPartKeyRecords(ref, shardNum)
-      .asyncBoundary(OverflowStrategy.Default)
-      .executeOn(ingestSched)
+    colStore.scanPartKeys(ref, shardNum)
       .map { pk =>
-        val partId = addPartKey(pk)
+        val partId = assignPartId(pk)
         index.addPartKey(pk.partKey, partId, pk.startTime, pk.endTime)()
       }
-      .countL.runAsync(ingestSched)
+      .countL
       .map { count =>
         index.refreshReadersBlocking()
         tracer.finish()
         count
-      }(ingestSched)
+      }
   }
 
-  /**
-    * Implementations of this method can customize the fetch of the persisted
-    * PartKeyRecords
-    */
-  def fetchPartKeyRecords(ref: DatasetRef, shardNum: Int): Observable[PartKeyRecord]
+  def updateIndex(index: PartKeyLuceneIndex,
+                  shardNum: Int,
+                  ref: DatasetRef,
+                  fromHour: Long,
+                  toHour: Long)
+                  (lookUpOrAssignPartId: PartKeyRecord => Int): Task[Long] = {
+    val tracer = Kamon.buildSpan("downsample-store-update-index-latency")
+      .withTag("dataset", ref.dataset)
+      .withTag("shard", shardNum).start()
 
-}
-
-/**
-  * Index Bootstrapper that fetches PartKeyRecords from a ColStore.
-  */
-class ColStoreIndexBootstrapper(colStore: ColumnStore) extends IndexBootstrapper {
-  override def fetchPartKeyRecords(ref: DatasetRef,
-                                   shardNum: Int): Observable[PartKeyRecord] = {
-    colStore.scanPartKeys(ref, shardNum)
+    Observable.fromIterable(fromHour to toHour).flatMap { hour =>
+      colStore.getPartKeysByUpdateHour(ref, shardNum, hour)
+    }.asyncBoundary(OverflowStrategy.Default)
+     .map { pk =>
+        val partId = lookUpOrAssignPartId(pk)
+        index.upsertPartKey(pk.partKey, partId, pk.startTime, pk.endTime)()
+     }
+     .countL
+     .map { count =>
+        index.refreshReadersBlocking()
+        tracer.finish()
+        count
+     }
   }
-}
 
+}
 

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -20,7 +20,7 @@ class IndexBootstrapper(colStore: ColumnStore) {
     * @param shardNum shard number
     * @param ref dataset ref
     * @param assignPartId the function to invoke to get the partitionId to be used to populate the index record
-    * @return
+    * @return number of updated records
     */
   def bootstrapIndex(index: PartKeyLuceneIndex,
                      shardNum: Int,
@@ -43,6 +43,14 @@ class IndexBootstrapper(colStore: ColumnStore) {
       }
   }
 
+  /**
+    * Refresh index
+    * @param fromHour
+    * @param toHour
+    * @param parallelism
+    * @param lookUpOrAssignPartId
+    * @return
+    */
   def refreshIndex(index: PartKeyLuceneIndex,
                    shardNum: Int,
                    ref: DatasetRef,
@@ -64,9 +72,10 @@ class IndexBootstrapper(colStore: ColumnStore) {
      }
      .countL
      .map { count =>
-        index.refreshReadersBlocking()
-        tracer.finish()
-        count
+       index.refreshReadersBlocking()
+       tracer.finish()
+
+       count
      }
   }
 

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -50,7 +50,7 @@ class IndexBootstrapper(colStore: ColumnStore) {
                    toHour: Long,
                    parallelism: Int = Runtime.getRuntime.availableProcessors())
                   (lookUpOrAssignPartId: PartKeyRecord => Int): Task[Long] = {
-    val tracer = Kamon.buildSpan("downsample-store-update-index-latency")
+    val tracer = Kamon.buildSpan("downsample-store-refresh-index-latency")
       .withTag("dataset", ref.dataset)
       .withTag("shard", shardNum).start()
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -510,6 +510,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     logger.debug(s"Querying dataset=$ref shard=$shardNum partKeyIndex with: $query")
     var chosenPartId: Option[Int] = None
     def handleMatch(partId: Int, candidate: BytesRef): Unit = {
+      // we need an equals check because there can potentially be another partKey with additional tags
       if (schema.binSchema.equals(partKeyBase, partKeyOffset,
         candidate.bytes, PartKeyLuceneIndex.bytesRefToUnsafeOffset(candidate.offset))) {
         logger.debug(s"There is already a partId=$partId assigned for " +

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -347,6 +347,8 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
     final def unlock(): Unit = chunkmapReleaseShared()
   }
 
+  def partKeyHash: Int = schema.partKeySchema.partitionHash(partKeyBase, partKeyOffset)
+
   /**
     * startTime of earliest chunk in memory.
     * Long.MaxValue if no chunk is present

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -39,6 +39,8 @@ trait ChunkSink {
   /**
     * Used by downsample shard to do periodic pulls of new partition keys
     * into lucene index
+    *
+    * @param updateHour hour since epoch, essentially millis / 1000 / 60 / 60
     */
   def getPartKeysByUpdateHour(ref: DatasetRef,
                               shard: Int,

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -13,7 +13,7 @@ import monix.reactive.Observable
 
 import filodb.core._
 
-case class PartKeyRecord(partKey: Array[Byte], startTime: Long, endTime: Long)
+case class PartKeyRecord(partKey: Array[Byte], startTime: Long, endTime: Long, hash: Option[Int])
 
 /**
  * ChunkSink is the base trait for a sink, or writer to a persistent store, of chunks
@@ -31,7 +31,18 @@ trait ChunkSink {
    */
   def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Int = 259200): Future[Response]
 
+  /**
+    * Used to bootstrap lucene index with partition keys for a shard
+    */
   def scanPartKeys(ref: DatasetRef, shard: Int): Observable[PartKeyRecord]
+
+  /**
+    * Used by downsample shard to do periodic pulls of new partition keys
+    * into lucene index
+    */
+  def getPartKeysByUpdateHour(ref: DatasetRef,
+                              shard: Int,
+                              updateHour: Long): Observable[PartKeyRecord]
 
   def writePartKeys(ref: DatasetRef, shard: Int,
                     partKeys: Observable[PartKeyRecord], diskTTLSeconds: Int): Future[Response]
@@ -146,4 +157,6 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
     partKeys.countL.map(c => sinkStats.partKeysWrite(c.toInt)).runAsync.map(_ => Success)
   }
 
+  override def getPartKeysByUpdateHour(ref: DatasetRef, shard: Int,
+                                       updateHour: Long): Observable[PartKeyRecord] = Observable.empty
 }

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -14,6 +14,9 @@ filodb {
     retry-interval = 10s
     retry-interval-max-jitter = 10s
     ingestion-consistency-level = "ONE"
+    pk-by-updated-time-table-num-splits = 200
+    pk-by-updated-time-table-num-ttl = 1 day
+
   }
 
   shard-manager {

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -303,8 +303,8 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val colStore = new NullColumnStore() {
       override def scanPartKeys(ref: DatasetRef, shard: Int): Observable[PartKeyRecord] = {
         val keys = Seq(
-          PartKeyRecord(pks(0), 50, 100), // series that has ended ingestion
-          PartKeyRecord(pks(1), 250, Long.MaxValue) // series that is currently ingesting
+          PartKeyRecord(pks(0), 50, 100, None), // series that has ended ingestion
+          PartKeyRecord(pks(1), 250, Long.MaxValue, None) // series that is currently ingesting
         )
         Observable.fromIterable(keys)
       }

--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -141,6 +141,8 @@ trait VectorDataReader extends AvailableReader {
   def toHexString(acc: MemoryReader, vector: BinaryVectorPtr): String =
     s"0x${toBytes(acc, vector).map("%02X" format _).mkString}"
 
+  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String
+
   def asIntReader: vectors.IntVectorDataReader = this.asInstanceOf[vectors.IntVectorDataReader]
   def asLongReader: vectors.LongVectorDataReader = this.asInstanceOf[vectors.LongVectorDataReader]
   def asDoubleReader: vectors.DoubleVectorDataReader = this.asInstanceOf[vectors.DoubleVectorDataReader]

--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -141,7 +141,7 @@ trait VectorDataReader extends AvailableReader {
   def toHexString(acc: MemoryReader, vector: BinaryVectorPtr): String =
     s"0x${toBytes(acc, vector).map("%02X" format _).mkString}"
 
-  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String
+  def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String
 
   def asIntReader: vectors.IntVectorDataReader = this.asInstanceOf[vectors.IntVectorDataReader]
   def asLongReader: vectors.LongVectorDataReader = this.asInstanceOf[vectors.LongVectorDataReader]

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -134,6 +134,12 @@ trait DoubleVectorDataReader extends CounterVectorReader {
    */
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): DoubleIterator
 
+  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
+    val it = iterate(acc, vector)
+    val size = numBytes(acc, vector)
+    (0 to size).map(_ => it.next).mkString(sep)
+  }
+
   /**
    * Sums up the Double values in the vector from position start to position end.
    * @param vector the BinaryVectorPtr native address of the BinaryVector

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -134,9 +134,9 @@ trait DoubleVectorDataReader extends CounterVectorReader {
    */
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): DoubleIterator
 
-  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
+  def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
     val it = iterate(acc, vector)
-    val size = numBytes(acc, vector)
+    val size = length(acc, vector)
     (0 to size).map(_ => it.next).mkString(sep)
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -455,6 +455,12 @@ class RowHistogramReader(val acc: MemoryReader, histVect: Ptr.U8) extends Histog
     }
   }
 
+  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = System.lineSeparator): String = {
+    val it = iterate(acc, vector)
+    val size = numBytes(acc, vector)
+    (0 to size).map(_ => it.asHistIt).mkString(sep)
+  }
+
   def length(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr): Int = length
 
   protected val dSink = NibblePack.DeltaSink(returnHist.values)

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -455,9 +455,9 @@ class RowHistogramReader(val acc: MemoryReader, histVect: Ptr.U8) extends Histog
     }
   }
 
-  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = System.lineSeparator): String = {
+  def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = System.lineSeparator): String = {
     val it = iterate(acc, vector)
-    val size = numBytes(acc, vector)
+    val size = length(acc, vector)
     (0 to size).map(_ => it.asHistIt).mkString(sep)
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
@@ -280,9 +280,9 @@ trait IntVectorDataReader extends VectorDataReader {
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): IntIterator =
     new GenericIntIterator(acc, vector, startElement)
 
-  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
+  def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
     val it = iterate(acc, vector)
-    val size = numBytes(acc, vector)
+    val size = length(acc, vector)
     (0 to size).map(_ => it.next).mkString(sep)
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
@@ -280,6 +280,12 @@ trait IntVectorDataReader extends VectorDataReader {
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): IntIterator =
     new GenericIntIterator(acc, vector, startElement)
 
+  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
+    val it = iterate(acc, vector)
+    val size = numBytes(acc, vector)
+    (0 to size).map(_ => it.next).mkString(sep)
+  }
+
   /**
    * Converts the BinaryVector to an unboxed Buffer.
    * Only returns elements that are "available".

--- a/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
@@ -126,6 +126,12 @@ trait LongVectorDataReader extends VectorDataReader {
    */
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): LongIterator
 
+  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
+    val it = iterate(acc, vector)
+    val size = numBytes(acc, vector)
+    (0 to size).map(_ => it.next).mkString(sep)
+  }
+
   /**
    * Sums up the Long values in the vector from position start to position end.
    * @param vector the BinaryVectorPtr native address of the BinaryVector

--- a/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
@@ -126,9 +126,9 @@ trait LongVectorDataReader extends VectorDataReader {
    */
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): LongIterator
 
-  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
+  def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
     val it = iterate(acc, vector)
-    val size = numBytes(acc, vector)
+    val size = length(acc, vector)
     (0 to size).map(_ => it.next).mkString(sep)
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
@@ -116,6 +116,12 @@ trait UTF8VectorDataReader extends VectorDataReader {
    */
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): UTF8Iterator
 
+  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = "\n"): String = {
+    val it = iterate(acc, vector)
+    val size = numBytes(acc, vector)
+    (0 to size).map(_ => it.next).mkString(sep)
+  }
+
   /**
    * Converts the BinaryVector to an unboxed Buffer.
    * Only returns elements that are "available".

--- a/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
@@ -116,9 +116,9 @@ trait UTF8VectorDataReader extends VectorDataReader {
    */
   def iterate(acc: MemoryReader, vector: BinaryVectorPtr, startElement: Int = 0): UTF8Iterator
 
-  def toHumanReadable(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = "\n"): String = {
+  def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = "\n"): String = {
     val it = iterate(acc, vector)
-    val size = numBytes(acc, vector)
+    val size = length(acc, vector)
     (0 to size).map(_ => it.next).mkString(sep)
   }
 

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -326,6 +326,17 @@ object Parser extends Expression {
     }
   }
 
+  def parseFilter(query: String): InstantExpression = {
+    parseAll(expression, query) match {
+      case s: Success[_] => s.get match {
+        case ie: InstantExpression => ie
+        case _ => throw new IllegalArgumentException(s"Expression $query is not a simple filter")
+      }
+      case e: Error => handleError(e, query)
+      case f: Failure => handleFailure(f, query)
+    }
+  }
+
   def metadataQueryToLogicalPlan(query: String, timeParams: TimeRangeParams): LogicalPlan = {
     val expression = parseQuery(query)
     expression match {

--- a/scripts/schema-create.sh
+++ b/scripts/schema-create.sh
@@ -2,8 +2,9 @@
 
 if [[ $# -ne 6 ]]; then
     echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <FILO_DOWNSAMPLE_KEYSPACE> <DATASET> <NUM_SHARDS> <RESOLUTIONS>"
-    echo "First Run: $0 filodb_admin filodb filodb_downsample prometheus 4 1,5 > ddl.cql"
-    echo "Then Run: cql --request-timeout 3000 -f ddl.cql"
+    echo "First Run:    $0 filodb_admin filodb filodb_downsample prometheus 4 1,5 > ddl.cql"
+    echo "Then Run:     cql -u cass_username -p cass_password --request-timeout 3000 -f ddl.cql cass_host 9992"
+    echo "Or for Local: cql --request-timeout 3000 -f ddl.cql"
     exit 1
 fi
 
@@ -20,6 +21,7 @@ function create_keyspaces() {
 local KEYSP=$1
 
 cat << EOF
+
 CREATE KEYSPACE IF NOT EXISTS ${KEYSP} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
 EOF
 
@@ -31,6 +33,7 @@ local KEYSP=$1
 local DSET=$2
 
 cat << EOF
+
 CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_tschunks (
     partition blob,
     chunkid bigint,
@@ -41,6 +44,7 @@ CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_tschunks (
 EOF
 
 cat << EOF
+
 CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_ingestion_time_index (
     partition blob,
     ingestion_time bigint,
@@ -49,6 +53,7 @@ CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_ingestion_time_index (
     PRIMARY KEY (partition, ingestion_time, start_time)
 ) WITH compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
 EOF
+
 }
 
 function create_partkey_tables() {
@@ -56,7 +61,6 @@ local KEYSP=$1
 local DSET=$2
 
 for SHARD in $(seq 0 $((NUM_SHARDS - 1))); do
-
 cat << EOF
 CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_$SHARD (
     partKey blob,
@@ -64,6 +68,10 @@ CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_$SHARD (
     endTime bigint,
     PRIMARY KEY (partKey)
 ) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+EOF
+done
+
+cat << EOF
 
 CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_by_update_time (
     shard int,
@@ -76,12 +84,12 @@ CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_by_update_time (
 ) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
 EOF
 
-done
 }
 
 function create_admin_tables() {
 
 cat << EOF
+
 CREATE TABLE IF NOT EXISTS ${FILO_ADMIN_KEYSPACE}.checkpoints (
     databasename text,
     datasetname text,
@@ -90,7 +98,6 @@ CREATE TABLE IF NOT EXISTS ${FILO_ADMIN_KEYSPACE}.checkpoints (
     offset bigint,
     PRIMARY KEY ((databasename, datasetname, shardnum), groupnum)
 ) WITH compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
-
 EOF
 
 }

--- a/scripts/schema-create.sh
+++ b/scripts/schema-create.sh
@@ -64,6 +64,16 @@ CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_$SHARD (
     endTime bigint,
     PRIMARY KEY (partKey)
 ) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+
+CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_by_update_time (
+    shard int,
+    epochHour bigint,
+    split int,
+    partKey blob,
+    startTime bigint,
+    endTime bigint,
+    PRIMARY KEY ((shard, epochHour, split), partKey))
+) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
 EOF
 
 done

--- a/scripts/schema-truncate.sh
+++ b/scripts/schema-truncate.sh
@@ -2,8 +2,9 @@
 
 if [[ $# -ne 6 ]]; then
     echo "Usage: $0 <FILO_ADMIN_KEYSPACE> <FILO_KEYSPACE> <FILO_DOWNSAMPLE_KEYSPACE> <DATASET> <NUM_SHARDS> <RESOLUTIONS>"
-    echo "First Run: $0 filodb_admin filodb filodb_downsample prometheus 4 1,5 > ddl.cql"
-    echo "Then Run: cql --request-timeout 3000 -f ddl.cql"
+    echo "First Run:    $0 filodb_admin filodb filodb_downsample prometheus 4 1,5 > ddl.cql"
+    echo "Then Run:     cql -u cass_username -p cass_password --request-timeout 3000 -f ddl.cql cass_host 9992"
+    echo "Or for Local: cql --request-timeout 3000 -f ddl.cql"
     exit 1
 fi
 
@@ -34,8 +35,12 @@ for SHARD in $(seq 0 $((NUM_SHARDS - 1))); do
 cat << EOF
 TRUNCATE ${KEYSP}.${DSET}_partitionkeys_$SHARD;
 EOF
-
 done
+
+cat << EOF
+TRUNCATE ${KEYSP}.${DSET}_partitionkeys_by_update_time
+EOF
+
 }
 
 function truncate_admin_tables() {

--- a/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb.downsampler/BatchDownsampler.scala
@@ -6,6 +6,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
+import java.util
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import scalaxy.loops._
@@ -239,7 +240,10 @@ object BatchDownsampler extends StrictLogging with Instance {
           downsampleResToPart.foreach { case (resolution, part) =>
             val resMillis = resolution.toMillis
 
-            val downsamplePeriods = periodMarker.periods(rawPartToDownsample, chunkset, resMillis, startRow, endRow)
+            val downsamplePeriods =
+              periodMarker.periods(rawPartToDownsample, chunkset, resMillis, startRow, endRow).toArray()
+            util.Arrays.sort(downsamplePeriods)
+
             try {
               // for each downsample period
               var first = startRow

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -49,9 +49,18 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
   val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram),
                                      Map.empty, 100, rawDataStoreConfig)
+  val gaugeName = "my_gauge"
   var gaugePartKeyBytes: Array[Byte] = _
+
+  val counterName = "my_counter"
   var counterPartKeyBytes: Array[Byte] = _
+
+  val histName = "my_histogram"
   var histPartKeyBytes: Array[Byte] = _
+
+  val gaugeLowFreqName = "my_gauge_low_freq"
+  var gaugeLowFreqPartKeyBytes: Array[Byte] = _
+
   val lastSampleTime = 1574273042000L
   val downsampler = new Downsampler
 
@@ -69,7 +78,6 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     downsampler.shutdown()
   }
 
-  val gaugeName = "my_gauge"
   it ("should write gauge data to cassandra") {
 
     val rawDataset = Dataset("prometheus", Schemas.gauge)
@@ -112,7 +120,46 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200).futureValue
   }
 
-  val counterName = "my_counter"
+  it ("should write low freq gauge data to cassandra") {
+
+    val rawDataset = Dataset("prometheus", Schemas.gauge)
+
+    val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
+    val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, gaugeLowFreqName, seriesTags)
+
+    val part = new TimeSeriesPartition(0, Schemas.gauge, partKey,
+      0, offheapMem.bufferPools(Schemas.gauge.schemaHash), shardStats,
+      offheapMem.nativeMemoryManager, 1)
+
+    gaugeLowFreqPartKeyBytes = part.partKeyBytes
+
+    val rawSamples = Stream(
+      Seq(1574272801000L, 3d, gaugeName, seriesTags),
+      Seq(1574272802000L, 5d, gaugeName, seriesTags),
+
+      // skip next minute
+
+      Seq(1574272921000L, 13d, gaugeName, seriesTags),
+      Seq(1574272922000L, 15d, gaugeName, seriesTags),
+
+      // skip next minute
+
+      Seq(1574273041000L, 13d, gaugeName, seriesTags),
+      Seq(1574273042000L, 11d, gaugeName, seriesTags)
+    )
+
+    MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
+      val rr = new BinaryRecordRowReader(Schemas.gauge.ingestionSchema, base, offset)
+      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+    }
+    part.switchBuffers(offheapMem.blockMemFactory, true)
+    val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
+
+    rawColStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
+    val pk = PartKeyRecord(gaugeLowFreqPartKeyBytes, 1574272801000L, 1574273042000L, Some(150))
+    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200).futureValue
+  }
+
   it ("should write prom counter data to cassandra") {
 
     val rawDataset = Dataset("prometheus", Schemas.promCounter)
@@ -159,7 +206,6 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200).futureValue
   }
 
-  val histName = "my_histogram"
   it ("should write prom histogram data to cassandra") {
 
     val rawDataset = Dataset("prometheus", Schemas.promHistogram)
@@ -217,14 +263,14 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     sparkConf.set("spark.filodb.downsampler.userTimeOverride", lastSampleTime.toString)
     downsampler.run(sparkConf)
   }
-
   it ("should migrate partKey data into the downsample dataset tables in cassandra using spark job") {
     // TODO add spark job in future PR
     // For now write part keys manually
     val dsDataset5Min = BatchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min"))
     val pks = Seq( PartKeyRecord(histPartKeyBytes, 1574272801000L, 1574273042000L, Some(199)),
                    PartKeyRecord(counterPartKeyBytes, 1574272801000L, 1574273042000L, Some(1)),
-                   PartKeyRecord(gaugePartKeyBytes, 1574272801000L, 1574273042000L, Some(150)))
+                   PartKeyRecord(gaugePartKeyBytes, 1574272801000L, 1574273042000L, Some(150)),
+                   PartKeyRecord(gaugeLowFreqPartKeyBytes, 1574272801000L, 1574273042000L, Some(345)))
 
     downsampleColStore.writePartKeys(dsDataset5Min, 0, Observable.fromIterable(pks), 259200).futureValue
 
@@ -254,6 +300,32 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
       (1574272862000L, 9.0, 11.0, 20.0, 2.0, 10.0),
       (1574272922000L, 13.0, 15.0, 28.0, 2.0, 14.0),
       (1574272982000L, 15.0, 17.0, 32.0, 2.0, 16.0),
+      (1574273042000L, 11.0, 13.0, 24.0, 2.0, 12.0)
+    )
+  }
+
+  it("should read and verify low freq gauge in cassandra using PagedReadablePartition for 1-min downsampled data") {
+
+    val downsampledPartData1 = downsampleColStore.readRawPartitions(
+      BatchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
+      0,
+      SinglePartitionScan(gaugeLowFreqPartKeyBytes))
+      .toListL.runAsync.futureValue.head
+
+    val downsampledPart1 = new PagedReadablePartition(Schemas.gauge.downsample.get, 0, 0, downsampledPartData1)
+
+    downsampledPart1.partKeyBytes shouldEqual gaugeLowFreqPartKeyBytes
+
+    val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3, 4, 5))
+
+    val downsampledData1 = rv1.rows.map { r =>
+      (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getDouble(3), r.getDouble(4), r.getDouble(5))
+    }.toList
+
+    // time, min, max, sum, count, avg
+    downsampledData1 shouldEqual Seq(
+      (1574272802000L, 3.0, 5.0, 8.0, 2.0, 4.0),
+      (1574272922000L, 13.0, 15.0, 28.0, 2.0, 14.0),
       (1574273042000L, 11.0, 13.0, 24.0, 2.0, 12.0)
     )
   }
@@ -452,7 +524,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
     val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
 
-    Seq(gaugeName, counterName, histName).foreach { metricName =>
+    Seq(gaugeName, gaugeLowFreqName, counterName, histName).foreach { metricName =>
       val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(metricName))
       val exec = MultiSchemaPartitionsExec("someId", System.currentTimeMillis(),
         1000, InProcessPlanDispatcher(), BatchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)

--- a/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb.downsampler/DownsamplerMainSpec.scala
@@ -1,8 +1,9 @@
 package filodb.downsampler
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigFactory
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import org.apache.spark.SparkConf
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
@@ -12,14 +13,19 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import filodb.core.GlobalScheduler._
 import filodb.core.MachineMetricsData
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, RecordBuilder}
+import filodb.core.downsample.DownsampledTimeSeriesStore
 import filodb.core.memstore.{PagedReadablePartition, TimeSeriesPartition}
+import filodb.core.memstore.FiloSchedulers.QuerySchedName
 import filodb.core.metadata.{Dataset, Schemas}
-import filodb.core.query.{CustomRangeVectorKey, RawDataRangeVector}
+import filodb.core.query.{ColumnFilter, CustomRangeVectorKey, RawDataRangeVector}
+import filodb.core.query.Filter.Equals
 import filodb.core.store.{AllChunkScan, PartKeyRecord, SinglePartitionScan, StoreConfig}
 import filodb.downsampler.BatchDownsampler.shardStats
 import filodb.memory.format.PrimitiveVectorReader
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.memory.format.vectors.{CustomBuckets, MutableHistogram}
+import filodb.query.{QueryConfig, QueryResult}
+import filodb.query.exec.{InProcessPlanDispatcher, MultiSchemaPartitionsExec}
 
 /**
   * Spec tests downsampling round trip.
@@ -30,17 +36,19 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   System.setProperty("config.file", "conf/timeseries-filodb-server.conf")
+  val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+    "_ns_".utf8 -> "my_ns".utf8)
 
   val rawColStore = BatchDownsampler.rawCassandraColStore
   val downsampleColStore = BatchDownsampler.downsampleCassandraColStore
 
-  val storeConfig = StoreConfig(ConfigFactory.parseString( """
+  val rawDataStoreConfig = StoreConfig(ConfigFactory.parseString( """
                   |flush-interval = 1h
                   |shard-mem-size = 1MB
                 """.stripMargin))
 
   val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram),
-                                     Map.empty, 100, storeConfig)
+                                     Map.empty, 100, rawDataStoreConfig)
   var gaugePartKeyBytes: Array[Byte] = _
   var counterPartKeyBytes: Array[Byte] = _
   var histPartKeyBytes: Array[Byte] = _
@@ -61,15 +69,13 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     downsampler.shutdown()
   }
 
+  val gaugeName = "my_gauge"
   it ("should write gauge data to cassandra") {
 
     val rawDataset = Dataset("prometheus", Schemas.gauge)
 
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
-    val seriesName = "my_gauge"
-    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
-                         "_ns_".utf8 -> "my_ns".utf8)
-    val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, seriesName, seriesTags)
+    val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, gaugeName, seriesTags)
 
     val part = new TimeSeriesPartition(0, Schemas.gauge, partKey,
       0, offheapMem.bufferPools(Schemas.gauge.schemaHash), shardStats,
@@ -78,20 +84,20 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     gaugePartKeyBytes = part.partKeyBytes
 
     val rawSamples = Stream(
-      Seq(1574272801000L, 3d, seriesName, seriesTags),
-      Seq(1574272802000L, 5d, seriesName, seriesTags),
+      Seq(1574272801000L, 3d, gaugeName, seriesTags),
+      Seq(1574272802000L, 5d, gaugeName, seriesTags),
 
-      Seq(1574272861000L, 9d, seriesName, seriesTags),
-      Seq(1574272862000L, 11d, seriesName, seriesTags),
+      Seq(1574272861000L, 9d, gaugeName, seriesTags),
+      Seq(1574272862000L, 11d, gaugeName, seriesTags),
 
-      Seq(1574272921000L, 13d, seriesName, seriesTags),
-      Seq(1574272922000L, 15d, seriesName, seriesTags),
+      Seq(1574272921000L, 13d, gaugeName, seriesTags),
+      Seq(1574272922000L, 15d, gaugeName, seriesTags),
 
-      Seq(1574272981000L, 17d, seriesName, seriesTags),
-      Seq(1574272982000L, 15d, seriesName, seriesTags),
+      Seq(1574272981000L, 17d, gaugeName, seriesTags),
+      Seq(1574272982000L, 15d, gaugeName, seriesTags),
 
-      Seq(1574273041000L, 13d, seriesName, seriesTags),
-      Seq(1574273042000L, 11d, seriesName, seriesTags)
+      Seq(1574273041000L, 13d, gaugeName, seriesTags),
+      Seq(1574273042000L, 11d, gaugeName, seriesTags)
     )
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
@@ -102,19 +108,17 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
-    val pk = PartKeyRecord(gaugePartKeyBytes, 1574272801000L, 1574273042000L)
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200)
+    val pk = PartKeyRecord(gaugePartKeyBytes, 1574272801000L, 1574273042000L, Some(150))
+    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200).futureValue
   }
 
+  val counterName = "my_counter"
   it ("should write prom counter data to cassandra") {
 
     val rawDataset = Dataset("prometheus", Schemas.promCounter)
 
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
-    val seriesName = "my_counter"
-    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
-                         "_ns_".utf8 -> "my_ns".utf8)
-    val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, seriesName, seriesTags)
+    val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, counterName, seriesTags)
 
     val part = new TimeSeriesPartition(0, Schemas.promCounter, partKey,
       0, offheapMem.bufferPools(Schemas.promCounter.schemaHash), shardStats,
@@ -123,24 +127,24 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     counterPartKeyBytes = part.partKeyBytes
 
     val rawSamples = Stream(
-      Seq(1574272801000L, 3d, seriesName, seriesTags),
-      Seq(1574272801500L, 4d, seriesName, seriesTags),
-      Seq(1574272802000L, 5d, seriesName, seriesTags),
+      Seq(1574272801000L, 3d, counterName, seriesTags),
+      Seq(1574272801500L, 4d, counterName, seriesTags),
+      Seq(1574272802000L, 5d, counterName, seriesTags),
 
-      Seq(1574272861000L, 9d, seriesName, seriesTags),
-      Seq(1574272861500L, 10d, seriesName, seriesTags),
-      Seq(1574272862000L, 11d, seriesName, seriesTags),
+      Seq(1574272861000L, 9d, counterName, seriesTags),
+      Seq(1574272861500L, 10d, counterName, seriesTags),
+      Seq(1574272862000L, 11d, counterName, seriesTags),
 
-      Seq(1574272921000L, 2d, seriesName, seriesTags),
-      Seq(1574272921500L, 7d, seriesName, seriesTags),
-      Seq(1574272922000L, 15d, seriesName, seriesTags),
+      Seq(1574272921000L, 2d, counterName, seriesTags),
+      Seq(1574272921500L, 7d, counterName, seriesTags),
+      Seq(1574272922000L, 15d, counterName, seriesTags),
 
-      Seq(1574272981000L, 17d, seriesName, seriesTags),
-      Seq(1574272981500L, 1d, seriesName, seriesTags),
-      Seq(1574272982000L, 15d, seriesName, seriesTags),
+      Seq(1574272981000L, 17d, counterName, seriesTags),
+      Seq(1574272981500L, 1d, counterName, seriesTags),
+      Seq(1574272982000L, 15d, counterName, seriesTags),
 
-      Seq(1574273041000L, 18d, seriesName, seriesTags),
-      Seq(1574273042000L, 20d, seriesName, seriesTags)
+      Seq(1574273041000L, 18d, counterName, seriesTags),
+      Seq(1574273042000L, 20d, counterName, seriesTags)
     )
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
@@ -151,19 +155,17 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
-    val pk = PartKeyRecord(counterPartKeyBytes, 1574272801000L, 1574273042000L)
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200)
+    val pk = PartKeyRecord(counterPartKeyBytes, 1574272801000L, 1574273042000L, Some(1))
+    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200).futureValue
   }
 
+  val histName = "my_histogram"
   it ("should write prom histogram data to cassandra") {
 
     val rawDataset = Dataset("prometheus", Schemas.promHistogram)
 
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
-    val seriesName = "my_histogram"
-    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
-                         "_ns_".utf8 -> "my_ns".utf8)
-    val partKey = partBuilder.partKeyFromObjects(Schemas.promHistogram, seriesName, seriesTags)
+    val partKey = partBuilder.partKeyFromObjects(Schemas.promHistogram, histName, seriesTags)
 
     val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey,
       0, offheapMem.bufferPools(Schemas.promHistogram.schemaHash), shardStats,
@@ -173,24 +175,24 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
     val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
     val rawSamples = Stream( // time, sum, count, hist, name, tags
-      Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d)), seriesName, seriesTags),
-      Seq(1574272801500L, 2d, 3d, MutableHistogram(bucketScheme, Array(0d, 2d, 3d)), seriesName, seriesTags),
-      Seq(1574272802000L, 5d, 6d, MutableHistogram(bucketScheme, Array(2d, 5d, 6d)), seriesName, seriesTags),
+      Seq(1574272801000L, 0d, 1d, MutableHistogram(bucketScheme, Array(0d, 0d, 1d)), histName, seriesTags),
+      Seq(1574272801500L, 2d, 3d, MutableHistogram(bucketScheme, Array(0d, 2d, 3d)), histName, seriesTags),
+      Seq(1574272802000L, 5d, 6d, MutableHistogram(bucketScheme, Array(2d, 5d, 6d)), histName, seriesTags),
 
-      Seq(1574272861000L, 9d, 9d, MutableHistogram(bucketScheme, Array(2d, 5d, 9d)), seriesName, seriesTags),
-      Seq(1574272861500L, 10d, 10d, MutableHistogram(bucketScheme, Array(2d, 5d, 10d)), seriesName, seriesTags),
-      Seq(1574272862000L, 11d, 14d, MutableHistogram(bucketScheme, Array(2d, 8d, 14d)), seriesName, seriesTags),
+      Seq(1574272861000L, 9d, 9d, MutableHistogram(bucketScheme, Array(2d, 5d, 9d)), histName, seriesTags),
+      Seq(1574272861500L, 10d, 10d, MutableHistogram(bucketScheme, Array(2d, 5d, 10d)), histName, seriesTags),
+      Seq(1574272862000L, 11d, 14d, MutableHistogram(bucketScheme, Array(2d, 8d, 14d)), histName, seriesTags),
 
-      Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d)), seriesName, seriesTags),
-      Seq(1574272921500L, 7d, 9d, MutableHistogram(bucketScheme, Array(1d, 7d, 9d)), seriesName, seriesTags),
-      Seq(1574272922000L, 15d, 19d, MutableHistogram(bucketScheme, Array(1d, 15d, 19d)), seriesName, seriesTags),
+      Seq(1574272921000L, 2d, 2d, MutableHistogram(bucketScheme, Array(0d, 0d, 2d)), histName, seriesTags),
+      Seq(1574272921500L, 7d, 9d, MutableHistogram(bucketScheme, Array(1d, 7d, 9d)), histName, seriesTags),
+      Seq(1574272922000L, 15d, 19d, MutableHistogram(bucketScheme, Array(1d, 15d, 19d)), histName, seriesTags),
 
-      Seq(1574272981000L, 17d, 21d, MutableHistogram(bucketScheme, Array(2d, 16d, 21d)), seriesName, seriesTags),
-      Seq(1574272981500L, 1d, 1d, MutableHistogram(bucketScheme, Array(0d, 1d, 1d)), seriesName, seriesTags),
-      Seq(1574272982000L, 15d, 15d, MutableHistogram(bucketScheme, Array(0d, 15d, 15d)), seriesName, seriesTags),
+      Seq(1574272981000L, 17d, 21d, MutableHistogram(bucketScheme, Array(2d, 16d, 21d)), histName, seriesTags),
+      Seq(1574272981500L, 1d, 1d, MutableHistogram(bucketScheme, Array(0d, 1d, 1d)), histName, seriesTags),
+      Seq(1574272982000L, 15d, 15d, MutableHistogram(bucketScheme, Array(0d, 15d, 15d)), histName, seriesTags),
 
-      Seq(1574273041000L, 18d, 19d, MutableHistogram(bucketScheme, Array(1d, 16d, 19d)), seriesName, seriesTags),
-      Seq(1574273042000L, 20d, 25d, MutableHistogram(bucketScheme, Array(4d, 20d, 25d)), seriesName, seriesTags)
+      Seq(1574273041000L, 18d, 19d, MutableHistogram(bucketScheme, Array(1d, 16d, 19d)), histName, seriesTags),
+      Seq(1574273042000L, 20d, 25d, MutableHistogram(bucketScheme, Array(4d, 20d, 25d)), histName, seriesTags)
     )
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
@@ -201,8 +203,8 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
-    val pk = PartKeyRecord(histPartKeyBytes, 1574272801000L, 1574273042000L)
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200)
+    val pk = PartKeyRecord(histPartKeyBytes, 1574272801000L, 1574273042000L, Some(199))
+    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200).futureValue
   }
 
   it ("should free all offheap memory") {
@@ -217,7 +219,15 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   }
 
   it ("should migrate partKey data into the downsample dataset tables in cassandra using spark job") {
-    // TODO in future PR
+    // TODO add spark job in future PR
+    // For now write part keys manually
+    val dsDataset5Min = BatchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min"))
+    val pks = Seq( PartKeyRecord(histPartKeyBytes, 1574272801000L, 1574273042000L, Some(199)),
+                   PartKeyRecord(counterPartKeyBytes, 1574272801000L, 1574273042000L, Some(1)),
+                   PartKeyRecord(gaugePartKeyBytes, 1574272801000L, 1574273042000L, Some(150)))
+
+    downsampleColStore.writePartKeys(dsDataset5Min, 0, Observable.fromIterable(pks), 259200).futureValue
+
   }
 
   it("should read and verify gauge data in cassandra using PagedReadablePartition for 1-min downsampled data") {
@@ -430,11 +440,32 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
   }
 
-  it("should read and verify part key migration in cassandra for 5-min downsampled data") {
-    // TODO in future PR
-  }
-
   it("should bring up DownsampledTimeSeriesShard and be able to read data using SelectRawPartitionsExec") {
-    // TODO in future PR when index migration is done
+
+    val downsampleTSStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore,
+      DownsamplerSettings.filodbConfig)
+
+    downsampleTSStore.setup(BatchDownsampler.rawDatasetRef, DownsamplerSettings.filodbSettings.schemas,
+      0, rawDataStoreConfig, DownsamplerSettings.rawDatasetIngestionConfig.downsampleConfig)
+
+    downsampleTSStore.recoverIndex(BatchDownsampler.rawDatasetRef, 0).futureValue
+
+    val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
+
+    Seq(gaugeName, counterName, histName).foreach { metricName =>
+      val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(metricName))
+      val exec = MultiSchemaPartitionsExec("someId", System.currentTimeMillis(),
+        1000, InProcessPlanDispatcher(), BatchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
+
+      val queryConfig = new QueryConfig(DownsamplerSettings.filodbConfig.getConfig("query"))
+      val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName", 3)
+      val res = exec.execute(downsampleTSStore, queryConfig)(queryScheduler, 1 minute)
+                    .runAsync(queryScheduler).futureValue.asInstanceOf[QueryResult]
+      queryScheduler.shutdown()
+
+      res.result.size shouldEqual 1
+      res.result.foreach(_.rows.nonEmpty shouldEqual true)
+    }
+
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

Redo https://github.com/filodb/FiloDB/pull/592 since commits were not squashed.

    feat(core): Downsample Cluster Index Refresh

    * New Cass table tracks part key start/end time mutations by hour. It is used to periodically
       refresh lucene index on downsample cluster
    * Async IO on Part Key tables
    * Downsample unit test now validates the Downsample shard as well
    * Multiple capabilities on Filo CLI to encode/decode partKeyBR, decode Binary Vector and ChunkSetInfo
