### PR TITLE
bug(query): getRawSeriesStartTimeshould not be called if logicalPlan is not routable

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -27,8 +27,9 @@ class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
       case p: PeriodicSeriesPlan =>
         val earliestRawTime = earliestRawTimestampFn
         // FIXME need to incorporate offset here - needs to be addressed in HA Planning too - punt to separate PR
-        val lookbackMs = getRawSeriesStartTime(logicalPlan).map(p.startMs - _).get
-        if (p.endMs < earliestRawTime) downsampleClusterPlanner.materialize(logicalPlan, qContext)
+        lazy val lookbackMs = getRawSeriesStartTime(logicalPlan).map(p.startMs - _).get
+        if (!logicalPlan.isRoutable) rawClusterPlanner.materialize(logicalPlan, qContext)
+        else if (p.endMs < earliestRawTime) downsampleClusterPlanner.materialize(logicalPlan, qContext)
         else if (p.startMs - lookbackMs >= earliestRawTime) rawClusterPlanner.materialize(logicalPlan, qContext)
         else {
           // Split the query between raw and downsample planners

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -6,6 +6,8 @@ import filodb.core.query.{ColumnFilter, RangeParams}
 sealed trait LogicalPlan {
   /**
     * Execute failure routing
+    * Override for Queries which should not be routed e.g time(), month()
+    * It is false for RawSeriesLikePlan, MetadataQueryPlan, RawChunkMeta, ScalarTimeBasedPlan and ScalarFixedDoublePlan
     */
   def isRoutable: Boolean = true
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
LongTimeRangePlanner calls getRawSeriesStartTime always. GetRawSeriestIme throws Invalid logical plan exception when logical is not routable like for scalar time functions

**New behavior :**
Make lookbackMs lazy and not call rawClusterPlanner.materialize when logicalPlan is not routable
