### PR TITLE
feat(query, core): TimeSeries Metadata query can include start/end times

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -180,7 +180,7 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
           val options = QOptions(args.limit, args.sampleLimit, args.everyNSeconds.map(_.toInt),
             timeout, args.shards.map(_.map(_.toInt)), args.spread)
           parseTimeSeriesMetadataQuery(remote, args.matcher.get, args.dataset.get,
-            getQueryRange(args), options)
+            getQueryRange(args), true, options)
 
         case Some("labelValues") =>
           require(args.host.nonEmpty && args.dataset.nonEmpty && args.labelNames.nonEmpty, "--host, --dataset and --labelName must be defined")
@@ -256,8 +256,9 @@ object CliMain extends ArgMain[Arguments] with FilodbClusterNode {
 
   def parseTimeSeriesMetadataQuery(client: LocalClient, query: String, dataset: String,
                                    timeParams: TimeRangeParams,
+                                   fetchStartEndTimes: Boolean,
                                    options: QOptions): Unit = {
-    val logicalPlan = Parser.metadataQueryToLogicalPlan(query, timeParams)
+    val logicalPlan = Parser.metadataQueryToLogicalPlan(query, timeParams, fetchStartEndTimes)
     executeQuery2(client, dataset, logicalPlan, options, UnavailablePromQlQueryParams)
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -136,7 +136,7 @@ final class QueryActor(memStore: MemStore,
     }
   }
 
-  private def processExplainPlanQuery(q: ExplainPlan2Query, replyTo: ActorRef) = {
+  private def processExplainPlanQuery(q: ExplainPlan2Query, replyTo: ActorRef): Unit = {
     try {
       val execPlan = queryPlanner.materialize(q.logicalPlan, q.qContext)
       replyTo ! execPlan

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -412,7 +412,8 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     }
     val metaExec = shardsToHit.map { shard =>
       val dispatcher = dispatcherForShard(shard)
-      PartKeysExec(qContext, dispatcher, dsRef, shard, schemas.part, renamedFilters, lp.startMs, lp.endMs)
+      PartKeysExec(qContext, dispatcher, dsRef, shard, schemas.part, renamedFilters,
+                   lp.fetchStartEndTimes, lp.startMs, lp.endMs)
     }
     PlanResult(metaExec, false)
   }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -90,11 +90,12 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
   }
 
   def partKeysWithFilters(filter: Seq[ColumnFilter],
+                          fetchStartEndTimes: Boolean,
                           endTime: Long,
                           startTime: Long,
-                          limit: Int): Iterator[PartKey] = {
-    partKeyIndex.partIdsFromFilters(filter, startTime, endTime).iterator().take(limit).map { pId =>
-      PartKey(partKeyFromPartId(pId), UnsafeUtils.arayOffset)
+                          limit: Int): Iterator[PartKeyWithTimes] = {
+    partKeyIndex.partKeyRecordFromFilters(filter, startTime, endTime).iterator.take(limit).map { pk =>
+      PartKeyWithTimes(pk.partKey.bytes, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
     }
   }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -94,8 +94,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                           endTime: Long,
                           startTime: Long,
                           limit: Int): Iterator[PartKeyWithTimes] = {
-    partKeyIndex.partKeyRecordFromFilters(filter, startTime, endTime).iterator.take(limit).map { pk =>
-      PartKeyWithTimes(pk.partKey.bytes, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
+    partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime).iterator.take(limit).map { pk =>
+      PartKeyWithTimes(pk.partKey, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
     }
   }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -80,9 +80,10 @@ extends MemStore with StrictLogging {
     = getShard(dataset, shard)
         .map(_.labelValuesWithFilters(filters, labelNames, end, start, limit)).getOrElse(Iterator.empty)
 
-  def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                             end: Long, start: Long, limit: Int): Iterator[PartKey] =
-    getShard(dataset, shard).map(_.partKeysWithFilters(filters, end, start, limit)).getOrElse(Iterator.empty)
+  def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter], fetchStartEndTimes: Boolean,
+                             end: Long, start: Long, limit: Int): Iterator[PartKeyWithTimes] =
+    getShard(dataset, shard).map(_.partKeysWithFilters(filters, fetchStartEndTimes,
+                                                       end, start, limit)).getOrElse(Iterator.empty)
 
   def lookupPartitions(ref: DatasetRef,
                        partMethod: PartitionScanMethod,

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -168,8 +168,8 @@ trait MemStore extends ChunkSource {
     * on the given shard on this node.
     * @return an Iterator for the TimeSeriesPartition
     */
-  def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                          end: Long, start: Long, limit: Int): Iterator[PartKey]
+  def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter], fetchStartEndTimes: Boolean,
+                          end: Long, start: Long, limit: Int): Iterator[PartKeyWithTimes]
 
   /**
    * Returns the number of partitions being maintained in the memtable for a given shard

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -5,6 +5,7 @@ import java.util.PriorityQueue
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.HashSet
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.FiniteDuration
 
 import com.googlecode.javaewah.{EWAHCompressedBitmap, IntIterator}
@@ -64,6 +65,7 @@ object PartKeyLuceneIndex {
 }
 
 final case class TermInfo(term: UTF8Str, freq: Int)
+final case class PartKeyLuceneIndexRecord(partKey: BytesRef, startTime: Long, endTime: Long)
 
 class PartKeyLuceneIndex(ref: DatasetRef,
                          schema: PartitionSchema,
@@ -474,6 +476,23 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   def partIdsFromFilters(columnFilters: Seq[ColumnFilter],
                          startTime: Long,
                          endTime: Long): debox.Buffer[Int] = {
+    val collector = new PartIdCollector() // passing zero for unlimited results
+    searchFromFilters(columnFilters, startTime, endTime, collector)
+    collector.result
+  }
+
+  def partKeyRecordFromFilters(columnFilters: Seq[ColumnFilter],
+                         startTime: Long,
+                         endTime: Long): Seq[PartKeyLuceneIndexRecord] = {
+    val collector = new PartKeyRecordCollector()
+    searchFromFilters(columnFilters, startTime, endTime, collector)
+    collector.records
+  }
+
+  private def searchFromFilters(columnFilters: Seq[ColumnFilter],
+                         startTime: Long,
+                         endTime: Long,
+                         collector: Collector): Unit = {
     val partKeySpan = Kamon.spanBuilder("index-partition-lookup-latency")
       .tag("dataset", ref.dataset)
       .tag("shard", shardNum)
@@ -488,10 +507,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     booleanQuery.add(LongPoint.newRangeQuery(END_TIME, startTime, Long.MaxValue), Occur.FILTER)
     val query = booleanQuery.build()
     logger.debug(s"Querying dataset=$ref shard=$shardNum partKeyIndex with: $query")
-    val collector = new PartIdCollector() // passing zero for unlimited results
     withNewSearcher(s => s.search(query, collector))
     partKeySpan.finish()
-    collector.result
   }
 
   def partIdFromPartKeySlow(partKeyBase: Any,
@@ -528,7 +545,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     partKeySpan.finish()
     chosenPartId
   }
-
 }
 
 class NumericDocValueCollector(docValueName: String) extends SimpleCollector {
@@ -698,6 +714,29 @@ class PartIdStartTimeCollector extends SimpleCollector {
       val partId = partIdDv.longValue().toInt
       val startTime = startTimeDv.longValue()
       startTimes(partId) = startTime
+    } else {
+      throw new IllegalStateException("This shouldn't happen since every document should have partIdDv and startTimeDv")
+    }
+  }
+}
+
+class PartKeyRecordCollector extends SimpleCollector {
+  val records = new ArrayBuffer[PartKeyLuceneIndexRecord]
+  private var partKeyDv: BinaryDocValues = _
+  private var startTimeDv: NumericDocValues = _
+  private var endTimeDv: NumericDocValues = _
+
+  override def needsScores(): Boolean = false
+
+  override def doSetNextReader(context: LeafReaderContext): Unit = {
+    partKeyDv = context.reader().getBinaryDocValues(PartKeyLuceneIndex.PART_KEY)
+    startTimeDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.START_TIME)
+    endTimeDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.END_TIME)
+  }
+
+  override def collect(doc: Int): Unit = {
+    if (partKeyDv.advanceExact(doc) && startTimeDv.advanceExact(doc) && endTimeDv.advanceExact(doc)) {
+      records += PartKeyLuceneIndexRecord(partKeyDv.binaryValue(), startTimeDv.longValue(), endTimeDv.longValue())
     } else {
       throw new IllegalStateException("This shouldn't happen since every document should have partIdDv and startTimeDv")
     }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -185,9 +185,10 @@ extends MemStore with StrictLogging {
     = getShard(dataset, shard)
         .map(_.labelValuesWithFilters(filters, labelNames, end, start, limit)).getOrElse(Iterator.empty)
 
-  def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
-                             end: Long, start: Long, limit: Int): Iterator[PartKey] =
-    getShard(dataset, shard).map(_.partKeysWithFilters(filters, end, start, limit)).getOrElse(Iterator.empty)
+  def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter], fetchStartEndTimes: Boolean,
+                             end: Long, start: Long, limit: Int): Iterator[PartKeyWithTimes] =
+    getShard(dataset, shard).map(_.partKeysWithFilters(filters, fetchStartEndTimes,
+      end, start, limit)).getOrElse(Iterator.empty)
 
   def numPartitions(dataset: DatasetRef, shard: Int): Int =
     getShard(dataset, shard).map(_.numActivePartitions).getOrElse(-1)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -282,7 +282,8 @@ class TimeSeriesShard(val ref: DatasetRef,
         assert(numBytes == partition.schema.data.blockMetaSize)
         val chunkID = UnsafeUtils.getLong(metaAddr + 4)
         partition.removeChunksAt(chunkID)
-        logger.debug(s"Reclaiming chunk chunkID=$chunkID from partID=$partID ${partition.stringPartition}")
+        logger.debug(s"Reclaiming chunk chunkID=$chunkID from shard=$shardNum " +
+          s"partID=$partID ${partition.stringPartition}")
       }
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -159,6 +159,7 @@ object TimeSeriesShard {
 }
 
 private[core] final case class PartKey(base: Any, offset: Long)
+private[core] final case class PartKeyWithTimes(base: Any, offset: Long, startTime: Long, endTime: Long)
 
 trait PartitionIterator extends Iterator[TimeSeriesPartition] {
   def skippedPartIDs: Buffer[Int]
@@ -658,26 +659,33 @@ class TimeSeriesShard(val ref: DatasetRef,
     * This method is to apply column filters and fetch matching time series partition keys.
     */
   def partKeysWithFilters(filter: Seq[ColumnFilter],
+                          fetchStartEndTimes: Boolean,
                           endTime: Long,
                           startTime: Long,
-                          limit: Int): Iterator[PartKey] = {
-    val partIds = partKeyIndex.partIdsFromFilters(filter, startTime, endTime)
-    val inMem = InMemPartitionIterator2(partIds)
-    val inMemPartKeys = inMem.map { p => PartKey(p.partKeyBase, p.partKeyOffset) }
-    val skippedPartKeys = inMem.skippedPartIDs.iterator().map(partKeyFromPartId)
-    (inMemPartKeys ++ skippedPartKeys).take(limit)
+                          limit: Int): Iterator[PartKeyWithTimes] = {
+    if (fetchStartEndTimes) {
+      partKeyIndex.partKeyRecordFromFilters(filter, startTime, endTime).iterator.map { pk =>
+        PartKeyWithTimes(pk.partKey.bytes, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
+      }
+    } else {
+      val partIds = partKeyIndex.partIdsFromFilters(filter, startTime, endTime)
+      val inMem = InMemPartitionIterator2(partIds)
+      val inMemPartKeys = inMem.map { p => PartKeyWithTimes(p.partKeyBase, p.partKeyOffset, -1, -1) }
+      val skippedPartKeys = inMem.skippedPartIDs.iterator().map(partKeyFromPartId)
+      (inMemPartKeys ++ skippedPartKeys).take(limit)
+    }
   }
 
   /**
     * retrieve partKey for a given PartId
     */
-  private def partKeyFromPartId(partId: Int): PartKey = {
+  private def partKeyFromPartId(partId: Int): PartKeyWithTimes = {
     val nextPart = partitions.get(partId)
     if (nextPart != UnsafeUtils.ZeroPointer)
-      PartKey(nextPart.partKeyBase, nextPart.partKeyOffset)
+      PartKeyWithTimes(nextPart.partKeyBase, nextPart.partKeyOffset, -1, -1)
     else { //retrieving PartKey from lucene index
       val partKeyByteBuf = partKeyIndex.partKeyFromPartId(partId)
-      if (partKeyByteBuf.isDefined) PartKey(partKeyByteBuf.get.bytes, UnsafeUtils.arayOffset)
+      if (partKeyByteBuf.isDefined) PartKeyWithTimes(partKeyByteBuf.get.bytes, UnsafeUtils.arayOffset, -1, -1)
       else throw new IllegalStateException("This is not an expected behavior." +
         " PartId should always have a corresponding PartKey!")
     }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -664,8 +664,8 @@ class TimeSeriesShard(val ref: DatasetRef,
                           startTime: Long,
                           limit: Int): Iterator[PartKeyWithTimes] = {
     if (fetchStartEndTimes) {
-      partKeyIndex.partKeyRecordFromFilters(filter, startTime, endTime).iterator.map { pk =>
-        PartKeyWithTimes(pk.partKey.bytes, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
+      partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime).iterator.map { pk =>
+        PartKeyWithTimes(pk.partKey, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
       }
     } else {
       val partIds = partKeyIndex.partIdsFromFilters(filter, startTime, endTime)

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -83,7 +83,25 @@ class PartKeyLuceneIndexSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   }
 
-  it("should upsert part keys with endtime and foreachPartKeyStillIngesting should work") {
+  it("should fetch part key records from filters correctly") {
+    // Add the first ten keys and row numbers
+    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+      .zipWithIndex.map { case (addr, i) =>
+      val pk = partKeyOnHeap(dataset6, ZeroPointer, addr)
+      keyIndex.addPartKey(pk, i, i, i + 10)()
+        PartKeyLuceneIndexRecord(pk, i, i + 10)
+    }
+    keyIndex.refreshReadersBlocking()
+
+    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+    val result = keyIndex.partKeyRecordsFromFilters(Seq(filter2), 0, Long.MaxValue)
+    val expected = Seq(pkrs(7), pkrs(8), pkrs(9))
+
+    result.map(_.partKey.toSeq) shouldEqual expected.map(_.partKey.toSeq)
+    result.map( p => (p.startTime, p.endTime)) shouldEqual expected.map( p => (p.startTime, p.endTime))
+  }
+
+    it("should upsert part keys with endtime and foreachPartKeyStillIngesting should work") {
     // Add the first ten keys and row numbers
     partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
       .zipWithIndex.foreach { case (addr, i) =>

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -59,10 +59,12 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
         ColumnFilter("id", Filter.Equals("0".utf8)))
-    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, now, now - 5000, 10)
+    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, false, now, now - 5000, 10)
     val seqMapConsumer = new SeqMapConsumer()
-    val tsPart = metadata.next()
-    timeseriesDataset.partKeySchema.consumeMapItems(tsPart.base, tsPart.offset, 0, seqMapConsumer)
+    val tsPartData = metadata.next()
+    timeseriesDataset.partKeySchema.consumeMapItems(tsPartData.base, tsPartData.offset, 0, seqMapConsumer)
+    tsPartData.startTime shouldEqual -1 // since fetchStartEndTimes is false
+    tsPartData.endTime shouldEqual -1 // since fetchStartEndTimes is false
     seqMapConsumer.pairs shouldEqual jobQueryResult2
   }
 
@@ -76,6 +78,7 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     shard.updatePartEndTimeInIndex(part, part.timestampOfLatestSample)
     memStore.refreshIndexForTesting(timeseriesDataset.ref)
     val endTime = part.timestampOfLatestSample
+    val startTime = part.earliestTime
 
     memStore.ingest(timeseriesDataset.ref, 0, SomeData(createRecordContainer(10, 20), 0))
     memStore.refreshIndexForTesting(timeseriesDataset.ref)
@@ -84,10 +87,12 @@ class TimeSeriesMemStoreForMetadataSpec extends FunSpec with Matchers with Scala
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
       ColumnFilter("id", Filter.Equals("0".utf8)))
-    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, endTime, endTime - 5000, 10)
+    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, true, endTime, endTime - 5000, 10)
     val seqMapConsumer = new SeqMapConsumer()
-    val tsPart = metadata.next()
-    timeseriesDataset.partKeySchema.consumeMapItems(tsPart.base, tsPart.offset, 0, seqMapConsumer)
+    val tsPartData = metadata.next()
+    timeseriesDataset.partKeySchema.consumeMapItems(tsPartData.base, tsPartData.offset, 0, seqMapConsumer)
+    tsPartData.startTime shouldEqual startTime
+    tsPartData.endTime shouldEqual endTime
     seqMapConsumer.pairs shouldEqual jobQueryResult2
   }
 

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -193,8 +193,8 @@ trait Vectors extends Scalars with TimeUnits with Base {
       }.getOrElse(ps)
     }
 
-    def toMetadataPlan(timeParams: TimeRangeParams): SeriesKeysByFilters = {
-      SeriesKeysByFilters(columnFilters, timeParams.start * 1000, timeParams.end * 1000)
+    def toMetadataPlan(timeParams: TimeRangeParams, fetchStartEndTimes: Boolean): SeriesKeysByFilters = {
+      SeriesKeysByFilters(columnFilters, fetchStartEndTimes, timeParams.start * 1000, timeParams.end * 1000)
     }
 
     def toRawSeriesPlan(timeParams: TimeRangeParams): RawSeries = {

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -348,10 +348,11 @@ object Parser extends Expression {
     }
   }
 
-  def metadataQueryToLogicalPlan(query: String, timeParams: TimeRangeParams): LogicalPlan = {
+  def metadataQueryToLogicalPlan(query: String, timeParams: TimeRangeParams,
+                                 fetchStartEndTimes: Boolean = false): LogicalPlan = {
     val expression = parseQuery(query)
     expression match {
-      case p: InstantExpression => p.toMetadataPlan(timeParams)
+      case p: InstantExpression => p.toMetadataPlan(timeParams, fetchStartEndTimes)
       case _ => throw new UnsupportedOperationException()
     }
   }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -15,10 +15,10 @@ class ParserSpec extends FunSpec with Matchers {
     parseError("job{__name__=\"prometheus\"}")
     parseError("job[__name__=\"prometheus\"]")
     val queryToLpString = ("http_requests_total{job=\"prometheus\", method=\"GET\"}" ->
-      "SeriesKeysByFilters(List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(method,Equals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),1524855988000,1524855988000)")
+      "SeriesKeysByFilters(List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(method,Equals(GET)), ColumnFilter(__name__,Equals(http_requests_total))),true,1524855988000,1524855988000)")
     val start: Long = 1524855988L
     val end: Long = 1524855988L
-    val lp = Parser.metadataQueryToLogicalPlan(queryToLpString._1, TimeStepParams(start, -1, end))
+    val lp = Parser.metadataQueryToLogicalPlan(queryToLpString._1, TimeStepParams(start, -1, end), true)
     lp.toString shouldEqual queryToLpString._2
   }
 

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -78,6 +78,7 @@ case class LabelValues(labelNames: Seq[String],
                        lookbackTimeMs: Long) extends MetadataQueryPlan
 
 case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
+                               fetchStartEndTimes: Boolean,
                                startMs: Long,
                                endMs: Long) extends MetadataQueryPlan
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -101,6 +101,7 @@ final case class PartKeysExec(queryContext: QueryContext,
                               shard: Int,
                               partSchema: PartitionSchema,
                               filters: Seq[ColumnFilter],
+                              fetchStartEndTimes: Boolean,
                               start: Long,
                               end: Long) extends LeafExecPlan {
 
@@ -111,13 +112,16 @@ final case class PartKeysExec(queryContext: QueryContext,
                (implicit sched: Scheduler): ExecResult = {
     val rvs = source match {
       case memStore: MemStore =>
-        val response = memStore.partKeysWithFilters(dataset, shard, filters, end, start, queryContext.sampleLimit)
-        Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty), new PartKeyRowReader(response)))
+        val response = memStore.partKeysWithFilters(dataset, shard, filters,
+          fetchStartEndTimes, end, start, queryContext.sampleLimit)
+        Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty), PartKeyRowReader(response)))
       case other =>
         Observable.empty
     }
     Kamon.currentSpan().mark("creating-resultschema")
-    val sch = new ResultSchema(Seq(ColumnInfo("TimeSeries", ColumnType.BinaryRecordColumn)), 1,
+    val sch = new ResultSchema(Seq(ColumnInfo("TimeSeries", ColumnType.BinaryRecordColumn),
+      ColumnInfo("StartTime", ColumnType.LongColumn),
+      ColumnInfo("EndTime", ColumnType.LongColumn)), 3,
                                Map(0 -> partSchema.binSchema))
     ExecResult(rvs, Task.eval(sch))
   }

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -105,7 +105,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
     val execPlan = PartKeysExec(QueryContext(), dummyDispatcher,
-      timeseriesDataset.ref, 0, Schemas.promCounter.partition, filters, now-5000, now)
+      timeseriesDataset.ref, 0, Schemas.promCounter.partition, filters, false, now-5000, now)
 
     val resp = execPlan.execute(memStore, queryConfig).runAsync.futureValue
     resp match {
@@ -119,7 +119,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
     val filters = Seq (ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
     val execPlan = PartKeysExec(QueryContext(), dummyDispatcher,
-      timeseriesDataset.ref, 0, Schemas.promCounter.partition, filters, now-5000, now)
+      timeseriesDataset.ref, 0, Schemas.promCounter.partition, filters, false, now-5000, now)
 
     val resp = execPlan.execute(memStore, queryConfig).runAsync.futureValue
     val result = resp match {
@@ -139,7 +139,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
 
     //Reducing limit results in truncated metadata response
     val execPlan = PartKeysExec(QueryContext(sampleLimit = limit-1), dummyDispatcher,
-      timeseriesDataset.ref, 0, Schemas.promCounter.partition, filters, now-5000, now)
+      timeseriesDataset.ref, 0, Schemas.promCounter.partition, filters, false, now-5000, now)
 
     val resp = execPlan.execute(memStore, queryConfig).runAsync.futureValue
     val result = resp match {

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -11,8 +11,8 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 
-import filodb.core.{TestData, query}
 import filodb.core.MetricsTestData._
+import filodb.core.TestData
 import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.Schemas
@@ -36,9 +36,8 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
     ("http_resp_time", Map("instance"->"someHost:8787", "job"->"myCoolService"))
   )
 
-  val typeLabel = "_type_" -> "prom-counter"
   val expectedLabelValues = partKeyLabelValues.map { case (metric, tags) =>
-    tags + typeLabel + ("_metric_" -> metric)
+    tags + ("_metric_" -> metric)
   }
 
   val jobQueryResult1 = ArrayBuffer(("job", "myCoolService"))
@@ -92,7 +91,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
-        rv.asInstanceOf[query.SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset)
+        rv.asInstanceOf[SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset)
       }
     }
     result shouldEqual jobQueryResult1
@@ -126,7 +125,7 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
       case QueryResult(id, _, response) => {
         response.size shouldEqual 1
         response(0).rows.map (row => response(0).asInstanceOf[SerializedRangeVector]
-          .schema.toStringPairs(row.getBlobBase(0),
+          .schema.brSchema(0).toStringPairs(row.getBlobBase(0),
           row.getBlobOffset(0)).toMap).toList
       }
     }
@@ -145,8 +144,8 @@ class MetadataExecSpec extends FunSpec with Matchers with ScalaFutures with Befo
     val result = resp match {
       case QueryResult(id, _, response) => {
         response.size shouldEqual 1
-        response(0).rows.map (row => response(0).asInstanceOf[query.SerializedRangeVector]
-          .schema.toStringPairs(row.getBlobBase(0),
+        response(0).rows.map (row => response(0).asInstanceOf[SerializedRangeVector]
+          .schema.brSchema(0).toStringPairs(row.getBlobBase(0),
           row.getBlobOffset(0)).toMap).toList
       }
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Metadata queries include partition keys along with start/end times. Slightly more expensive query when reqested.

TODO
* There is a bug in printing the part key key-value pairs when tested from CLI
* Test from HTTP 