### PR TITLE
fix(query): Fix extraction of +Inf bucket from histogram RV

### DIFF
--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -342,9 +342,14 @@ object MachineMetricsData {
                             DatasetOptions.DefaultOptions.copy(metricColumn = "metric"))
 
   var histBucketScheme: bv.HistogramBuckets = _
-  def linearHistSeries(startTs: Long = 100000L, numSeries: Int = 10, timeStep: Int = 1000, numBuckets: Int = 8):
+  def linearHistSeries(startTs: Long = 100000L, numSeries: Int = 10, timeStep: Int = 1000, numBuckets: Int = 8,
+                       infBucket: Boolean = false):
   Stream[Seq[Any]] = {
-    val scheme = bv.GeometricBuckets(2.0, 2.0, numBuckets)
+    val scheme = if (infBucket) {
+                   // Custom geometric buckets, with top bucket being +Inf
+                   val buckets = (0 to numBuckets - 2).map(n => Math.pow(2.0, n + 1)) ++ Seq(Double.PositiveInfinity)
+                   bv.CustomBuckets(buckets.toArray)
+                 } else bv.GeometricBuckets(2.0, 2.0, numBuckets)
     histBucketScheme = scheme
     val buckets = new Array[Long](numBuckets)
     def updateBuckets(bucketNo: Int): Unit = {
@@ -401,9 +406,9 @@ object MachineMetricsData {
 
   // Designed explicitly to work with linearHistSeries records and histDataset from MachineMetricsData
   def histogramRV(startTS: Long, pubFreq: Long = 10000L, numSamples: Int = 100, numBuckets: Int = 8,
-                  ds: Dataset = histDataset, pool: WriteBufferPool = histBufferPool):
+                  infBucket: Boolean = false, ds: Dataset = histDataset, pool: WriteBufferPool = histBufferPool):
   (Stream[Seq[Any]], RawDataRangeVector) = {
-    val histData = linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets).take(numSamples)
+    val histData = linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets, infBucket).take(numSamples)
     val container = records(ds, histData).records
     val part = TimeSeriesPartitionSpec.makePart(0, ds, partKey=histPartKey, bufferPool=pool)
     container.iterate(ds.ingestionSchema).foreach { row => part.ingest(0, row, histIngestBH, 1.hour.toMillis) }

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -119,7 +119,7 @@ trait Vectors extends Scalars with TimeUnits with Base {
     }
 
     private def parseBucketValue(value: String): Option[Double] =
-      if (value == "+Inf") Some(Double.PositiveInfinity) else Try(value.toDouble).toOption
+      if (value.toLowerCase == "+inf") Some(Double.PositiveInfinity) else Try(value.toDouble).toOption
 
     /**
      * Converts LabelMatches to ColumnFilters.  Along the way:

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -369,7 +369,8 @@ final case class HistogramBucketImpl() extends HistToDoubleIFunction {
     val bucket = scalarParams(0)
     if (bucket == Double.PositiveInfinity) {
       // Just get the top bucket if bucket scheme has +Inf at top, or return NaN
-      if (value.bucketTop(value.numBuckets - 1) == Double.PositiveInfinity) value.topBucketValue else Double.NaN
+      if (value.bucketTop(value.numBuckets - 1) == Double.PositiveInfinity) value.topBucketValue
+      else throw new IllegalArgumentException(s"+Inf bucket not in the last position!")
     } else {
       for { b <- 0 until value.numBuckets optimized } {
         // This comparison does not work for +Inf

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -367,9 +367,16 @@ final case class HistogramBucketImpl() extends HistToDoubleIFunction {
   final def apply(value: Histogram, scalarParams: Seq[Double]): Double = {
     require(scalarParams.length == 1, "Bucket/le required for histogram bucket")
     val bucket = scalarParams(0)
-    for { b <- 0 until value.numBuckets optimized } {
-      if (Math.abs(value.bucketTop(b) - bucket) <= 1E-10) return value.bucketValue(b)
+    if (bucket == Double.PositiveInfinity) {
+      // Just get the top bucket if bucket scheme has +Inf at top, or return NaN
+      if (value.bucketTop(value.numBuckets - 1) == Double.PositiveInfinity) value.topBucketValue else Double.NaN
+    } else {
+      for { b <- 0 until value.numBuckets optimized } {
+        // This comparison does not work for +Inf
+        if (Math.abs(value.bucketTop(b) - bucket) <= 1E-10) return value.bucketValue(b)
+      }
+      Double.NaN
+
     }
-    Double.NaN
   }
 }

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -180,8 +180,9 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
   def emptyAggHist: bv.MutableHistogram = bv.MutableHistogram.empty(MMD.histBucketScheme)
 
   // Designed explicitly to work with linearHistSeries records and histDataset from MachineMetricsData
-  def histogramRV(numSamples: Int = 100, numBuckets: Int = 8): (Stream[Seq[Any]], RawDataRangeVector) =
-    MMD.histogramRV(defaultStartTS, pubFreq, numSamples, numBuckets)
+  def histogramRV(numSamples: Int = 100, numBuckets: Int = 8, infBucket: Boolean = false):
+  (Stream[Seq[Any]], RawDataRangeVector) =
+    MMD.histogramRV(defaultStartTS, pubFreq, numSamples, numBuckets, infBucket)
 
   def chunkedWindowIt(data: Seq[Double],
                       rv: RawDataRangeVector,

--- a/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
@@ -255,10 +255,14 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
   }
 
   it("should compute histogram_bucket on Histogram RV") {
-    val (data, histRV) = histogramRV(numSamples = 10)
+    val (data, histRV) = histogramRV(numSamples = 10, infBucket = true)
     val expected = Seq(1.0, 2.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0)
     applyFunctionAndAssertResult(Array(histRV), Array(expected.toIterator),
                                  InstantFunctionId.HistogramBucket, Seq(16.0), histSchema)
+
+    val infExpected = (1 to 10).map(_.toDouble)
+    applyFunctionAndAssertResult(Array(histRV), Array(infExpected.toIterator),
+                                 InstantFunctionId.HistogramBucket, Seq(Double.PositiveInfinity), histSchema)
 
     // Specifying a nonexistant bucket returns NaN
     applyFunctionAndAssertResult(Array(histRV), Array(Seq.fill(8)(Double.NaN).toIterator),


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Extracting the `+Inf` bucket out of a histogram vector via `_bucket_="+Inf"` or `histogram_bucket(+Inf` was not working due to a bug in the `HistogramBucketImpl`.  The problem was that we were using code to compare the bucket value using double epsilon, ie (expected - actual) < (epsilon), but subtraction of infinity from infinity yields NaN in JVM.  

**New behavior :**

We add code to specialize the +Inf case so we wouldn't need to do an epsilon comparison.

