### PR TITLE
fix(query): modify extract column name logic to take after the last occurence of "::" pattern

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -94,6 +94,7 @@ trait Vectors extends Scalars with TimeUnits with Base {
   sealed trait Vector extends Expression {
     def metricName: Option[String]
     def labelSelection: Seq[LabelMatch]
+    val regexColumnName: String = "::(?=[^::]+$)" //regex pattern to extract ::columnName at the end
 
     // Convert metricName{labels} -> {labels, __name__="metricName"} so it's uniform
     lazy val mergeNameToLabels: Seq[LabelMatch] = {
@@ -113,7 +114,7 @@ trait Vectors extends Scalars with TimeUnits with Base {
 
     // Returns (trimmedMetricName, column) after stripping ::columnName
     private def extractStripColumn(metricName: String): (String, Option[String]) = {
-      val parts = metricName.split("::", 2)
+      val parts = metricName.split(regexColumnName)
       if (parts.size > 1) {
         require(parts(1).nonEmpty, "cannot use empty column name")
         (parts(0), Some(parts(1)))

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -373,7 +373,6 @@ class ParserSpec extends FunSpec with Matchers {
     parseError("timestamp(some_metric, hello)") // reason : Expected only 1 arg, got 2
   }
 
-
   it("Should be able to make logical plans for Series Expressions") {
     val queryToLpString = Map(
       "http_requests_total + time()" -> "ScalarVectorBinaryOperation(ADD,ScalarTimeBasedPlan(Time,RangeParams(1524855988,1000,1524855988)),PeriodicSeries(RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List(),Some(300000),None),1524855988000,1000000,1524855988000,None),false)",
@@ -396,6 +395,8 @@ class ParserSpec extends FunSpec with Matchers {
         "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List(),Some(300000),None),1524855988000,1000000,1524855988000,None),List(5.0),List(),List())",
       "topk(5, http_requests_total::foo)" ->
         "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List(foo),Some(300000),None),1524855988000,1000000,1524855988000,None),List(5.0),List(),List())",
+      "topk(5, http_requests_total::foo::bar)" ->
+        "Aggregate(TopK,PeriodicSeries(RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total::foo))),List(bar),Some(300000),None),1524855988000,1000000,1524855988000,None),List(5.0),List(),List())",
       "stdvar(http_requests_total)" ->
         "Aggregate(Stdvar,PeriodicSeries(RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List(),Some(300000),None),1524855988000,1000000,1524855988000,None),List(),List(),List())",
       "stddev(http_requests_total)" ->
@@ -416,6 +417,8 @@ class ParserSpec extends FunSpec with Matchers {
         "RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(),Some(300000),None)",
       "http_requests_total::sum{job=\"prometheus\"}[5m]" ->
         "RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total))),List(sum),Some(300000),None)",
+      "http_requests_total::foo::sum{job=\"prometheus\"}[5m]" ->
+        "RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(__name__,Equals(http_requests_total::foo))),List(sum),Some(300000),None)",
       "http_requests_total offset 5m" ->
         "PeriodicSeries(RawSeries(IntervalSelector(1524855988000,1524855988000),List(ColumnFilter(__name__,Equals(http_requests_total))),List(),Some(300000),Some(300000)),1524855988000,1000000,1524855988000,Some(300000))",
       "http_requests_total{environment=~\"staging|testing|development\",method!=\"GET\"}" ->


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

**Current behavior :**
Column name is extracted by splitting metric name at the first occurrence of `::`. This may cause 
incorrect column name extraction if metric name has `::`.

**New behavior :**
Fix is to split at the last occurrence of `::`