### PR TITLE
fix(query): fix parsing of queries having aggregate function in metric name

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -293,15 +293,22 @@ trait Expression extends Aggregates with Selector with Numeric with Join {
     case name ~ params => Function(name.str, params)
   }
 
-  lazy val aggregateExpression: PackratParser[AggregateExpression] =
-    aggregateOperator ~ functionParams.? ~ aggregateGrouping.? ~ functionParams.? ^^ {
-      case fn ~ params ~ ag ~ ls => AggregateExpression(
-        fn, params.getOrElse(Seq.empty), ag, ls.getOrElse(Seq.empty)
+  lazy val aggregateExpression1: PackratParser[AggregateExpression] =
+    aggregateOperator ~ aggregateGrouping.?  ~ functionParams ~ functionParams.? ^^ {
+      case fn ~ ag ~ params ~  ls => AggregateExpression(
+        fn, params, ag, ls.getOrElse(Seq.empty)
+      )
+    }
+
+  lazy val aggregateExpression2: PackratParser[AggregateExpression] =
+    aggregateOperator ~ functionParams ~ aggregateGrouping.? ~ functionParams.? ^^ {
+      case fn ~ params ~ ag  ~  ls => AggregateExpression(
+        fn, params, ag, ls.getOrElse(Seq.empty)
       )
     }
 
   lazy val expression: PackratParser[Expression] =
-    binaryExpression | aggregateExpression |
+    binaryExpression | aggregateExpression2 | aggregateExpression1 |
       function | unaryExpression | vector | numericalExpression | simpleSeries | "(" ~> expression <~ ")"
 
 }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -187,7 +187,13 @@ class ParserSpec extends FunSpec with Matchers {
     parseSuccessfully("count_values(\"value\",some_metric)")
     parseSuccessfully("sum without(and, by, avg, count, alert, annotations)(some_metric)")
     parseSuccessfully("sum_over_time(foo)")
-    parseSuccessfully("sum:some_metric:dataset:1m{_ws_=\"demo\", _ns_=\"test\"}")
+    parseSuccessfully("sum:some_metric:dataset:1m{_ws_=\"some_workspace\", _ns_=\"some_namespace\"}")
+    parseSuccessfully("count:some_metric:dataset:1m{_ws_=\"some_workspace\", _ns_=\"some_namespace\"}")
+    parseSuccessfully("avg:some_metric:dataset:1m{_ws_=\"some_workspace\", _ns_=\"some_namespace\"}")
+    parseSuccessfully("min:some_metric:dataset:1m{_ws_=\"some_workspace\", _ns_=\"some_namespace\"}")
+    parseSuccessfully("max:some_metric:dataset:1m{_ws_=\"some_workspace\", _ns_=\"some_namespace\"}")
+    parseSuccessfully("stddev:some_metric:dataset:1m{_ws_=\"some_workspace\", _ns_=\"some_namespace\"}")
+    parseSuccessfully("stdvar:some_metric:dataset:1m{_ws_=\"some_workspace\", _ns_=\"some_namespace\"}")
 
     parseError("sum(other_metric) by (foo)(some_metric)")
     parseError("sum without(==)(some_metric)")
@@ -367,7 +373,8 @@ class ParserSpec extends FunSpec with Matchers {
       "absent(http_requests_total{host=\"api-server\"})" -> "ApplyAbsentFunction(PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(host,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,None),List(ColumnFilter(host,Equals(api-server)), ColumnFilter(__name__,Equals(http_requests_total))),RangeParams(1524855988,1000,1524855988),List())",
       "count_values(\"freq\", http_requests_total)" ->
         "Aggregate(CountValues,PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,None),List(\"freq\"),List(),List())",
-      "timestamp(http_requests_total)" -> "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,0,Timestamp,List(),None)"
+      "timestamp(http_requests_total)" -> "PeriodicSeriesWithWindowing(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List()),1524855988000,1000000,1524855988000,0,Timestamp,List(),None)",
+      "sum:some_metric:dataset:1m{_ws_=\"demo\", _ns_=\"test\"}" -> "PeriodicSeries(RawSeries(IntervalSelector(1524855688000,1524855988000),List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(test)), ColumnFilter(__name__,Equals(sum:some_metric:dataset:1m))),List()),1524855988000,1000000,1524855988000,None)"
     )
 
     val qts: Long = 1524855988L

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -187,7 +187,7 @@ class ParserSpec extends FunSpec with Matchers {
     parseSuccessfully("count_values(\"value\",some_metric)")
     parseSuccessfully("sum without(and, by, avg, count, alert, annotations)(some_metric)")
     parseSuccessfully("sum_over_time(foo)")
-
+    parseSuccessfully("sum:some_metric:dataset:1m{_ws_=\"demo\", _ns_=\"test\"}")
 
     parseError("sum(other_metric) by (foo)(some_metric)")
     parseError("sum without(==)(some_metric)")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Parsing of queries with aggregate function in name  throws exception : java.lang.IllegalArgumentException: Aggregate functions have at least 1 parameter and utmost 2 parameters\n\tat 
Example: `sum:some_metric:dataset:1m{_ws_="some-workspace", _ns_="some-namespace"}`

**New behavior :**
Make first functionParams mandatory in aggregateExpression. Also added another aggregateExpression so that queries with aggregateGrouping before and after metric name are supported. 
Example: sum without (foo) (some_metric) and sum (some_metric) without (foo).


