### PR TITLE
bug(query): Apply newXFormersForHistMax only on selected columns

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -59,14 +59,14 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
             // in bootstrapPartKeys().  This might happen after schema changes if old partkeys are not truncated.
             if (sch == Schemas.UnknownSchema) throw UnknownSchemaQueryErr(lookupRes.firstSchemaId.getOrElse(-1))
 
-            // Modify transformers as needed for histogram w/ max, downsample, other schemas
-            val newxformers1 = newXFormersForDownsample(sch, rangeVectorTransformers)
-            val newxformers = newXFormersForHistMax(sch, newxformers1)
-
             // Get exact column IDs needed, including max column as needed for histogram calculations.
             // This code is responsible for putting exact IDs needed by any range functions.
             val colIDs1 = getColumnIDs(sch, colName.toSeq, rangeVectorTransformers)
             val colIDs  = addIDsForHistMax(sch, colIDs1)
+
+            // Modify transformers as needed for histogram w/ max, downsample, other schemas
+            val newxformers1 = newXFormersForDownsample(sch, rangeVectorTransformers)
+            val newxformers = newXFormersForHistMax(sch, colIDs, newxformers1)
 
             val newPlan = SelectRawPartitionsExec(queryContext, dispatcher, dataset,
                                                   Some(sch), Some(lookupRes),

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -49,8 +49,10 @@ object SelectRawPartitionsExec extends  {
     }
   }
 
-  def newXFormersForHistMax(schema: Schema, transformers: Seq[RangeVectorTransformer]): Seq[RangeVectorTransformer] = {
-    histMaxColumn(schema, schema.data.columns.map(_.id)).map { maxColID =>
+  def newXFormersForHistMax(schema: Schema,
+                            colIDs: Seq[Types.ColumnId],
+                            transformers: Seq[RangeVectorTransformer]): Seq[RangeVectorTransformer] = {
+    histMaxColumn(schema, colIDs).map { maxColID =>
       // Histogram with max column present.  Check for range functions and change if needed
       val origFunc = findFirstRangeFunction(transformers)
       val newFunc = RangeFunction.histMaxRangeFunction(origFunc)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
HistMax transformers are being applied to the queries irrespective of what column is being selected.

**New behavior :**
HistMax transformers will applied to the queries only if the selected columns has max and histogram.
