### PR TITLE
feat(sparkJobs): Cardinality Buster to handle ingestion of bad data

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -381,6 +381,15 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     ret
   }
 
+  def deletePartKeys(ref: DatasetRef,
+                     shard: Int,
+                     pks: Observable[Array[Byte]]): Future[Long] = {
+    val pkTable = getOrCreatePartitionKeysTable(ref, shard)
+    pks.mapAsync(writeParallelism) { pk =>
+      Task.fromFuture(pkTable.deletePartKey(pk, shard))
+    }.countL.runAsync
+  }
+
   def getPartKeysByUpdateHour(ref: DatasetRef,
                               shard: Int,
                               updateHour: Long): Observable[PartKeyRecord] = {

--- a/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
@@ -1,0 +1,53 @@
+package filodb.cardbuster
+
+import com.typesafe.scalalogging.{Logger, StrictLogging}
+import kamon.Kamon
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+import filodb.downsampler.chunk.DownsamplerSettings
+import filodb.downsampler.index.DSIndexJobSettings
+
+object CardinalityBusterMain extends App {
+
+  val dsSettings = new DownsamplerSettings()
+  val dsIndexJobSettings = new DSIndexJobSettings(dsSettings)
+
+  //migrate partkeys between these hours
+  val iu = new CardinalityBuster(dsSettings, dsIndexJobSettings)
+  val sparkConf = new SparkConf(loadDefaults = true)
+  iu.run(sparkConf)
+
+}
+
+object BusterContext extends StrictLogging {
+  lazy protected[cardbuster] val log: Logger = logger
+}
+
+class CardinalityBuster(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSIndexJobSettings) extends Serializable {
+
+  // scalastyle:off method.length
+  def run(conf: SparkConf): SparkSession = {
+    val spark = SparkSession.builder()
+      .appName("FiloDB_Cardinality_Buster")
+      .config(conf)
+      .getOrCreate()
+
+    val inDownsampleTables = spark.sparkContext.getConf.getBoolean("spark.filodb.cardbuster.inDownsampleTables",
+                                                        true)
+    BusterContext.log.info(s"This is the Cardinality Buster. Starting job. inDownsampleTables=$inDownsampleTables ")
+
+    val numShards = dsIndexJobSettings.numShards
+    val busterForShard = new PerShardCardinalityBuster(dsSettings, dsIndexJobSettings, inDownsampleTables)
+
+    spark.sparkContext
+      .makeRDD(0 until numShards)
+      .foreach { shard =>
+        Kamon.init() // kamon init should be first thing in worker jvm
+        busterForShard.bustIndexRecords(shard)
+      }
+    BusterContext.log.info(s"CardinalityBuster completed successfully")
+    spark
+  }
+
+}

--- a/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
@@ -13,7 +13,6 @@ object CardinalityBusterMain extends App {
   val dsSettings = new DownsamplerSettings()
   val dsIndexJobSettings = new DSIndexJobSettings(dsSettings)
 
-  //migrate partkeys between these hours
   val iu = new CardinalityBuster(dsSettings, dsIndexJobSettings)
   val sparkConf = new SparkConf(loadDefaults = true)
   iu.run(sparkConf)
@@ -26,7 +25,6 @@ object BusterContext extends StrictLogging {
 
 class CardinalityBuster(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSIndexJobSettings) extends Serializable {
 
-  // scalastyle:off method.length
   def run(conf: SparkConf): SparkSession = {
     val spark = SparkSession.builder()
       .appName("FiloDB_Cardinality_Buster")
@@ -38,7 +36,7 @@ class CardinalityBuster(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSI
     BusterContext.log.info(s"This is the Cardinality Buster. Starting job. inDownsampleTables=$inDownsampleTables ")
 
     val numShards = dsIndexJobSettings.numShards
-    val busterForShard = new PerShardCardinalityBuster(dsSettings, dsIndexJobSettings, inDownsampleTables)
+    val busterForShard = new PerShardCardinalityBuster(dsSettings, inDownsampleTables)
 
     spark.sparkContext
       .makeRDD(0 until numShards)

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -12,11 +12,9 @@ import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Schemas
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.DownsamplerSettings
-import filodb.downsampler.index.DSIndexJobSettings
 import filodb.memory.format.UnsafeUtils
 
 class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
-                                dsIndexJobSettings: DSIndexJobSettings,
                                 inDownsampleTables: Boolean) extends Serializable {
 
   @transient lazy private val numPartKeysDeleting = Kamon.counter("num-partkeys-deleting").withoutTags()
@@ -40,17 +38,14 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
   @transient lazy val deleteFilter = dsSettings.filodbConfig
     .as[Seq[Map[String, String]]]("cardbuster.delete-pk-filters").map(_.toSeq)
 
-  def filterFunc(pkPairs: Seq[(String, String)]): Boolean = {
-    deleteFilter.exists(filter => filter.forall(pkPairs.contains))
-  }
-
   def bustIndexRecords(shard: Int): Unit = {
+    BusterContext.log.info(s"Busting cardinality in shard=$shard with filter=$deleteFilter")
     val toDelete = colStore.scanPartKeys(dataset, shard).map(_.partKey)
       .filter { pk =>
         val rawSchemaId = RecordSchema.schemaID(pk, UnsafeUtils.arayOffset)
         val schema = schemas(rawSchemaId)
         val pkPairs = schema.partKeySchema.toStringPairs(pk, UnsafeUtils.arayOffset)
-        val willDelete = filterFunc(pkPairs)
+        val willDelete = deleteFilter.exists(filter => filter.forall(pkPairs.contains))
         if (willDelete) {
           BusterContext.log.debug(s"Deleting part key ${schema.partKeySchema.stringify(pk)}")
           numPartKeysDeleting.increment()

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -1,0 +1,64 @@
+package filodb.cardbuster
+
+import scala.concurrent.Await
+
+import kamon.Kamon
+import monix.execution.Scheduler
+import net.ceedubs.ficus.Ficus._
+
+import filodb.cassandra.columnstore.CassandraColumnStore
+import filodb.core.DatasetRef
+import filodb.core.binaryrecord2.RecordSchema
+import filodb.core.metadata.Schemas
+import filodb.downsampler.DownsamplerContext
+import filodb.downsampler.chunk.DownsamplerSettings
+import filodb.downsampler.index.DSIndexJobSettings
+import filodb.memory.format.UnsafeUtils
+
+class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
+                                dsIndexJobSettings: DSIndexJobSettings,
+                                inDownsampleTables: Boolean) extends Serializable {
+
+  @transient lazy private val numPartKeysDeleting = Kamon.counter("num-partkeys-deleting").withoutTags()
+  @transient lazy protected val readSched = Scheduler.io("cass-read-sched")
+  @transient lazy protected val writeSched = Scheduler.io("cass-write-sched")
+  @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(dsSettings.cassandraConfig)
+  @transient lazy private val schemas = Schemas.fromConfig(dsSettings.filodbConfig).get
+
+  @transient lazy private val colStore =
+                new CassandraColumnStore(dsSettings.filodbConfig, readSched, session, inDownsampleTables)(writeSched)
+
+  @transient lazy private val downsampleRefsByRes = dsSettings.downsampleResolutions
+                                                              .zip(dsSettings.downsampledDatasetRefs).toMap
+  @transient lazy private val rawDatasetRef = DatasetRef(dsSettings.rawDatasetName)
+  @transient lazy private val highestDSResolution =
+                                  dsSettings.rawDatasetIngestionConfig.downsampleConfig.resolutions.last
+  @transient lazy private val dsDatasetRef = downsampleRefsByRes(highestDSResolution)
+
+  @transient lazy private val dataset = if (inDownsampleTables) dsDatasetRef else rawDatasetRef
+
+  @transient lazy val deleteFilter = dsSettings.filodbConfig
+    .as[Seq[Map[String, String]]]("cardbuster.delete-pk-filters").map(_.toSeq)
+
+  def filterFunc(pkPairs: Seq[(String, String)]): Boolean = {
+    deleteFilter.exists(filter => filter.forall(pkPairs.contains))
+  }
+
+  def bustIndexRecords(shard: Int): Unit = {
+    val toDelete = colStore.scanPartKeys(dataset, shard).map(_.partKey)
+      .filter { pk =>
+        val rawSchemaId = RecordSchema.schemaID(pk, UnsafeUtils.arayOffset)
+        val schema = schemas(rawSchemaId)
+        val pkPairs = schema.partKeySchema.toStringPairs(pk, UnsafeUtils.arayOffset)
+        val willDelete = filterFunc(pkPairs)
+        if (willDelete) {
+          BusterContext.log.debug(s"Deleting part key ${schema.partKeySchema.stringify(pk)}")
+          numPartKeysDeleting.increment()
+        }
+        willDelete
+      }
+    val fut = colStore.deletePartKeys(dataset, shard, toDelete)
+    val numKeysDeleted = Await.result(fut, dsSettings.cassWriteTimeout)
+    BusterContext.log.info(s"Deleted keys from shard shard=$shard numKeysDeleted=$numKeysDeleted")
+  }
+}

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -98,7 +98,7 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
       val hasDownsampleSchema = schema.downsample.isDefined
       if (blacklisted) numPartKeysBlacklisted.increment()
       if (!hasDownsampleSchema) numPartKeysNoDownsampleSchema.increment()
-      DownsamplerContext.dsLogger.info(s"Migrating partition partKey=$pkPairs schema=${schema.name} " +
+      DownsamplerContext.dsLogger.debug(s"Migrating partition partKey=$pkPairs schema=${schema.name} " +
         s"startTime=${pk.startTime} endTime=${pk.endTime} blacklisted=$blacklisted " +
         s"hasDownsampleSchema=$hasDownsampleSchema")
       val eligible = hasDownsampleSchema && !blacklisted

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -67,7 +67,7 @@ class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSInde
     val fromHour = hourInMigrationPeriod / jobIntervalInHours * jobIntervalInHours
 
     // Index migration cannot be rerun just for specific hours, since there could have been
-    // subsequent updates. Perform migration or all hours until last downsample period's hour.
+    // subsequent updates. Perform migration for all hours until last downsample period's hour.
     val currentHour = hour(System.currentTimeMillis())
     val toHourExclDefault  = currentHour / jobIntervalInHours * jobIntervalInHours
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -86,7 +86,7 @@ class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSInde
     DownsamplerContext.dsLogger.info(s"This is the Downsampling Index Migration driver. Starting job... " +
       s"fromHour=$fromHour " +
       s"toHourExcl=$toHourExcl " +
-      s"timeInMigrationPeriod=$timeInMigrationPeriod " +
+      s"timeInMigrationPeriod=${java.time.Instant.ofEpochMilli(timeInMigrationPeriod)} " +
       s"doFullMigration=$doFullMigration")
 
     val numShards = dsIndexJobSettings.numShards

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -14,6 +14,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 
+import filodb.cardbuster.CardinalityBuster
 import filodb.core.GlobalScheduler._
 import filodb.core.MachineMetricsData
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, RecordBuilder, RecordSchema}
@@ -47,6 +48,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
   val batchDownsampler = new BatchDownsampler(settings)
 
   val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8, "_ns_".utf8 -> "my_ns".utf8)
+  val bulkSeriesTags = Map("_ws_".utf8 -> "bulk_ws".utf8, "_ns_".utf8 -> "bulk_ns".utf8)
 
   val rawColStore = batchDownsampler.rawCassandraColStore
   val downsampleColStore = batchDownsampler.downsampleCassandraColStore
@@ -80,11 +82,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
 
   val metricNames = Seq(gaugeName, gaugeLowFreqName, counterName, histName, untypedName)
 
-  val downsampler = new Downsampler(settings, batchDownsampler)
-
   def hour(millis: Long = System.currentTimeMillis()): Long = millis / 1000 / 60 / 60
-
-  val indexUpdater = new IndexJobDriver(settings, dsIndexJobSettings)
 
   override def beforeAll(): Unit = {
     batchDownsampler.downsampleRefsByRes.values.foreach { ds =>
@@ -321,13 +319,14 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val start = pkUpdateHour / 6 * 6 // 6 is number of hours per downsample chunk
     start until start + 6
   }
+
   it("should simulate bulk part key records being written for migration") {
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val schemas = Seq(Schemas.promHistogram, Schemas.gauge, Schemas.promCounter)
     case class PkToWrite(pkr: PartKeyRecord, shard: Int, updateHour: Long)
     val pks = for { i <- 0 to 10000 } yield {
       val schema = schemas(i % schemas.size)
-      val partKey = partBuilder.partKeyFromObjects(schema, s"metric$i", seriesTags)
+      val partKey = partBuilder.partKeyFromObjects(schema, s"metric$i", bulkSeriesTags)
       val bytes = schema.partKeySchema.asByteArray(UnsafeUtils.ZeroPointer, partKey)
       PkToWrite(PartKeyRecord(bytes, 0L, 1000L, Some(-i)), i % numShards, bulkPkUpdateHours(i % bulkPkUpdateHours.size))
     }
@@ -347,6 +346,7 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     val sparkConf = new SparkConf(loadDefaults = true)
     sparkConf.setMaster("local[2]")
     sparkConf.set("spark.filodb.downsampler.userTimeOverride", Instant.ofEpochMilli(lastSampleTime).toString)
+    val downsampler = new Downsampler(settings, batchDownsampler)
     downsampler.run(sparkConf).close()
   }
 
@@ -355,10 +355,11 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     sparkConf.setMaster("local[2]")
     sparkConf.set("spark.filodb.downsampler.index.timeInPeriodOverride", Instant.ofEpochMilli(lastSampleTime).toString)
     sparkConf.set("spark.filodb.downsampler.index.toHourExclOverride", (pkUpdateHour + 6 + 1).toString)
+    val indexUpdater = new IndexJobDriver(settings, dsIndexJobSettings)
     indexUpdater.run(sparkConf).close()
   }
 
-  it ("should recover migrated partKey data and match the downsampled schema") {
+  it ("should verify migrated partKey data and match the downsampled schema") {
 
     def pkMetricSchemaReader(pkr: PartKeyRecord): (String, String) = {
       val schemaId = RecordSchema.schemaID(pkr.partKey, UnsafeUtils.arayOffset)
@@ -710,5 +711,51 @@ class DownsamplerMainSpec extends FunSpec with Matchers with BeforeAndAfterAll w
     res.result.head.rows.map(r => (r.getLong(0), r.getDouble(1))).toList shouldEqual
       List((1574372982000L, 88.0), (1574373042000L, 24.0))
   }
+
+  it ("should be able to bust cardinality in raw and downsample tables with spark job") {
+    val sparkConf = new SparkConf(loadDefaults = true)
+    sparkConf.setMaster("local[2]")
+    val deleteFilterConfig = ConfigFactory.parseString( """
+                                                          |filodb.cardbuster.delete-pk-filters = [
+                                                          | {
+                                                          |    _ns_ = "bulk_ns"
+                                                          |    _ws_ = "bulk_ws"
+                                                          | }
+                                                          |]
+                                                        """.stripMargin)
+    val settings2 = new DownsamplerSettings(deleteFilterConfig.withFallback(conf))
+    val dsIndexJobSettings2 = new DSIndexJobSettings(settings2)
+    val cardBuster = new CardinalityBuster(settings2, dsIndexJobSettings2)
+    cardBuster.run(sparkConf).close()
+
+    sparkConf.set("spark.filodb.cardbuster.inDownsampleTables", "false")
+    cardBuster.run(sparkConf).close()
+  }
+
+  it("should verify bulk part key records are absent after deletion in both raw and downsample tables") {
+
+    def pkMetricName(pkr: PartKeyRecord): String = {
+      val strPairs = batchDownsampler.schemas.part.binSchema.toStringPairs(pkr.partKey, UnsafeUtils.arayOffset)
+      strPairs.find(p => p._1 == "_metric_").head._2
+    }
+
+    val readKeys = (0 until 4).flatMap { shard =>
+      val partKeys = downsampleColStore.scanPartKeys(batchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
+        shard)
+      Await.result(partKeys.map(pkMetricName).toListL.runAsync, 1 minutes)
+    }.toSet
+
+    // readKeys should not contain bulk PK records
+    readKeys shouldEqual (metricNames.toSet - untypedName)
+
+    val readKeys2 = (0 until 4).flatMap { shard =>
+      val partKeys = rawColStore.scanPartKeys(batchDownsampler.rawDatasetRef, shard)
+      Await.result(partKeys.map(pkMetricName).toListL.runAsync, 1 minutes)
+    }.toSet
+
+    // readKeys should not contain bulk PK records
+    readKeys2 shouldEqual metricNames.toSet
+  }
+
 
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Bad data will be ingested - it is a certainty. If the bad data is extreme high cardinality (like ip addresses and uuids assigned to tags), it will affect performance of the downsample index.  This spark job helps with deleting bad entries from the PartitionKeys table based on a filter passed as job config. It deletes from downsample tables by default. But can can configured to delete from raw tables as well.

Use with care since it deletes data from the tables!