### PR TITLE
BUG fix for (sum/avg/stddev)_over_time & zscore promql functions

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -236,15 +236,19 @@ object DoubleVectorDataReader64 extends DoubleVectorDataReader {
       s"length=${length(acc, vector)}")
     var addr = vector + OffsetData + start * 8
     val untilAddr = vector + OffsetData + end * 8 + 8   // one past the end
-    var sum: Double = 0d
+    var sum: Double = Double.NaN
     if (ignoreNaN) {
       while (addr < untilAddr) {
         val nextDbl = acc.getDouble(addr)
         // There are many possible values of NaN.  Use a function to ignore them reliably.
-        if (!java.lang.Double.isNaN(nextDbl)) sum += nextDbl
+        if (!java.lang.Double.isNaN(nextDbl)) {
+          if (sum.isNaN) sum = 0d
+          sum += nextDbl
+        }
         addr += 8
       }
     } else {
+      sum = 0d
       while (addr < untilAddr) {
         sum += acc.getDouble(addr)
         addr += 8

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -557,16 +557,3 @@ class TimestampChunkedFunction (var value: Double = Double.NaN) extends ChunkedR
   }
 }
 
-class LastSampleChunkedFunctionWithNanD extends LastSampleChunkedFuncDblVal() {
-  def updateValue(ts: Long, valAcc: MemoryReader, valVector: BinaryVectorPtr,
-                  valReader: VectorDataReader, endRowNum: Int): Unit = {
-    val dblReader = valReader.asDoubleReader
-    val doubleVal = dblReader(valAcc, valVector, endRowNum)
-    // If the last value is NaN, that may be Prometheus end of time series marker.
-    // In that case try to get the sample before last.
-    // If endRowNum==0, we are at beginning of chunk, and if the window included the last chunk, then
-    // the call to addChunks to the last chunk would have gotten the last sample value anyways.
-    timestamp = ts
-    value = doubleVal
-  }
-}


### PR DESCRIPTION
This commit addresses below mentioned issues:

1.) sum_over_time()

If the sequence contains all NaNs, current implementation is giving 0 as result. Instead, it should give NaN as result.

2.) avg_over_time()

If the sequence contains all NaNs, current implementation is giving 0 as result. Instead, it should give NaN as result.

3.) stddev_over_time()

On debugging above functions 1 & 2:

sum_over_time() function will calculate the sum of only non-NaN values and ignore all the NaN values which is CORRECT.

Similarly, avg_over_time() function is also computing the average as  sum of non-NaN values / count of non-NaN values in the sequence which is CORRECT

For stddev_over_time() computation, we need sum, squared sum, avg and count of the non-NaN values in the sequence.

Current code CORRECTLY calculates the  sum, squared sum by making use of non-NaN values.

But it has following two issues:

1.) count in this function is counting ALL the values irrespective of whether they are NaN or not NaN -> this will cause a problem when sequence is a combination of both NaN and not NaN values.

2.) while loop is used to iterate in the sequence, but the variable used to traverse the entire sequence which does work like i+=1, is done ONLY when value is not NaN -> this will cause a problem when sequence is a combination of both NaN and not NaN values because in order to traverse the ENTIRE sequence, we have to this  i+=1 always, irrespective of whether it is NaN or not NaN.

4.) z_score():

Because z_score() is based on avg_over_time() & stdev_over_time(), it is also giving WRONG results when sequence contains both NaN and not NaN values or only NaNs.

It works FINE when there are all not NaNs in the sequence.

Other improvements :

1.)  For unit testing, added more and more test-data sequences for sum/avg/stddev_over_time() & zscore which are combination of NaN & not NaN’s, empty sequence, or only NaN’s sequence.

2.) For unit testing, added zscore simple math function in the test file to see if the result given by promql zscore is correct or not.

3.) For unit testing, there are 3 functions in the test file : avg, squared sums & stdvar.
Limitation of these functions is : If the sequence contains combination of NaN and not NaN values, the computed result will be NaN only.
So, these functions are not good for the sequences which contains NaNs in it.

So in the test file, I have added 4 other functions for computing sum, squared sums, avg, stdvar, count ; which works well for the test-cases when sequences have NaNs wherein NaN is just ignored to compute any sort of result and have used the same to test sum_over_time(), avg_over_time(), stddev_over_time() with variety of test-cases.

4.) Earlier, for ZScoreChunkedFunction implementation an abstract class was also created. Removed it and made use of existing VarOverTimeChunkedFunctionD to achieve the result.

5.) Earlier, for Zscore implementation, LastSampleChunkedFunctionWithNanD was also added in RangeFunctions. Removed it and made use of existing VarOverTimeChunkedFunctionD to achieve the result.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: