### PR TITLE
feat(sparkJobs): More tunability in index migration; unit tests

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -1,25 +1,24 @@
 package filodb.cassandra.columnstore
 
-import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration._
-
 import java.lang.ref.Reference
 import java.nio.ByteBuffer
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
 
 import com.datastax.driver.core.Row
 import com.typesafe.config.ConfigFactory
 import monix.reactive.Observable
 
+import filodb.cassandra.DefaultFiloSessionProvider
+import filodb.cassandra.metastore.CassandraMetaStore
 import filodb.core._
 import filodb.core.binaryrecord2.RecordBuilder
+import filodb.core.metadata.{Dataset, Schemas}
+import filodb.core.store.{ChunkSet, ChunkSetInfo, ColumnStoreSpec, PartKeyRecord}
 import filodb.memory.BinaryRegionLarge
 import filodb.memory.format.UnsafeUtils
 import filodb.memory.format.ZeroCopyUTF8String._
-import filodb.core.metadata.{Dataset, Schemas}
-import filodb.core.store.{ChunkSet, ChunkSetInfo}
-import filodb.core.store.ColumnStoreSpec
-import filodb.cassandra.DefaultFiloSessionProvider
-import filodb.cassandra.metastore.CassandraMetaStore
 
 class CassandraColumnStoreSpec extends ColumnStoreSpec {
   import NamesTestData._
@@ -44,6 +43,29 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
       split.tokens.head._1 should not equal (split.tokens.head._2)
       split.replicas.size should equal (1)
     }
+  }
+
+  "PartKey Reads and Writes" should "work" in {
+    val dataset = Dataset("prometheus", Schemas.gauge).ref
+
+    colStore.initialize(dataset, 1).futureValue
+    colStore.truncate(dataset, 1).futureValue
+
+    val pks = (10000 to 30000).map(_.toString.getBytes)
+                              .zipWithIndex.map { case (pk, i) => PartKeyRecord(pk, 5, 10, Some(i))}.toSet
+
+    val updateHour = 10
+    colStore.writePartKeys(dataset, 0, Observable.fromIterable(pks), 1.hour.toSeconds.toInt, 10, true )
+      .futureValue shouldEqual Success
+
+    val expectedKeys = pks.map(pk => new String(pk.partKey).toInt)
+
+    val readData = colStore.getPartKeysByUpdateHour(dataset, 0, updateHour).toListL.runAsync.futureValue.toSet
+    readData.map(pk => new String(pk.partKey).toInt) shouldEqual expectedKeys
+
+    val readData2 = colStore.scanPartKeys(dataset, 0).toListL.runAsync.futureValue.toSet
+    readData2.map(pk => new String(pk.partKey).toInt) shouldEqual expectedKeys
+
   }
 
   "copyChunksByIngestionTimeRange" should "actually work" in {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -304,12 +304,6 @@ filodb {
 
   ds-index-job {
 
-    # config to run one time complete partkey migration from raw cluster to downsampler cluster.
-    # This is required in the following scenarios
-    # 1. Initial refresh of partkey index to downsampler cluster
-    # 2. For fixing corrupt downsampler index
-    migrate-full-index = false
-
     # Name of the dataset from which to downsample
     # raw-dataset-name = "prometheus"
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -949,9 +949,10 @@ class TimeSeriesShard(val ref: DatasetRef,
         s"shard=$shardNum partKey[${p.stringPartition}] with startTime=${pk.startTime} endTime=${pk.endTime}")
       pk
     }
+    val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
     colStore.writePartKeys(ref, shardNum,
                            Observable.fromIterator(partKeyRecords),
-                           storeConfig.diskTTLSeconds).map { case resp =>
+                           storeConfig.diskTTLSeconds, updateHour).map { case resp =>
       if (flushGroup.dirtyPartsToFlush.length > 0) {
         logger.info(s"Finished flush of partKeys numPartKeys=${flushGroup.dirtyPartsToFlush.length}" +
           s" resp=$resp for dataset=$ref shard=$shardNum")

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -48,7 +48,7 @@ trait ChunkSink {
 
   def writePartKeys(ref: DatasetRef, shard: Int,
                     partKeys: Observable[PartKeyRecord], diskTTLSeconds: Int,
-                    writeToPkUTTable: Boolean = true): Future[Response]
+                    updateHour: Long, writeToPkUTTable: Boolean = true): Future[Response]
   /**
    * Initializes the ChunkSink for a given dataset.  Must be called once before writing.
    */
@@ -157,7 +157,7 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
 
   override def writePartKeys(ref: DatasetRef, shard: Int,
                              partKeys: Observable[PartKeyRecord], diskTTLSeconds: Int,
-                             writeToPkUTTable: Boolean = true): Future[Response] = {
+                             updateHour: Long, writeToPkUTTable: Boolean = true): Future[Response] = {
     partKeys.countL.map(c => sinkStats.partKeysWrite(c.toInt)).runAsync.map(_ => Success)
   }
 

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -21,7 +21,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
   import TestData._
 
   implicit val defaultPatience =
-    PatienceConfig(timeout = Span(15, Seconds), interval = Span(250, Millis))
+    PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   implicit val s = monix.execution.Scheduler.Implicits.global
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -15,7 +15,7 @@ import filodb.downsampler.DownsamplerContext
   * Goal: Align chunks when this job is run in multiple DCs so that cross-dc repairs can be done.
   * Non-Goal: Downsampling of non-real time data or data with different epoch.
   *
-  * Strategy is to run this spark job every 6 hours at 8am, 2pm, 8pm, 2am each day.
+  * Strategy is to run this spark job every 6 hours at 8am, 2pm, 8pm, 2am UTC each day.
   *
   * Run at 8am: We query data with ingestionTime from 10pm to 8am.
   *             Then query and downsample data with userTime between 12am to 6am.

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -1,48 +1,46 @@
 package filodb.downsampler.index
 
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.DownsamplerSettings
 
+/**
+  *
+  * Goal: Migrate Part keys into downsample cassandra tables.
+  *
+  * Strategy is to run this spark job every 6 hours at 7:15am, 1:15pm, 7:15pm, 1:15am UTC each day.
+  *
+  * Run at 7:15am: Will migrate all entries added for update hours 12am, 1am ... and 5am.
+  * Run at 1:15pm: Will migrate all entries added for update hours 6am, 7am ... and 11am.
+  * Run at 7:15pm: Will migrate all entries added for update hours 12pm, 1pm ... and 5pm.
+  * Run at 1:15am: Will migrate all entries added for update hours 6pm, 7pm ... and 11pm.
+  *
+  * Job behavior can be overridden/controlled in two ways:
+  * 1. If `spark.filodb.downsampler.index.doFullMigration` is set to true, full migration is done
+  * 2. If `spark.filodb.downsampler.index.timeInPeriodOverride` is set to an ISO timestamp, index migration
+  *    for that period will be done. For example: setting to `2020-03-13T15:44:56` will cause migration to
+  *    be run for hours 12pm, 1pm ... and 5pm on 2020-03-13
+  *
+  */
 object DSIndexJobMain extends App {
 
   //Kamon.init()  // kamon init should be first thing in driver jvm
   val dsSettings = new DownsamplerSettings()
   val dsIndexJobSettings = new DSIndexJobSettings(dsSettings)
-  val job = new DSIndexJob(dsSettings, dsIndexJobSettings)
 
-  val migrateUpto: Long = hour() - 1
   //migrate partkeys between these hours
-  val iu = new IndexJobDriver(migrateUpto - dsIndexJobSettings.batchLookbackInHours,
-                              migrateUpto, dsIndexJobSettings.numShards, job)
+  val iu = new IndexJobDriver(dsSettings, dsIndexJobSettings)
   val sparkConf = new SparkConf(loadDefaults = true)
   iu.run(sparkConf)
 
-  def hour(millis: Long = System.currentTimeMillis()): Long = millis / 1000 / 60 / 60
-
 }
 
-/**
-  * Migrate index updates from Raw dataset to Downsampled dataset.
-  * Updates get applied only to the dataset with highest ttl.
-  *
-  * Updates are applied sequentially between the provided hours inclusive. As the updates are incremental, if a job run
-  * fails and successive runs complete successfully, migration still needs to happen from the failed batch upto the
-  * latest hour. This is to ensure that subsequent mutations were not overwritten. Hence job will be submitted once to
-  * fix the failed cases.
-  *
-  * For e.g if there was a failure 12 hours ago. Job will be submitted to run once with 12 hours as lookback time to
-  * fix the indexes before resuming the regular schedule.
-  *
-  * @param fromHour from epoch hour - inclusive
-  * @param toHour to epoch hour - inclusive
-  */
-class IndexJobDriver(fromHour: Long,
-                     toHour: Long,
-                     numShards: Int,
-                     job: DSIndexJob) extends Serializable {
+class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSIndexJobSettings) extends Serializable {
 
   def run(conf: SparkConf): SparkSession = {
     val spark = SparkSession.builder()
@@ -50,14 +48,43 @@ class IndexJobDriver(fromHour: Long,
       .config(conf)
       .getOrCreate()
 
+    val timeInMigrationPeriod: Long = spark.sparkContext.getConf
+      .getOption("spark.filodb.downsampler.index.timeInPeriodOverride") match {
+      // by default assume a time in the previous downsample period
+      case None => System.currentTimeMillis() - dsSettings.downsampleChunkDuration
+      // examples: 2019-10-20T12:34:56Z  or  2019-10-20T12:34:56-08:00
+      case Some(str) => Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str)).toEpochMilli()
+    }
+
+    // This is required in the following scenarios
+    // 1. Initial refresh of partkey index to downsampler cluster
+    // 2. For fixing corrupt downsampler index
+    val doFullMigration = spark.sparkContext.getConf
+      .getBoolean("spark.filodb.downsampler.index.doFullMigration", false)
+
+    val hourInMigrationPeriod = timeInMigrationPeriod / 1000 / 60 / 60
+    val jobIntervalInHours = dsIndexJobSettings.batchLookbackInHours
+
+    val fromHour = hourInMigrationPeriod / jobIntervalInHours * jobIntervalInHours
+    val toHourExcl = fromHour + jobIntervalInHours
+
+    val job = new DSIndexJob(dsSettings, dsIndexJobSettings)
+
+    DownsamplerContext.dsLogger.info(s"This is the Downsampling Index Migration driver. Starting job... " +
+      s"fromHour=$fromHour " +
+      s"toHourExcl=$toHourExcl " +
+      s"doFullMigration=$doFullMigration")
+
+    val numShards = dsIndexJobSettings.numShards
+
     DownsamplerContext.dsLogger.info(s"Spark Job Properties: ${spark.sparkContext.getConf.toDebugString}")
     val startHour = fromHour
-    val endHour = toHour
+    val endHourExcl = toHourExcl
     spark.sparkContext
       .makeRDD(0 until numShards)
       .foreach { shard =>
         //Kamon.init() // kamon init should be first thing in worker jvm
-        job.updateDSPartKeyIndex(shard, startHour, endHour)
+        job.updateDSPartKeyIndex(shard, startHour, endHourExcl, doFullMigration)
       }
     DownsamplerContext.dsLogger.info(s"IndexUpdater Driver completed successfully")
     spark

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobSettings.scala
@@ -30,8 +30,6 @@ class DSIndexJobSettings(settings: DownsamplerSettings) extends Serializable {
 
   @transient lazy val cassWriteTimeout = dsIndexJobConfig.as[FiniteDuration]("cassandra-write-timeout")
 
-  @transient lazy val migrateRawIndex = dsIndexJobConfig.getBoolean("migrate-full-index")
-
   // Longer lookback-time is needed to account for failures in the job runs.
   // As the updates need to be applied incrementally, migration needs to happen from the failed batch until the
   // latest hour. This is to ensure that subsequent mutations were not overwritten.


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Index migration job should calculate migration hours not based on current hour, but current downsample period
* Migration hours should be overridable
* Added unit test to verify part key persistence in cassandra

