### PR TITLE
misc(debug): add metrics-dropped metric in ingestion exception block

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1162,8 +1162,10 @@ class TimeSeriesShard(val ref: DatasetRef,
       }
     } catch {
       case e: OutOfOffheapMemoryException => disableAddPartitions()
-      case e: Exception => logger.error(s"Unexpected ingestion err in dataset=$ref " +
-        s"shard=$shardNum partition=${schema.ingestionSchema.debugString(recordBase, recordOff)}", e)
+      case e: Exception =>
+        logger.error(s"Unexpected ingestion err in dataset=$ref " +
+          s"shard=$shardNum partition=${schema.ingestionSchema.debugString(recordBase, recordOff)}", e)
+        shardStats.dataDropped.increment()
     }
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1163,9 +1163,9 @@ class TimeSeriesShard(val ref: DatasetRef,
     } catch {
       case e: OutOfOffheapMemoryException => disableAddPartitions()
       case e: Exception =>
+        shardStats.dataDropped.increment()
         logger.error(s"Unexpected ingestion err in dataset=$ref " +
           s"shard=$shardNum partition=${schema.ingestionSchema.debugString(recordBase, recordOff)}", e)
-        shardStats.dataDropped.increment()
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

add data-dropped metric when there is a generic exception. There is already a data-dropped metric captured inside `disableAddPartitions` whenever `OutOfOffheapMemoryException` occurs. This change covers the generic exception case.