### PR TITLE
bug(core): Kamon needs a shutdown hook to drain metrics

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/KamonLogger.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/KamonLogger.scala
@@ -1,5 +1,7 @@
 package filodb.coordinator
 
+import scala.concurrent.Await
+
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import kamon.metric.{MeasurementUnit, MetricSnapshot, PeriodSnapshot}
@@ -9,6 +11,7 @@ import kamon.module.{MetricReporter, Module, ModuleFactory, SpanReporter}
 import kamon.tag.TagSet
 import kamon.trace.Span
 import kamon.util.Clock
+import kamon.Kamon
 
 class KamonMetricsLogReporter extends MetricReporter with StrictLogging {
 
@@ -117,5 +120,28 @@ object KamonLogger {
   class SpanLogFactory extends ModuleFactory {
     override def create(settings: ModuleFactory.Settings): Module =
       new KamonSpanLogReporter
+  }
+}
+
+object KamonShutdownHook extends StrictLogging {
+
+  import scala.concurrent.duration._
+
+  private val shutdownHookAdded = new java.util.concurrent.atomic.AtomicBoolean(false)
+  def registerShutdownHook(): Unit = {
+    if (shutdownHookAdded.compareAndSet(false, true)) {
+      logger.info(s"Registering Kamon Shutdown Hook...")
+      Runtime.getRuntime.addShutdownHook(new Thread() {
+        override def run(): Unit = {
+          logger.info(s"Stopping Kamon modules - this will ensure that last few metrics are drained")
+          try {
+            Await.result(Kamon.stopModules(), 5.minutes)
+            logger.info(s"Finished stopping Kamon modules")
+          } catch { case e: Exception =>
+              logger.error(s"Exception when stopping Kamon Modules", e)
+          }
+        }
+      })
+    }
   }
 }

--- a/coordinator/src/main/scala/filodb.coordinator/KamonLogger.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/KamonLogger.scala
@@ -4,6 +4,7 @@ import scala.concurrent.Await
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
 import kamon.metric.{MeasurementUnit, MetricSnapshot, PeriodSnapshot}
 import kamon.metric.MeasurementUnit.{information, time}
 import kamon.metric.MeasurementUnit.Dimension.{Information, Time}
@@ -11,7 +12,6 @@ import kamon.module.{MetricReporter, Module, ModuleFactory, SpanReporter}
 import kamon.tag.TagSet
 import kamon.trace.Span
 import kamon.util.Clock
-import kamon.Kamon
 
 class KamonMetricsLogReporter extends MetricReporter with StrictLogging {
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1518,5 +1518,6 @@ class TimeSeriesShard(val ref: DatasetRef,
        method to ensure that no threads are accessing the memory before it's freed.
     blockStore.releaseBlocks()
     */
+    ingestSched.shutdown()
   }
 }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -7,6 +7,7 @@ import kamon.Kamon
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
+import filodb.coordinator.KamonShutdownHook
 import filodb.downsampler.DownsamplerContext
 
 /**
@@ -100,10 +101,12 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
     DownsamplerContext.dsLogger.info(s"Cassandra split size: ${splits.size}. We will have this many spark " +
       s"partitions. Tune splitsPerNode which was ${settings.splitsPerNode} if parallelism is low")
 
+    KamonShutdownHook.registerShutdownHook()
+
     spark.sparkContext
       .makeRDD(splits)
       .mapPartitions { splitIter =>
-        Kamon.init() // kamon init should be first thing in worker jvm
+        KamonShutdownHook.registerShutdownHook()
         import filodb.core.Iterators._
         val rawDataSource = batchDownsampler.rawCassandraColStore
         val batchReadSpan = Kamon.spanBuilder("cassandra-raw-data-read-latency").start()
@@ -117,7 +120,7 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
         batchIter // iterator of batches
       }
       .foreach { rawPartsBatch =>
-        Kamon.init() // kamon init should be first thing in worker jvm
+        KamonShutdownHook.registerShutdownHook()
         batchDownsampler.downsampleBatch(rawPartsBatch, userTimeStart, userTimeEndExclusive)
       }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -76,7 +76,7 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
             shard = shard.toInt, updateHour = epochHour)
           count += migrateWithDownsamplePartKeys(partKeys, shard)
         }
-        DownsamplerContext.dsLogger.info(s"Successfully Completed Full PartKey Migration for shard=$shard " +
+        DownsamplerContext.dsLogger.info(s"Successfully Completed Partial PartKey Migration for shard=$shard " +
           s"count=$count fromHour=$fromHour toHourExcl=$toHourExcl")
       }
       sparkForeachTasksCompleted.increment()

--- a/standalone/src/main/scala/filodb.standalone/FiloServer.scala
+++ b/standalone/src/main/scala/filodb.standalone/FiloServer.scala
@@ -68,6 +68,7 @@ class FiloServer(watcher: Option[ActorRef]) extends FilodbClusterNode {
       filoHttpServer.start(coordinatorActor, singleton, bootstrapper.getAkkaHttpRoute())
       // Launch the profiler after startup, if configured.
       SimpleProfiler.launch(systemConfig.getConfig("filodb.profiler"))
+      KamonShutdownHook.registerShutdownHook()
     } catch {
       // if there is an error in the initialization, we need to fail fast so that the process can be rescheduled
       case NonFatal(e) =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

It is possible to miss metrics from FiloDB since any shutdown may miss metrics from the last time interval. This commit adds shutdown hook to drain kamon metrics to reporters.

Added to both server and spark jobs.
