### PR TITLE
bug(cassandra): Dont auto-create Cassandra tables in prod

### DIFF
--- a/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/ClusterSeedDiscovery.scala
+++ b/akka-bootstrapper/src/main/scala/filodb/akkabootstrapper/ClusterSeedDiscovery.scala
@@ -67,11 +67,12 @@ abstract class ClusterSeedDiscovery(val cluster: Cluster,
   }
 }
 
-object ClusterSeedDiscovery {
+object ClusterSeedDiscovery extends StrictLogging {
   /** Seed node strategy. Some implementations discover, some simply read them. */
   def apply(cluster: Cluster, settings: AkkaBootstrapperSettings): ClusterSeedDiscovery = {
     import settings.{seedDiscoveryClass => fqcn}
 
+    logger.info(s"Using $fqcn strategy to discover cluster seeds")
     cluster.system.dynamicAccess.createInstanceFor[ClusterSeedDiscovery](
       fqcn, Seq((cluster.getClass, cluster), (settings.getClass, settings))) match {
         case Failure(e) =>

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -60,8 +60,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
 
   private val writeParallelism = cassandraConfig.getInt("write-parallelism")
   private val pkByUTNumSplits = cassandraConfig.getInt("pk-by-updated-time-table-num-splits")
-  private val pkByUTTtlSeconds = cassandraConfig.getDuration("pk-by-updated-time-table-ttl",
-    TimeUnit.SECONDS).toInt
+  private val pkByUTTtlSeconds = cassandraConfig.getDuration("pk-by-updated-time-table-ttl", TimeUnit.SECONDS).toInt
   private val createTablesEnabled = cassandraConfig.getBoolean("create-tables-enabled")
 
   val sinkStats = new ChunkSinkStats

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -60,26 +60,33 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
 
   private val writeParallelism = cassandraConfig.getInt("write-parallelism")
   private val pkByUTNumSplits = cassandraConfig.getInt("pk-by-updated-time-table-num-splits")
-  private val pkByUTTtlSeconds = cassandraConfig.getDuration("pk-by-updated-time-table-num-ttl",
+  private val pkByUTTtlSeconds = cassandraConfig.getDuration("pk-by-updated-time-table-ttl",
     TimeUnit.SECONDS).toInt
+  private val createTablesEnabled = cassandraConfig.getBoolean("create-tables-enabled")
 
   val sinkStats = new ChunkSinkStats
 
   def initialize(dataset: DatasetRef, numShards: Int): Future[Response] = {
-    val chunkTable = getOrCreateChunkTable(dataset)
-    val partitionKeysByUpdateTimeTable = getOrCreatePartitionKeysByUpdateTimeTable(dataset)
-    val partKeyTablesInit = Observable.fromIterable(0.until(numShards)).map { s =>
-      getOrCreatePartitionKeysTable(dataset, s)
-    }.mapAsync(t => Task.fromFuture(t.initialize())).toListL
-    clusterConnector.createKeyspace(chunkTable.keyspace)
-    val indexTable = getOrCreateIngestionTimeIndexTable(dataset)
-    // Important: make sure nodes are in agreement before any schema changes
-    clusterMeta.checkSchemaAgreement()
-    for { ctResp    <- chunkTable.initialize() if ctResp == Success
-          ixResp    <- indexTable.initialize() if ixResp == Success
-          pkutResp  <- partitionKeysByUpdateTimeTable.initialize() if pkutResp == Success
-          partKeyTablesResp <- partKeyTablesInit.runAsync if partKeyTablesResp.forall( _ == Success)
-        } yield Success
+      val chunkTable = getOrCreateChunkTable(dataset)
+      val partitionKeysByUpdateTimeTable = getOrCreatePartitionKeysByUpdateTimeTable(dataset)
+    if (createTablesEnabled) {
+      val partKeyTablesInit = Observable.fromIterable(0.until(numShards)).map { s =>
+        getOrCreatePartitionKeysTable(dataset, s)
+      }.mapAsync(t => Task.fromFuture(t.initialize())).toListL
+      clusterConnector.createKeyspace(chunkTable.keyspace)
+      val indexTable = getOrCreateIngestionTimeIndexTable(dataset)
+      // Important: make sure nodes are in agreement before any schema changes
+      clusterMeta.checkSchemaAgreement()
+      for {ctResp <- chunkTable.initialize() if ctResp == Success
+           ixResp <- indexTable.initialize() if ixResp == Success
+           pkutResp <- partitionKeysByUpdateTimeTable.initialize() if pkutResp == Success
+           partKeyTablesResp <- partKeyTablesInit.runAsync if partKeyTablesResp.forall(_ == Success)
+      } yield Success
+    } else {
+      // ensure the table handles are eagerly created
+      0.until(numShards).foreach(getOrCreatePartitionKeysTable(dataset, _))
+      Future.successful(Success)
+    }
   }
 
   def truncate(dataset: DatasetRef, numShards: Int): Future[Response] = {

--- a/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
@@ -20,12 +20,13 @@ class CassandraMetaStore(config: Config, filoSessionProvider: Option[FiloSession
   private val ingestionConsistencyLevel = ConsistencyLevel.valueOf(config.getString("ingestion-consistency-level"))
   private val sessionProvider = filoSessionProvider.getOrElse(new DefaultFiloSessionProvider(config))
   val checkpointTable = new CheckpointTable(config, sessionProvider, ingestionConsistencyLevel)
+  private val createTablesEnabled = config.getBoolean("create-tables-enabled")
 
   val defaultKeySpace = config.getString("keyspace")
 
   def initialize(): Future[Response] = {
     checkpointTable.createKeyspace(checkpointTable.keyspace)
-    checkpointTable.initialize()
+    if (createTablesEnabled) checkpointTable.initialize() else Future.successful(Success)
   }
 
   def clearAllData(): Future[Response] = {

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -4,6 +4,7 @@ filodb {
     hosts = "localhost"
     port = 9042
     partition-list-num-groups = 1
+    create-tables-enabled = true
   }
   dataset-configs = [
     "conf/timeseries-dev-source.conf"

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -215,7 +215,13 @@ filodb {
     #      = 5MB per cass partition. Goal is to keep it under 10MB.
     pk-by-updated-time-table-num-splits = 200
 
-    pk-by-updated-time-table-num-ttl = 1 day
+    # TTL for rows in partitionkeys_by_update_time table. Ensure it is long enough to ensure that
+    # downsampler or repair migration will complete in that time
+    pk-by-updated-time-table-ttl = 3 days
+
+    # Creation of tables is enabled. Do not set to true in production to avoid
+    # multiple nodes trying to create table at once
+    create-tables-enabled = false
   }
 
   downsampler {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -15,7 +15,7 @@ filodb {
     retry-interval-max-jitter = 10s
     ingestion-consistency-level = "ONE"
     pk-by-updated-time-table-num-splits = 200
-    pk-by-updated-time-table-num-ttl = 1 day
+    pk-by-updated-time-table-ttl = 1 day
     create-tables-enabled = true
   }
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -16,7 +16,7 @@ filodb {
     ingestion-consistency-level = "ONE"
     pk-by-updated-time-table-num-splits = 200
     pk-by-updated-time-table-num-ttl = 1 day
-
+    create-tables-enabled = true
   }
 
   shard-manager {

--- a/standalone/src/main/scala/filodb.standalone/FiloServer.scala
+++ b/standalone/src/main/scala/filodb.standalone/FiloServer.scala
@@ -44,8 +44,6 @@ class FiloServer(watcher: Option[ActorRef]) extends FilodbClusterNode {
 
   lazy val config = cluster.settings.config
 
-  logger.info(s"Bootstrapping cluster with settings: ${cluster.system.settings.config.root().render()}")
-
   var filoHttpServer: FiloHttpServer = _
 
   // Now, initialize any datasets using in memory MetaStore.

--- a/standalone/src/main/scala/filodb.standalone/FiloServer.scala
+++ b/standalone/src/main/scala/filodb.standalone/FiloServer.scala
@@ -5,6 +5,7 @@ import scala.util.control.NonFatal
 
 import akka.actor.ActorRef
 import akka.cluster.Cluster
+import com.typesafe.scalalogging.StrictLogging
 
 import filodb.akkabootstrapper.AkkaBootstrapper
 import filodb.coordinator._
@@ -86,7 +87,12 @@ class FiloServer(watcher: Option[ActorRef]) extends FilodbClusterNode {
   }
 }
 
-object FiloServer {
-  def main(args: Array[String]): Unit =
-    new FiloServer().start()
+object FiloServer extends StrictLogging {
+  def main(args: Array[String]): Unit = {
+    try {
+      new FiloServer().start()
+    } catch { case e: Exception =>
+      logger.error("Could not start FiloDB server", e)
+    }
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

New tables get auto-created when server comes up. Multiple tables attempt creating same table and schema disagreement ensues on Cassandra.

**New behavior :**

Disable creation of tables. Enable auto-create only for local dev environment, and unit tests.
