### PR TITLE
debug(standalone): Logging server config on start; toSeconds not Java-8 compat

### DIFF
--- a/standalone/src/main/scala/filodb.standalone/FiloServer.scala
+++ b/standalone/src/main/scala/filodb.standalone/FiloServer.scala
@@ -44,6 +44,8 @@ class FiloServer(watcher: Option[ActorRef]) extends FilodbClusterNode {
 
   lazy val config = cluster.settings.config
 
+  logger.info(s"Starting FiloDB with settings: ${cluster.settings.allConfig.root().render()}")
+
   var filoHttpServer: FiloHttpServer = _
 
   // Now, initialize any datasets using in memory MetaStore.


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Logging config on startup to debug downsample server load
* `Duration.toSeconds` not available in java-8