### PR TITLE
bug(core): Downsample cluster real time index updates should use downsample schema

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -697,7 +697,7 @@ object RecordBuilder {
   final def updateDownsampleSchema(partKeyBase: Any, partKeyOffset: Long, schemas: Schemas): Unit = {
     val rawSchema = schemas(schemaID(partKeyBase, partKeyOffset))
     val downsampleSchema = rawSchema.downsample.get
-    if (rawSchema != downsampleSchema) {
+    if (rawSchema.schemaHash != downsampleSchema.schemaHash) {
       UnsafeUtils.setShort(partKeyBase, partKeyOffset + 4, downsampleSchema.schemaHash.toShort)
     }
   }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -155,7 +155,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     // before refresh happens because we will not revist the hour again.
     val toHour = hour() - 2
     val fromHour = indexUpdatedHour.get() + 1
-    indexRefresher.refreshIndex(partKeyIndex, shardNum, rawDatasetRef, fromHour, toHour)(lookupOrCreatePartId)
+    indexRefresher.refreshWithDownsamplePartKeys(partKeyIndex, shardNum, rawDatasetRef,
+                                                 fromHour, toHour, schemas)(lookupOrCreatePartId)
       .map { count =>
         indexUpdatedHour.set(toHour)
         stats.indexEntriesRefreshed.increment(count)
@@ -181,8 +182,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     stats.indexRamBytes.update(partKeyIndex.indexRamBytes)
   }
 
-  private def lookupOrCreatePartId(pk: PartKeyRecord): Int = {
-    partKeyIndex.partIdFromPartKeySlow(pk.partKey, UnsafeUtils.arayOffset).getOrElse(createPartitionID())
+  private def lookupOrCreatePartId(pk: Array[Byte]): Int = {
+    partKeyIndex.partIdFromPartKeySlow(pk, UnsafeUtils.arayOffset).getOrElse(createPartitionID())
   }
 
   /**

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -5,6 +5,8 @@ import monix.eval.Task
 import monix.reactive.Observable
 
 import filodb.core.DatasetRef
+import filodb.core.binaryrecord2.RecordBuilder
+import filodb.core.metadata.Schemas
 import filodb.core.store.{ColumnStore, PartKeyRecord}
 
 class IndexBootstrapper(colStore: ColumnStore) {
@@ -45,20 +47,23 @@ class IndexBootstrapper(colStore: ColumnStore) {
   }
 
   /**
-    * Refresh index
-    * @param fromHour
-    * @param toHour
-    * @param parallelism
-    * @param lookUpOrAssignPartId
-    * @return
+    * Refresh index with real-time data rom colStore's raw dataset
+    * @param fromHour fromHour inclusive
+    * @param toHour toHour inclusive
+    * @param parallelism number of threads to use to concurrently load the index
+    * @param lookUpOrAssignPartId function to invoke to assign (or lookup) partId to the partKey
+    *
+    * @return number of records refreshed
     */
-  def refreshIndex(index: PartKeyLuceneIndex,
+  def refreshWithDownsamplePartKeys(
+                   index: PartKeyLuceneIndex,
                    shardNum: Int,
                    ref: DatasetRef,
                    fromHour: Long,
                    toHour: Long,
+                   schemas: Schemas,
                    parallelism: Int = Runtime.getRuntime.availableProcessors())
-                  (lookUpOrAssignPartId: PartKeyRecord => Int): Task[Long] = {
+                   (lookUpOrAssignPartId: Array[Byte] => Int): Task[Long] = {
     val tracer = Kamon.spanBuilder("downsample-store-refresh-index-latency")
       .asChildOf(Kamon.currentSpan())
       .tag("dataset", ref.dataset)
@@ -68,7 +73,8 @@ class IndexBootstrapper(colStore: ColumnStore) {
       colStore.getPartKeysByUpdateHour(ref, shardNum, hour)
     }.mapAsync(parallelism) { pk =>
       Task {
-        val partId = lookUpOrAssignPartId(pk)
+        val downsamplPartKey = RecordBuilder.buildDownsamplePartKey(pk.partKey, schemas)
+        val partId = lookUpOrAssignPartId(downsamplPartKey)
         index.upsertPartKey(pk.partKey, partId, pk.startTime, pk.endTime)()
       }
      }
@@ -76,7 +82,6 @@ class IndexBootstrapper(colStore: ColumnStore) {
      .map { count =>
        index.refreshReadersBlocking()
        tracer.finish()
-
        count
      }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Housekeeping index refresh task was still using original schema when adding entries into downsample cluster's lucene index.

**New behavior :**

Convert part key to downsample schema during index refresh
