### PR TITLE
bug(core): Index Refresh in DownsampleShard should start with currentHour - 6

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -108,7 +108,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
         // need to start recovering 6 hours prior to now since last index migration could have run 6 hours ago
         // and we'd be missing entries that would be migrated in the last 6 hours.
         // Hence indexUpdatedHour should be: currentHour - 6
-        val indexJobIntervalInHours = Math.ceil(downsampleStoreConfig.maxChunkTime.toMinutes.toDouble / 60).toInt
+        val indexJobIntervalInHours = (downsampleStoreConfig.maxChunkTime.toMinutes + 59) / 60 // for ceil division
         indexUpdatedHour.set(hour() - indexJobIntervalInHours - 1)
         startHousekeepingTask()
         startStatsUpdateTask()

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -101,11 +101,15 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
   private def hour(millis: Long = System.currentTimeMillis()) = millis / 1000 / 60 / 60
 
   def recoverIndex(): Future[Unit] = {
-    indexUpdatedHour.set(hour() - 1)
     indexBootstrapper.bootstrapIndex(partKeyIndex, shardNum, indexDataset){ _ => createPartitionID() }
       .map { count =>
         logger.info(s"Bootstrapped index for dataset=$indexDataset shard=$shardNum with $count records")
       }.map { _ =>
+        // need to start recovering 6 hours prior to now since last index migration could have run 6 hours ago
+        // and we'd be missing entries that would be migrated in the last 6 hours.
+        // Hence indexUpdatedHour should be: currentHour - 6
+        val indexJobIntervalInHours = Math.ceil(downsampleStoreConfig.maxChunkTime.toMinutes.toDouble / 60).toInt
+        indexUpdatedHour.set(hour() - indexJobIntervalInHours - 1)
         startHousekeepingTask()
         startStatsUpdateTask()
       }.runAsync(housekeepingSched)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

When downsample shard comes up, first index refresh needs to happen at least 
from currentHour-6 - otherwise mutations that happened between last index migration job and "now" will be missed.