### PR TITLE
misc(query): consolidate isPeriodicSeriesPlan and isRoutable

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -71,8 +71,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
     lazy val failures = failureProvider.getFailures(dsRef, routingTime).sortBy(_.timeRange.startInMillis)
 
     val tsdbQueryParams = qContext.origQueryParams
-    if (!isPeriodicSeriesPlan(logicalPlan) || // It is a raw data query
-        !logicalPlan.isRoutable ||
+    if (!logicalPlan.isRoutable ||
         !tsdbQueryParams.isInstanceOf[PromQlQueryParams] || // We don't know the promql issued (unusual)
         (tsdbQueryParams.isInstanceOf[PromQlQueryParams]
           && !tsdbQueryParams.asInstanceOf[PromQlQueryParams].processFailure) || // This is a query that was part of

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -3,7 +3,7 @@ package filodb.coordinator.queryplanner
 import filodb.query._
 
 object LogicalPlanUtils {
-  
+
   /**
     * Check whether all child logical plans have same start and end time
     */

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -3,24 +3,7 @@ package filodb.coordinator.queryplanner
 import filodb.query._
 
 object LogicalPlanUtils {
-
-  /**
-    * Check whether logical plan is a PeriodicSeriesPlan
-    */
-  def isPeriodicSeriesPlan(logicalPlan: LogicalPlan): Boolean = {
-    if (!logicalPlan.isRoutable) {
-      false
-    } else {
-      logicalPlan match {
-        case s: ScalarVectorBinaryOperation => isPeriodicSeriesPlan(s.vector)
-        case v: VectorPlan                  => isPeriodicSeriesPlan(v.scalars)
-        case i: ApplyInstantFunction        => isPeriodicSeriesPlan(i.vectors)
-        case b: BinaryJoin                  => isPeriodicSeriesPlan(b.lhs)
-        case _                              => true
-      }
-    }
-  }
-
+  
   /**
     * Check whether all child logical plans have same start and end time
     */

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/FailureProviderSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/FailureProviderSpec.scala
@@ -43,8 +43,8 @@ class FailureProviderSpec extends FunSpec with Matchers {
   val datasetRef = DatasetRef("dataset", Some("cassandra"))
 
   it("should check for PeriodicSeries plan") {
-    isPeriodicSeriesPlan(summed1) shouldEqual (true)
-    isPeriodicSeriesPlan(raw2) shouldEqual (false)
+    summed1.isRoutable shouldEqual (true)
+    raw2.isRoutable shouldEqual (false)
   }
 
   it("should extract time from logical plan") {

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -146,7 +146,7 @@ case class BinaryJoin(lhs: PeriodicSeriesPlan,
                       include: Seq[String] = Nil) extends PeriodicSeriesPlan with NonLeafLogicalPlan {
   override def children: Seq[LogicalPlan] = Seq(lhs, rhs)
 
-  override def isRoutable: Boolean = lhs.isRoutable
+  override def isRoutable: Boolean = lhs.isRoutable && rhs.isRoutable
 }
 
 /**

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -145,6 +145,8 @@ case class BinaryJoin(lhs: PeriodicSeriesPlan,
                       ignoring: Seq[String] = Nil,
                       include: Seq[String] = Nil) extends PeriodicSeriesPlan with NonLeafLogicalPlan {
   override def children: Seq[LogicalPlan] = Seq(lhs, rhs)
+
+  override def isRoutable: Boolean = lhs.isRoutable
 }
 
 /**
@@ -155,6 +157,8 @@ case class ScalarVectorBinaryOperation(operator: BinaryOperator,
                                        vector: PeriodicSeriesPlan,
                                        scalarIsLhs: Boolean) extends PeriodicSeriesPlan with NonLeafLogicalPlan {
   override def children: Seq[LogicalPlan] = Seq(vector)
+
+  override def isRoutable: Boolean = vector.isRoutable
 }
 
 /**
@@ -166,6 +170,8 @@ case class ApplyInstantFunction(vectors: PeriodicSeriesPlan,
                                 functionArgs: Seq[FunctionArgsPlan] = Nil) extends PeriodicSeriesPlan
   with NonLeafLogicalPlan {
   override def children: Seq[LogicalPlan] = Seq(vectors)
+
+  override def isRoutable: Boolean = vectors.isRoutable
 }
 
 /**
@@ -222,6 +228,8 @@ final case class ScalarFixedDoublePlan(scalar: Double,
 //scalastyle:off number.of.types
 final case class VectorPlan(scalars: ScalarPlan) extends PeriodicSeriesPlan with NonLeafLogicalPlan {
   override def children: Seq[LogicalPlan] = Seq(scalars)
+
+  override def isRoutable: Boolean = scalars.isRoutable
 }
 
 /**


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Remove isPeriodicSeriesPlan and put the logic in isRoutable