### PR TITLE
misc(cassandra): Reduce PartitionKeysByUpdateTime table name length

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
@@ -17,7 +17,7 @@ sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
 
   import filodb.cassandra.Util._
 
-  val suffix = s"partitionkeys_by_update_time"
+  val suffix = s"pkeys_by_update_time"
 
   val createCql =
     s"""

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
@@ -17,7 +17,7 @@ sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
 
   import filodb.cassandra.Util._
 
-  val suffix = s"pkeys_by_update_time"
+  val suffix = s"pks_by_update_time"
 
   val createCql =
     s"""


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Expects partitionkeys_by_update_time table.

**New behavior :**
Table name is renamed to pkeys_by_update_time.

**BREAKING CHANGES**
Need to pre-create the new table pkeys_by_update_time before restarting the cluster with this change.
