### PR TITLE
bug(queryPlanning): Long Lookback cases in downsample queries

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/CompositePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/CompositePlanner.scala
@@ -21,6 +21,7 @@ class CompositePlanner(dsRef: DatasetRef,
                        failureProvider: FailureProvider,
                        earliestRawTimestampFn: => Long,
                        earliestDownsampleTimestampFn: => Long,
+                       latestDownsampleTimestampFn: => Long,
                        queryConfig: QueryConfig,
                        spreadProvider: SpreadProvider = StaticSpreadProvider(),
                        stitchDispatcher: => PlanDispatcher = { InProcessPlanDispatcher }) extends QueryPlanner
@@ -31,7 +32,7 @@ class CompositePlanner(dsRef: DatasetRef,
   val downsampleClusterPlanner = new SingleClusterPlanner(dsRef, schemas, downsampleMapperFunc,
                                   earliestDownsampleTimestampFn, queryConfig, spreadProvider)
   val longTimeRangePlanner = new LongTimeRangePlanner(rawClusterPlanner, downsampleClusterPlanner,
-                                          earliestRawTimestampFn, stitchDispatcher)
+                                          earliestRawTimestampFn, latestDownsampleTimestampFn, stitchDispatcher)
   val haPlanner = new HighAvailabilityPlanner(dsRef, longTimeRangePlanner, failureProvider, queryConfig)
   //val multiPodPlanner = new MultiClusterPlanner(podLocalityProvider, haPlanner)
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -18,7 +18,7 @@ import filodb.query.exec.{ExecPlan, PlanDispatcher, StitchRvsExec}
   *                             would be available in the raw cluster
   * @param latestDownsampleTimestampFn the function that will provide millis timestamp of newest sample
   *                                    that would be available in the downsample cluster. This typically
-  *                                    is not "now" because of the delay in popuation of downsampled data
+  *                                    is not "now" because of the delay in population of downsampled data
   *                                    via spark job. If job is run every 6 hours,
   *                                    `(System.currentTimeMillis - 12.hours.toMillis)`
   *                                    may a function that could be passed. 12 hours to account for failures/reruns etc.

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -19,8 +19,9 @@ import filodb.query.exec.{ExecPlan, PlanDispatcher, StitchRvsExec}
   * @param latestDownsampleTimestampFn the function that will provide millis timestamp of newest sample
   *                                    that would be available in the downsample cluster. This typically
   *                                    is not "now" because of the delay in popuation of downsampled data
-  *                                    via spark job. If job is run every 6 hours, `(System.currentTimeMillis - 12.hours.toMillis)`
-  *                                    may a function that would be passed. 12 hours to account for failures/reruns etc.
+  *                                    via spark job. If job is run every 6 hours,
+  *                                    `(System.currentTimeMillis - 12.hours.toMillis)`
+  *                                    may a function that could be passed. 12 hours to account for failures/reruns etc.
   * @param stitchDispatcher function to get the dispatcher for the stitch exec plan node
   */
 class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -16,11 +16,14 @@ import filodb.query.exec.{ExecPlan, PlanDispatcher, StitchRvsExec}
   *                                 abstracts planning for downsample cluster data
   * @param earliestRawTimestampFn the function that will provide millis timestamp of earliest sample that
   *                             would be available in the raw cluster
+  * @param latestDownsampleTimestampFn the function that will provide millis timestamp of newest sample
+  *                                    that would be available in the downsample cluster
   * @param stitchDispatcher function to get the dispatcher for the stitch exec plan node
   */
 class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
                            downsampleClusterPlanner: QueryPlanner,
                            earliestRawTimestampFn: => Long,
+                           latestDownsampleTimestampFn: => Long,
                            stitchDispatcher: => PlanDispatcher) extends QueryPlanner {
 
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
@@ -35,10 +38,19 @@ class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
         else if (endWithOffsetMs < earliestRawTime) downsampleClusterPlanner.materialize(logicalPlan, qContext)
         else if (startWithOffsetMs - lookbackMs >= earliestRawTime)
           rawClusterPlanner.materialize(logicalPlan, qContext)
-        else {
+        else if (endWithOffsetMs - lookbackMs < earliestRawTime) {
+          val lastDownsampleSampleTime = latestDownsampleTimestampFn
+          val downsampleLp = if (endWithOffsetMs < lastDownsampleSampleTime) {
+            logicalPlan
+          } else {
+            copyWithUpdatedTimeRange(logicalPlan,
+              TimeRange(p.startMs, latestDownsampleTimestampFn + offsetMillis), lookbackMs)
+          }
+          downsampleClusterPlanner.materialize(downsampleLp, qContext)
+        } else {
           // Split the query between raw and downsample planners
           val numStepsInDownsample = (earliestRawTime - startWithOffsetMs + lookbackMs) / p.stepMs
-          val lastDownsampleInstant = startWithOffsetMs + numStepsInDownsample * p.stepMs
+          val lastDownsampleInstant = p.startMs + numStepsInDownsample * p.stepMs
           val firstInstantInRaw = lastDownsampleInstant + p.stepMs
 
           val downsampleLp = copyWithUpdatedTimeRange(logicalPlan,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -17,7 +17,10 @@ import filodb.query.exec.{ExecPlan, PlanDispatcher, StitchRvsExec}
   * @param earliestRawTimestampFn the function that will provide millis timestamp of earliest sample that
   *                             would be available in the raw cluster
   * @param latestDownsampleTimestampFn the function that will provide millis timestamp of newest sample
-  *                                    that would be available in the downsample cluster
+  *                                    that would be available in the downsample cluster. This typically
+  *                                    is not "now" because of the delay in popuation of downsampled data
+  *                                    via spark job. If job is run every 6 hours, `(System.currentTimeMillis - 12.hours.toMillis)`
+  *                                    may a function that would be passed. 12 hours to account for failures/reruns etc.
   * @param stitchDispatcher function to get the dispatcher for the stitch exec plan node
   */
 class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Since raw data retention is finite (say 3 days), long lookback queries ( > 3d) cannot be handled by raw cluster. They end up being delegated to downsample cluster.

However, there is a delay in population of downsample data. Most recent data would not be available immediately. Hence results of latest instants may not be complete.

This PR omits instants with incomplete window aggregations from query results. We will consider feature of performant window aggregations across raw/downsample clusters for the future.

