### PR TITLE
misc(downsampler): make index-migration batch job lookback time configurable

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -297,6 +297,13 @@ filodb {
   }
 
   ds-index-job {
+
+    # config to run one time complete partkey migration from raw cluster to downsampler cluster.
+    # This is required in the following scenarios
+    # 1. Initial refresh of partkey index to downsampler cluster
+    # 2. For fixing corrupt downsampler index
+    migrate-raw-index = false
+
     # Name of the dataset from which to downsample
     # raw-dataset-name = "prometheus"
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -302,7 +302,7 @@ filodb {
     # This is required in the following scenarios
     # 1. Initial refresh of partkey index to downsampler cluster
     # 2. For fixing corrupt downsampler index
-    migrate-raw-index = false
+    migrate-full-index = false
 
     # Name of the dataset from which to downsample
     # raw-dataset-name = "prometheus"

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -78,14 +78,14 @@ object DSIndexJob extends StrictLogging with Instance {
           partKeys = pkRecords,
           diskTTLSeconds = dsJobsettings.ttlByResolution(highestDSResolution),
           writeToPkUTTable = false), cassWriteTimeout)
-        logger.info(s"Number of partitionKeys written numPkeysWritten=$count shard=$shard hour=$epochHour")
       }
       sparkForeachTasksCompleted.increment()
       totalPartkeysUpdated.increment(count)
-      logger.info(s"Part key migration successful for shard=$shard numPartKeysWritten=$count hour=$epochHour")
+      logger.info(s"Part key migration successful for shard=$shard count=$count from=$fromHour to=$toHour")
     } catch {
       case e: Exception =>
-        logger.error(s"Exception in task count=$count shard=$shard hour=$epochHour", e)
+        logger.error(s"Exception in task count=$count " +
+          s"shard=$shard from=$fromHour to=$toHour", e)
         sparkTasksFailed.increment
         throw e
     } finally {

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -104,12 +104,11 @@ object DSIndexJob extends StrictLogging with Instance {
 
   def updateDSPartkeys(partKeys: Observable[PartKeyRecord], shard: Int): Int = {
     @volatile var count = 0
-    val pkRecords = partKeys.map(toPartkeyRecordWithHash).map{pkey => {
+    val pkRecords = partKeys.map(toPartkeyRecordWithHash).map{pkey =>
         count += 1
         logger.debug(s"migrating partition pkstring=${schemas.part.binSchema.stringify(pkey.partKey)}" +
           s" start=${pkey.startTime} end=${pkey.endTime}")
         pkey
-      }
     }
     Await.result(dsDatasource.writePartKeys(ref = dsDatasetRef, shard = shard.toInt,
       partKeys = pkRecords,

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -74,13 +74,12 @@ object DSIndexJob extends StrictLogging with Instance {
         val partKeys = rawDataSource.getPartKeysByUpdateHour(ref = rawDatasetRef,
           shard = shard.toInt, updateHour = epochHour)
         val pkRecords = partKeys.map(toPartkeyRecordWithHash).map{pkey => {
-            count += 1
-            logger.debug(s"migrating partition pkstring=${schemas.part.binSchema.stringify(pkey.partKey)}" +
-              s" start=${pkey.startTime} end=${pkey.endTime}")
-            pkey
-          }
+          count += 1
+          logger.debug(s"migrating partition pkstring=${schemas.part.binSchema.stringify(pkey.partKey)}" +
+            s" start=${pkey.startTime} end=${pkey.endTime}")
+          pkey
         }
-
+        }
         Await.result(dsDatasource.writePartKeys(ref = dsDatasetRef, shard = shard.toInt,
           partKeys = pkRecords,
           diskTTLSeconds = dsJobsettings.ttlByResolution(highestDSResolution),

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -20,7 +20,9 @@ object DSIndexJobMain extends App {
   *
   * Updates are applied sequentially between the provided hours inclusive. As the updates are incremental, if a job run
   * fails and successive runs complete successfully, migration still needs to happen from the failed batch upto the
-  * latest hour. This is to avoid any unwanted overwrites. Hence job will be submitted once to fix the failed cases.
+  * latest hour. This is to ensure that subsequent mutations were not overwritten. Hence job will be submitted once to
+  * fix the failed cases.
+  *
   * For e.g if there was a failure 12 hours ago. Job will be submitted to run once with 12 hours as lookback time to
   * fix the indexes before resuming the regular schedule.
   *

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.SparkSession
 
 object DSIndexJobMain extends App {
   import DSIndexJobSettings._
-  val migrateUpto = hour() - 1
+  val migrateUpto: Long = hour() - 1
   val iu = new IndexJobDriver(migrateUpto - batchLookbackInHours, migrateUpto) //migrate partkeys between these hours
   val sparkConf = new SparkConf(loadDefaults = true)
   iu.run(sparkConf)
@@ -32,11 +32,11 @@ class IndexJobDriver(fromHour: Long, toHour: Long) extends StrictLogging {
       .getOrCreate()
 
     logger.info(s"Spark Job Properties: ${spark.sparkContext.getConf.toDebugString}")
-    val fromHour = fromHour
-    val toHour = toHour
+    val startHour = fromHour
+    val endHour = toHour
     val rdd = spark.sparkContext
       .makeRDD(0 until numShards)
-      .foreach(updateDSPartKeyIndex(_, fromHour, toHour))
+      .foreach(updateDSPartKeyIndex(_, startHour, endHour))
 
     Kamon.counter("index-migration-completed").withoutTags().increment
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -14,6 +14,13 @@ object DSIndexJobMain extends App {
   iu.shutdown()
 }
 
+/**
+  * Migrate index updates from Raw dataset to Downsampled dataset.
+  * Updates get applied only to the dataset with highest ttl. Updates are applied sequentially between
+  * the provided hours inclusive.
+  * @param from from epoch hour - inclusive
+  * @param to to epoch hour - inclusive
+  */
 class IndexJobDriver(from: Long, to: Long) extends StrictLogging {
   import DSIndexJobSettings._
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -16,8 +16,14 @@ object DSIndexJobMain extends App {
 
 /**
   * Migrate index updates from Raw dataset to Downsampled dataset.
-  * Updates get applied only to the dataset with highest ttl. Updates are applied sequentially between
-  * the provided hours inclusive.
+  * Updates get applied only to the dataset with highest ttl.
+  *
+  * Updates are applied sequentially between the provided hours inclusive. As the updates are incremental, if a job run
+  * fails and successive runs complete successfully, migration still needs to happen from the failed batch upto the
+  * latest hour. This is to avoid any unwanted overwrites. Hence job will be submitted once to fix the failed cases.
+  * For e.g if there was a failure 12 hours ago. Job will be submitted to run once with 12 hours as lookback time to
+  * fix the indexes before resuming the regular schedule.
+  *
   * @param fromHour from epoch hour - inclusive
   * @param toHour to epoch hour - inclusive
   */

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -18,10 +18,10 @@ object DSIndexJobMain extends App {
   * Migrate index updates from Raw dataset to Downsampled dataset.
   * Updates get applied only to the dataset with highest ttl. Updates are applied sequentially between
   * the provided hours inclusive.
-  * @param from from epoch hour - inclusive
-  * @param to to epoch hour - inclusive
+  * @param fromHour from epoch hour - inclusive
+  * @param toHour to epoch hour - inclusive
   */
-class IndexJobDriver(from: Long, to: Long) extends StrictLogging {
+class IndexJobDriver(fromHour: Long, toHour: Long) extends StrictLogging {
   import DSIndexJobSettings._
 
   def run(conf: SparkConf): Unit = {
@@ -32,8 +32,8 @@ class IndexJobDriver(from: Long, to: Long) extends StrictLogging {
       .getOrCreate()
 
     logger.info(s"Spark Job Properties: ${spark.sparkContext.getConf.toDebugString}")
-    val fromHour = from
-    val toHour = to
+    val fromHour = fromHour
+    val toHour = toHour
     val rdd = spark.sparkContext
       .makeRDD(0 until numShards)
       .foreach(updateDSPartKeyIndex(_, fromHour, toHour))

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
@@ -30,8 +30,8 @@ object DSIndexJobSettings extends StrictLogging {
   val cassWriteTimeout = dsIndexJobConfig.as[FiniteDuration]("cassandra-write-timeout")
 
   // Longer lookback-time is needed to account for failures in the job runs.
-  // As the updates need to be applied incrementally, this batching gives us the buffer
-  // required to fix previous run failures.
+  // As the updates need to be applied incrementally, migration needs to happen from the failed batch until the
+  // latest hour. This is to ensure that subsequent mutations were not overwritten.
   val batchLookbackInHours = dsIndexJobConfig.as[Option[Long]]("batch-lookback-in-hours")
                                 .getOrElse(downsampleStoreConfig.flushInterval.toHours)
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
@@ -29,7 +29,7 @@ object DSIndexJobSettings extends StrictLogging {
 
   val cassWriteTimeout = dsIndexJobConfig.as[FiniteDuration]("cassandra-write-timeout")
 
-  val migrateRawIndex = dsIndexJobConfig.getBoolean("migrate-raw-index")
+  val migrateRawIndex = dsIndexJobConfig.getBoolean("migrate-full-index")
 
   // Longer lookback-time is needed to account for failures in the job runs.
   // As the updates need to be applied incrementally, migration needs to happen from the failed batch until the

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
@@ -28,6 +28,9 @@ object DSIndexJobSettings extends StrictLogging {
 
   val cassWriteTimeout = dsIndexJobConfig.as[FiniteDuration]("cassandra-write-timeout")
 
+  //default 6hours
+  val batchLookbackInHours = dsIndexJobConfig.as[Option[Int]]("batch-lookback-in-hours").getOrElse(6)
+
   val numShards = filodbSettings.streamConfigs
     .find(_.getString("dataset") == DownsamplerSettings.rawDatasetName)
     .headOption.getOrElse(ConfigFactory.empty())

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
@@ -32,7 +32,7 @@ object DSIndexJobSettings extends StrictLogging {
   // Longer lookback-time is needed to account for failures in the job runs.
   // As the updates need to be applied incrementally, this batching gives us the buffer
   // required to fix previous run failures.
-  val batchLookbackInHours = dsIndexJobConfig.as[Option[Int]]("batch-lookback-in-hours")
+  val batchLookbackInHours = dsIndexJobConfig.as[Option[Long]]("batch-lookback-in-hours")
                                 .getOrElse(downsampleStoreConfig.flushInterval.toHours)
 
   val numShards = filodbSettings.streamConfigs

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
@@ -29,6 +29,8 @@ object DSIndexJobSettings extends StrictLogging {
 
   val cassWriteTimeout = dsIndexJobConfig.as[FiniteDuration]("cassandra-write-timeout")
 
+  val migrateRawIndex = dsIndexJobConfig.getBoolean("migrate-raw-index")
+
   // Longer lookback-time is needed to account for failures in the job runs.
   // As the updates need to be applied incrementally, migration needs to happen from the failed batch until the
   // latest hour. This is to ensure that subsequent mutations were not overwritten.

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
@@ -33,7 +33,7 @@ object DSIndexJobSettings extends StrictLogging {
   // As the updates need to be applied incrementally, migration needs to happen from the failed batch until the
   // latest hour. This is to ensure that subsequent mutations were not overwritten.
   val batchLookbackInHours = dsIndexJobConfig.as[Option[Long]]("batch-lookback-in-hours")
-                                .getOrElse(downsampleStoreConfig.flushInterval.toHours)
+    .getOrElse(downsampleStoreConfig.flushInterval.toHours)
 
   val numShards = filodbSettings.streamConfigs
     .find(_.getString("dataset") == DownsamplerSettings.rawDatasetName)
@@ -42,4 +42,3 @@ object DSIndexJobSettings extends StrictLogging {
 
   def hour(millis: Long = System.currentTimeMillis()): Long = millis / 1000 / 60 / 60
 }
-

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -67,8 +67,9 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   val lastSampleTime = 1574273042000L
   val downsampler = new Downsampler
 
-  //Run for current hour for testing, actual job migrates previous hour's index updates
-  val indexUpdater = new IndexJobDriver(hour())
+  //Index migration job, runs for current 2hours for testing. actual job migrates last 6 hour's index updates
+  val currentHour = hour()
+  val indexUpdater = new IndexJobDriver(currentHour - 2, currentHour)
 
   def partKeyReader(pkr: PartKeyRecord): Seq[(String, String)] = {
     schemas.part.binSchema.toStringPairs(pkr.partKey, UnsafeUtils.arayOffset)


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

- changes to Index migration job
    - to make look-back time configurable. Index updates are applied incrementally/sequantially fro m earliest hour.
    - add a config flag to enable complete index refresh from raw cluster to data sampler clusters. This is needed for initial migration when downsampler is enabled as well as to fix corrupt downsampler index.