### PR TITLE
fix(spark-jobs): downsample index migration, initialize kamon in foreachRDD

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -113,6 +113,7 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
         batchIter // iterator of batches
       }
       .foreach { rawPartsBatch =>
+        Kamon.init()
         batchDownsampler.downsampleBatch(rawPartsBatch, userTimeStart, userTimeEndExclusive)
       }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -60,6 +60,7 @@ class IndexJobDriver(fromHour: Long,
         it
       }
       .foreach { shard =>
+        Kamon.init()
         val job = new DSIndexJob(dsSettings, dsIndexJobSettings)
         job.updateDSPartKeyIndex(shard, startHour, endHour)
       }


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
add `Kamon.init` as the first statement inside `foreach`