### PR TITLE
bug(query): Wrong retention was configured in QueryActor for downsample cluster

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -168,7 +168,7 @@ private[filodb] final class IngestionActor(ref: DatasetRef,
     }
 
     implicit val futureMapDispatcher: ExecutionContext = actorDispatcher
-    val ingestion = if (memStore.isReadOnly) {
+    val ingestion = if (memStore.isDownsampleStore) {
       logger.info(s"Initiating shard startup on read-only memstore for dataset=$ref shard=$shard")
       for {
         _ <- memStore.recoverIndex(ref, shard)

--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -61,13 +61,6 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
   var statusActor: Option[ActorRef] = None
   var datasetsInitialized = false
 
-  val filodbConfig = settings.allConfig.getConfig("filodb")
-  val downsamplerConfig = filodbConfig.getConfig("downsampler")
-  // Tech Debt TODO: Move downsample store config section out from
-  // server config into raw store config. Everything should come from
-  // store config since it can change per-dataset
-  val downsampleStoreConfig = StoreConfig(downsamplerConfig.getConfig("downsample-store-config"))
-
   private val statusAckTimeout = settings.config.as[FiniteDuration]("tasks.timeouts.status-ack-timeout")
 
   // By default, stop children IngestionActors when something goes wrong.
@@ -164,7 +157,7 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
 
         logger.info(s"Creating QueryActor for dataset $ref")
         def earliestRawTimestampFn = if (memStore.isReadOnly) {
-          System.currentTimeMillis() - downsampleStoreConfig.diskTTLSeconds * 1000
+          System.currentTimeMillis() - downsample.ttls.last.toMillis
         } else {
           System.currentTimeMillis() - storeConf.diskTTLSeconds * 1000
         }

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -85,7 +85,7 @@ final class QueryActor(memStore: MemStore,
 
   logger.info(s"Starting QueryActor and QueryEngine for ds=$dsRef schemas=$schemas")
   val queryPlanner = new SingleClusterPlanner(dsRef, schemas, shardMapFunc,
-                                              functionalSpreadProvider, earliestRawTimestampFn)
+                                              earliestRawTimestampFn, functionalSpreadProvider)
   val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
   val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor") * sys.runtime.availableProcessors)
   val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName-$dsRef", numSchedThreads.toInt)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/CompositePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/CompositePlanner.scala
@@ -27,9 +27,9 @@ class CompositePlanner(dsRef: DatasetRef,
 
   // Note the composition of query planners below using decorator pattern
   val rawClusterPlanner = new SingleClusterPlanner(dsRef, schemas, shardMapperFunc,
-                                  spreadProvider, earliestRawTimestampFn)
+                                  earliestRawTimestampFn, spreadProvider)
   val downsampleClusterPlanner = new SingleClusterPlanner(dsRef, schemas, downsampleMapperFunc,
-                                  spreadProvider, earliestDownsampleTimestampFn)
+                                  earliestDownsampleTimestampFn, spreadProvider)
   val longTimeRangePlanner = new LongTimeRangePlanner(rawClusterPlanner, downsampleClusterPlanner,
                                           earliestRawTimestampFn, stitchDispatcher)
   val haPlanner = new HighAvailabilityPlanner(dsRef, longTimeRangePlanner, failureProvider, queryEngineConfig)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -2,8 +2,6 @@ package filodb.coordinator.queryplanner
 
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.concurrent.duration._
-
 import akka.actor.ActorRef
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
@@ -35,8 +33,8 @@ object SingleClusterPlanner {
 class SingleClusterPlanner(dsRef: DatasetRef,
                            schemas: Schemas,
                            shardMapperFunc: => ShardMapper,
-                           spreadProvider: SpreadProvider = StaticSpreadProvider(),
-                           earliestRetainedTimestampFn: => Long = { System.currentTimeMillis - 3.days.toMillis})
+                           earliestRetainedTimestampFn: => Long,
+                           spreadProvider: SpreadProvider = StaticSpreadProvider())
                                 extends QueryPlanner with StrictLogging {
 
   private val dsOptions = schemas.part.options

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -172,7 +172,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val mapper = new ShardMapper(1)
     mapper.registerNode(Seq(0), node0)
     def mapperRef: ShardMapper = mapper
-    val engine = new SingleClusterPlanner(dataset.ref, Schemas.global, mapperRef)
+    val engine = new SingleClusterPlanner(dataset.ref, Schemas.global, mapperRef, 0)
     val f1 = Seq(ColumnFilter("__name__", Filter.Equals("http_request_duration_seconds_bucket")),
       ColumnFilter("job", Filter.Equals("myService")),
       ColumnFilter("le", Filter.Equals("0.3")),
@@ -211,7 +211,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val to = System.currentTimeMillis() / 1000
     val from = to - 50
     val qParams = TimeStepParams(from, 10, to)
-    val engine = new SingleClusterPlanner(dataset.ref, Schemas.global, mapperRef)
+    val engine = new SingleClusterPlanner(dataset.ref, Schemas.global, mapperRef, 0)
 
     val logicalPlan1 = Parser.queryRangeToLogicalPlan(
       s"""sum(rate(http_request_duration_seconds_bucket{job="prometheus",$shardKeyStr}[20s])) by (handler)""",
@@ -240,7 +240,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val to = System.currentTimeMillis() / 1000
     val from = to - 50
     val qParams = TimeStepParams(from, 10, to)
-    val engine = new SingleClusterPlanner(dataset.ref, Schemas.global, mapperRef)
+    val engine = new SingleClusterPlanner(dataset.ref, Schemas.global, mapperRef, 0)
 
     // with column filters having shardcolumns
     val logicalPlan1 = Parser.metadataQueryToLogicalPlan(

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -155,7 +155,7 @@ class SingleClusterPlannerSpec extends FunSpec with Matchers {
     // Custom SingleClusterPlanner with different dataset with different metric name
     val datasetOpts = dataset.options.copy(metricColumn = "kpi", shardKeyColumns = Seq("kpi", "job"))
     val dataset2 = dataset.modify(_.schema.partition.options).setTo(datasetOpts)
-    val engine2 = new SingleClusterPlanner(dataset2.ref, Schemas(dataset2.schema), mapperRef)
+    val engine2 = new SingleClusterPlanner(dataset2.ref, Schemas(dataset2.schema), mapperRef, 0)
 
     // materialized exec plan
     val execPlan = engine2.materialize(raw2, QueryContext(origQueryParams = promQlQueryParams))

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -28,7 +28,7 @@ extends MemStore with StrictLogging {
 
   val stats = new ChunkSourceStats
 
-  override def isReadOnly: Boolean = true
+  override def isDownsampleStore: Boolean = true
 
   override def metastore: MetaStore = ??? // Not needed
 

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -41,7 +41,11 @@ final case class FlushError(err: ErrorResponse) extends Exception(s"Flush error 
  */
 trait MemStore extends ChunkSource {
 
-  def isReadOnly: Boolean
+  /**
+    * True if this store is in the mode of serving downsampled data.
+    * This is used to switch ingestion and query behaviors for downsample cluster.
+    */
+  def isDownsampleStore: Boolean
 
   /**
     * Persistent column store. Ingested data will eventually be poured into this sink for persistence, and

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -44,7 +44,7 @@ extends MemStore with StrictLogging {
     new WriteBufferFreeEvictionPolicy(config.getMemorySize("memstore.min-write-buffers-free").toBytes)
   }
 
-  def isReadOnly: Boolean = false
+  def isDownsampleStore: Boolean = false
 
   private def makeAndStartPublisher(downsample: DownsampleConfig): DownsamplePublisher = {
     val pub = downsample.makePublisher()

--- a/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
@@ -79,8 +79,8 @@ class HistogramQueryBenchmark {
   shardMapper.updateFromEvent(IngestionStarted(histDataset.ref, 0, coordinator))
 
   // Query configuration
-  val hEngine = new SingleClusterPlanner(histDataset.ref, histSchemas, shardMapper)
-  val pEngine = new SingleClusterPlanner(promDataset.ref, promSchemas, shardMapper)
+  val hEngine = new SingleClusterPlanner(histDataset.ref, histSchemas, shardMapper, 0)
+  val pEngine = new SingleClusterPlanner(promDataset.ref, promSchemas, shardMapper, 0)
   val startTime = 100000L + 100*1000  // 100 samples in.  Look back 30 samples, which normally would be 5min
 
   val histQuery = """histogram_quantile(0.9, sum_over_time(http_requests_total::h{job="prometheus"}[30s]))"""

--- a/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
@@ -102,7 +102,7 @@ class QueryHiCardInMemoryBenchmark extends StrictLogging {
   println(s"Ingestion ended")
 
   // Stuff for directly executing queries ourselves
-  val engine = new SingleClusterPlanner(dataset.ref, Schemas(dataset.schema), shardMapper)
+  val engine = new SingleClusterPlanner(dataset.ref, Schemas(dataset.schema), shardMapper, 0)
 
   val numQueries = 100       // Please make sure this number matches the OperationsPerInvocation below
   val queryIntervalSec = samplesDuration.toSeconds  // # minutes between start and stop

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -103,7 +103,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   println(s"Ingestion ended")
 
   // Stuff for directly executing queries ourselves
-  val engine = new SingleClusterPlanner(dataset.ref, Schemas(dataset.schema), shardMapper)
+  val engine = new SingleClusterPlanner(dataset.ref, Schemas(dataset.schema), shardMapper, 0)
 
   /**
    * ## ========  Queries ===========

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -69,7 +69,7 @@ object SelectRawPartitionsExec extends  {
       if (colNames.nonEmpty) {
         // query is selecting specific columns
         dataSchema.colIDs(colNames: _*).get
-      } else if (!(dataSchema == Schemas.dsGauge)) {
+      } else if (dataSchema != Schemas.dsGauge) {
         // needs to select raw data
         dataSchema.colIDs(dataSchema.data.valueColName).get
       } else {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Retention of downsample dataset was being wrongly configured with retention of raw dataset. Fixed by choosing right retention when downsample/non-downsample mode.

Also removed default param value for earliestRetainedTimestamp to make consumers
more conscious of the retention arg.
