### PR TITLE
feat(core, sparkJobs): Stop downsampling untyped schema

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -73,8 +73,7 @@ filodb {
     untyped {
       columns = ["timestamp:ts", "number:double"]
       value-column = "number"
-      downsamplers = [ "tTime(0)", "dMin(1)", "dMax(1)", "dSum(1)", "dCount(1)", "dAvg(1)" ]
-      downsample-schema = "ds-gauge"
+      downsamplers = []
     }
 
     prom-counter {

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -694,21 +694,20 @@ object RecordBuilder {
     * mutate dataschema of the partitionKey for downsampling, only when downsample dataschema is different
     * than raw schema (e.g. Guages)
     */
-  final def updateDownsampleSchema(partKeyBase: Any, partKeyOffset: Long, schemas: Schemas): Unit = {
-    val rawSchema = schemas(schemaID(partKeyBase, partKeyOffset))
-    val downsampleSchema = rawSchema.downsample.get
-    if (rawSchema.schemaHash != downsampleSchema.schemaHash) {
-      UnsafeUtils.setShort(partKeyBase, partKeyOffset + 4, downsampleSchema.schemaHash.toShort)
-    }
+  final def updateSchema(partKeyBase: Any, partKeyOffset: Long, schema: Schema): Unit = {
+    UnsafeUtils.setShort(partKeyBase, partKeyOffset + 4, schema.schemaHash.toShort)
   }
 
   /**
     * Build a partkey from the source partkey and change the downsample schema.
     * Useful during downsampling as dataschema may differ.
     */
-  final def buildDownsamplePartKey(pkByte: Array[Byte], schemas: Schemas): Array[Byte] = {
-    val dsPkeyByte = pkByte.clone
-    updateDownsampleSchema(dsPkeyByte, UnsafeUtils.arayOffset, schemas)
-    dsPkeyByte
+  final def buildDownsamplePartKey(pkBytes: Array[Byte], schemas: Schemas): Option[Array[Byte]] = {
+    val rawSchema = schemas(schemaID(pkBytes, UnsafeUtils.arayOffset))
+    rawSchema.downsample.map { downSch =>
+      val dsPkeyBytes = pkBytes.clone
+      updateSchema(dsPkeyBytes, UnsafeUtils.arayOffset, downSch)
+      dsPkeyBytes
+    }
   }
 }

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -74,8 +74,10 @@ class IndexBootstrapper(colStore: ColumnStore) {
     }.mapAsync(parallelism) { pk =>
       Task {
         val downsamplPartKey = RecordBuilder.buildDownsamplePartKey(pk.partKey, schemas)
-        val partId = lookUpOrAssignPartId(downsamplPartKey)
-        index.upsertPartKey(downsamplPartKey, partId, pk.startTime, pk.endTime)()
+        downsamplPartKey.foreach { dpk =>
+          val partId = lookUpOrAssignPartId(dpk)
+          index.upsertPartKey(dpk, partId, pk.startTime, pk.endTime)()
+        }
       }
      }
      .countL

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -66,7 +66,7 @@ final case class AssignShardConfig(address: String, shardList: Seq[Int])
 final case class UnassignShardConfig(shardList: Seq[Int])
 
 object StoreConfig {
-  // NOTE: there are no defaults for flush interval and shard memory, those should fbe explicitly calculated
+  // NOTE: there are no defaults for flush interval and shard memory, those should be explicitly calculated
   val defaults = ConfigFactory.parseString("""
                                            |disk-time-to-live = 3 days
                                            |demand-paged-chunk-retention-period = 72 hours

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -66,7 +66,7 @@ final case class AssignShardConfig(address: String, shardList: Seq[Int])
 final case class UnassignShardConfig(shardList: Seq[Int])
 
 object StoreConfig {
-  // NOTE: there are no defaults for flush interval and shard memory, those should be explicitly calculated
+  // NOTE: there are no defaults for flush interval and shard memory, those should fbe explicitly calculated
   val defaults = ConfigFactory.parseString("""
                                            |disk-time-to-live = 3 days
                                            |demand-paged-chunk-retention-period = 72 hours

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -225,7 +225,7 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
         downsamplePartSpan.finish()
       case None =>
         numPartitionsNoDownsampleSchema.increment()
-        DownsamplerContext.dsLogger.debug(s"Encountered partition " +
+        DownsamplerContext.dsLogger.debug(s"Skipping downsampling of partition " +
           s"${rawPartSchema.partKeySchema.stringify(rawPart.partitionKey)} which does not have a downsample schema")
     }
   }

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -96,8 +96,8 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
     @volatile var count = 0
     val pkRecords = partKeys.flatMap(toPartKeyRecordWithHash).map{ pkey =>
       count += 1
-      DownsamplerContext.dsLogger.debug(s"migrating partition " +
-        s"PartKey=${schemas.part.binSchema.stringify(pkey.partKey)}" +
+      DownsamplerContext.dsLogger.debug(s"Migrating partition " +
+        s"partKey=${schemas.part.binSchema.stringify(pkey.partKey)}" +
         s" startTime=${pkey.startTime} endTime=${pkey.endTime}")
       pkey
     }
@@ -114,6 +114,11 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
     val pkr = dsPartKey.map { dpk =>
       val hash = Option(schemas.part.binSchema.partitionHash(dsPartKey, UnsafeUtils.arayOffset))
       PartKeyRecord(dpk, pkRecord.startTime, pkRecord.endTime, hash)
+    }
+    if (pkr.isEmpty) {
+      DownsamplerContext.dsLogger.debug(s"Skipping partition without downsample schema " +
+        s"partKey=${schemas.part.binSchema.stringify(pkRecord.partKey)}" +
+        s" startTime=${pkRecord.startTime} endTime=${pkRecord.endTime}")
     }
     Observable.fromIterable(pkr)
   }

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -54,10 +54,15 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   val rawDataStoreConfig = StoreConfig(ConfigFactory.parseString( """
                   |flush-interval = 1h
                   |shard-mem-size = 1MB
+                  |ingestion-buffer-mem-size = 30MB
                 """.stripMargin))
 
-  val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram),
+  val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram, Schemas.untyped),
                                      Map.empty, 100, rawDataStoreConfig)
+
+  val untypedName = "my_untyped"
+  var untypedPartKeyBytes: Array[Byte] = _
+
   val gaugeName = "my_gauge"
   var gaugePartKeyBytes: Array[Byte] = _
 
@@ -73,7 +78,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   val lastSampleTime = 1574373042000L
   val pkUpdateHour = hour(lastSampleTime)
 
-  val metricNames = Seq(gaugeName, gaugeLowFreqName, counterName, histName)
+  val metricNames = Seq(gaugeName, gaugeLowFreqName, counterName, histName, untypedName)
 
   val downsampler = new Downsampler(settings, batchDownsampler)
 
@@ -92,6 +97,48 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
   override def afterAll(): Unit = {
     offheapMem.free()
+  }
+
+  it ("should write untyped data to cassandra") {
+
+    val rawDataset = Dataset("prometheus", Schemas.untyped)
+
+    val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
+    val partKey = partBuilder.partKeyFromObjects(Schemas.untyped, untypedName, seriesTags)
+
+    val part = new TimeSeriesPartition(0, Schemas.untyped, partKey,
+      0, offheapMem.bufferPools(Schemas.untyped.schemaHash), batchDownsampler.shardStats,
+      offheapMem.nativeMemoryManager, 1)
+
+    untypedPartKeyBytes = part.partKeyBytes
+
+    val rawSamples = Stream(
+      Seq(1574372801000L, 3d, untypedName, seriesTags),
+      Seq(1574372802000L, 5d, untypedName, seriesTags),
+
+      Seq(1574372861000L, 9d, untypedName, seriesTags),
+      Seq(1574372862000L, 11d, untypedName, seriesTags),
+
+      Seq(1574372921000L, 13d, untypedName, seriesTags),
+      Seq(1574372922000L, 15d, untypedName, seriesTags),
+
+      Seq(1574372981000L, 17d, untypedName, seriesTags),
+      Seq(1574372982000L, 15d, untypedName, seriesTags),
+
+      Seq(1574373041000L, 13d, untypedName, seriesTags),
+      Seq(1574373042000L, 11d, untypedName, seriesTags)
+    )
+
+    MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
+      val rr = new BinaryRecordRowReader(Schemas.untyped.ingestionSchema, base, offset)
+      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+    }
+    part.switchBuffers(offheapMem.blockMemFactory, true)
+    val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
+
+    rawColStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
+    val pk = PartKeyRecord(untypedPartKeyBytes, 1574372801000L, 1574373042000L, Some(150))
+    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it ("should write gauge data to cassandra") {
@@ -339,12 +386,14 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
                                                      shard)
       Await.result(partKeys.map(pkMetricName).toListL.runAsync, 1 minutes)
     }.toSet
-    readKeys shouldEqual (0 to 10000).map(i => s"metric$i").toSet ++ metricNames
+
+    // readKeys should not contain untyped part key - we dont downsample untyped
+    readKeys shouldEqual (0 to 10000).map(i => s"metric$i").toSet ++ (metricNames.toSet - untypedName)
   }
 
   it("should read and verify gauge data in cassandra using PagedReadablePartition for 1-min downsampled data") {
 
-    val dsGaugePartKeyBytes = RecordBuilder.buildDownsamplePartKey(gaugePartKeyBytes, batchDownsampler.schemas)
+    val dsGaugePartKeyBytes = RecordBuilder.buildDownsamplePartKey(gaugePartKeyBytes, batchDownsampler.schemas).get
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
       batchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
       0,
@@ -374,7 +423,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   it("should read and verify low freq gauge in cassandra using PagedReadablePartition for 1-min downsampled data") {
 
     val dsGaugeLowFreqPartKeyBytes = RecordBuilder.buildDownsamplePartKey(gaugeLowFreqPartKeyBytes,
-                                                                          batchDownsampler.schemas)
+                                                                          batchDownsampler.schemas).get
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
       batchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
       0,
@@ -484,7 +533,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   }
 
   it("should read and verify gauge data in cassandra using PagedReadablePartition for 5-min downsampled data") {
-    val dsGaugePartKeyBytes = RecordBuilder.buildDownsamplePartKey(gaugePartKeyBytes, batchDownsampler.schemas)
+    val dsGaugePartKeyBytes = RecordBuilder.buildDownsamplePartKey(gaugePartKeyBytes, batchDownsampler.schemas).get
     val downsampledPartData2 = downsampleColStore.readRawPartitions(
       batchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
       0,
@@ -611,6 +660,31 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
       res.result.foreach(_.rows.nonEmpty shouldEqual true)
     }
 
+  }
+
+  it("should bring up DownsampledTimeSeriesShard and NOT be able to read untyped data using SelectRawPartitionsExec") {
+
+    val downsampleTSStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore,
+      settings.filodbConfig)
+
+    downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
+      0, rawDataStoreConfig, settings.rawDatasetIngestionConfig.downsampleConfig)
+
+    downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
+
+    val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
+
+      val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(untypedName))
+      val exec = MultiSchemaPartitionsExec(QueryContext(sampleLimit = 1000), InProcessPlanDispatcher,
+        batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
+
+      val queryConfig = new QueryConfig(settings.filodbConfig.getConfig("query"))
+      val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName", 3)
+      val res = exec.execute(downsampleTSStore, queryConfig)(queryScheduler)
+        .runAsync(queryScheduler).futureValue.asInstanceOf[QueryResult]
+      queryScheduler.shutdown()
+
+      res.result.size shouldEqual 0
   }
 
   it("should bring up DownsampledTimeSeriesShard and be able to read specific columns " +


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

We should not downsample untyped schema. Earlier, untyped schema was being downsampled as gauge.