### PR TITLE
feat(spark-jobs): Chunk copier supports explicit deletion.

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -225,14 +225,14 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     * @param diskTimeToLiveSeconds pass zero to delete chunks
     */
   // scalastyle:off null method.length
-  def copyChunksByIngestionTimeRange(datasetRef: DatasetRef,
-                                     splits: Iterator[ScanSplit],
-                                     ingestionTimeStart: Long,
-                                     ingestionTimeEnd: Long,
-                                     batchSize: Int,
-                                     target: CassandraColumnStore,
-                                     targetDatasetRef: DatasetRef,
-                                     diskTimeToLiveSeconds: Int): Unit =
+  def copyOrDeleteChunksByIngestionTimeRange(datasetRef: DatasetRef,
+                                             splits: Iterator[ScanSplit],
+                                             ingestionTimeStart: Long,
+                                             ingestionTimeEnd: Long,
+                                             batchSize: Int,
+                                             target: CassandraColumnStore,
+                                             targetDatasetRef: DatasetRef,
+                                             diskTimeToLiveSeconds: Int): Unit =
   {
     val sourceIndexTable = getOrCreateIngestionTimeIndexTable(datasetRef)
     val sourceChunksTable = getOrCreateChunkTable(datasetRef)

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -160,8 +160,10 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
   }
 
   /**
-    * Deletes a single record, specified by a row from the scanRowsByIngestionTimeNoAsync method.
-    * Is used to delete records which are incorrect or inconsistent.
+    * Deletes a single record, specified by a row from the scanRowsByIngestionTimeNoAsync
+    * method.  Is used to delete records which are incorrect or inconsistent. The row object
+    * passed in contains the fields which uniquely identify the row to delete -- it doesn't
+    * specify the row entirely.
     */
   def deleteIndex(row: Row): Future[Response] = {
     connector.execStmtWithRetries(deleteIndexCql.bind(

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -45,6 +45,10 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
     s"VALUES (?, ?, ?, ?) USING TTL ?")
     .setConsistencyLevel(writeConsistencyLevel)
 
+  private lazy val deleteChunksCql = session.prepare(
+    s"DELETE FROM $tableString WHERE partition=? AND chunkid IN ?")
+    .setConsistencyLevel(writeConsistencyLevel)
+
   private lazy val readChunkInCql = session.prepare(
     s"SELECT info, chunks FROM $tableString " +
     s"WHERE partition = ? AND chunkid IN ?")
@@ -92,7 +96,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
   }
 
   /**
-    * Writes a single record, exactly as-is from the readChunks method. Is
+    * Writes a single record, exactly as-is from the readChunksNoAsync method. Is
     * used to copy records from one column store to another.
     */
   def writeChunks(partKeyBytes: ByteBuffer,
@@ -105,6 +109,16 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
       row.getList(2, classOf[ByteBuffer]), // chunks
       diskTimeToLiveSeconds: java.lang.Integer)
     )
+  }
+
+  /**
+    * Deletes raw chunk set rows.
+    */
+  def deleteChunks(partKeyBytes: ByteBuffer,
+                   chunkInfos: Seq[ByteBuffer]): Future[Response] = {
+    val query = deleteChunksCql.bind().setBytes(0, partKeyBytes)
+                                      .setList(1, chunkInfos.map(ChunkSetInfo.getChunkID).asJava)
+    connector.execStmtWithRetries(query)
   }
 
   /**

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -68,7 +68,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
 
   }
 
-  "copyChunksByIngestionTimeRange" should "actually work" in {
+  "copyOrDeleteChunksByIngestionTimeRange" should "actually work" in {
     val dataset = Dataset("source", Schemas.gauge)
     val targetDataset = Dataset("target", Schemas.gauge)
 
@@ -135,7 +135,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
     var chunks2 = colStore.getOrCreateChunkTable(targetDataset.ref).readAllChunksNoAsync(part2Bytes).all()
     chunks2 should have size (0)
 
-    colStore.copyChunksByIngestionTimeRange(
+    colStore.copyOrDeleteChunksByIngestionTimeRange(
       dataset.ref,
       colStore.getScanSplits(dataset.ref).iterator,
       startTimeMillis, // ingestionTimeStart
@@ -180,7 +180,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
 
     // Now delete from the source.
 
-    colStore.copyChunksByIngestionTimeRange(
+    colStore.copyOrDeleteChunksByIngestionTimeRange(
       dataset.ref,
       colStore.getScanSplits(dataset.ref).iterator,
       startTimeMillis, // ingestionTimeStart

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -188,7 +188,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
       7,         // batchSize
       colStore,  // target
       dataset.ref, // targetDatasetRef is the the source, to delete from it
-      -1) // diskTimeToLiveSeconds is negative, which means delete
+      0) // diskTimeToLiveSeconds is 0, which means delete
 
     chunks1 = colStore.getOrCreateChunkTable(dataset.ref).readAllChunksNoAsync(part1Bytes).all()
     chunks1 should have size (0)

--- a/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
@@ -66,7 +66,7 @@ class ChunkCopier(conf: SparkConf) {
   private[repair] def getTargetScanSplits = targetCassandraColStore.getScanSplits(targetDatasetRef, splitsPerNode)
 
   def copySourceToTarget(splitIter: Iterator[ScanSplit]): Unit = {
-    sourceCassandraColStore.copyChunksByIngestionTimeRange(
+    sourceCassandraColStore.copyOrDeleteChunksByIngestionTimeRange(
       sourceDatasetRef,
       splitIter,
       ingestionTimeStart.toEpochMilli(),
@@ -78,7 +78,7 @@ class ChunkCopier(conf: SparkConf) {
   }
 
   def deleteFromTarget(splitIter: Iterator[ScanSplit]): Unit = {
-    targetCassandraColStore.copyChunksByIngestionTimeRange(
+    targetCassandraColStore.copyOrDeleteChunksByIngestionTimeRange(
       targetDatasetRef,
       splitIter,
       ingestionTimeStart.toEpochMilli(),


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Chunk copier supports 0 TTL, which is effectively like a delete.

**New behavior :**
Use 0 TTL to indicate that an explicit delete must be performed on the target, which can be the same as the source.
