### PR TITLE
cherry-pick(5ebcb8): Clear sinks at reset() to fix histogram multiple bucket schema ingestion bug (#645)

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -137,6 +137,10 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
           case r: VectorTooSmall =>
             switchBuffersAndIngest(ingestionTime, ts, row, blockHolder, maxChunkTime)
             return
+          // Different histogram bucket schema: need a new vector here
+          case BucketSchemaMismatch =>
+            switchBuffersAndIngest(ingestionTime, ts, row, blockHolder, maxChunkTime)
+            return
           case other: AddResponse =>
         }
       }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -370,6 +370,13 @@ class Appendable2DDeltaHistVector(factory: MemFactory,
       appendBlob(encodingBuf.byteArray, encodingBuf.addressOffset, repackedLen)
     }
   }
+
+  override def reset(): Unit = {
+    super.reset()
+    // IMPORTANT! Reset the sink so it can create a new sink with new bucket scheme.  Otherwise there is a bug
+    // where a different time series can obtain the smae vector with a stale sink.
+    repackSink = BinaryHistogram.empty2DSink
+  }
 }
 
 /**
@@ -412,6 +419,13 @@ class AppendableSectDeltaHistVector(factory: MemFactory,
       repackSink.reset()
       appendBlob(encodingBuf.byteArray, encodingBuf.addressOffset, repackedLen)
     }
+  }
+
+  override def reset(): Unit = {
+    super.reset()
+    // IMPORTANT! Reset the sink so it can create a new sink with new bucket scheme.  Otherwise there is a bug
+    // where a different time series can obtain the smae vector with a stale sink.
+    repackSink = BinaryHistogram.emptySectSink
   }
 
   override lazy val reader: VectorDataReader = new SectDeltaHistogramReader(nativePtrReader, vectPtr)


### PR DESCRIPTION
Cherry-pick: cherry-pick 5ebcb83 - fix(memory): Clear sinks at reset() to fix histogram multiple bucket schema ingestion bug (#645)