### PR TITLE
fix(query): throw exception when shardMapper is null and return execPlan head  in materialize when only one execPlan is present

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -73,6 +73,8 @@ class SingleClusterPlanner(dsRef: DatasetRef,
 
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
 
+    if (shardMapperFunc == null) throw new RuntimeException(s"ShardMapper: $shardMapperFunc is not available")
+    
     val materialized = walkLogicalPlanTree(logicalPlan, qContext)
     match {
       case PlanResult(Seq(justOne), stitch) =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -73,8 +73,8 @@ class SingleClusterPlanner(dsRef: DatasetRef,
 
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
 
-    if (shardMapperFunc == null) throw new RuntimeException(s"ShardMapper: $shardMapperFunc is not available")
-    
+    if (shardMapperFunc == null) throw new IllegalStateException("ShardMapper is not available")
+
     val materialized = walkLogicalPlanTree(logicalPlan, qContext)
     match {
       case PlanResult(Seq(justOne), stitch) =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -73,8 +73,6 @@ class SingleClusterPlanner(dsRef: DatasetRef,
 
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
 
-    if (shardMapperFunc == null) throw new IllegalStateException("ShardMapper is not available")
-
     val materialized = walkLogicalPlanTree(logicalPlan, qContext)
     match {
       case PlanResult(Seq(justOne), stitch) =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -73,6 +73,7 @@ class SingleClusterPlanner(dsRef: DatasetRef,
 
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
 
+    if (shardMapperFunc.numShards == 0) throw new IllegalStateException("No shards available")
     val materialized = walkLogicalPlanTree(logicalPlan, qContext)
     match {
       case PlanResult(Seq(justOne), stitch) =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
@@ -65,12 +65,14 @@ class SinglePartitionPlanner(planners: Map[String, QueryPlanner], plannerSelecto
 
   private def materializeLabelValues(logicalPlan: LogicalPlan, qContext: QueryContext) = {
     val execPlans = planners.values.toList.distinct.map(_.materialize(logicalPlan, qContext))
-    LabelValuesDistConcatExec(qContext, InProcessPlanDispatcher, execPlans)
+    if (execPlans.size == 1) execPlans.head
+    else LabelValuesDistConcatExec(qContext, InProcessPlanDispatcher, execPlans)
   }
 
   private def materializeSeriesKeysFilters(logicalPlan: LogicalPlan, qContext: QueryContext) = {
     val execPlans = planners.values.toList.distinct.map(_.materialize(logicalPlan, qContext))
-    PartKeysDistConcatExec(qContext, InProcessPlanDispatcher, execPlans)
+    if (execPlans.size == 1) execPlans.head
+    else PartKeysDistConcatExec(qContext, InProcessPlanDispatcher, execPlans)
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

- Metadata queries will go to multiple clusters. Even if one cluster is unhealthy SingleClusterPlanner throws null pointer exception as shardMapper is null
- Return execPlan.head when only one planner/execPlan is present