### PR TITLE
feat(core): Query sizing based limits

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -95,9 +95,8 @@
         #   metric = "bad-metric-to-log"
         # }
 
-        # Maximum number of partitions per shard scanned per query. This is necessary
-        # to ensure no run-away query hogs memory and destabilizes the server.
-        # max-query-matches = 250000
+        # Limits maximum amount of data a single leaf query can scan
+        max-data-per-shard-query = 50MB
       }
       downsample {
         # can be disabled by setting this flag to false

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -96,7 +96,7 @@
         # }
 
         # Limits maximum amount of data a single leaf query can scan
-        max-data-per-shard-query = 50MB
+        max-data-per-shard-query = 50 MB
       }
       downsample {
         # can be disabled by setting this flag to false

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -261,7 +261,7 @@ filodb {
       demand-paging-parallelism = 30
 
       # Limits maximum amount of data a single leaf query can scan per shard
-      max-data-per-shard-query = 500MB
+      max-data-per-shard-query = 500 MB
 
       # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,
       # we need a maximum size, not a maximum number of items.

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -163,6 +163,7 @@ filodb {
 
     # Enable faster rate/increase/delta calculations. Depends on drop detection in chunks (detectDrops=true)
     faster-rate = true
+
   }
 
   shard-manager {
@@ -259,8 +260,8 @@ filodb {
       # Read parallelism in downsample cluster
       demand-paging-parallelism = 30
 
-      # Maximum number of TS partitions paged in in downsample cluster queries
-      max-query-matches = 100000
+      # Limits maximum amount of data a single leaf query can scan per shard
+      max-data-per-shard-query = 500MB
 
       # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,
       # we need a maximum size, not a maximum number of items.

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -261,7 +261,7 @@ filodb {
       demand-paging-parallelism = 30
 
       # Limits maximum amount of data a single leaf query can scan per shard
-      max-data-per-shard-query = 500 MB
+      max-data-per-shard-query = 100 MB
 
       # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,
       # we need a maximum size, not a maximum number of items.

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -282,7 +282,6 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
           val numSamplesPerChunk = downsampleStoreConfig.flushInterval.toMillis / resolution
           val numChunksPerTs = (end-st + downsampleStoreConfig.flushInterval.toMillis - 1) /
                                            downsampleStoreConfig.flushInterval.toMillis
-
           val estDataSize = schemas.bytesPerSampleSwag(schemas(schId).downsample.get.schemaHash) *
                           lookup.partsInMemory.length * numSamplesPerChunk * numChunksPerTs
           require(estDataSize > downsampleStoreConfig.maxDataPerShardQuery,

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -282,9 +282,9 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
           val numSamplesPerChunk = downsampleStoreConfig.flushInterval.toMillis / resolution
           val numChunksPerTs = (end-st + downsampleStoreConfig.flushInterval.toMillis - 1) /
                                            downsampleStoreConfig.flushInterval.toMillis
-          val estDataSize = schemas.bytesPerSampleSwag(schemas(schId).downsample.get.schemaHash) *
+          val estDataSize = schemas.bytesPerSampleSwag(schemas(schId).schemaHash) *
                           lookup.partsInMemory.length * numSamplesPerChunk * numChunksPerTs
-          require(estDataSize > downsampleStoreConfig.maxDataPerShardQuery,
+          require(estDataSize < downsampleStoreConfig.maxDataPerShardQuery,
             s"Estimate of $estDataSize bytes exceeds limit of " +
               s"${downsampleStoreConfig.maxDataPerShardQuery} bytes queried per shard. Try one or more of these: " +
               s"(a) narrow your query filters to reduce to fewer than the current ${lookup.partsInMemory.length} " +
@@ -309,7 +309,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
         downsampleTtls.last.toMillis -> downsampledDatasetRefs.last
       case TimeRangeChunkScan(startTime, _) =>
         val ttlIndex = downsampleTtls.indexWhere(t => startTime > System.currentTimeMillis() - t.toMillis)
-        downsampleTtls(ttlIndex).toMillis -> downsampledDatasetRefs(ttlIndex)
+        downsampleConfig.resolutions(ttlIndex).toMillis -> downsampledDatasetRefs(ttlIndex)
       case _ => ???
     }
   }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -54,9 +54,6 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   private val downsampleStoreConfig = StoreConfig(filodbConfig.getConfig("downsampler.downsample-store-config"))
 
-  // since all partitions are paged from store, this would be much lower than what is configured for raw data
-  private val maxQueryMatches = downsampleStoreConfig.maxQueryMatches
-
   private val nextPartitionID = new AtomicInteger(0)
 
   private val stats = new DownsampledTimeSeriesShardStats(rawDatasetRef, shardNum)
@@ -235,26 +232,21 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                      querySession: QuerySession): Observable[ReadablePartition] = {
 
     // Step 1: Choose the downsample level depending on the range requested
-    val downsampledDataset = chooseDownsampleResolution(lookup.chunkMethod)
+    val (resolution, downsampledDataset) = chooseDownsampleResolution(lookup.chunkMethod)
     logger.debug(s"Chose resolution $downsampledDataset for chunk method ${lookup.chunkMethod}")
+
+    capDataScannedPerShardCheck(lookup, resolution)
+
     // Step 2: Query Cassandra table for that downsample level using downsampleColStore
     // Create a ReadablePartition objects that contain the time series data. This can be either a
     // PagedReadablePartitionOnHeap or PagedReadablePartitionOffHeap. This will be garbage collected/freed
     // when query is complete.
-
-    if (lookup.partsInMemory.length > maxQueryMatches)
-      throw new IllegalArgumentException(s"Seeing ${lookup.partsInMemory.length} matching time series per shard. Try " +
-        s"to narrow your query by adding more filters so there is less than $maxQueryMatches matches " +
-        s"or request for increasing number of shards this metric lives in")
-
     val partKeys = lookup.partsInMemory.iterator().map(partKeyFromPartId)
     Observable.fromIterator(partKeys)
       // 3 times value configured for raw dataset since expected throughput for downsampled cluster is much lower
       .mapAsync(downsampleStoreConfig.demandPagingParallelism) { partBytes =>
         val partLoadSpan = Kamon.spanBuilder(s"single-partition-cassandra-latency")
-          .asChildOf(Kamon.currentSpan())
-          .tag("dataset", rawDatasetRef.toString)
-          .tag("shard", shardNum)
+          .asChildOf(Kamon.currentSpan()).tag("dataset", rawDatasetRef.toString).tag("shard", shardNum)
           .start()
         // TODO test multi-partition scan if latencies are high
         store.readRawPartitions(downsampledDataset,
@@ -273,6 +265,34 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       }
   }
 
+  /**
+    * Note this approach below assumes the following for quick size estimation. The sizing is more
+    * a swag than reality:
+    * (a) every matched time series ingests at all query times. Looking up start/end times and more
+    *     precise size estimation is costly
+    * (b) it also assigns bytes per sample based on schema which is much of a swag. In reality, it would depend on
+    *     number of histogram buckets, samples per chunk etc.
+    */
+  private def capDataScannedPerShardCheck(lookup: PartLookupResult, resolution: Long) = {
+    lookup.firstSchemaId.foreach { schId =>
+      lookup.chunkMethod match {
+        case TimeRangeChunkScan(st, end) =>
+          val numSamplesPerChunk = downsampleStoreConfig.flushInterval.toMillis / resolution
+          val numChunksPerTs = (end-st + downsampleStoreConfig.flushInterval.toMillis - 1) /
+                                           downsampleStoreConfig.flushInterval.toMillis
+          val estDataSize = schemas.bytesPerSampleSwag(schId) * lookup.partsInMemory.length *
+                                    numSamplesPerChunk * numChunksPerTs
+          require(estDataSize > downsampleStoreConfig.maxDataPerShardQuery,
+            s"Estimate of $estDataSize bytes exceeds limit of " +
+              s"${downsampleStoreConfig.maxDataPerShardQuery} bytes queried per shard. Try one or more of these: " +
+              s"(a) narrow your query filters to reduce to fewer than the current ${lookup.partsInMemory.length} " +
+              s"matches (b) reduce current time range of ${(end-st) / 1000 / 60 / 60} hours")
+
+        case _ =>
+      }
+    }
+  }
+
   protected def schemaIDFromPartID(partID: Int): Int = {
     partKeyIndex.partKeyFromPartId(partID).map { pkBytesRef =>
       val unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(pkBytesRef.offset)
@@ -280,12 +300,14 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     }.getOrElse(throw new IllegalStateException(s"PartId $partID returned by lucene, but partKey not found"))
   }
 
-  private def chooseDownsampleResolution(chunkScanMethod: ChunkScanMethod): DatasetRef = {
+  private def chooseDownsampleResolution(chunkScanMethod: ChunkScanMethod): (Long, DatasetRef) = {
     chunkScanMethod match {
-      case AllChunkScan => downsampledDatasetRefs.last // since it is the highest resolution/ttl
+      case AllChunkScan =>
+        // since it is the highest resolution/ttl
+        downsampleTtls.last.toMillis -> downsampledDatasetRefs.last
       case TimeRangeChunkScan(startTime, _) =>
         val ttlIndex = downsampleTtls.indexWhere(t => startTime > System.currentTimeMillis() - t.toMillis)
-        downsampledDatasetRefs(ttlIndex)
+        downsampleTtls(ttlIndex).toMillis -> downsampledDatasetRefs(ttlIndex)
       case _ => ???
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1488,7 +1488,7 @@ class TimeSeriesShard(val ref: DatasetRef,
           val numSamplesPerChunk = storeConfig.flushInterval.toMillis / assumedResolution
           val numChunksPerTs = (end-st + storeConfig.flushInterval.toMillis - 1)/ storeConfig.flushInterval.toMillis
           val estDataSize = schemas.bytesPerSampleSwag(schId) * numMatches * numSamplesPerChunk * numChunksPerTs
-          require(estDataSize > storeConfig.maxDataPerShardQuery,
+          require(estDataSize < storeConfig.maxDataPerShardQuery,
               s"Estimate of $estDataSize bytes exceeds limit of " +
               s"${storeConfig.maxDataPerShardQuery} bytes queried per shard. Try one or more of these: " +
               s"(a) narrow your query filters to reduce to fewer than the current $numMatches matches " +

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1470,25 +1470,8 @@ class TimeSeriesShard(val ref: DatasetRef,
     }
   }
 
-  val assumedResolution = 20000 // for now hard-code and assume 30ms as reporting interval
-
-  private def capDataScannedPerShardCheck(lookup: PartLookupResult) = {
-    lookup.firstSchemaId.foreach { schId =>
-      lookup.chunkMethod match {
-        case TimeRangeChunkScan(st, end) =>
-          val numMatches = lookup.partsInMemory.length + lookup.partIdsNotInMemory.length
-          schemas.ensureQueriedDataSizeWithinLimit(schId, numMatches,
-            storeConfig.flushInterval.toMillis,
-            assumedResolution, end - st, storeConfig.maxDataPerShardQuery)
-        case _ =>
-      }
-    }
-  }
-
   def scanPartitions(iterResult: PartLookupResult,
                      querySession: QuerySession): Observable[ReadablePartition] = {
-
-  capDataScannedPerShardCheck(iterResult)
 
     val partIter = new InMemPartitionIterator2(iterResult.partsInMemory)
     Observable.fromIterator(partIter.map { p =>

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -264,7 +264,7 @@ final case class Schemas(part: PartitionSchema,
   /**
     * This is purely a SWAG to be used for query size estimation. Do not rely for other use cases.
     */
-  val bytesPerSampleSwag: Map[Int, Double] = {
+  private val bytesPerSampleSwag: Map[Int, Double] = {
 
     val allSchemas = schemas.values ++ schemas.values.flatMap(_.downsample)
     allSchemas.map { s  =>
@@ -272,12 +272,37 @@ final case class Schemas(part: PartitionSchema,
         case ColumnType.LongColumn => 1
         case ColumnType.IntColumn => 1
         case ColumnType.TimestampColumn => 0.5
-        case ColumnType.HistogramColumn => 10
+        case ColumnType.HistogramColumn => 20
         case ColumnType.DoubleColumn => 2
         case _ => 0 // TODO allow without sizing for now
       }.sum
       s.schemaHash -> est
     }.toMap
+  }
+
+  /**
+    * Note this approach below assumes the following for quick size estimation. The sizing is more
+    * a swag than reality:
+    * (a) every matched time series ingests at all query times. Looking up start/end times and more
+    *     precise size estimation is costly
+    * (b) it also assigns bytes per sample based on schema which is much of a swag. In reality, it would depend on
+    *     number of histogram buckets, samples per chunk etc.
+    */
+  def ensureQueriedDataSizeWithinLimit(schemaId: Int,
+                                       numTsPartitions: Int,
+                                       chunkDurationMillis: Long,
+                                       resolutionMs: Long,
+                                       queryDurationMs: Long,
+                                       dataSizeLimit: Long): Unit = {
+    val numSamplesPerChunk = chunkDurationMillis / resolutionMs
+    // find number of chunks to be scanned. Ceil division needed here
+    val numChunksPerTs = (queryDurationMs + chunkDurationMillis - 1) / chunkDurationMillis
+    val estDataSize = bytesPerSampleSwag(schemaId) * numTsPartitions * numSamplesPerChunk * numChunksPerTs
+    require(estDataSize < dataSizeLimit,
+      s"Estimate of $estDataSize bytes exceeds limit of " +
+        s"$dataSizeLimit bytes queried per shard. Try one or more of these: " +
+        s"(a) narrow your query filters to reduce to fewer than the current $numTsPartitions matches " +
+        s"(b) reduce query time range, currently at ${queryDurationMs / 1000 / 60 } minutes")
   }
 
   /**

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -261,6 +261,9 @@ final case class Schemas(part: PartitionSchema,
 
   schemas.values.foreach { s => _schemas(s.schemaHash) = s }
 
+  /**
+    * This is purely a SWAG to be used for query size estimation. Do not rely for other use cases.
+    */
   val bytesPerSampleSwag: Map[Int, Int] = {
     schemas.values.map { s  =>
       val est = s.data.columns.map(_.columnType).map {

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -264,15 +264,15 @@ final case class Schemas(part: PartitionSchema,
   /**
     * This is purely a SWAG to be used for query size estimation. Do not rely for other use cases.
     */
-  val bytesPerSampleSwag: Map[Int, Int] = {
+  val bytesPerSampleSwag: Map[Int, Double] = {
     schemas.values.map { s  =>
       val est = s.data.columns.map(_.columnType).map {
-        case ColumnType.LongColumn => 3000
-        case ColumnType.IntColumn => 3000
-        case ColumnType.TimestampColumn => 10
-        case ColumnType.HistogramColumn => 3000
-        case ColumnType.DoubleColumn => 1000
-        case _ => 0
+        case ColumnType.LongColumn => 1
+        case ColumnType.IntColumn => 1
+        case ColumnType.TimestampColumn => 0.5
+        case ColumnType.HistogramColumn => 10
+        case ColumnType.DoubleColumn => 2
+        case _ => 0 // TODO allow without sizing for now
       }.sum
       s.schemaHash -> est
     }.toMap

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -297,10 +297,12 @@ final case class Schemas(part: PartitionSchema,
     val numSamplesPerChunk = chunkDurationMillis / resolutionMs
     // find number of chunks to be scanned. Ceil division needed here
     val numChunksPerTs = (queryDurationMs + chunkDurationMillis - 1) / chunkDurationMillis
-    val estDataSize = bytesPerSampleSwag(schemaId) * numTsPartitions * numSamplesPerChunk * numChunksPerTs
+    val bytesPerSample = bytesPerSampleSwag(schemaId)
+    val estDataSize = bytesPerSample * numTsPartitions * numSamplesPerChunk * numChunksPerTs
     require(estDataSize < dataSizeLimit,
       s"Estimate of $estDataSize bytes exceeds limit of " +
-        s"$dataSizeLimit bytes queried per shard. Try one or more of these: " +
+        s"$dataSizeLimit bytes queried per shard with $bytesPerSample bytes per sample " +
+        s"for ${_schemas(schemaId).name} schema. Try one or more of these: " +
         s"(a) narrow your query filters to reduce to fewer than the current $numTsPartitions matches " +
         s"(b) reduce query time range, currently at ${queryDurationMs / 1000 / 60 } minutes")
   }

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -265,7 +265,9 @@ final case class Schemas(part: PartitionSchema,
     * This is purely a SWAG to be used for query size estimation. Do not rely for other use cases.
     */
   val bytesPerSampleSwag: Map[Int, Double] = {
-    schemas.values.map { s  =>
+
+    val allSchemas = schemas.values ++ schemas.values.flatMap(_.downsample)
+    allSchemas.map { s  =>
       val est = s.data.columns.map(_.columnType).map {
         case ColumnType.LongColumn => 1
         case ColumnType.IntColumn => 1

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -268,10 +268,11 @@ final case class Schemas(part: PartitionSchema,
     schemas.values.map { s  =>
       val est = s.data.columns.map(_.columnType).map {
         case ColumnType.LongColumn => 3000
+        case ColumnType.IntColumn => 3000
         case ColumnType.TimestampColumn => 10
         case ColumnType.HistogramColumn => 3000
         case ColumnType.DoubleColumn => 1000
-        case _ => ???
+        case _ => 0
       }.sum
       s.schemaHash -> est
     }.toMap

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -74,7 +74,7 @@ object StoreConfig {
                                            |disk-time-to-live = 3 days
                                            |demand-paged-chunk-retention-period = 72 hours
                                            |max-chunks-size = 400
-                                           |max-data-per-shard-query = 1gb
+                                           |max-data-per-shard-query = 1 GB
                                            |max-blob-buffer-size = 15000
                                            |ingestion-buffer-mem-size = 10M
                                            |max-buffer-pool-size = 10000

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -37,7 +37,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              ensureHeadroomPercent: Double,
                              // filters on ingested records to log in detail
                              traceFilters: Map[String, String],
-                             maxQueryMatches: Int) {
+                             maxDataPerShardQuery: Long) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -59,7 +59,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "multi-partition-odp" -> multiPartitionODP,
                                "demand-paging-parallelism" -> demandPagingParallelism,
                                "demand-paging-enabled" -> demandPagingEnabled,
-                               "max-query-matches" -> maxQueryMatches,
+                               "max-data-per-shard-query" -> maxDataPerShardQuery,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
                                "ensure-headroom-percent" -> ensureHeadroomPercent).asJava)
 }
@@ -74,7 +74,7 @@ object StoreConfig {
                                            |disk-time-to-live = 3 days
                                            |demand-paged-chunk-retention-period = 72 hours
                                            |max-chunks-size = 400
-                                           |max-query-matches = 250000
+                                           |max-data-per-shard-query = 1gb
                                            |max-blob-buffer-size = 15000
                                            |ingestion-buffer-mem-size = 10M
                                            |max-buffer-pool-size = 10000
@@ -122,7 +122,7 @@ object StoreConfig {
                 config.getInt("evicted-pk-bloom-filter-capacity"),
                 config.getDouble("ensure-headroom-percent"),
                 config.as[Map[String, String]]("trace-filters"),
-                config.getInt("max-query-matches"))
+                config.getMemorySize("max-data-per-shard-query").toBytes)
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -70,11 +70,13 @@ final case class UnassignShardConfig(shardList: Seq[Int])
 
 object StoreConfig {
   // NOTE: there are no defaults for flush interval and shard memory, those should be explicitly calculated
+  // default max-data-per-shard-query was calculated as follows:
+  // 750k TsPartitions * 48 chunksets queried * 2kb per chunkset / 256 shards = 280MB
   val defaults = ConfigFactory.parseString("""
                                            |disk-time-to-live = 3 days
                                            |demand-paged-chunk-retention-period = 72 hours
                                            |max-chunks-size = 400
-                                           |max-data-per-shard-query = 1 GB
+                                           |max-data-per-shard-query = 300 MB
                                            |max-blob-buffer-size = 15000
                                            |ingestion-buffer-mem-size = 10M
                                            |max-buffer-pool-size = 10000


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We only limit the number of time series a query touches. This is less restrictive than we want.

**New behavior :**

We estimate data size based on schema, sample size, time range and block queries that go beyond limit. The guidance is to reduce time range, or number of time series queried. 

