### PR TITLE
fix(spark-jobs): Move exception handler such that there's no backdoor way around it.

### DIFF
--- a/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
@@ -107,7 +107,7 @@ object ChunkCopier {
 object ChunkCopierMain extends App with StrictLogging {
   run(new SparkConf(loadDefaults = true))
 
-  private def run(conf: SparkConf): SparkSession = {
+  def run(conf: SparkConf): SparkSession = {
     try {
       logger.info(s"ChunkCopier Spark Job Properties: ${conf.toDebugString}")
 

--- a/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
@@ -105,39 +105,39 @@ object ChunkCopier {
   * For launching the Spark job.
   */
 object ChunkCopierMain extends App with StrictLogging {
-  try {
-    run(new SparkConf(loadDefaults = true))
-  } catch {
-    case e: Throwable => {
-      val trace = e.getStackTrace().mkString(" at ")
-      val e2 = new RuntimeException(s"$e: $trace")
-      e2.initCause(e)
-      throw e2
+  run(new SparkConf(loadDefaults = true))
+
+  private def run(conf: SparkConf): SparkSession = {
+    try {
+      logger.info(s"ChunkCopier Spark Job Properties: ${conf.toDebugString}")
+
+      val copier = ChunkCopier.lookup(conf)
+
+      val spark = SparkSession.builder()
+        .appName("FiloDBChunkCopier")
+        .config(conf)
+        .getOrCreate()
+
+      val splits = copier.getScanSplits
+
+      logger.info(s"Cassandra split size: ${splits.size}. We will have this many spark partitions. " +
+        s"Tune splitsPerNode which was $copier.splitsPerNode if parallelism is low")
+
+      spark.sparkContext
+        .makeRDD(splits)
+        .foreachPartition(splitIter => ChunkCopier.lookup(conf).run(splitIter))
+
+      logger.info(s"ChunkCopier Driver completed successfully")
+
+      copier.shutdown()
+      spark
+    } catch {
+      case e: Throwable => {
+        val trace = e.getStackTrace().mkString(" at ")
+        val e2 = new RuntimeException(s"$e: $trace")
+        e2.initCause(e)
+        throw e2
+      }
     }
-  }
-
-  def run(conf: SparkConf): SparkSession = {
-    logger.info(s"ChunkCopier Spark Job Properties: ${conf.toDebugString}")
-
-    val copier = ChunkCopier.lookup(conf)
-
-    val spark = SparkSession.builder()
-      .appName("FiloDBChunkCopier")
-      .config(conf)
-      .getOrCreate()
-
-    val splits = copier.getScanSplits
-
-    logger.info(s"Cassandra split size: ${splits.size}. We will have this many spark partitions. " +
-      s"Tune splitsPerNode which was $copier.splitsPerNode if parallelism is low")
-
-    spark.sparkContext
-      .makeRDD(splits)
-      .foreachPartition(splitIter => ChunkCopier.lookup(conf).run(splitIter))
-
-    logger.info(s"ChunkCopier Driver completed successfully")
-
-    copier.shutdown()
-    spark
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Exception handler isn't being called.

**New behavior :**
The compiled code generated a way to bypass the handler, but the way App works is a mystery to me. Moved the exception handler such that it cannot be bypassed.
