### PR TITLE
fix(spark-jobs): Revert exception wrapping, since it didn't help.

### DIFF
--- a/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
@@ -120,7 +120,7 @@ object ChunkCopierMain extends App with StrictLogging {
     val splits = copier.getScanSplits
 
     logger.info(s"Cassandra split size: ${splits.size}. We will have this many spark partitions. " +
-      s"Tune splitsPerNode which was $copier.splitsPerNode if parallelism is low")
+      s"Tune splitsPerNode which was ${copier.splitsPerNode} if parallelism is low")
 
     spark.sparkContext
       .makeRDD(splits)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
All exceptions are wrapped to capture the trace in the message, because it seemed necessary.

**New behavior :**
Revert the wrapping, because it has no useful effect.
