### PR TITLE
bug(cassandra): Prepared stmts everywhere, fix stmt consistency

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -477,14 +477,14 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
 
   def getOrCreateIngestionTimeIndexTable(dataset: DatasetRef): IngestionTimeIndexTable = {
     indexTableCache.getOrElseUpdate(dataset,
-                                    { dataset: DatasetRef =>
-                                      new IngestionTimeIndexTable(dataset, clusterConnector)(readEc) })
-  }
+                        { dataset: DatasetRef =>
+                          new IngestionTimeIndexTable(dataset, clusterConnector, ingestionConsistencyLevel)(readEc) })
+}
 
   def getOrCreatePartitionKeysByUpdateTimeTable(dataset: DatasetRef): PartitionKeysByUpdateTimeTable = {
     partKeysByUTTableCache.getOrElseUpdate(dataset,
       { dataset: DatasetRef =>
-        new PartitionKeysByUpdateTimeTable(dataset, clusterConnector)(readEc) })
+        new PartitionKeysByUpdateTimeTable(dataset, clusterConnector, ingestionConsistencyLevel)(readEc) })
   }
 
   def getOrCreatePartitionKeysTable(dataset: DatasetRef, shard: Int): PartitionKeysTable = {

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -391,6 +391,11 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   }
 }
 
+/**
+  * FIXME this works only for Murmur3Partitioner because it generates
+  * Long based tokens. If other partitioners are used, this can potentially break.
+  * Correct way is to pass Token objects so CQL stmts can bind tokens with stmt.bind().setPartitionKeyToken(token)
+  */
 case class CassandraTokenRangeSplit(tokens: Seq[(String, String)],
                                     replicas: Set[InetSocketAddress]) extends ScanSplit {
   // NOTE: You need both the host string and the IP address for Spark's locality to work

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -19,7 +19,9 @@ import filodb.core.store.ChunkSinkStats
  * using TimeSeriesChunksTable. This is because the chunks are likely to be fetched from
  * Cassandra due to locality when using TimeSeriesChunksTable, and the chunks table is smaller.
  */
-sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: FiloCassandraConnector)
+sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
+                                     val connector: FiloCassandraConnector,
+                                     writeConsistencyLevel: ConsistencyLevel)
                                     (implicit ec: ExecutionContext) extends BaseDatasetTable {
   import scala.collection.JavaConverters._
 
@@ -36,9 +38,26 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
                      |) WITH compression = {
                     'sstable_compression': '$sstableCompression'}""".stripMargin
 
-  lazy val allCql = session.prepare(
-      s"SELECT ingestion_time, start_time, info FROM $tableString " +
-      s" WHERE partition = ?")
+  private lazy val writeIndexCql = session.prepare(
+    s"INSERT INTO $tableString (partition, ingestion_time, start_time, info) " +
+    s"VALUES (?, ?, ?, ?) USING TTL ?")
+    .setConsistencyLevel(writeConsistencyLevel)
+
+  private lazy val allCql = session.prepare(
+    s"SELECT ingestion_time, start_time, info FROM $tableString " +
+    s"WHERE partition = ?")
+    .setConsistencyLevel(ConsistencyLevel.ONE)
+
+  private lazy val scanCql1 = session.prepare(
+    s"SELECT partition, ingestion_time, start_time, info FROM $tableString " +
+    s"WHERE TOKEN(partition) >= ? AND TOKEN(partition) < ? AND ingestion_time >= ? AND ingestion_time <= ? " +
+    s"ALLOW FILTERING")
+    .setConsistencyLevel(ConsistencyLevel.ONE)
+
+  private lazy val scanCql2 = session.prepare(
+    s"SELECT partition FROM $tableString " +
+    s"WHERE TOKEN(partition) >= ? AND TOKEN(partition) < ? AND ingestion_time >= ? AND ingestion_time <= ? " +
+    s"ALLOW FILTERING")
     .setConsistencyLevel(ConsistencyLevel.ONE)
 
   /**
@@ -63,35 +82,29 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef, val connector: Fil
   def scanRowsByIngestionTimeNoAsync(tokens: Seq[(String, String)],
                                      ingestionTimeStart: Long,
                                      ingestionTimeEnd: Long): Iterator[Row] = {
-    def cql(start: String, end: String): String =
-      s"SELECT partition, ingestion_time, start_time, info FROM $tableString " +
-      s"WHERE TOKEN(partition) >= $start AND TOKEN(partition) < $end " +
-      s"AND ingestion_time >= $ingestionTimeStart AND ingestion_time <= $ingestionTimeEnd " +
-      s"ALLOW FILTERING"
 
     tokens.iterator.flatMap { case (start, end) =>
-      session.execute(cql(start, end)).iterator.asScala
+      val stmt = scanCql1.bind(start.toLong: java.lang.Long,
+                               end.toLong: java.lang.Long,
+                               ingestionTimeStart: java.lang.Long,
+                               ingestionTimeEnd: java.lang.Long)
+      session.execute(stmt).iterator.asScala
     }
   }
 
   def scanPartKeysByIngestionTime(tokens: Seq[(String, String)],
                                   ingestionTimeStart: Long,
                                   ingestionTimeEnd: Long): Observable[ByteBuffer] = {
-    def cql(start: String, end: String): String =
-      s"SELECT partition FROM $tableString WHERE TOKEN(partition) >= $start AND TOKEN(partition) < $end " +
-        s"AND ingestion_time >= $ingestionTimeStart AND ingestion_time <= $ingestionTimeEnd " +
-        s"ALLOW FILTERING"
     val it = tokens.iterator.flatMap { case (start, end) =>
-      session.execute(cql(start, end)).iterator.asScala
+      val stmt = scanCql2.bind(start.toLong: java.lang.Long,
+                               end.toLong: java.lang.Long,
+                               ingestionTimeStart: java.lang.Long,
+                               ingestionTimeEnd: java.lang.Long)
+      session.execute(stmt).iterator.asScala
         .map { row => row.getBytes("partition") }
     }
     Observable.fromIterator(it).handleObservableErrors
   }
-
-  lazy val writeIndexCql = session.prepare(
-    s"INSERT INTO $tableString (partition, ingestion_time, start_time, info) " +
-    "VALUES (?, ?, ?, ?) USING TTL ?")
-    .setConsistencyLevel(ConsistencyLevel.ONE)
 
   /**
    * Writes new records to the ingestion table.

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -84,6 +84,11 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
                                      ingestionTimeEnd: Long): Iterator[Row] = {
 
     tokens.iterator.flatMap { case (start, end) =>
+      /*
+       * FIXME conversion of tokens to Long works only for Murmur3Partitioner because it generates
+       * Long based tokens. If other partitioners are used, this can potentially break.
+       * Correct way is to pass Token objects around and bind tokens with stmt.bind().setPartitionKeyToken(token)
+       */
       val stmt = scanCql1.bind(start.toLong: java.lang.Long,
                                end.toLong: java.lang.Long,
                                ingestionTimeStart: java.lang.Long,
@@ -96,6 +101,11 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
                                   ingestionTimeStart: Long,
                                   ingestionTimeEnd: Long): Observable[ByteBuffer] = {
     val it = tokens.iterator.flatMap { case (start, end) =>
+      /*
+       * FIXME conversion of tokens to Long works only for Murmur3Partitioner because it generates
+       * Long based tokens. If other partitioners are used, this can potentially break.
+       * Correct way is to pass Token objects around and bind tokens with stmt.bind().setPartitionKeyToken(token)
+       */
       val stmt = scanCql2.bind(start.toLong: java.lang.Long,
                                end.toLong: java.lang.Long,
                                ingestionTimeStart: java.lang.Long,

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -185,6 +185,11 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
   def scanPartitionsBySplit(tokens: Seq[(String, String)]): Observable[RawPartData] = {
 
     val res: Observable[Future[Iterator[RawPartData]]] = Observable.fromIterable(tokens).map { case (start, end) =>
+      /*
+       * FIXME conversion of tokens to Long works only for Murmur3Partitioner because it generates
+       * Long based tokens. If other partitioners are used, this can potentially break.
+       * Correct way to bind tokens is to do stmt.bind().setPartitionKeyToken(token)
+       */
       val stmt = scanBySplit.bind(start.toLong: java.lang.Long, end.toLong: java.lang.Long)
       session.executeAsync(stmt).toIterator.handleErrors
               .map { rowIt =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We were not using prepared statements everywhere paying cost of inefficient queries.
Read consistency of ONE was not used everywhere.

**New behavior :**

* Organize CQL statements by preparing
* Set consistency of ONE for reads, and the configured writeConsistency for writes.

