### PR TITLE
fix(core): When removing a chunk, remove all lower ones too.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -387,8 +387,10 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
   //def dataChunkPointer(id: ChunkID, columnID: Int): BinaryVector.BinaryVectorPtr = infoGet(id).vectorPtr(columnID)
 
   final def removeChunksAt(id: ChunkID): Unit = {
-    chunkmapWithExclusive(chunkmapDoRemove(id))
-    shardStats.chunkIdsEvicted.increment()
+    // Remove all chunks at and lower than the given chunk. Doing so prevents a hole from
+    // emerging in the middle which ODP can't easily cope with.
+    val amt = chunkmapWithExclusive(chunkmapDoRemoveFloor(id))
+    shardStats.chunkIdsEvicted.increment(amt)
   }
 
   final def hasChunksAt(id: ChunkID): Boolean = chunkmapContains(id)

--- a/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
@@ -566,6 +566,36 @@ class ChunkMap(val memFactory: MemFactory, var capacity: Int) {
     size -= 1
   }
 
+  /**
+   * Removes all elements for the given key and lower. Caller must hold exclusive lock.
+   * @param key the highest key to remove
+   * @return amount removed
+   */
+  final def chunkmapDoRemoveFloor(key: Long): Int = {
+    if (size <= 0) {
+      return 0
+    }
+
+    val newFirst = {
+      // Check if matches the first key, or else search for it.
+      if (key == chunkmapKeyRetrieve(arrayGet(first))) {
+        first + 1
+      } else {
+        val ix = doBinarySearch(key)
+        if (ix < 0) {
+          ix & 0x7fffffff
+        } else {
+          ix + 1
+        }
+      }
+    }
+
+    val amt = newFirst - first
+    first = realIndex(newFirst)
+    size -= amt;
+    amt
+  }
+
   final def chunkmapFree(): Unit = {
     try {
       chunkmapAcquireExclusive()

--- a/memory/src/test/scala/filodb.memory/data/ChunkMapTest.scala
+++ b/memory/src/test/scala/filodb.memory/data/ChunkMapTest.scala
@@ -209,6 +209,40 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
     map.chunkmapFree()
   }
 
+  it("should remove floor") {
+    val map = new ChunkMap(memFactory, 12)
+    val elems = makeElems((0 to 30 by 3).map(_.toLong))
+    elems.foreach { elem =>
+      map.chunkmapDoPut(elem)
+    }
+    map.chunkmapSize shouldEqual elems.length
+
+    map.chunkmapDoRemoveFloor(0L) shouldEqual 1
+    map.chunkmapSize shouldEqual 10
+    map.chunkmapDoRemoveFloor(0L) shouldEqual 0
+    map.chunkmapSize shouldEqual 10
+
+    map.chunkmapDoRemoveFloor(6L) shouldEqual 2
+    map.chunkmapSize shouldEqual 8
+
+    map.chunkmapDoRemoveFloor(16L) shouldEqual 3
+    map.chunkmapSize shouldEqual 5
+
+    // With internal wraparound...
+    map.chunkmapDoPut(makeElementWithID(33))
+    map.chunkmapDoPut(makeElementWithID(36))
+    map.chunkmapDoPut(makeElementWithID(39))
+    map.chunkmapSize shouldEqual 8
+    map.chunkmapDoRemoveFloor(36L) shouldEqual 7
+    map.chunkmapSize shouldEqual 1
+
+    // All gone.
+    map.chunkmapDoRemoveFloor(40L) shouldEqual 1
+    map.chunkmapSize shouldEqual 0
+
+    map.chunkmapFree()
+  }
+
   import scala.concurrent.ExecutionContext.Implicits.global
 
   it("should handle concurrent inserts in various places") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
When a block is reclaimed, chunks can be removed from partitions leaving "gaps" or "holes" in the time range. ODP isn't able to detect these holes, and so data remains missing until after a restart. 

**New behavior :**
Removing a chunk forces all lower chunks in the partition to be removed as well. ODP can detect the missing data properly and fill in the gap. Although more chunks are effectively reclaimed with this new logic, it's compatible with the original model of time-ordered reclamation. In such a model, gaps aren't expected anyhow.
