### PR TITLE
bug(core): Check if paged chunk exists in chunkMap before copying to block

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -94,9 +94,8 @@ extends RawToPartitionMaker with StrictLogging {
             logger.debug(s"Populating paged chunk into memory chunkId=$chunkID inserted=$inserted " +
               s"partId=${tsPart.partID} shard=${tsShard.shardNum} ${tsPart.stringPartition}")
             if (!inserted) {
-              logger
-                .error(s"Chunks not copied to partId=${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
-                  s"$chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
+              logger.error(s"Chunks not copied to partId=${tsPart.partID} ${tsPart.stringPartition}, already has " +
+                  s"chunk $chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
                   s"${ChunkSetInfo.getEndTime(infoBytes)}) partition currentEarliestTime=${tsPart.earliestTime}")
             }
           }

--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -82,20 +82,23 @@ extends RawToPartitionMaker with StrictLogging {
           val memFactory = getMemFactory(timeBucketForChunkSet(infoBytes))
           val chunkID = ChunkSetInfo.getChunkID(infoBytes)
 
-          memFactory.startMetaSpan()
-          val chunkPtrs = copyToOffHeap(rawVectors, memFactory)
-          val metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),
-                                                tsPart.schema.data.blockMetaSize.toShort)
-          require(metaAddr != 0)
-          val infoAddr = metaAddr + 4   // Important: don't point at partID
-          val inserted = tsPart.addChunkInfoIfAbsent(chunkID, infoAddr)
+          if (!tsPart.chunkmapContains(chunkID)) {
+            memFactory.startMetaSpan()
+            val chunkPtrs = copyToOffHeap(rawVectors, memFactory)
+            val metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),
+              tsPart.schema.data.blockMetaSize.toShort)
+            require(metaAddr != 0)
+            val infoAddr = metaAddr + 4 // Important: don't point at partID
+            val inserted = tsPart.addChunkInfoIfAbsent(chunkID, infoAddr)
 
-          logger.debug(s"Populating paged chunk into memory chunkId=$chunkID inserted=$inserted " +
-            s"partId=${tsPart.partID} shard=${tsShard.shardNum} ${tsPart.stringPartition}")
-          if (!inserted) {
-            logger.info(s"Chunks not copied to partId=${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
-              s"$chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
-              s"${ChunkSetInfo.getEndTime(infoBytes)}) partition earliestTime=${tsPart.earliestTime}")
+            logger.debug(s"Populating paged chunk into memory chunkId=$chunkID inserted=$inserted " +
+              s"partId=${tsPart.partID} shard=${tsShard.shardNum} ${tsPart.stringPartition}")
+            if (!inserted) {
+              logger
+                .error(s"Chunks not copied to partId=${tsPart.partID} ${tsPart.stringPartition}, already has chunk " +
+                  s"$chunkID. Chunk time range (${ChunkSetInfo.getStartTime(infoBytes)}, " +
+                  s"${ChunkSetInfo.getEndTime(infoBytes)}) partition currentEarliestTime=${tsPart.earliestTime}")
+            }
           }
         }
       }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -223,11 +223,10 @@ TimeSeriesShard(ref, schemas, storeConfig, shardNum, bufferMemoryManager, rawSto
         case req: TimeRangeChunkScan      =>  if (partition.numChunks > 0) {
                                                 val memStartTime = partition.earliestTime
                                                 if (req.startTime < memStartTime && partStartTime < memStartTime) {
-                                                  val toODP = TimeRangeChunkScan(req.startTime, memStartTime - 1)
+                                                  val toODP = TimeRangeChunkScan(req.startTime, memStartTime)
                                                   logger.debug(s"Decided to ODP time range $toODP for " +
                                                     s"partID=${partition.partID} memStartTime=$memStartTime " +
                                                     s"shard=$shardNum ${partition.stringPartition}")
-                                                  // do not include earliestTime, otherwise will pull in first chunk
                                                   Some(toODP)
                                                 }
                                                 else None


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Before:
Paged chunk from Cassandra was copied to off-heap ODP block without checking if it exists in chunkMap. If it already existed, allocated memory is wasted. This with concurrent queries from dashboards caused too many chunks to be paged in and allocated but not added to chunkMap.

After:
We first do the contains check in the single threaded populateOdpChunks method and only then allocate in off-heap. 

