### PR TITLE
misc(Downsampler): register metric reporters for downsampler spark jobs

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerMain.scala
@@ -99,7 +99,6 @@ class Downsampler extends StrictLogging {
       .foreach { rawPartsBatch =>
         downsampleBatch(rawPartsBatch, userTimeStart, userTimeEndExclusive)
       }
-    spark.sparkContext.stop()
 
     logger.info(s"Downsampling Driver completed successfully")
   }

--- a/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerSettings.scala
@@ -4,6 +4,7 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
 import net.ceedubs.ficus.Ficus._
 
 import filodb.coordinator.{FilodbSettings, NodeClusterActor}
@@ -63,6 +64,8 @@ object DownsamplerSettings extends StrictLogging {
   val whitelist = downsamplerConfig.as[Seq[Map[String, String]]]("whitelist-filters").map(_.toSeq)
 
   val blacklist = downsamplerConfig.as[Seq[Map[String, String]]]("blacklist-filters").map(_.toSeq)
+
+  Kamon.loadReportersFromConfig() // register metric reporters
 
 }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -1,6 +1,7 @@
 package filodb.downsampler.index
 
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
@@ -29,7 +30,7 @@ class IndexJobDriver(epochHour: Long) extends StrictLogging {
       .makeRDD(0 until numShards)
       .foreach(updateDSPartKeyIndex(_, hour))
 
-    spark.sparkContext.stop()
+    Kamon.counter("index-migration-completed").increment
 
     logger.info(s"IndexUpdater Driver completed successfully")
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

- Register Kamon plugged-in metric reporters for Downsampled spark jobs
- Remove spark-context stop statement from the Driver