### PR TITLE
feat(memory): Eliminate time ordered block reclamation.

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
@@ -75,7 +75,7 @@ class MemstoreCassandraSinkSpec extends AllTablesTest {
                        .map(_.getDouble(0)).toSeq
     // 4 partitions were flushed and not in memory anymore (should be at least 60, but
     // ingestion-based flushing can flush a bit more)
-    data1 should have length (62)
+    data1.length >= 60 shouldEqual true
 
     // Re-read data in memstore.  Verify that on-demand paging will bring data back
     val agg2 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(splits.head))

--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -2,8 +2,6 @@ package filodb.core.memstore
 
 import java.nio.ByteBuffer
 
-import scala.concurrent.duration._
-
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
 import org.jctools.maps.NonBlockingHashMapLong
@@ -21,28 +19,20 @@ import filodb.memory.format.UnsafeUtils
   * for each incoming RawPartData.  This class will identify the right memstore TSPartition and populate it.
   * NOTE: for now these tasks must be run in serial and not concurrently, due to limitations in BlockManager.
   *
-  * Buckets are created on demand depending on the end time of incoming chunks.  One bucket per flush interval.
-  * Memory blocks in buckets older than chunkRetentionHours are all marked reclaimable (even if not full) and
-  * buckets are cleaned up as memory pressure forces reclamation.  The effect is that there is always guaranteed
-  * at least one block for ODP data for chunkRetentionHours.
-  *
   * @param tsShard the TimeSeriesShard containing the time series for the given shard
   * @param blockManager The block manager to be used for block allocation
-  * @param chunkRetentionHours number of hours chunks need to be retained for. Beyond this time, ODP blocks will be
-  *                    marked as reclaimable even if they are not full, so they can be reused for newer data.
+  * @param numTimeBuckets number of block factories to use, distributed by hour
   */
 class DemandPagedChunkStore(tsShard: TimeSeriesShard,
                             val blockManager: BlockManager,
-                            chunkRetentionHours: Int)
+                            numTimeBuckets: Int)
 extends RawToPartitionMaker with StrictLogging {
   val flushIntervalMillis = tsShard.storeConfig.flushInterval.toMillis
-  val retentionMillis = chunkRetentionHours * (1.hour.toMillis)
 
   // block factories for each time bucket
-  private val memFactories = new NonBlockingHashMapLong[BlockMemFactory](chunkRetentionHours, false)
+  private val memFactories = new NonBlockingHashMapLong[BlockMemFactory](numTimeBuckets, false)
 
   import TimeSeriesShard._
-  import collection.JavaConverters._
 
   private val baseContext = Map("dataset" -> tsShard.ref.toString,
                                 "shard"   -> tsShard.shardNum.toString)
@@ -51,7 +41,7 @@ extends RawToPartitionMaker with StrictLogging {
     val factory = memFactories.get(bucket)
     if (factory == UnsafeUtils.ZeroPointer) {
       val newFactory = new BlockMemFactory(blockManager,
-                                           Some(bucket),
+                                           true,
                                            tsShard.maxMetaSize,
                                            baseContext ++ Map("bucket" -> bucket.toString),
                                            markFullBlocksAsReclaimable = true)
@@ -126,18 +116,6 @@ extends RawToPartitionMaker with StrictLogging {
       val vectorAddr = memFactory.allocateOffheap(bufLen)
       UnsafeUtils.unsafe.copyMemory(bufBase, bufOffset, UnsafeUtils.ZeroPointer, vectorAddr, bufLen)
       vectorAddr
-    }
-  }
-
-  /**
-   * Ensures the oldest ODP time buckets, blocks, and BlockMemFactory's are reclaimable and cleaned up
-   * so we don't leak memory and blocks.  Call this ideally every flushInterval.
-   */
-  def cleanupOldestBuckets(): Unit = {
-    blockManager.markBucketedBlocksReclaimable(System.currentTimeMillis - retentionMillis)
-    // Now, iterate through memFactories and clean up ones with no blocks
-    memFactories.keySet.asScala.foreach { bucket =>
-      if (!blockManager.hasTimeBucket(bucket)) memFactories.remove(bucket)
     }
   }
 }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -330,7 +330,7 @@ class TimeSeriesShard(val ref: DatasetRef,
 
   // Each shard has a single ingestion stream at a time.  This BlockMemFactory is used for buffer overflow encoding
   // strictly during ingest() and switchBuffers().
-  private[core] val overflowBlockFactory = new BlockMemFactory(blockStore, None, maxMetaSize,
+  private[core] val overflowBlockFactory = new BlockMemFactory(blockStore, false, maxMetaSize,
                                              shardTags ++ Map("overflow" -> "true"), true)
   val partitionMaker = new DemandPagedChunkStore(this, blockStore, chunkRetentionHours)
 
@@ -961,7 +961,6 @@ class TimeSeriesShard(val ref: DatasetRef,
       logger.info(s"Flush of dataset=$ref shard=$shardNum group=${flushGroup.groupNum} " +
         s"flushWatermark=${flushGroup.flushWatermark} response=$resp offset=${_offset}")
     }
-    partitionMaker.cleanupOldestBuckets()
     // Some partitions might be evictable, see if need to free write buffer memory
     checkEnableAddPartitions()
     updateGauges()

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -80,7 +80,7 @@ object StoreConfig {
                                            |max-buffer-pool-size = 10000
                                            |num-partitions-to-evict = 1000
                                            |groups-per-shard = 60
-                                           |num-block-pages = 1000
+                                           |num-block-pages = 100
                                            |failure-retries = 3
                                            |retry-delay = 15 seconds
                                            |part-index-flush-max-delay = 60 seconds

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -398,9 +398,9 @@ object MachineMetricsData {
   val histPartKey = histKeyBuilder.partKeyFromObjects(histDataset.schema, "request-latency", extraTags)
 
   val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024, new MemoryStats(Map("test"-> "test")), null, 16)
-  val histIngestBH = new BlockMemFactory(blockStore, None, histDataset.schema.data.blockMetaSize,
+  val histIngestBH = new BlockMemFactory(blockStore, false, histDataset.schema.data.blockMetaSize,
                                          dummyContext, true)
-  val histMaxBH = new BlockMemFactory(blockStore, None, histMaxDS.schema.data.blockMetaSize,
+  val histMaxBH = new BlockMemFactory(blockStore, false, histMaxDS.schema.data.blockMetaSize,
                                       dummyContext, true)
   private val histBufferPool = new WriteBufferPool(TestData.nativeMem, histDataset.schema.data, TestData.storeConf)
 

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -46,7 +46,7 @@ class ShardDownsamplerSpec extends FunSpec with Matchers with BeforeAndAfterAll 
   val customSchema = customDataset.schema
 
   private val blockStore = MMD.blockStore
-  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, promDataset.schema.data.blockMetaSize,
+  protected val ingestBlockHolder = new BlockMemFactory(blockStore, false, promDataset.schema.data.blockMetaSize,
                                                         MMD.dummyContext, true)
 
   val storeConf = TestData.storeConf.copy(maxChunksSize = 200)

--- a/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
@@ -58,13 +58,8 @@ class DemandPagedChunkStoreSpec extends FunSpec with AsyncTest {
       tsPartition.numChunks shouldEqual 10          // write buffers + 9 chunks above
     }
 
-    pageManager.numTimeOrderedBlocks should be > 1
+    pageManager.usedBlocksSize should be > 1
     pageManager.numFreeBlocks should be >= (initFreeBlocks - 12)
-    val buckets = pageManager.timeBuckets
-    buckets.foreach { b => pageManager.hasTimeBucket(b) shouldEqual true }
-
-    // Now, reclaim four time buckets, even if they are not full
-    pageManager.markBucketedBlocksReclaimable(buckets(4))
 
     // try and ODP more data.  Load older data than chunk retention, should still be able to load
     val data2 = linearMultiSeries(start - 2.hours.toMillis, timeStep=100000).take(20)

--- a/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
@@ -32,7 +32,7 @@ class PartitionSetSpec extends MemFactoryCleanupTest with ScalaFutures {
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
     new MemoryStats(Map("test"-> "test")), reclaimer, 1)
   protected val bufferPool = new WriteBufferPool(memFactory, dataset2.schema.data, TestData.storeConf)
-  private val ingestBlockHolder = new BlockMemFactory(blockStore, None, dataset2.schema.data.blockMetaSize,
+  private val ingestBlockHolder = new BlockMemFactory(blockStore, false, dataset2.schema.data.blockMetaSize,
                                     dummyContext, true)
 
   val builder = new RecordBuilder(memFactory)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -69,7 +69,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
   private val blockStore = new PageAlignedBlockManager(200 * 1024 * 1024,
     new MemoryStats(Map("test"-> "test")), reclaimer, 1)
-  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, schema1.data.blockMetaSize,
+  protected val ingestBlockHolder = new BlockMemFactory(blockStore, false, schema1.data.blockMetaSize,
                                       dummyContext, true)
 
   before {
@@ -112,7 +112,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val data1 = part.timeRangeRows(AllChunkScan, Array(1)).map(_.getDouble(0)).toBuffer
     data1 shouldEqual (minData take 10)
 
-    val blockHolder = new BlockMemFactory(blockStore, None, schema1.data.blockMetaSize, dummyContext)
+    val blockHolder = new BlockMemFactory(blockStore, false, schema1.data.blockMetaSize, dummyContext)
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
     data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -170,7 +170,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part.switchBuffers(ingestBlockHolder)
     part.appendingChunkLen shouldEqual 0
 
-    val blockHolder = new BlockMemFactory(blockStore, None, schema1.data.blockMetaSize, dummyContext)
+    val blockHolder = new BlockMemFactory(blockStore, false, schema1.data.blockMetaSize, dummyContext)
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
     data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -227,7 +227,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      // First 10 rows ingested. Now flush in a separate Future while ingesting 6 more rows
      part.switchBuffers(ingestBlockHolder)
      myBufferPool.poolSize shouldEqual origPoolSize    // current chunks become null, no new allocation yet
-     val blockHolder = new BlockMemFactory(blockStore, None, schema1.data.blockMetaSize, dummyContext)
+     val blockHolder = new BlockMemFactory(blockStore, false, schema1.data.blockMetaSize, dummyContext)
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
      data.drop(10).take(6).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -258,7 +258,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      // Now, switch buffers and flush again, ingesting 5 more rows
      // There should now be 3 chunks total, the current write buffers plus the two flushed ones
      part.switchBuffers(ingestBlockHolder)
-     val holder2 = new BlockMemFactory(blockStore, None, schema1.data.blockMetaSize, dummyContext)
+     val holder2 = new BlockMemFactory(blockStore, false, schema1.data.blockMetaSize, dummyContext)
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut2 = Future(part.makeFlushChunks(holder2).toBuffer)
      data.drop(16).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder) }
@@ -287,7 +287,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     // Now, switch buffers and flush.  Appenders will be empty.
     part.switchBuffers(ingestBlockHolder)
-    val blockHolder = new BlockMemFactory(blockStore, None, schema1.data.blockMetaSize, dummyContext)
+    val blockHolder = new BlockMemFactory(blockStore, false, schema1.data.blockMetaSize, dummyContext)
     val chunkSets = part.makeFlushChunks(blockHolder)
     chunkSets.isEmpty shouldEqual false
     part.numChunks shouldEqual 1
@@ -377,7 +377,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     // Now simulate a flush, verify that both chunksets flushed
     // Now, switch buffers and flush.  Appenders will be empty.
     part.switchBuffers(ingestBlockHolder)
-    val blockHolder = new BlockMemFactory(blockStore, None, schema1.data.blockMetaSize, dummyContext)
+    val blockHolder = new BlockMemFactory(blockStore, false, schema1.data.blockMetaSize, dummyContext)
     val chunkSets = part.makeFlushChunks(blockHolder).toSeq
     chunkSets should have length (2)
     part.numChunks shouldEqual 2

--- a/memory/src/main/scala/filodb.memory/Block.scala
+++ b/memory/src/main/scala/filodb.memory/Block.scala
@@ -84,6 +84,13 @@ trait ReusableMemory extends StrictLogging {
   }
 
   /**
+    * Marks this memory as reclaimable or not.
+    */
+  def markReclaimable(reclaimable: Boolean): Unit = {
+    _isReusable.set(reclaimable)
+  }
+
+  /**
    * Calls the reclaimListener for each piece of metadata that we own
    */
   protected def reclaimWithMetadata(): Unit

--- a/memory/src/main/scala/filodb.memory/BlockDetective.scala
+++ b/memory/src/main/scala/filodb.memory/BlockDetective.scala
@@ -25,7 +25,6 @@ object BlockDetective {
                    manager: PageAlignedBlockManager,
                    pool: BlockMemFactoryPool): String = {
     val reclaimEvents = manager.reclaimEventsForPtr(ptr)
-    val timeBucketBlocks = manager.timeBlocksForPtr(ptr)
     val flushBlocks = pool.blocksContainingPtr(ptr)
 
     f"=== BlockDetective Report for 0x$ptr%016x ===\nReclaim Events:\n" +
@@ -33,8 +32,6 @@ object BlockDetective {
       f"  Block 0x${blk.address}%016x at ${(new DateTime(reclaimTime)).toString()}%s with $remaining%d bytes left" +
       oldOwner.map { bmf => s"\tfrom ${bmf.debugString}" }.getOrElse("")
     }.mkString("\n") +
-    "\nTime bucketed blocks:\n" +
-    timeBucketBlocks.map(_.debugString).mkString("\n") +
     "\nFlush block lists:\n" +
     flushBlocks.map(_.debugString).mkString("\n")
   }

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -27,7 +27,7 @@ class BlockMemFactoryPool(blockStore: BlockManager,
       factoryPool.dequeue
     } else {
       logger.debug(s"Nothing in BlockMemFactory pool.  Creating a new one")
-      new BlockMemFactory(blockStore, None, metadataAllocSize, baseTags)
+      new BlockMemFactory(blockStore, false, metadataAllocSize, baseTags)
     }
     fact.tags = baseTags ++ moreTags
     fact

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -202,14 +202,14 @@ object BlockMemFactory {
   *
   * @param blockStore The BlockManager which is used to request more blocks when the current
   *                   block is full.
-  * @param bucketTime the timebucket (timestamp) from which to allocate block(s), or None for the general list
+  * @param reclaimable true if allocated blocks are immediately reclaimable
   * @param metadataAllocSize the additional size in bytes to ensure is free for writing metadata, per chunk
   * @param tags a set of keys/values to identify the purpose of this MemFactory for debugging
   * @param markFullBlocksAsReclaimable Immediately mark and fully used block as reclaimable.
   *                                    Typically true during on-demand paging of optimized chunks from persistent store
   */
 class BlockMemFactory(blockStore: BlockManager,
-                      bucketTime: Option[Long],
+                      reclaimable: Boolean,
                       metadataAllocSize: Int,
                       var tags: Map[String, String],
                       markFullBlocksAsReclaimable: Boolean = false) extends MemFactory with StrictLogging {
@@ -222,7 +222,9 @@ class BlockMemFactory(blockStore: BlockManager,
   // tracks block currently being populated
   var currentBlock = requestBlock()
 
-  private def requestBlock() = blockStore.requestBlock(bucketTime, optionSelf).get
+  private def requestBlock() =
+    (if (reclaimable) blockStore.requestReclaimableBlock(optionSelf)
+     else blockStore.requestNonReclaimableBlock(optionSelf)).get
 
   // tracks blocks that should share metadata
   private val metadataSpan: ListBuffer[Block] = ListBuffer[Block]()
@@ -371,7 +373,7 @@ class BlockMemFactory(blockStore: BlockManager,
   def shutdown(): Unit = {}
 
   def debugString: String =
-    s"BlockMemFactory($bucketTime) ${tags.map { case (k, v) => s"$k=$v" }.mkString(" ")}"
+    s"BlockMemFactory($reclaimable) ${tags.map { case (k, v) => s"$k=$v" }.mkString(" ")}"
 }
 
 

--- a/memory/src/test/scala/filodb.memory/BlockSpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockSpec.scala
@@ -20,7 +20,7 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
   }
 
   it should "allocate metadata and report remaining bytes accurately" in {
-    val block = blockManager.requestBlock(None).get
+    val block = blockManager.requestNonReclaimableBlock().get
     block.own()
     block.capacity shouldEqual 4096
     block.remaining shouldEqual 4096
@@ -35,7 +35,7 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
   }
 
   it should "return null when allocate metadata if not enough space" in {
-    val block = blockManager.requestBlock(None).get
+    val block = blockManager.requestNonReclaimableBlock().get
     block.own()
     block.capacity shouldEqual 4096
     block.remaining shouldEqual 4096
@@ -47,14 +47,14 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
   }
 
   it should "not reclaim when block has not been marked reclaimable" in {
-    val block = blockManager.requestBlock(None).get
+    val block = blockManager.requestNonReclaimableBlock().get
     block.own()
 
     intercept[IllegalStateException] { block.reclaim() }
   }
 
   it should "call reclaimListener with address of all allocated metadatas" in {
-    val block = blockManager.requestBlock(None).get
+    val block = blockManager.requestNonReclaimableBlock().get
     block.own()
     block.capacity shouldEqual 4096
     block.remaining shouldEqual 4096

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerConcurrentSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerConcurrentSpec.scala
@@ -22,7 +22,7 @@ with ConductorFixture with Matchers with BeforeAndAfterAll {
 
       thread("Random guy") {
         //1 page
-        val blocks = blockManager.requestBlocks(pageSize, None)
+        val blocks = blockManager.requestNonReclaimableBlocks(pageSize)
         blocks.size should be(1)
         val block = blocks.head
         block.own()
@@ -31,7 +31,7 @@ with ConductorFixture with Matchers with BeforeAndAfterAll {
       }
       thread("Another dude") {
         //2 page
-        val blocks = blockManager.requestBlocks(2 * pageSize, None)
+        val blocks = blockManager.requestNonReclaimableBlocks(2 * pageSize)
         blocks.size should be(2)
         val block = blocks.head
         block.own()
@@ -40,7 +40,7 @@ with ConductorFixture with Matchers with BeforeAndAfterAll {
       }
       thread("Yet another dude") {
         //3 page
-        val blocks = blockManager.requestBlocks(3 * pageSize, None)
+        val blocks = blockManager.requestNonReclaimableBlocks(3 * pageSize)
         blocks.size should be(3)
         val block = blocks.head
         block.own()

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -18,7 +18,6 @@ object PageAlignedBlockManagerSpec {
 
 class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndAfter {
   import PageAlignedBlockManagerSpec._
-  import collection.JavaConverters._
 
   val pageSize = PageManager.getInstance().pageSize()
 
@@ -34,7 +33,7 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
 //    val fbm = freeBlocksMetric(stats)
 //    fbm.max should be(512)
     val blockSize = blockManager.blockSizeInBytes
-    val blocks = blockManager.requestBlocks(blockSize * 10, None)
+    val blocks = blockManager.requestNonReclaimableBlocks(blockSize * 10)
     blocks.size should be(10)
 //    val ubm = usedBlocksMetric(stats)
 //    ubm.max should be(10)
@@ -60,7 +59,7 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     val blockSize = blockManager.blockSizeInBytes
 //    val fbm = freeBlocksMetric(stats)
 //    fbm.max should be(2)
-    val firstRequest = blockManager.requestBlocks(blockSize * 2, None)
+    val firstRequest = blockManager.requestNonReclaimableBlocks(blockSize * 2)
     //used 2 out of 2
     firstRequest.size should be(2)
 //    val ubm = usedBlocksMetric(stats)
@@ -68,7 +67,7 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     //cannot fulfill
 //    val fbm2 = freeBlocksMetric(stats)
 //    fbm2.min should be(0)
-    val secondRequest = blockManager.requestBlocks(blockSize * 2, None)
+    val secondRequest = blockManager.requestNonReclaimableBlocks(blockSize * 2)
     secondRequest should be(Seq.empty)
 
     blockManager.releaseBlocks()
@@ -79,7 +78,7 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     val stats = new MemoryStats(Map("test4" -> "test4"))
     val blockManager = new PageAlignedBlockManager(2 * pageSize, stats, testReclaimer, 1)
     val blockSize = blockManager.blockSizeInBytes
-    val firstRequest = blockManager.requestBlocks(blockSize * 2, None)
+    val firstRequest = blockManager.requestNonReclaimableBlocks(blockSize * 2)
     //used 2 out of 2
     firstRequest.size should be(2)
     //simulate writing to the block
@@ -87,7 +86,7 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     firstRequest.head.position(blockSize.toInt - 1)
     //mark them as reclaimable
     firstRequest.foreach(_.markReclaimable())
-    val secondRequest = blockManager.requestBlocks(blockSize * 2, None)
+    val secondRequest = blockManager.requestNonReclaimableBlocks(blockSize * 2)
 //    val brm = reclaimedBlocksMetric(stats)
 //    brm.count should be(2)
     //this request will fulfill
@@ -102,11 +101,11 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     val stats = new MemoryStats(Map("test5" -> "test5"))
     val blockManager = new PageAlignedBlockManager(4 * pageSize, stats, testReclaimer, 1)
     val blockSize = blockManager.blockSizeInBytes
-    val firstRequest = blockManager.requestBlocks(blockSize * 2, None)
+    val firstRequest = blockManager.requestNonReclaimableBlocks(blockSize * 2)
     //used 2 out of 4
     firstRequest.size should be(2)
     //only 2 left - cannot fulfill request
-    val secondRequest = blockManager.requestBlocks(blockSize * 3, None)
+    val secondRequest = blockManager.requestNonReclaimableBlocks(blockSize * 3)
 //    val brm = reclaimedBlocksMetric(stats)
 //    brm.count should be(0)
     secondRequest should be(Seq.empty)
@@ -114,57 +113,31 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     blockManager.releaseBlocks()
   }
 
-  it should "allocate and reclaim blocks with time order" in {
+  it should "allocate and reclaim blocks" in {
     val stats = new MemoryStats(Map("test5" -> "test5"))
     // This block manager has 5 blocks capacity
     val blockManager = new PageAlignedBlockManager(5 * pageSize, stats, testReclaimer, 1)
 
     blockManager.usedBlocks.size() shouldEqual 0
-    blockManager.numTimeOrderedBlocks shouldEqual 0
-    blockManager.usedBlocksTimeOrdered.size shouldEqual 0
 
-    // first allocate non-time ordered block
-    blockManager.requestBlock(None).map(_.markReclaimable).isDefined shouldEqual true
+    // first allocate non-reclaimable block
+    blockManager.requestNonReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
     blockManager.usedBlocks.size shouldEqual 1
 
-    blockManager.requestBlock(Some(1000L)).map(_.markReclaimable).isDefined shouldEqual true
-    blockManager.requestBlock(Some(1000L)).map(_.markReclaimable).isDefined shouldEqual true
-    blockManager.requestBlock(Some(1000L)).isDefined shouldEqual true
-    blockManager.usedBlocksTimeOrdered.get(1000L).size() shouldEqual 3
+    blockManager.requestReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
+    blockManager.requestReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
+    blockManager.requestReclaimableBlock().isDefined shouldEqual true
+    blockManager.usedBlocks.size() shouldEqual 4
 
-    blockManager.requestBlock(Some(9000L)).map(_.markReclaimable).isDefined shouldEqual true
-    blockManager.usedBlocksTimeOrdered.get(9000L).size() shouldEqual 1
+    blockManager.requestReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
+    blockManager.usedBlocks.size() shouldEqual 5
 
-    blockManager.numTimeOrderedBlocks shouldEqual 4
-    blockManager.usedBlocksTimeOrdered.size shouldEqual 2
+    // requesting more blocks should force reclamation of the older ones
+    blockManager.requestReclaimableBlock().isDefined shouldEqual true
+    blockManager.requestReclaimableBlock().isDefined shouldEqual true
+    blockManager.requestReclaimableBlock().isDefined shouldEqual true
 
-    // reclaim from time ordered blocks should kick in for next 3 requests
-    blockManager.requestBlock(Some(10000L)).isDefined shouldEqual true
-    blockManager.requestBlock(Some(10000L)).isDefined shouldEqual true
-    blockManager.requestBlock(Some(10000L)).isDefined shouldEqual true
-    blockManager.usedBlocksTimeOrdered.get(10000L).size() shouldEqual 3
-    blockManager.usedBlocksTimeOrdered.get(1000L).size() shouldEqual 1 // should have reduced to 2
-    // 9000L list should be gone since last block reclaimed
-    blockManager.hasTimeBucket(9000L) shouldEqual false
-
-    blockManager.numTimeOrderedBlocks shouldEqual 4
-    blockManager.usedBlocksTimeOrdered.keySet.asScala shouldEqual Set(1000L, 10000L)
-
-    // reclaim should first happen to time ordered blocks, not the regular ones first. Should still be 1
-    blockManager.usedBlocks.size shouldEqual 1
-
-    blockManager.requestBlock(Some(12)).isDefined shouldEqual true
-    // now, reclaim should have happened from regular list
-    blockManager.usedBlocks.size shouldEqual 0
-
-    // since only 4 blocks were marked reclaimable, next request should fail to allocate
-    // there are no blocks reclaimable in any list
-    blockManager.requestBlock(Some(12)).isDefined shouldEqual false
-
-    // Mark everything up to 5000L time as reclaimable even if not full.
-    // Then request another block, and this time it should succeed.
-    blockManager.markBucketedBlocksReclaimable(5000L)
-    blockManager.requestBlock(Some(12)).isDefined shouldEqual true
+    blockManager.usedBlocks.size() shouldEqual 5
 
     blockManager.releaseBlocks()
   }
@@ -175,32 +148,25 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     val blockManager = new PageAlignedBlockManager(5 * pageSize, stats, testReclaimer, 1)
 
     blockManager.usedBlocks.size() shouldEqual 0
-    blockManager.numTimeOrderedBlocks shouldEqual 0
-    blockManager.usedBlocksTimeOrdered.size shouldEqual 0
 
-    val factory = new BlockMemFactory(blockManager, Some(10000L), 24, Map("foo" -> "bar"), false)
+    val factory = new BlockMemFactory(blockManager, true, 24, Map("foo" -> "bar"), false)
 
-    // There should be one time ordered block allocated, owned by factory
-    blockManager.usedBlocks.size shouldEqual 0
-    blockManager.numTimeOrderedBlocks shouldEqual 1
-    blockManager.hasTimeBucket(10000L) shouldEqual true
+    // There should be one non-reclaimable block allocated, owned by factory
+    blockManager.usedBlocks.size shouldEqual 1
 
     factory.currentBlock.owner shouldEqual Some(factory)
 
-    // Now allocate 4 more regular blocks, that will use up all blocks
-    blockManager.requestBlock(None).isDefined shouldEqual true
-    blockManager.requestBlock(None).isDefined shouldEqual true
-    blockManager.requestBlock(None).isDefined shouldEqual true
-    blockManager.requestBlock(None).isDefined shouldEqual true
-    blockManager.usedBlocks.size shouldEqual 4
-    blockManager.numTimeOrderedBlocks shouldEqual 1
+    // Now allocate 4 more non-reclaimable blocks, that will use up all blocks
+    blockManager.requestNonReclaimableBlock().isDefined shouldEqual true
+    blockManager.requestNonReclaimableBlock().isDefined shouldEqual true
+    blockManager.requestNonReclaimableBlock().isDefined shouldEqual true
+    blockManager.requestNonReclaimableBlock().isDefined shouldEqual true
+    blockManager.usedBlocks.size shouldEqual 5
 
     // Mark as reclaimable the blockMemFactory's block.  Then request more blocks, that one will be reclaimed.
     // Check ownership is now cleared.
     factory.currentBlock.markReclaimable
-    blockManager.requestBlock(Some(9000L)).isDefined shouldEqual true
-    blockManager.hasTimeBucket(10000L) shouldEqual false
-    blockManager.hasTimeBucket(9000L) shouldEqual true
+    blockManager.requestReclaimableBlock().isDefined shouldEqual true
 
     factory.currentBlock.owner shouldEqual None  // new requestor did not have owner
   }
@@ -214,23 +180,23 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     blockManager.ensureFreePercent(50)
     blockManager.numFreeBlocks shouldEqual 5
 
-    blockManager.requestBlock(None).map(_.markReclaimable).isDefined shouldEqual true
+    blockManager.requestNonReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
     blockManager.numFreeBlocks shouldEqual 4
     blockManager.ensureFreePercent(50)
     blockManager.numFreeBlocks shouldEqual 4
 
-    blockManager.requestBlock(None).map(_.markReclaimable).isDefined shouldEqual true
+    blockManager.requestNonReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
     blockManager.numFreeBlocks shouldEqual 3
     blockManager.ensureFreePercent(50)
     blockManager.numFreeBlocks shouldEqual 3
 
-    blockManager.requestBlock(None).map(_.markReclaimable).isDefined shouldEqual true
+    blockManager.requestNonReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
     blockManager.numFreeBlocks shouldEqual 2
     blockManager.ensureFreePercent(50)
     // Should actually have done something this time.
     blockManager.numFreeBlocks shouldEqual 3
 
-    blockManager.requestBlock(None).map(_.markReclaimable).isDefined shouldEqual true
+    blockManager.requestNonReclaimableBlock().map(_.markReclaimable).isDefined shouldEqual true
     blockManager.numFreeBlocks shouldEqual 2
     blockManager.ensureFreePercent(90)
     // Should reclaim multiple blocks.

--- a/memory/src/test/scala/filodb.memory/format/vectors/IntBinaryVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/IntBinaryVectorTest.scala
@@ -119,7 +119,7 @@ class IntBinaryVectorTest extends NativeVectorTest {
         new MemoryStats(Map("test"-> "test")), null, 16) {
         freeBlocks.asScala.foreach(_.set(0x55))   // initialize blocks to nonzero value
       }
-      val blockFactory = new BlockMemFactory(blockStore, None, 24, Map("foo" -> "bar"), true)
+      val blockFactory = new BlockMemFactory(blockStore, false, 24, Map("foo" -> "bar"), true)
 
       // original values will get mixed with nonzero contents if append does not overwrite original memory
       val builder = IntBinaryVector.appendingVectorNoNA(blockFactory, 10, nbits = 4, signed = false)

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -23,11 +23,11 @@ trait RawDataWindowingSpec extends FunSpec with Matchers with BeforeAndAfterAll 
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
     new MemoryStats(Map("test"-> "test")), null, 16)
   val storeConf = TestData.storeConf.copy(maxChunksSize = 200)
-  protected val ingestBlockHolder = new BlockMemFactory(blockStore, None, timeseriesSchema.data.blockMetaSize,
+  protected val ingestBlockHolder = new BlockMemFactory(blockStore, false, timeseriesSchema.data.blockMetaSize,
                                       MMD.dummyContext, true)
   protected val tsBufferPool = new WriteBufferPool(TestData.nativeMem, timeseriesSchema.data, storeConf)
 
-  protected val ingestBlockHolder2 = new BlockMemFactory(blockStore, None, downsampleSchema.data.blockMetaSize,
+  protected val ingestBlockHolder2 = new BlockMemFactory(blockStore, false, downsampleSchema.data.blockMetaSize,
                                       MMD.dummyContext, true)
   protected val tsBufferPool2 = new WriteBufferPool(TestData.nativeMem, downsampleSchema.data, storeConf)
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/OffHeapMemory.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/OffHeapMemory.scala
@@ -25,7 +25,7 @@ class OffHeapMemory(schemas: Seq[Schema],
     },
     numPagesPerBlock = 50)
 
-  val blockMemFactory = new BlockMemFactory(blockStore, None, maxMetaSize, kamonTags, false)
+  val blockMemFactory = new BlockMemFactory(blockStore, false, maxMetaSize, kamonTags, false)
 
   val nativeMemoryManager = new NativeMemoryManager(nativeMemSize, kamonTags)
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
ODP blocks are only reclaimed after a retention period has expired, which can cause memory hogging.

**New behavior :**
All blocks allocated by ODP are marked as reclaimable immediately, but they're evicted in FIFO order. They won't be truly reclaimed immediately, and the recently added reclaim lock helps too.
