### PR TITLE
feat(query): be able to count Histogram RVs

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -18,6 +18,11 @@ trait Histogram extends Ordered[Histogram] {
   def numBuckets: Int
 
   /**
+   * An empty histogram is one with no buckets
+   */
+  def isEmpty: Boolean = numBuckets == 0
+
+  /**
    * Gets the bucket definition for number no.  Observations for values <= this bucket, so it represents
    * an upper limit.
    */

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
@@ -47,6 +47,6 @@ object CountRowAggregator {
 
   // For histograms, we skip counting if histogram is empty or has no buckets
   val hist = new CountRowAggregator {
-    def isNull(item: RowReader): Boolean = item.getHistogram(1).numBuckets == 0
+    def isNull(item: RowReader): Boolean = item.getHistogram(1)isEmpty
   }
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
@@ -10,7 +10,7 @@ import filodb.memory.format.RowReader
   *                  Reduction happens by adding the count to the sum of counts.
   * Present: The count is directly presented
   */
-object CountRowAggregator extends RowAggregator {
+abstract class CountRowAggregator extends RowAggregator {
   class CountHolder(var timestamp: Long = 0L, var count: Double = Double.NaN) extends AggregateHolder {
     val row = new TransientRow()
     def toRowReader: MutableRowReader = { row.setValues(timestamp, count); row }
@@ -19,9 +19,12 @@ object CountRowAggregator extends RowAggregator {
   type AggHolderType = CountHolder
   def zero: CountHolder = new CountHolder()
   def newRowToMapInto: MutableRowReader = new TransientRow()
+
+  def isNull(item: RowReader): Boolean
+
   def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = {
     mapInto.setLong(0, item.getLong(0))
-    mapInto.setDouble(1, if (item.getDouble(1).isNaN) 0d else 1d)
+    mapInto.setDouble(1, if (isNull(item)) 0d else 1d)
     mapInto
   }
   def reduceAggregate(acc: CountHolder, aggRes: RowReader): CountHolder = {
@@ -34,4 +37,16 @@ object CountRowAggregator extends RowAggregator {
   def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
+}
+
+object CountRowAggregator {
+  // To count double values we skip counting of where values are NaN
+  val double = new CountRowAggregator {
+    def isNull(item: RowReader): Boolean = item.getDouble(1).isNaN
+  }
+
+  // For histograms, we skip counting if histogram is empty or has no buckets
+  val hist = new CountRowAggregator {
+    def isNull(item: RowReader): Boolean = item.getHistogram(1).numBuckets == 0
+  }
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
@@ -110,6 +110,7 @@ trait RowAggregator {
   def presentationSchema(source: ResultSchema): ResultSchema
 }
 
+//scalastyle:off cyclomatic.complexity
 object RowAggregator {
   def isHistMax(valColType: ColumnType, schema: ResultSchema): Boolean =
     valColType == ColumnType.HistogramColumn && schema.isHistDouble && schema.columns(2).name == "max"
@@ -125,7 +126,8 @@ object RowAggregator {
       case Sum if valColType == ColumnType.DoubleColumn => SumRowAggregator
       case Sum if isHistMax(valColType, schema)            => HistMaxSumAggregator
       case Sum if valColType == ColumnType.HistogramColumn => HistSumRowAggregator
-      case Count    => CountRowAggregator
+      case Count if valColType == ColumnType.DoubleColumn    => CountRowAggregator.double
+      case Count if valColType == ColumnType.HistogramColumn => CountRowAggregator.hist
       case Avg      => AvgRowAggregator
       case TopK     => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, false)
       case BottomK  => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, true)

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -498,6 +498,31 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     result2(0).key shouldEqual noKey
   }
 
+  it("should count histogram RVs") {
+    val (data1, rv1) = histogramRV(numSamples = 5)
+    val (data2, rv2) = histogramRV(numSamples = 5)
+    val samples: Array[RangeVector] = Array(rv1, rv2)
+
+    val agg1 = RowAggregator(AggregationOperator.Count, Nil, histSchema)
+    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping)
+    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key)
+
+    val result = resultObs.toListL.runAsync.futureValue
+    result.size shouldEqual 1
+    result(0).key shouldEqual noKey
+
+    val counts = data1.map(_ => 2).toList
+    result(0).rows.map(_.getDouble(1)).toList shouldEqual counts
+
+    // Test mapReduce of empty histogram sums
+    // val agg2 = RowAggregator(AggregationOperator.Sum, Nil, histSchema)
+    // val emptyObs = RangeVectorAggregator.mapReduce(agg2, false, Observable.empty, noGrouping)
+    // val resultObs2 = RangeVectorAggregator.mapReduce(agg2, true, emptyObs ++ resultObs1, rv=>rv.key)
+    // val result2 = resultObs2.toListL.runAsync.futureValue
+    // result2.size shouldEqual 1
+    // result2(0).key shouldEqual noKey
+  }
+
   it("should sum and compute max of histogram & max RVs") {
     val (data1, rv1) = MMD.histMaxRV(100000L, numSamples = 5)
     val (data2, rv2) = MMD.histMaxRV(100000L, numSamples = 5)

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -513,14 +513,6 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     val counts = data1.map(_ => 2).toList
     result(0).rows.map(_.getDouble(1)).toList shouldEqual counts
-
-    // Test mapReduce of empty histogram sums
-    // val agg2 = RowAggregator(AggregationOperator.Sum, Nil, histSchema)
-    // val emptyObs = RangeVectorAggregator.mapReduce(agg2, false, Observable.empty, noGrouping)
-    // val resultObs2 = RangeVectorAggregator.mapReduce(agg2, true, emptyObs ++ resultObs1, rv=>rv.key)
-    // val result2 = resultObs2.toListL.runAsync.futureValue
-    // result2.size shouldEqual 1
-    // result2(0).key shouldEqual noKey
   }
 
   it("should sum and compute max of histogram & max RVs") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

`count(my_histogram_metric)` fails with exceptions.  The Count RV aggregation logic assumes the values are doubles.

**New behavior :**

This adds support of count() of histogram RVs.   `CountRowAggregator` is abstracted to support both double and histogram data.
