### PR TITLE
bug(query): comparison operators with bool should return NaN when lhs or rhs is NaN

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -152,7 +152,7 @@ trait ExecPlan extends QueryCommand {
               numResultSamples += srv.numRowsInt
               // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
               if (enforceLimit && numResultSamples > queryContext.sampleLimit)
-                throw new BadQueryException(s"This query results in more than $queryContext.sampleLimit samples. " +
+                throw new BadQueryException(s"This query results in more than ${queryContext.sampleLimit} samples. " +
                   s"Try applying more filters or reduce time range.")
               srv
           }

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -206,7 +206,9 @@ final case class ScalarOperationMapper(operator: BinaryOperator,
     funcParams.head match {
     case s: StaticFuncArgs   => evaluate(source, ScalarFixedDouble(s.timeStepParams, s.scalar))
     case t: TimeFuncArgs     => evaluate(source, TimeScalar(t.timeStepParams))
-    case e: ExecPlanFuncArgs => paramResponse.head.map(param => evaluate(source, param)).flatten
+    case e: ExecPlanFuncArgs => if (paramResponse.size > 1)
+                                 throw new UnsupportedOperationException("Multiple ExecPlanFunArgs not supported yet")
+                                paramResponse.head.map(param => evaluate(source, param)).flatten
    }
   }
 

--- a/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/binaryOp/BinaryOperatorFunction.scala
@@ -32,12 +32,42 @@ object BinaryOperatorFunction {
       case GTE                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs >= rhs) lhs else Double.NaN }
       case EQL                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs == rhs) lhs else Double.NaN }
       case NEQ                => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs != rhs) lhs else Double.NaN }
-      case LSS_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs < rhs)  1.0 else 0.0 }
-      case LTE_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs <= rhs) 1.0 else 0.0 }
-      case GTR_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs > rhs)  1.0 else 0.0 }
-      case GTE_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs >= rhs) 1.0 else 0.0 }
-      case EQL_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs == rhs) 1.0 else 0.0 }
-      case NEQ_BOOL           => new ScalarFunction { override def calculate(lhs: Double, rhs: Double): Double = if (lhs != rhs) 1.0 else 0.0 }
+      case LSS_BOOL           => new ScalarFunction {
+                                  override def calculate(lhs: Double, rhs: Double): Double = {
+                                    if (lhs.isNaN || rhs.isNaN) Double.NaN
+                                    else if (lhs < rhs) 1.0 else 0.0
+                                  }
+                                 }
+      case LTE_BOOL           => new ScalarFunction {
+                                  override def calculate(lhs: Double, rhs: Double): Double = {
+                                    if (lhs.isNaN || rhs.isNaN) Double.NaN
+                                    else if (lhs <= rhs) 1.0 else 0.0
+                                  }
+                                 }
+      case GTR_BOOL           => new ScalarFunction {
+                                  override def calculate(lhs: Double, rhs: Double): Double = {
+                                    if (lhs.isNaN || rhs.isNaN) Double.NaN
+                                    else if (lhs > rhs) 1.0 else 0.0
+                                  }
+                                 }
+      case GTE_BOOL           => new ScalarFunction {
+                                  override def calculate(lhs: Double, rhs: Double): Double = {
+                                    if (lhs.isNaN || rhs.isNaN) Double.NaN
+                                    else if (lhs >= rhs) 1.0 else 0.0
+                                  }
+                                 }
+      case EQL_BOOL           => new ScalarFunction {
+                                  override def calculate(lhs: Double, rhs: Double): Double = {
+                                    if (lhs.isNaN || rhs.isNaN) Double.NaN
+                                    else if (lhs == rhs) 1.0 else 0.0
+                                  }
+                                 }
+      case NEQ_BOOL           => new ScalarFunction {
+                                  override def calculate(lhs: Double, rhs: Double): Double = {
+                                    if (lhs.isNaN || rhs.isNaN) Double.NaN
+                                    else if (lhs != rhs) 1.0 else 0.0
+                                  }
+                                 }
       case _                  => throw new UnsupportedOperationException(s"$function not supported.")
     }
   }

--- a/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
@@ -49,8 +49,8 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
 
       override def rows: Iterator[RowReader] = data.iterator
     })
-    fireBinaryOperatorTests(samples)
-    fireComparatorOperatorTests(samples)
+    fireBinaryOperatorTests(samples, scalar)
+    fireComparatorOperatorTests(samples, scalar)
 
   }
 
@@ -78,8 +78,8 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
           new TransientRow(2L, 5.4d)).iterator
       }
     )
-    fireBinaryOperatorTests(samples)
-    fireComparatorOperatorTests(samples)
+    fireBinaryOperatorTests(samples, Double.NaN)
+    fireComparatorOperatorTests(samples, Double.NaN)
 
   }
 
@@ -101,11 +101,11 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
           new TransientRow(2L, 3.3d)).iterator
       }
     )
-    fireBinaryOperatorTests(samples)
-    fireComparatorOperatorTests(samples)
+    fireBinaryOperatorTests(samples, scalar)
+    fireComparatorOperatorTests(samples, scalar)
   }
 
-  private def fireBinaryOperatorTests(samples: Array[RangeVector]): Unit = {
+  private def fireBinaryOperatorTests(samples: Array[RangeVector], scalar: Double): Unit = {
 
     // Subtraction - prefix
     val expectedSub1 = samples.map(_.rows.map(v => scalar - v.getDouble(1)))
@@ -157,7 +157,9 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
 
   }
 
-  private def fireComparatorOperatorTests(samples: Array[RangeVector]): Unit = {
+  //scalastyle:off method.length
+  //scalastyle:off cyclomatic.complexity
+  private def fireComparatorOperatorTests(samples: Array[RangeVector], scalar: Double): Unit = {
 
     // GTE - prefix
     val expectedGTE = samples.map(_.rows.map(v => if (scalar >= v.getDouble(1)) scalar else Double.NaN))
@@ -184,29 +186,48 @@ class BinaryOperatorSpec extends FunSpec with Matchers with ScalaFutures {
     applyBinaryOperationAndAssertResult(samples, expectedNEQ, BinaryOperator.NEQ, scalar, true)
 
     // GTE_BOOL - prefix
-    val expectedGTE_BOOL = samples.map(_.rows.map(v => if (scalar >= v.getDouble(1)) 1.0 else 0.0))
+    val expectedGTE_BOOL = samples.map(_.rows.map { v =>
+      if (scalar.isNaN || v.getDouble(1).isNaN) Double.NaN
+      else if (scalar >= v.getDouble(1)) 1.0 else 0.0
+    })
     applyBinaryOperationAndAssertResult(samples, expectedGTE_BOOL, BinaryOperator.GTE_BOOL, scalar, true)
 
     // GTR_BOOL - prefix
-    val expectedGTR_BOOL = samples.map(_.rows.map(v => if (scalar > v.getDouble(1))  1.0 else 0.0))
+    val expectedGTR_BOOL = samples.map(_.rows.map { v =>
+      if (scalar.isNaN || v.getDouble(1).isNaN) Double.NaN
+      else if (scalar > v.getDouble(1)) 1.0 else 0.0
+    })
     applyBinaryOperationAndAssertResult(samples, expectedGTR_BOOL, BinaryOperator.GTR_BOOL, scalar, true)
 
     // LTE_BOOL - prefix
-    val expectedLTE_BOOL = samples.map(_.rows.map(v => if (scalar <= v.getDouble(1))  1.0 else 0.0))
-    applyBinaryOperationAndAssertResult(samples, expectedLTE_BOOL, BinaryOperator.LTE_BOOL, scalar, true)
+    val expectedLTE_BOOL = samples.map(_.rows.map { v =>
+      if (scalar.isNaN || v.getDouble(1).isNaN) Double.NaN
+      else if (scalar <= v.getDouble(1)) 1.0 else 0.0
+    })
 
     // LTR_BOOL - prefix
-    val expectedLTR_BOOL = samples.map(_.rows.map(v => if (scalar < v.getDouble(1))  1.0 else 0.0))
+    val expectedLTR_BOOL = samples.map(_.rows.map { v =>
+      if (scalar.isNaN || v.getDouble(1).isNaN) Double.NaN
+      else if (scalar < v.getDouble(1)) 1.0 else 0.0
+    })
     applyBinaryOperationAndAssertResult(samples, expectedLTR_BOOL, BinaryOperator.LSS_BOOL, scalar, true)
 
     // EQL_BOOL - prefix
-    val expectedEQL_BOOL = samples.map(_.rows.map(v => if (scalar == v.getDouble(1))  1.0 else 0.0))
+    val expectedEQL_BOOL = samples.map(_.rows.map { v =>
+      if (scalar.isNaN || v.getDouble(1).isNaN) Double.NaN
+      else if (scalar == v.getDouble(1)) 1.0 else 0.0
+    })
     applyBinaryOperationAndAssertResult(samples, expectedEQL_BOOL, BinaryOperator.EQL_BOOL, scalar, true)
 
     // NEQ_BOOL - prefix
-    val expectedNEQ_BOOL = samples.map(_.rows.map(v => if (scalar != v.getDouble(1))  1.0 else 0.0))
+    val expectedNEQ_BOOL = samples.map(_.rows.map { v =>
+      if (scalar.isNaN || v.getDouble(1).isNaN) Double.NaN
+      else if (scalar != v.getDouble(1)) 1.0 else 0.0
+    })
     applyBinaryOperationAndAssertResult(samples, expectedNEQ_BOOL, BinaryOperator.NEQ_BOOL, scalar, true)
   }
+  //scalastyle:on method.length
+  //scalastyle:on cyclomatic.complexity
 
   it ("should fail with wrong calculation") {
     // ceil


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Comparison operators with Bool return 0 if lhs or rhs is NaN

**New behavior :**
Comparison operators with Bool should return NaN if lhs or rhs is NaN
