### PR TITLE
bug(query): AvgOverTime on downsample data fails

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -75,7 +75,8 @@ object PrometheusModel {
   }
 
   def toPromSuccessResponse(qr: FiloQueryResult, verbose: Boolean): SuccessResponse = {
-    val results = if (qr.resultSchema.columns(1).colType == ColumnType.HistogramColumn)
+    val results = if (qr.resultSchema.columns.nonEmpty &&
+                      qr.resultSchema.columns(1).colType == ColumnType.HistogramColumn)
                     qr.result.map(toHistResult(_, verbose, qr.resultType))
                   else
                     qr.result.map(toPromResult(_, verbose, qr.resultType))

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -117,8 +117,12 @@ final case class PeriodicSamplesMapper(start: Long,
 
   // Transform source double or long to double schema
   override def schema(source: ResultSchema): ResultSchema = {
-    // Special treatment for downsampled gauge schema - return regular timestamp/value
-    if (functionId.contains(AvgWithSumAndCountOverTime)) {
+    // Special treatment for downsampled gauge schema.
+    // Source schema will be the selected columns. Result of this mapper should be regular timestamp/value
+    // since the avg will be calculated using sum and count
+    // FIXME dont like that this is hardcoded; but the check is needed.
+    if (functionId.contains(AvgWithSumAndCountOverTime) &&
+                        source.columns.map(_.name) == Seq("timestamp", "sum", "count")) {
       source.copy(columns = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
                                 ColumnInfo("value", ColumnType.DoubleColumn)))
     } else {

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -5,13 +5,13 @@ import monix.reactive.Observable
 import org.jctools.queues.SpscUnboundedArrayQueue
 
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.metadata.Schemas
 import filodb.core.query._
 import filodb.core.store.WindowedChunkIterator
 import filodb.memory.format._
 import filodb.memory.format.vectors.LongBinaryVector
 import filodb.query._
 import filodb.query.Query.qLogger
+import filodb.query.exec.InternalRangeFunction.AvgWithSumAndCountOverTime
 import filodb.query.exec.rangefn._
 import filodb.query.util.IndexedArrayQueue
 
@@ -118,9 +118,9 @@ final case class PeriodicSamplesMapper(start: Long,
   // Transform source double or long to double schema
   override def schema(source: ResultSchema): ResultSchema = {
     // Special treatment for downsampled gauge schema - return regular timestamp/value
-    if (source.columns == Schemas.dsGauge.dataInfos) {
+    if (functionId.contains(AvgWithSumAndCountOverTime)) {
       source.copy(columns = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
-        ColumnInfo("value", ColumnType.DoubleColumn)))
+                                ColumnInfo("value", ColumnType.DoubleColumn)))
     } else {
       source.copy(columns = source.columns.zipWithIndex.map {
         // Transform if its not a row key column


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Result schema for AvgOverTime on downsample data was wrong because of a
check that was not fixed during introduction of multi-schema queries.

Because of this we saw:

```
java.lang.IllegalArgumentException: Invalid col 2 
at filodb.core.query.TransientRow.getDouble(TransientRow.scala:47) 
at filodb.core.binaryrecord2.RecordSchema$$anonfun$11$$anonfun$apply$3.apply(RecordSchema.scala:77) 
at filodb.core.binaryrecord2.RecordSchema$$anonfun$11$$anonfun$apply$3.apply(RecordSchema.scala:77) 
at filodb.core.binaryrecord2.RecordBuilder.addFromReader(RecordBuilder.scala:287) 
at filodb.core.query.SerializedRangeVector$.apply(RangeVector.scala:316) 
at filodb.query.exec.ExecPlan$$anonfun$step2$1$2$$anonfun$7.apply(ExecPlan.scala:151) 
at filodb.query.exec.ExecPlan$$anonfun$step2$1$2$$anonfun$7.apply(ExecPlan.scala:141)```

