### PR TITLE
bug(query): Handle queries fully outside retention period in SingleClusterPlanner

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -272,25 +272,40 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     val execRangeFn = InternalRangeFunction.lpToInternalFunc(lp.function)
     val paramsExec = materializeFunctionArgs(lp.functionArgs, qContext)
 
-    val newStartMs = boundStartInstant(lp.startMs, lp.stepMs, lp.endMs, lp.window, lp.offset.getOrElse(0))
-    val window = if (execRangeFn == InternalRangeFunction.Timestamp) None else Some(lp.window)
-    series.plans.foreach(_.addRangeVectorTransformer(PeriodicSamplesMapper(newStartMs, lp.stepMs,
-      lp.endMs, window, Some(execRangeFn), qContext, paramsExec, lp.offset, rawSource)))
-    series
+    val newStartMs = earliestRetainedStartTime(lp.startMs, lp.stepMs, lp.window, lp.offset.getOrElse(0))
+    if (newStartMs <= lp.endMs) {
+      val window = if (execRangeFn == InternalRangeFunction.Timestamp) None else Some(lp.window)
+      series.plans.foreach(_.addRangeVectorTransformer(PeriodicSamplesMapper(newStartMs, lp.stepMs,
+        lp.endMs, window, Some(execRangeFn), qContext, paramsExec, lp.offset, rawSource)))
+      series
+    } else { // query is outside retention period, simply return empty result
+      PlanResult(Seq(EmptyResultExec(qContext, dsRef)))
+    }
   }
 
   private def materializePeriodicSeries(qContext: QueryContext,
                                         lp: PeriodicSeries): PlanResult = {
     val rawSeries = walkLogicalPlanTree(lp.rawSeries, qContext)
-    val newStartMs = boundStartInstant(lp.startMs, lp.stepMs, lp.endMs,
+    val newStartMs = earliestRetainedStartTime(lp.startMs, lp.stepMs,
       WindowConstants.staleDataLookbackSeconds * 1000, lp.offset.getOrElse(0))
-    rawSeries.plans.foreach(_.addRangeVectorTransformer(PeriodicSamplesMapper(newStartMs, lp.stepMs, lp.endMs,
-      None, None, qContext, Nil, lp.offset)))
-    rawSeries
+    if (newStartMs <= lp.endMs) {
+      rawSeries.plans.foreach(_.addRangeVectorTransformer(PeriodicSamplesMapper(newStartMs, lp.stepMs, lp.endMs,
+        None, None, qContext, Nil, lp.offset)))
+      rawSeries
+    } else { // query is outside retention period, simply return empty result
+      PlanResult(Seq(EmptyResultExec(qContext, dsRef)))
+    }
   }
 
-  private def boundStartInstant(startMs: Long, stepMs: Long, endMs: Long,
-                                windowMs: Long, offsetMs: Long): Long = {
+  /**
+    * Calculates the earliest startTime possible given the query's start/window/step/offset.
+    * This is used to bound the startTime of queries so we dont create possibility of aggregating
+    * partially expired data and return incomplete results.
+    *
+    * @return new startTime to be used for query in ms
+    */
+  private def earliestRetainedStartTime(startMs: Long, stepMs: Long,
+                                        windowMs: Long, offsetMs: Long): Long = {
     // In case query is earlier than earliestRetainedTimestamp then we need to drop the first few instants
     // to prevent inaccurate results being served. Inaccuracy creeps in because data can be in memory for which
     // equivalent data may not be in cassandra. Aggregations cannot be guaranteed to be complete.

--- a/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
+++ b/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
@@ -1,0 +1,29 @@
+package filodb.query.exec
+
+import monix.eval.Task
+import monix.execution.Scheduler
+
+import filodb.core.DatasetRef
+import filodb.core.metadata.Column.ColumnType
+import filodb.core.query.{ColumnInfo, QueryContext, ResultSchema}
+import filodb.core.store.ChunkSource
+import filodb.query.{QueryConfig, QueryResponse, QueryResult}
+
+case class EmptyResultExec(queryContext: QueryContext,
+                           dataset: DatasetRef) extends LeafExecPlan {
+  override def dispatcher: PlanDispatcher = InProcessPlanDispatcher
+
+  override def execute(source: ChunkSource,
+                       queryConfig: QueryConfig)
+                      (implicit sched: Scheduler): Task[QueryResponse] = {
+    Task(QueryResult(queryContext.queryId,
+      new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
+                           ColumnInfo("value", ColumnType.DoubleColumn)), 1),
+      Seq.empty))
+  }
+
+  override def doExecute(source: ChunkSource, queryConfig: QueryConfig)
+                        (implicit sched: Scheduler): ExecResult = ???
+
+  override protected def args: String = ""
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

If query is fully outside retention period it is possible to get a start > end error. This PR addresses this use case by returning empty result without execution. Earlier PRs address the cases where query is partially outside retention period.
