### PR TITLE
fix(memory): Clear sinks at reset() to fix histogram multiple bucket schema ingestion bug

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -137,6 +137,10 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
           case r: VectorTooSmall =>
             switchBuffersAndIngest(ingestionTime, ts, row, blockHolder, maxChunkTime)
             return
+          // Different histogram bucket schema: need a new vector here
+          case BucketSchemaMismatch =>
+            switchBuffersAndIngest(ingestionTime, ts, row, blockHolder, maxChunkTime)
+            return
           case other: AddResponse =>
         }
       }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -379,6 +379,13 @@ class Appendable2DDeltaHistVector(factory: MemFactory,
       appendBlob(encodingBuf.byteArray, encodingBuf.addressOffset, repackedLen)
     }
   }
+
+  override def reset(): Unit = {
+    super.reset()
+    // IMPORTANT! Reset the sink so it can create a new sink with new bucket scheme.  Otherwise there is a bug
+    // where a different time series can obtain the smae vector with a stale sink.
+    repackSink = BinaryHistogram.empty2DSink
+  }
 }
 
 /**
@@ -429,6 +436,13 @@ class AppendableSectDeltaHistVector(factory: MemFactory,
       repackSink.reset()
       appendBlob(encodingBuf.byteArray, encodingBuf.addressOffset, repackedLen)
     }
+  }
+
+  override def reset(): Unit = {
+    super.reset()
+    // IMPORTANT! Reset the sink so it can create a new sink with new bucket scheme.  Otherwise there is a bug
+    // where a different time series can obtain the smae vector with a stale sink.
+    repackSink = BinaryHistogram.emptySectSink
   }
 
   override lazy val reader: VectorDataReader = new SectDeltaHistogramReader(nativePtrReader, vectPtr)


### PR DESCRIPTION
Bug manifests itself when vectors are returned to writeBufferPools and loaned out to a different time series
with a different histogram schema, and the sink is not reset, causing bucket changes to throw an exception.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

1. Appending*HistogramVector uses this logic to determine if it should initialize a new sink: `if (repackSink == BinaryHistogram.emptySectSink)`
2. Above should happen at beginning of each new chunk/writebuffer.
3. TS1 finishes encoding a chunk, calls switchBuffers . Subsequently the chunk is encoded and returned to the writeBufferPool.
4. When writeBufferPool gets the appender back, it calls the reset() method.  However, the reset() method is currently not resetting repackSink back to emptySectSink.
5. TS2, with a diff histogram schema, now obtains the same appender back from the writeBufferPool.
6.  The appender never creates a new sink.  It reuses the same sink from the previous time series, with the wrong bucket schema.
7. Boom, exception happens

**New behavior :**

Appenders with custom sinks will extend the reset() method to reset the sinks.

