### PR TITLE
Downsample stitch fix

### DIFF
--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -44,11 +44,17 @@ final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
   import Column.ColumnType._
 
   def length: Int = columns.length
-  def isTimeSeries: Boolean = columns.length >= 1 && numRowKeyColumns == 1 &&
+  def isTimeSeries: Boolean = columns.nonEmpty && numRowKeyColumns == 1 &&
                               (columns.head.colType == LongColumn || columns.head.colType == TimestampColumn)
   // True if main col is Histogram and extra column is a Double
   def isHistDouble: Boolean = columns.length == 3 &&
                               columns(1).colType == HistogramColumn && columns(2).colType == DoubleColumn
+
+  def hasSameColumnsAs(other: ResultSchema): Boolean = {
+    // exclude fixedVectorLen
+    other.columns == columns && other.numRowKeyColumns == numRowKeyColumns &&
+      other.brSchemas == brSchemas && other.colIDs == colIDs
+  }
 }
 
 object ResultSchema {

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -396,7 +396,7 @@ abstract class NonLeafExecPlan extends ExecPlan {
     var sch = ResultSchema.empty
     val processedTasks = childTasks.collect {
       case (res @ QueryResult(_, schema, _), i) if schema != ResultSchema.empty =>
-        sch = reduceSchemas(sch, res, i.toInt)
+        sch = reduceSchemas(sch, res)
         (res, i.toInt)
       case (e: QueryError, i) =>
         (e, i.toInt)
@@ -418,7 +418,7 @@ abstract class NonLeafExecPlan extends ExecPlan {
    * Can be overridden if needed.
    * @param rs the ResultSchema from previous calls to reduceSchemas / previous child nodes.  May be empty for first.
    */
-  def reduceSchemas(rs: ResultSchema, resp: QueryResult, i: Int): ResultSchema = {
+  def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
     resp match {
       case QueryResult(_, schema, _) if rs == ResultSchema.empty =>
         schema     /// First schema, take as is

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable
 import monix.eval.Task
 import monix.reactive.Observable
 
+import filodb.core.memstore.SchemaMismatch
 import filodb.core.query._
 import filodb.memory.format.RowReader
 import filodb.query._
@@ -80,6 +81,20 @@ final case class StitchRvsExec(id: String,
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten
   }
+
+  // overriden since stitch can reduce schemas with different vector lengths as long as the columns are same
+  override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
+    resp match {
+      case QueryResult(_, schema, _) if rs == ResultSchema.empty =>
+        schema     /// First schema, take as is
+      case QueryResult(_, schema, _) =>
+        if (!rs.hasSameColumnsAs(schema)) throw SchemaMismatch(rs.toString, schema.toString)
+        val fixedVecLen = if (rs.fixedVectorLen.isEmpty && schema.fixedVectorLen.isEmpty) None
+                          else Some(rs.fixedVectorLen.getOrElse(0) + schema.fixedVectorLen.getOrElse(0))
+        rs.copy(fixedVectorLen = fixedVecLen)
+    }
+  }
+
 }
 
 /**

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -1,9 +1,13 @@
 package filodb.query.exec
 
-import filodb.core.query.TransientRow
-
+import filodb.core.query.{ColumnInfo, ResultSchema, TransientRow}
 import scala.annotation.tailrec
+
 import org.scalatest.{FunSpec, Matchers}
+
+import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
+import filodb.memory.format.UnsafeUtils
+import filodb.query.QueryResult
 
 // scalastyle:off null
 class StitchRvsExecSpec extends FunSpec with Matchers {
@@ -91,6 +95,23 @@ class StitchRvsExecSpec extends FunSpec with Matchers {
     mergeAndValidate(rvs, expected)
   }
 
+  it ("should reduce result schemas with different fixedVecLengths without error") {
+
+    // null needed below since there is a require in code that prevents empty children
+    val exec = StitchRvsExec("someId", InProcessPlanDispatcher, Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
+
+    val rs1 = ResultSchema(List(ColumnInfo("timestamp",
+      TimestampColumn), ColumnInfo("value", DoubleColumn)), 1, Map(), Some(430), List(0, 1))
+    val rs2 = ResultSchema(List(ColumnInfo("timestamp",
+      TimestampColumn), ColumnInfo("value", DoubleColumn)), 1, Map(), Some(147), List(0, 1))
+
+    val reduced = exec.reduceSchemas(rs1, QueryResult("someId", rs2, Seq.empty))
+    reduced.columns shouldEqual rs1.columns
+    reduced.numRowKeyColumns shouldEqual rs1.numRowKeyColumns
+    reduced.brSchemas shouldEqual rs1.brSchemas
+    reduced.fixedVectorLen shouldEqual Some(430 + 147)
+    reduced.colIDs shouldEqual rs1.colIDs
+  }
 
   it ("should merge with no overlap correctly") {
     val rvs = Seq (

--- a/spark-jobs/src/main/scala/filodb/downsampler/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/BatchDownsampler.scala
@@ -45,7 +45,6 @@ object BatchDownsampler extends StrictLogging with Instance {
   val numBatchesCompleted = Kamon.counter("num-batches-completed").withoutTags()
   val numBatchesFailed = Kamon.counter("num-batches-failed").withoutTags()
   val numPartitionsEncountered = Kamon.counter("num-partitions-encountered").withoutTags()
-  val numPartitionsDownsampled = Kamon.counter("num-partitions-downsampled").withoutTags()
   val numPartitionsBlacklisted = Kamon.counter("num-partitions-blacklisted").withoutTags()
   val numPartitionsCompleted = Kamon.counter("num-partitions-completed").withoutTags()
   val numPartitionsFailed = Kamon.counter("num-partitions-failed").withoutTags()


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Got exception when stitching raw/downsampled data:

```filodb.core.memstore.SchemaMismatch: Multiple schemas found, please filter. Expected schema ResultSchema(List(ColumnInfo(timestamp,TimestampColumn), ColumnInfo(value,DoubleColumn)),1,Map(),Some(430),List(0, 1)), found schema ResultSchema(List(ColumnInfo(timestamp,TimestampColumn), ColumnInfo(value,DoubleColumn)),1,Map(),Some(147),List(0, 1))```

Notice that the only attribute different in schema is fixedVectorLen

**New behavior :**

Override reduceSchema method for StitchRvsExec and omit vector length comparison