### PR TITLE
bug(query): override isRoutable in ScalarVaryingDoublePlan 

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -105,4 +105,13 @@ class LongTimeRangePlannerSpec extends FunSpec with Matchers {
       ep.lp shouldEqual logicalPlan
     }
   }
+
+  it("should direct raw-cluster-only queries to raw planner for scalar vector queries") {
+    val logicalPlan = Parser.queryRangeToLogicalPlan("scalar(vector(1)) * 10",
+      TimeStepParams(now/1000 - 7.minutes.toSeconds, 1.minute.toSeconds, now/1000 - 1.minutes.toSeconds))
+
+    val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
+    ep.name shouldEqual "raw"
+    ep.lp shouldEqual logicalPlan
+  }
 }

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -266,6 +266,7 @@ final case class ScalarVaryingDoublePlan(vectors: PeriodicSeriesPlan,
   override def startMs: Long = vectors.startMs
   override def stepMs: Long = vectors.stepMs
   override def endMs: Long = vectors.endMs
+  override def isRoutable: Boolean = vectors.isRoutable
 }
 
 /**


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
All ScalarVaryingDoublePlan  queries are routed. LongTimeRangePlanner throws `filodb.query.BadQueryException: Invalid logical plan` when it tries to get lookBackTime from LogicalPlan for queries which should not be routed.


**New behavior :**
Override isRoutable in ScalarVaryingDoublePlan so that queries like scalar(vector(1)) are not routed


