### PR TITLE
fix(query): Set Ops/binary joins fail when a range vector joined with timestamp

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -33,7 +33,7 @@ object LogicalPlanUtils {
       case lp: ApplyMiscellaneousFunction  => getPeriodicSeriesTimeFromLogicalPlan(lp.vectors)
       case lp: ApplySortFunction           => getPeriodicSeriesTimeFromLogicalPlan(lp.vectors)
       case lp: ScalarVaryingDoublePlan     => getPeriodicSeriesTimeFromLogicalPlan(lp.vectors)
-      case lp: ScalarTimeBasedPlan         => TimeRange(lp.rangeParams.start, lp.rangeParams.end)
+      case lp: ScalarTimeBasedPlan         => TimeRange(lp.rangeParams.startSecs, lp.rangeParams.endSecs)
       case lp: VectorPlan                  => getPeriodicSeriesTimeFromLogicalPlan(lp.scalars)
       case lp: ApplyAbsentFunction         => getPeriodicSeriesTimeFromLogicalPlan(lp.vectors)
       case _                               => throw new BadQueryException(s"Invalid logical plan")

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -119,9 +119,9 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     }
   }
 
-  val timeMinSchema = ResultSchema(Seq(ColumnInfo("timestamp", LongColumn), ColumnInfo("min", DoubleColumn)), 1)
-  val countSchema = ResultSchema(Seq(ColumnInfo("timestamp", LongColumn), ColumnInfo("count", DoubleColumn)), 1)
-  val valueSchema = ResultSchema(Seq(ColumnInfo("timestamp", LongColumn), ColumnInfo("value", DoubleColumn)), 1)
+  val timeMinSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("min", DoubleColumn)), 1)
+  val countSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("count", DoubleColumn)), 1)
+  val valueSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("value", DoubleColumn)), 1)
   val qOpt = QueryContext(shardOverrides = Some(Seq(0)))
 
   describe("QueryActor commands and responses") {

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -131,7 +131,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     }.toBuffer
 
 
-    val cols = Array(new ColumnInfo("timestamp", ColumnType.LongColumn),
+    val cols = Array(new ColumnInfo("timestamp", ColumnType.TimestampColumn),
       new ColumnInfo("value", ColumnType.DoubleColumn))
     val srvs = for { i <- 0 to 9 } yield {
       val rv = new RangeVector {

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -124,16 +124,16 @@ final case class ScalarVaryingDouble(private val timeValueMap: Map[Long, Double]
   override def numRowsInt: Int = timeValueMap.size
 }
 
-final case class RangeParams(start: Long, step: Long, end: Long)
+final case class RangeParams(startSecs: Long, stepSecs: Long, endSecs: Long)
 
 trait ScalarSingleValue extends ScalarRangeVector {
   def rangeParams: RangeParams
   var numRowsInt : Int = 0
 
   override def rows: Iterator[RowReader] = {
-    Iterator.from(0, rangeParams.step.toInt).takeWhile(_ <= rangeParams.end - rangeParams.start).map { i =>
+    Iterator.from(0, rangeParams.stepSecs.toInt).takeWhile(_ <= rangeParams.endSecs - rangeParams.startSecs).map { i =>
       numRowsInt += 1
-      val t = i + rangeParams.start
+      val t = i + rangeParams.startSecs
       new TransientRow(t * 1000, getValue(t * 1000))
     }
   }

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -52,9 +52,9 @@ final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
                               columns(1).colType == HistogramColumn && columns(2).colType == DoubleColumn
 
   def hasSameColumnsAs(other: ResultSchema): Boolean = {
-    // exclude fixedVectorLen
+    // exclude fixedVectorLen & colIDs
     other.columns == columns && other.numRowKeyColumns == numRowKeyColumns &&
-      other.brSchemas == brSchemas && other.colIDs == colIDs
+      other.brSchemas == brSchemas
   }
 }
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -217,7 +217,7 @@ object GdeltTestData {
 object MachineMetricsData {
   import scala.util.Random.nextInt
 
-  val columns = Seq("timestamp:long", "min:double", "avg:double", "max:double", "count:long")
+  val columns = Seq("timestamp:ts", "min:double", "avg:double", "max:double", "count:long")
   val dummyContext = Map("test" -> "test")
 
   def singleSeriesData(initTs: Long = System.currentTimeMillis,

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -23,7 +23,7 @@ class RangeVectorSpec  extends FunSpec with Matchers {
     }
   }
 
-  val cols = Array(new ColumnInfo("timestamp", ColumnType.LongColumn),
+  val cols = Array(new ColumnInfo("timestamp", ColumnType.TimestampColumn),
                    new ColumnInfo("value", ColumnType.DoubleColumn))
 
   it("should be able to create and read from SerializedRangeVector") {

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -274,9 +274,9 @@ final case class ScalarVaryingDoublePlan(vectors: PeriodicSeriesPlan,
   */
 final case class ScalarTimeBasedPlan(function: ScalarFunctionId, rangeParams: RangeParams) extends ScalarPlan {
   override def isRoutable: Boolean = false
-  override def startMs: Long = rangeParams.start
-  override def stepMs: Long = rangeParams.step
-  override def endMs: Long = rangeParams.end
+  override def startMs: Long = rangeParams.startSecs * 1000
+  override def stepMs: Long = rangeParams.stepSecs * 1000
+  override def endMs: Long = rangeParams.endSecs * 1000
 }
 
 /**
@@ -287,9 +287,9 @@ final case class ScalarFixedDoublePlan(scalar: Double,
                                        timeStepParams: RangeParams)
                                        extends ScalarPlan with FunctionArgsPlan {
   override def isRoutable: Boolean = false
-  override def startMs: Long = timeStepParams.start
-  override def stepMs: Long = timeStepParams.step
-  override def endMs: Long = timeStepParams.end
+  override def startMs: Long = timeStepParams.startSecs * 1000
+  override def stepMs: Long = timeStepParams.stepSecs * 1000
+  override def endMs: Long = timeStepParams.endSecs * 1000
 }
 
 //scalastyle:off number.of.types

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable
 import monix.eval.Task
 import monix.reactive.Observable
 
+import filodb.core.memstore.SchemaMismatch
 import filodb.core.query._
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String => Utf8Str}
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -152,6 +153,20 @@ final case class BinaryJoinExec(queryContext: QueryContext,
         cur.setValues(lhsRow.getLong(0), binFunc.calculate(lhsRow.getDouble(1), rhsRow.getDouble(1)))
         cur
       }
+    }
+  }
+
+  /**
+    * overridden to allow schemas with different vector lengths, colids as long as the columns are same - to handle
+    * binary joins between scalar/rangevectors
+    */
+  override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
+    resp match {
+      case QueryResult(_, schema, _) if rs == ResultSchema.empty =>
+        schema     /// First schema, take as is
+      case QueryResult(_, schema, _) =>
+        if (!rs.hasSameColumnsAs(schema)) throw SchemaMismatch(rs.toString, schema.toString)
+        else rs
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -123,7 +123,7 @@ final case class PeriodicSamplesMapper(start: Long,
     // FIXME dont like that this is hardcoded; but the check is needed.
     if (functionId.contains(AvgWithSumAndCountOverTime) &&
                         source.columns.map(_.name) == Seq("timestamp", "sum", "count")) {
-      source.copy(columns = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+      source.copy(columns = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                 ColumnInfo("value", ColumnType.DoubleColumn)))
     } else {
       source.copy(columns = source.columns.zipWithIndex.map {

--- a/query/src/main/scala/filodb/query/exec/PromQlExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlExec.scala
@@ -104,7 +104,7 @@ object PromQlExec extends StrictLogging {
   import io.circe.generic.auto._
   import net.ceedubs.ficus.Ficus._
 
-  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
    ColumnInfo("value", ColumnType.DoubleColumn))
   val recSchema = SerializedRangeVector.toSchema(columns)
   val resultSchema = ResultSchema(columns, 1)

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -368,7 +368,7 @@ final case class AbsentFunctionMapper(columnFilter: Seq[ColumnFilter], rangePara
     val resultRv = nonNanTimestamps.map {
       t =>
         val rowList = new ListBuffer[TransientRow]()
-        for (i <- rangeParams.start to rangeParams.end by rangeParams.step) {
+        for (i <- rangeParams.startSecs to rangeParams.endSecs by rangeParams.stepSecs) {
           if (!t.contains(i * 1000))
             rowList += new TransientRow(i * 1000, 1)
         }
@@ -382,7 +382,7 @@ final case class AbsentFunctionMapper(columnFilter: Seq[ColumnFilter], rangePara
   }
   override def funcParams: Seq[FuncArgs] = Nil
   override def schema(source: ResultSchema): ResultSchema = ResultSchema(Seq(ColumnInfo("timestamp",
-    ColumnType.LongColumn), ColumnInfo("value", ColumnType.DoubleColumn)), 1)
+    ColumnType.TimestampColumn), ColumnInfo("value", ColumnType.DoubleColumn)), 1)
 
   override def canHandleEmptySchemas: Boolean = true
 }
@@ -454,7 +454,8 @@ final case class HistToPromSeriesMapper(sch: PartitionSchema) extends RangeVecto
 
   override def schema(source: ResultSchema): ResultSchema =
     if (valueColumnType(source) != ColumnType.HistogramColumn) source else
-    ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn), ColumnInfo("value", ColumnType.DoubleColumn)), 1)
+    ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
+      ColumnInfo("value", ColumnType.DoubleColumn)), 1)
 
   private def addNewBuckets(newScheme: HistogramBuckets,
                             buckets: debox.Map[Double, debox.Buffer[Double]],

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -21,7 +21,7 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
                                  params: RangeParams,
                                  value: Double) extends LeafExecPlan {
 
-  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
 
   /**

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable.ListBuffer
 import monix.eval.Task
 import monix.reactive.Observable
 
+import filodb.core.memstore.SchemaMismatch
 import filodb.core.query._
 import filodb.memory.format.{ZeroCopyUTF8String => Utf8Str}
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -135,5 +136,19 @@ final case class SetOperatorExec(queryContext: QueryContext,
       }
     }
     result.toList
+  }
+
+  /**
+    * overridden to allow schemas with different vector lengths, colids as long as the columns are same - to handle
+    * binary joins between scalar/rangevectors
+    */
+  override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
+    resp match {
+      case QueryResult(_, schema, _) if rs == ResultSchema.empty =>
+        schema     /// First schema, take as is
+      case QueryResult(_, schema, _) =>
+        if (!rs.hasSameColumnsAs(schema)) throw SchemaMismatch(rs.toString, schema.toString)
+        else rs
+    }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -20,7 +20,7 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
                                    dataset: DatasetRef, params: RangeParams,
                                    function: ScalarFunctionId) extends LeafExecPlan {
 
-  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
 
   /**

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
@@ -82,7 +82,8 @@ class CountValuesRowAggregator(label: String, limit: Int = 1000) extends RowAggr
   }
 
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = {
-    val colSchema = Seq(ColumnInfo("timestamp", ColumnType.LongColumn), ColumnInfo("value", ColumnType.DoubleColumn))
+    val colSchema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
+      ColumnInfo("value", ColumnType.DoubleColumn))
     val recSchema = SerializedRangeVector.toSchema(colSchema)
     val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
     // Important TODO / TechDebt: We need to replace Iterators with cursors to better control

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -82,7 +82,8 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
   }
 
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = {
-    val colSchema = Seq(ColumnInfo("timestamp", ColumnType.LongColumn), ColumnInfo("value", ColumnType.DoubleColumn))
+    val colSchema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
+      ColumnInfo("value", ColumnType.DoubleColumn))
     val recSchema = SerializedRangeVector.toSchema(colSchema)
     val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
     // Important TODO / TechDebt: We need to replace Iterators with cursors to better control

--- a/query/src/test/scala/filodb/query/ResultTypesSpec.scala
+++ b/query/src/test/scala/filodb/query/ResultTypesSpec.scala
@@ -10,7 +10,7 @@ import filodb.memory.format.{RowReader, ZeroCopyUTF8String}
 
 class ResultTypesSpec extends FunSpec with Matchers with ScalaFutures {
 
-  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
   val resultSchema = ResultSchema(columns, 1)
   val ignoreKey = CustomRangeVectorKey(

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -19,7 +19,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
   val rand = new Random()
   val error = 0.0000001d
 
-  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                   ColumnInfo("value", ColumnType.DoubleColumn)), 1)
   val histSchema = ResultSchema(MMD.histDataset.schema.infosFromIDs(Seq(0, 3)), 1)
   val histMaxSchema = ResultSchema(MMD.histMaxDS.schema.infosFromIDs(Seq(0, 4, 3)), 1, colIDs = Seq(0, 4, 3))
@@ -282,7 +282,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val result7 = resultObs7.toListL.runAsync.futureValue
     result7.size shouldEqual 1
 
-    val recSchema = SerializedRangeVector.toSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+    val recSchema = SerializedRangeVector.toSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                                          ColumnInfo("tdig", ColumnType.StringColumn)))
     val builder = SerializedRangeVector.newBuilder()
     val srv = SerializedRangeVector(result7(0), builder, recSchema, "Unit-Test")

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -24,9 +24,9 @@ class BinaryJoinExecSpec extends FunSpec with Matchers with ScalaFutures {
   val rand = new Random()
   val error = 0.00000001d
 
-  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn)), 1)
-  val schema = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val schema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
   val tvSchemaTask = Task.now(tvSchema)
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -22,9 +22,9 @@ class BinaryJoinGroupingSpec extends FunSpec with Matchers with ScalaFutures {
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
   val queryConfig = new QueryConfig(config.getConfig("query"))
-  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn)), 1)
-  val schema = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val schema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
   val tvSchemaTask = Task.now(tvSchema)
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -24,9 +24,9 @@ class BinaryJoinSetOperatorSpec extends FunSpec with Matchers with ScalaFutures 
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
   val queryConfig = new QueryConfig(config.getConfig("query"))
-  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn)), 1)
-  val schema = Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val schema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
 
   val rand = new Random()

--- a/query/src/test/scala/filodb/query/exec/HistToPromSeriesMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistToPromSeriesMapperSpec.scala
@@ -24,7 +24,7 @@ class HistToPromSeriesMapperSpec extends FunSpec with Matchers with ScalaFutures
   val eightBTimes = eightBucketData.map(_(0).asInstanceOf[Long])
   val eightBHists = eightBucketData.map(_(3).asInstanceOf[HistogramWithBuckets])
   val rows = eightBTimes.zip(eightBHists).map { case (t, h) => new TransientHistRow(t, h) }
-  val sourceSchema = new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+  val sourceSchema = new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                           ColumnInfo("value", ColumnType.HistogramColumn)), 1)
 
   it("should convert single schema histogram to appropriate Prom bucket time series") {
@@ -33,7 +33,7 @@ class HistToPromSeriesMapperSpec extends FunSpec with Matchers with ScalaFutures
     val mapper = HistToPromSeriesMapper(MMD.histDataset.schema.partition)
     val sourceObs = Observable.now(rv)
 
-    mapper.schema(sourceSchema).columns shouldEqual Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+    mapper.schema(sourceSchema).columns shouldEqual Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                                         ColumnInfo("value", ColumnType.DoubleColumn))
 
     val destObs = mapper.apply(sourceObs, queryConfig, 1000, sourceSchema, Nil)
@@ -68,7 +68,7 @@ class HistToPromSeriesMapperSpec extends FunSpec with Matchers with ScalaFutures
     val mapper = HistToPromSeriesMapper(MMD.histDataset.schema.partition)
     val sourceObs = Observable.now(rv)
 
-    mapper.schema(sourceSchema).columns shouldEqual Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+    mapper.schema(sourceSchema).columns shouldEqual Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                                         ColumnInfo("value", ColumnType.DoubleColumn))
 
     val destObs = mapper.apply(sourceObs, queryConfig, 1000, sourceSchema, Nil)

--- a/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
@@ -58,7 +58,7 @@ class HistogramQuantileMapperSpec extends FunSpec with Matchers with ScalaFuture
     val hqMapper = HistogramQuantileMapper(Seq(StaticFuncArgs(q, rangeParams)))
 
     val result = hqMapper.apply(Observable.fromIterable(histRvs), queryConfig, 10,
-                                new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.LongColumn),
+                                new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                   ColumnInfo("value", ColumnType.DoubleColumn)), 1), Nil)
                          .toListL.runAsync.futureValue
     for { i <- expectedResult.indices } {

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -154,7 +154,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
     val resp = execPlan.execute(memStore, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
-    result.resultSchema.columns.map(_.colType) shouldEqual Seq(LongColumn, LongColumn)
+    result.resultSchema.columns.map(_.colType) shouldEqual Seq(TimestampColumn, LongColumn)
     result.result.size shouldEqual 1
     val dataRead = result.result(0).rows.map(r=>(r.getLong(0), r.getLong(1))).toList
     dataRead shouldEqual mmdTuples.filter(_(5) == "Series 1").map(r => (r(0), r(4))).take(5)
@@ -226,7 +226,7 @@ class MultiSchemaPartitionsExecSpec extends FunSpec with Matchers with ScalaFutu
 
     val resp = execPlan.execute(memStore, queryConfig).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
-    result.resultSchema.columns.map(_.colType) shouldEqual Seq(LongColumn, DoubleColumn)
+    result.resultSchema.columns.map(_.colType) shouldEqual Seq(TimestampColumn, DoubleColumn)
     result.result.size shouldEqual 1
     val dataRead = result.result(0).rows.map(r=>(r.getLong(0), r.getDouble(1))).toList
     dataRead.map(_._1) shouldEqual (start to end by step)


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

- In `reduceSchemas`, ResultSchema comparison is made less restrictive for SetOps and Binary-Joins. fixedVectorLen & colIDs are excluded in the check.
- In order make it consistent, ResultSchema timestamp column type is changed from `LongColumn` to `TimestampColumn`.
- RangeParams fields are renamed to indicate time unit is Seconds