### PR TITLE
feat(cassandra): Add method to copy chunks to a different C* column store.

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -235,7 +235,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     val sourceChunksTable = getOrCreateChunkTable(datasetRef)
 
     val targetIndexTable = target.getOrCreateIngestionTimeIndexTable(targetDatasetRef)
-    val targetChunksTable = target.getOrCreateChunkTable(datasetRef)
+    val targetChunksTable = target.getOrCreateChunkTable(targetDatasetRef)
 
     val chunkInfos = new ArrayBuffer[ByteBuffer]()
     val futures = new ArrayBuffer[Future[Response]]()

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -241,7 +241,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     val futures = new ArrayBuffer[Future[Response]]()
 
     def finishBatch(partition: ByteBuffer): Unit = {
-      for (row <- sourceChunksTable.readChunks(partition, chunkInfos).iterator.asScala) {
+      for (row <- sourceChunksTable.readChunksNoAsync(partition, chunkInfos).iterator.asScala) {
         futures += targetChunksTable.writeChunks(partition, row, diskTimeToLiveSeconds)
       }
 
@@ -264,7 +264,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
 
     for (split <- splits) {
       val tokens = split.asInstanceOf[CassandraTokenRangeSplit].tokens
-      val rows = sourceIndexTable.scanRowsByIngestionTime(tokens, ingestionTimeStart, ingestionTimeEnd)
+      val rows = sourceIndexTable.scanRowsByIngestionTimeNoAsync(tokens, ingestionTimeStart, ingestionTimeEnd)
       for (row <- rows) {
         val partition = row.getBytes(0) // partition
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -44,7 +44,7 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
   /**
     * Test method which returns all rows for a partition. Not async-friendly.
     */
-  def readAllRows(partKeyBytes: ByteBuffer): ResultSet = {
+  def readAllRowsNoAsync(partKeyBytes: ByteBuffer): ResultSet = {
     session.execute(allCql.bind().setBytes(0, partKeyBytes))
   }
 
@@ -60,9 +60,9 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
     *
     * Note: This method is intended for use by repair jobs and isn't async-friendly.
     */
-  def scanRowsByIngestionTime(tokens: Seq[(String, String)],
-                              ingestionTimeStart: Long,
-                              ingestionTimeEnd: Long): Iterator[Row] = {
+  def scanRowsByIngestionTimeNoAsync(tokens: Seq[(String, String)],
+                                     ingestionTimeStart: Long,
+                                     ingestionTimeEnd: Long): Iterator[Row] = {
     def cql(start: String, end: String): String =
       s"SELECT partition, ingestion_time, start_time, info FROM $tableString " +
       s"WHERE TOKEN(partition) >= $start AND TOKEN(partition) < $end " +

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -10,11 +10,6 @@ import monix.reactive.Observable
 import filodb.cassandra.FiloCassandraConnector
 import filodb.core._
 import filodb.core.store.ChunkSinkStats
-import filodb.memory.format.UnsafeUtils
-
-case class InfoRecord(binPartition: ByteBuffer, data: ByteBuffer) {
-  def partBaseOffset: (Any, Long, Int) = UnsafeUtils.BOLfromBuffer(binPartition)
-}
 
 /**
  * Mapping to chunk set info records using a full ingestion time, positioned in the cluster key
@@ -41,37 +36,32 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
                      |) WITH compression = {
                     'sstable_compression': '$sstableCompression'}""".stripMargin
 
-  def fromRow(row: Row): InfoRecord =
-    InfoRecord(row.getBytes("partition"), row.getBytes("info"))
-
   val selectCql = s"SELECT partition, info FROM $tableString WHERE "
   lazy val allPartReadCql = session.prepare(selectCql + "partition = ?")
   lazy val inPartReadCql = session.prepare(selectCql + "partition IN ?")
 
   /**
-   * Retrieves all infos from a single partition.
-   */
-  def getInfos(binPartition: Array[Byte]): Observable[InfoRecord] = {
-    val it = session.execute(allPartReadCql.bind(toBuffer(binPartition)))
-                    .asScala.toIterator.map(fromRow)
-    Observable.fromIterator(it).handleObservableErrors
-  }
-
-  def getMultiInfos(partitions: Seq[Array[Byte]]): Observable[InfoRecord] = {
-    val query = inPartReadCql.bind().setList(0, partitions.map(toBuffer).asJava, classOf[ByteBuffer])
-    val it = session.execute(query).asScala.toIterator.map(fromRow)
-    Observable.fromIterator(it).handleObservableErrors
-  }
-
-  def scanInfos(tokens: Seq[(String, String)]): Observable[InfoRecord] = {
+    * Returns Rows consisting of:
+    *
+    * partition:      ByteBuffer
+    * ingestion_time: long
+    * start_time:     long
+    * info:           ByteBuffer
+    *
+    * The ChunkSetInfo object contains methods for extracting fields from the info column.
+    */
+  def scanRowsByIngestionTime(tokens: Seq[(String, String)],
+                              ingestionTimeStart: Long,
+                              ingestionTimeEnd: Long): Iterator[Row] = {
     def cql(start: String, end: String): String =
-      s"SELECT * FROM $tableString WHERE TOKEN(partition) >= $start AND TOKEN(partition) < $end " +
+      s"SELECT partition, ingestion_time, start_time, info FROM $tableString " +
+      s"WHERE TOKEN(partition) >= $start AND TOKEN(partition) < $end " +
+      s"AND ingestion_time >= $ingestionTimeStart AND ingestion_time <= $ingestionTimeEnd " +
       s"ALLOW FILTERING"
-    val it = tokens.iterator.flatMap { case (start, end) =>
-        session.execute(cql(start, end)).iterator.asScala
-               .map { row => fromRow(row) }
-      }
-    Observable.fromIterator(it).handleObservableErrors
+
+    tokens.iterator.flatMap { case (start, end) =>
+      session.execute(cql(start, end)).iterator.asScala
+    }
   }
 
   def scanPartKeysByIngestionTime(tokens: Seq[(String, String)],
@@ -116,5 +106,19 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
     }
     stats.addIndexWriteStats(infoBytes)
     connector.execStmtWithRetries(unloggedBatch(statements).setConsistencyLevel(ConsistencyLevel.ONE))
+  }
+
+  /**
+    * Writes a single record, exactly as-is from the scanInfosByIngestionTime method. Is
+    * used to copy records from one column store to another.
+    */
+  def writeIndex(row: Row, diskTimeToLiveSeconds: Int): Future[Response] = {
+    connector.execStmtWithRetries(writeIndexCql.bind(
+      row.getBytes(0),                // partition
+      row.getLong(1): java.lang.Long, // ingestion_time
+      row.getLong(2): java.lang.Long, // start_time
+      row.getBytes(3),                // info
+      diskTimeToLiveSeconds: java.lang.Integer)
+    )
   }
 }

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -42,7 +42,7 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
     .setConsistencyLevel(ConsistencyLevel.ONE)
 
   /**
-    * Test method which returns all rows for a partition.
+    * Test method which returns all rows for a partition. Not async-friendly.
     */
   def readAllRows(partKeyBytes: ByteBuffer): ResultSet = {
     session.execute(allCql.bind().setBytes(0, partKeyBytes))
@@ -57,6 +57,8 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
     * info:           ByteBuffer
     *
     * The ChunkSetInfo object contains methods for extracting fields from the info column.
+    *
+    * Note: This method is intended for use by repair jobs and isn't async-friendly.
     */
   def scanRowsByIngestionTime(tokens: Seq[(String, String)],
                               ingestionTimeStart: Long,

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -62,6 +62,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
                                       .setList(3, chunkList, classOf[ByteBuffer])
                                       .setInt(4, diskTimeToLive)
     stats.addChunkWriteStats(chunks.length, chunkBytes, chunkInfo.numRows)
+    System.out.print(insert + ", " + Thread.currentThread() + "\n")
     connector.execStmtWithRetries(insert.setConsistencyLevel(writeConsistencyLevel))
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -122,8 +122,8 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
     *
     * Note: This method is intended for use by repair jobs and isn't async-friendly.
     */
-  def readChunks(partKeyBytes: ByteBuffer,
-                 chunkInfos: Seq[ByteBuffer]): ResultSet = {
+  def readChunksNoAsync(partKeyBytes: ByteBuffer,
+                        chunkInfos: Seq[ByteBuffer]): ResultSet = {
     val query = readChunksCql.bind().setBytes(0, partKeyBytes)
                                     .setList(1, chunkInfos.map(ChunkSetInfo.getChunkID).asJava)
     session.execute(query)
@@ -136,7 +136,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
   /**
     * Test method which returns the same results as the readChunks method. Not async-friendly.
     */
-  def readAllChunks(partKeyBytes: ByteBuffer): ResultSet = {
+  def readAllChunksNoAsync(partKeyBytes: ByteBuffer): ResultSet = {
     session.execute(readAllChunksCql.bind().setBytes(0, partKeyBytes))
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -119,6 +119,8 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
     * chunkid: Long
     * info:    ByteBuffer
     * chunks:  List<ByteBuffer>
+    *
+    * Note: This method is intended for use by repair jobs and isn't async-friendly.
     */
   def readChunks(partKeyBytes: ByteBuffer,
                  chunkInfos: Seq[ByteBuffer]): ResultSet = {
@@ -132,7 +134,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
     .setConsistencyLevel(ConsistencyLevel.ONE)
 
   /**
-    * Test method which returns the same results as the readChunks method.
+    * Test method which returns the same results as the readChunks method. Not async-friendly.
     */
   def readAllChunks(partKeyBytes: ByteBuffer): ResultSet = {
     session.execute(readAllChunksCql.bind().setBytes(0, partKeyBytes))

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -100,15 +100,15 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
     val part1Bytes = ByteBuffer.wrap(BinaryRegionLarge.asNewByteArray(partKey1))
     val part2Bytes = ByteBuffer.wrap(BinaryRegionLarge.asNewByteArray(partKey2))
 
-    val expectChunks1 = colStore.getOrCreateChunkTable(dataset.ref).readAllChunks(part1Bytes).all()
+    val expectChunks1 = colStore.getOrCreateChunkTable(dataset.ref).readAllChunksNoAsync(part1Bytes).all()
     expectChunks1 should have size (9)
-    val expectChunks2 = colStore.getOrCreateChunkTable(dataset.ref).readAllChunks(part2Bytes).all()
+    val expectChunks2 = colStore.getOrCreateChunkTable(dataset.ref).readAllChunksNoAsync(part2Bytes).all()
     expectChunks2 should have size (11)
 
     // Expect 0 chunk records in the target at this point.
-    var chunks1 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunks(part1Bytes).all()
+    var chunks1 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunksNoAsync(part1Bytes).all()
     chunks1 should have size (0)
-    var chunks2 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunks(part2Bytes).all()
+    var chunks2 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunksNoAsync(part2Bytes).all()
     chunks2 should have size (0)
 
     colStore.copyChunksByIngestionTimeRange(
@@ -139,19 +139,19 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
       }
     }
 
-    chunks1 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunks(part1Bytes).all()
+    chunks1 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunksNoAsync(part1Bytes).all()
     checkRows(expectChunks1, chunks1)
-    chunks2 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunks(part2Bytes).all()
+    chunks2 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunksNoAsync(part2Bytes).all()
     checkRows(expectChunks2, chunks2)
 
-    val expectIndex1 = colStore.getOrCreateIngestionTimeIndexTable(dataset.ref).readAllRows(part1Bytes).all()
+    val expectIndex1 = colStore.getOrCreateIngestionTimeIndexTable(dataset.ref).readAllRowsNoAsync(part1Bytes).all()
     expectIndex1 should have size (9)
-    val expectIndex2 = colStore.getOrCreateIngestionTimeIndexTable(dataset.ref).readAllRows(part2Bytes).all()
+    val expectIndex2 = colStore.getOrCreateIngestionTimeIndexTable(dataset.ref).readAllRowsNoAsync(part2Bytes).all()
     expectIndex2 should have size (11)
 
-    val index1 = colStore.getOrCreateIngestionTimeIndexTable(targetDataset.ref).readAllRows(part1Bytes).all()
+    val index1 = colStore.getOrCreateIngestionTimeIndexTable(targetDataset.ref).readAllRowsNoAsync(part1Bytes).all()
     checkRows(expectIndex1, index1)
-    val index2 = colStore.getOrCreateIngestionTimeIndexTable(targetDataset.ref).readAllRows(part2Bytes).all()
+    val index2 = colStore.getOrCreateIngestionTimeIndexTable(targetDataset.ref).readAllRowsNoAsync(part2Bytes).all()
     checkRows(expectIndex2, index2)
   }
 

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -2,9 +2,18 @@ package filodb.cassandra.columnstore
 
 import scala.concurrent.duration._
 
+import java.lang.ref.Reference
+import java.nio.ByteBuffer
+
 import com.typesafe.config.ConfigFactory
+import monix.reactive.Observable
 
 import filodb.core._
+import filodb.core.binaryrecord2.RecordBuilder
+import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.ZeroCopyUTF8String._
+import filodb.core.metadata.{Dataset, Schemas}
+import filodb.core.store.{ChunkSet, ChunkSetInfo}
 import filodb.core.store.ColumnStoreSpec
 import filodb.cassandra.metastore.CassandraMetaStore
 
@@ -30,6 +39,67 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
       split.tokens.head._1 should not equal (split.tokens.head._2)
       split.replicas.size should equal (1)
     }
+  }
+
+  "copyChunksByIngestionTimeRange" should "actually work" in {
+    val dataset = Dataset("source", Schemas.gauge)
+    val targetDataset = Dataset("target", Schemas.gauge)
+
+    colStore.initialize(dataset.ref, 1).futureValue
+    colStore.truncate(dataset.ref, 1).futureValue
+
+    colStore.initialize(targetDataset.ref, 1).futureValue
+    colStore.truncate(targetDataset.ref, 1).futureValue
+
+    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8, "_ns_".utf8 -> "my_ns".utf8)
+
+    val partBuilder = new RecordBuilder(TestData.nativeMem)
+    val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, "stuff", seriesTags)
+
+    val infoBuf = ByteBuffer.allocateDirect(100)
+    val infoPtr = UnsafeUtils.addressFromDirectBuffer(infoBuf)
+    val info = ChunkSetInfo(infoPtr)
+    try {
+      infoBuf.clear()
+
+      // FIXME final def chunkID(startTime: Long, ingestionTime: Long): Long
+
+      ChunkSetInfo.setChunkID(infoPtr, 0) // FIXME
+      ChunkSetInfo.setIngestionTime(infoPtr, 0) // FIXME
+      ChunkSetInfo.setNumRows(infoPtr, 10) // FIXME (just keep lying?)
+      ChunkSetInfo.setEndTime(infoPtr, 10) // FIXME
+
+      val set = ChunkSet(info, partKey, Nil, Nil) // FIXME: last is chunks: Seq[ByteBuffer]
+
+      System.out.print("yo\n")
+      colStore.write(dataset.ref, Observable.fromIterable(Iterable(set))).futureValue
+      System.out.print("yo!\n")
+    } finally {
+      // Ensure that GC doesn't reclaim the native memory too soon.
+      Reference.reachabilityFence(infoBuf)
+    }
+
+    colStore.copyChunksByIngestionTimeRange(
+      dataset.ref,
+      colStore.getScanSplits(dataset.ref).iterator,
+      0,
+      0,
+      1,
+      colStore,
+      targetDataset.ref,
+      1)
+
+    /*
+    colStore.copyChunksByIngestionTimeRange(
+      datasetRef,
+      splits: Iterator[ScanSplit],
+      ingestionTimeStart: Long,
+      ingestionTimeEnd: Long,
+      batchSize: Int,
+      target: CassandraColumnStore,
+      targetDatasetRef: DatasetRef,
+      diskTimeToLiveSeconds: Int)
+     */
   }
 
   val configWithChunkCompress = ConfigFactory.parseString("cassandra.lz4-chunk-compress = true")

--- a/core/src/main/scala/filodb.core/Perftools.scala
+++ b/core/src/main/scala/filodb.core/Perftools.scala
@@ -44,7 +44,7 @@ object Perftools {
                        library: String = "filodb_core")
                       (code: => Future[T])
                       (implicit ec: ExecutionContext): Future[T] = {
-    val span = Kamon.buildSpan(s"$library.$category.$name").start()
+    val span = Kamon.spanBuilder(s"$library.$category.$name").asChildOf(Kamon.currentSpan()).start()
     // This assignment actually resolves the lazy parameter!!! Make sure it's only done once.
     val result: Future[T] = code
     result.onComplete { case _ => span.finish() }

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -164,7 +164,9 @@ object ChunkSetInfo extends StrictLogging {
 
   def getNumRows(infoAcc: MemoryReader, infoAddr: Long): Int = infoAcc.getInt(infoAddr + OffsetNumRows)
 
-  def resetNumRows(infoPointer: NativePointer): Unit = UnsafeUtils.setInt(infoPointer + OffsetNumRows, 0)
+  def setNumRows(infoPointer: NativePointer, num: Int): Unit = UnsafeUtils.setInt(infoPointer + OffsetNumRows, num)
+
+  def resetNumRows(infoPointer: NativePointer): Unit = setNumRows(infoPointer, 0);
 
   def incrNumRows(infoPointer: NativePointer): Unit =
     UnsafeUtils.unsafe.getAndAddInt(UnsafeUtils.ZeroPointer, infoPointer + OffsetNumRows, 1)

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -185,23 +185,25 @@ object ChunkSetInfo extends StrictLogging {
   def setVectorPtr(infoPointer: NativePointer, colNo: Int, vector: BinaryVector.BinaryVectorPtr): Unit =
     UnsafeUtils.setLong(infoPointer + OffsetVectors + 8 * colNo, vector)
 
-  // deprecated - Use reader api instead TODO remove this API
-  def getNumRows(infoBytes: Array[Byte]): Int = UnsafeUtils.getInt(infoBytes, UnsafeUtils.arayOffset + OffsetNumRows)
+  def getNumRows(info: ByteBuffer): Int = getNumRows(fromByteBuffer(info), 0)
 
-  // deprecated - Use reader api instead TODO remove this API
-  def getChunkID(infoBytes: Array[Byte]): ChunkID =
-    UnsafeUtils.getLong(infoBytes, UnsafeUtils.arayOffset + OffsetChunkID)
+  def getChunkID(info: ByteBuffer): ChunkID = getChunkID(fromByteBuffer(info), 0)
 
-  // deprecated - Use reader api instead TODO remove this API
-  def getIngestionTime(infoBytes: Array[Byte]): Long =
-    UnsafeUtils.getLong(infoBytes, UnsafeUtils.arayOffset + OffsetIngestionTime)
+  def getIngestionTime(info: ByteBuffer): Long = getIngestionTime(fromByteBuffer(info), 0)
 
-  // deprecated - Use reader api instead TODO remove this API
-  def getStartTime(infoBytes: Array[Byte]): Long = startTimeFromChunkID(getChunkID(infoBytes))
+  def getStartTime(info: ByteBuffer): Long = startTimeFromChunkID(getChunkID(info))
 
-  // deprecated - Use reader api instead TODO remove this API
-  def getEndTime(infoBytes: Array[Byte]): Long =
-    UnsafeUtils.getLong(infoBytes, UnsafeUtils.arayOffset + OffsetEndTime)
+  def getEndTime(info: ByteBuffer): Long = getEndTime(fromByteBuffer(info), 0)
+
+  def getNumRows(info: Array[Byte]): Int = getNumRows(fromArray(info), 0)
+
+  def getChunkID(info: Array[Byte]): ChunkID = getChunkID(fromArray(info), 0)
+
+  def getIngestionTime(info: Array[Byte]): Long = getIngestionTime(fromArray(info), 0)
+
+  def getStartTime(info: Array[Byte]): Long = startTimeFromChunkID(getChunkID(info))
+
+  def getEndTime(info: Array[Byte]): Long = getEndTime(fromArray(info), 0)
 
   /**
    * Copies the non-vector-pointer portion of ChunkSetInfo


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This is the first step for supporting a spark job which can copy chunks (and the ingestion time index) to another C* cluster or keyspace. This will make it possible to perform disaster recovery and backfilling.
