### PR TITLE
feat(query):  sort LabelValueOperators and LabelValueOperatorGroups

### DIFF
--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -1,5 +1,7 @@
 package filodb.query
 
+import scalaxy.loops._
+
 import filodb.core.query.{ColumnFilter, RangeParams}
 
 //scalastyle:off number.of.types
@@ -336,25 +338,38 @@ case class ApplyAbsentFunction(vectors: PeriodicSeriesPlan,
   override def endMs: Long = vectors.endMs
 }
 
-//case class LabelValueOperator(columnName: String, value: Seq[String], operator: String)
-//  extends Ordered[LabelValueOperator]
-//{
-//  //import scala.math.Ordered.orderingToOrdered
-//  def compare(that: LabelValueOperator): Int = (this.columnName, this.value.head, this.operator) compare
-//    (that.columnName, that.value.head, that.operator)
-//}
-
-case class LabelValueOperator(columnName: String, value: Seq[String], operator: String)
-object LabelValueOperator {
-  // Note that because `Ordering[A]` is not contravariant, the declaration
-  // must be type-parametrized in the event that you want the implicit
-  // ordering to apply to subclasses of `Employee`.
-  implicit def orderingByName[A <: LabelValueOperator]: Ordering[A] =
-    Ordering.by(e => (e.columnName, e.value.head, e.operator))
-
+case class LabelValueOperator(columnName: String,
+                              value: Seq[String],
+                              operator: String) extends Ordered[LabelValueOperator] {
+  override def compare(that: LabelValueOperator): Int = {
+    val comp1 = columnName.compareTo(that.columnName)
+    if (comp1 != 0) comp1
+    else {
+      val comp2 = value.head.compareTo(that.value.head)
+      if (comp2 != 0) comp2
+      else operator.compareTo(that.operator)
+    }
+  }
 }
-//case class LabelValueOperator(columnName: String, value: Seq[String], operator: String)
+
 case class LabelValueOperatorGroup(labelValueOperators: Seq[LabelValueOperator])
+  extends Ordered[LabelValueOperatorGroup] {
+
+  override def compare(that: LabelValueOperatorGroup): Int = {
+    val l1 = labelValueOperators.sorted
+    val l2 = that.labelValueOperators.sorted
+
+    for {i <- 0 until (Math.min(l1.size, l2.size)) optimized} {
+      val c = l1(i).compare(l2(i))
+      if (c != 0) return c
+    }
+    Integer.compare(l1.size, l2.size)
+  }
+}
+
+object LabelGroupOrdering extends Ordering[LabelValueOperatorGroup] {
+  override def compare(a: LabelValueOperatorGroup, b: LabelValueOperatorGroup): Int = a.compare(b)
+}
 
 object LogicalPlan {
   /**
@@ -372,37 +387,34 @@ object LogicalPlan {
     getLabelValueFromLogicalPlan(getLabelValueOperatorsFromLogicalPlan(logicalPlan), labelName)
   }
 
-  def getLabelValueFromLogicalPlan(labelValues: Option[LabelValueOperatorGroup],
+  def getLabelValueFromLogicalPlan(labelValues: Option[Seq[LabelValueOperatorGroup]],
                                    labelName: String): Option[Seq[String]] = {
     labelValues match {
       case None => None
-      case _    => labelValues.get.labelValueOperators.flatMap(l =>
-          l.columnName.equals(labelName) match {
-            case true  => l.value
+      case _    => labelValues.get.flatMap(group =>
+        group.labelValueOperators.flatMap(lops => {
+          lops.columnName.equals(labelName) match {
+            case true  => lops.value
             case false => Seq()
           }
-        ).distinct match {
+        })).distinct match {
         case Nil                    => None
         case lVFilters: Seq[String] => Some(lVFilters)
       }
     }
   }
 
-  private def getLabelValueOpsFromFilters(filters: Seq[ColumnFilter]): Seq[LabelValueOperator] = {
-    filters.map(cf => LabelValueOperator(cf.column,
-      cf.filter.valuesStrings.map(_.toString).toSeq.sorted, cf.filter.operatorString))
-      .sorted(LabelValueOperator.orderingByName)
-
+  private def getLabelValueOpsFromFilters(filters: Seq[ColumnFilter]): Option[LabelValueOperatorGroup] = {
+    Some(LabelValueOperatorGroup(filters.map(cf => LabelValueOperator(cf.column,
+      cf.filter.valuesStrings.map(_.toString).toSeq.sorted, cf.filter.operatorString)).sorted))
   }
 
-  def getLabelValueOperatorsFromLogicalPlan(logicalPlan: LogicalPlan): Option[LabelValueOperatorGroup] = {
+  def getLabelValueOperatorsFromLogicalPlan(logicalPlan: LogicalPlan): Option[Seq[LabelValueOperatorGroup]] = {
     LogicalPlan.findLeafLogicalPlans(logicalPlan).flatMap { lp =>
       lp match {
-//        case lp: LabelValues           => LabelValueOperatorGroup(
-//            lp.labelConstraints.map(lbc => LabelValueOperator(lbc._1, Seq(lbc._2), "=")).toSeq)
-//        case lp: LabelValues           => val r = lp.labelConstraints.map(lbc =>
-//                                          LabelValueOperator(lbc._1, Seq(lbc._2), "=")).toSeq
-//                                          LabelValueOperatorGroup(r)
+        case lp: LabelValues           => Some(
+          LabelValueOperatorGroup(
+            lp.labelConstraints.map(lbc => LabelValueOperator(lbc._1, Seq(lbc._2), "=")).toSeq))
         case lp: RawSeries             => getLabelValueOpsFromFilters(lp.filters)
         case lp: RawChunkMeta          => getLabelValueOpsFromFilters(lp.filters)
         case lp: SeriesKeysByFilters   => getLabelValueOpsFromFilters(lp.filters)
@@ -413,9 +425,7 @@ object LogicalPlan {
       }
     } match {
       case Nil => None
-      //case groupSeq: Seq[LabelValueOperatorGroup] => Some(groupSeq.sorted)
-     // case groupSeq: Seq[LabelValueOperatorGroup] => Some(groupSeq.sorted(LabelValueOperator.orderingByName))
-      case groupSeq: Seq[LabelValueOperator] => Some(LabelValueOperatorGroup(groupSeq))
+      case groupSeq: Seq[LabelValueOperatorGroup] => Some(groupSeq.sorted(LabelGroupOrdering))
     }
   }
 }

--- a/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
@@ -207,4 +207,16 @@ class LogicalPlanSpec extends FunSpec with Matchers {
    res.get(2).labelValueOperators(1).value.shouldEqual(Seq("Inst-1"))
    res.get(2).labelValueOperators(1).operator.shouldEqual("!~")
  }
+
+  it("should have equal hashcode for identical LabelValueOperatorGroups") {
+    val rawSeries1 = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("name", Equals("MetricName")),
+      ColumnFilter("instance", NotEquals("Inst-0"))), Seq("name", "instance"), Some(300000), None)
+    val periodicSeriesWithWindowing1 = PeriodicSeriesWithWindowing(rawSeries1, 1000, 500, 5000, 100, SumOverTime)
+    val res1 = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing1)
+    val rawSeries2 = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("instance", NotEquals("Inst-0")),
+      ColumnFilter("name", Equals("MetricName"))), Seq("name", "instance"), Some(300000), None)
+    val periodicSeriesWithWindowing2 = PeriodicSeriesWithWindowing(rawSeries2, 1000, 500, 5000, 100, SumOverTime)
+    val res2 = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing2)
+    res1.get.hashCode() shouldEqual res2.get.hashCode()
+  }
 }

--- a/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
@@ -1,7 +1,7 @@
 package filodb.query
 
 import filodb.core.query.{ColumnFilter, RangeParams}
-import filodb.core.query.Filter.{Equals, EqualsRegex, In, NotEquals, NotEqualsRegex}
+import filodb.core.query.Filter.{Equals, In}
 import filodb.query.BinaryOperator.DIV
 import filodb.query.Cardinality.OneToOne
 import filodb.query.RangeFunctionId.SumOverTime
@@ -9,70 +9,69 @@ import org.scalatest.{FunSpec, Matchers}
 
 class LogicalPlanSpec extends FunSpec with Matchers {
 
-  it("should get labelValueOps from logicalPlan") {
-
-    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName")),
-      ColumnFilter("instance", NotEquals("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
-    val periodicSeriesWithWindowing = PeriodicSeriesWithWindowing(rawSeries, 1000, 500, 5000, 100, SumOverTime)
-
-    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
-    res.get.size.shouldEqual(1)
-    res.get(0).labelValueOperators.size.shouldEqual(2)
-    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
-    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
-    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
-    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
-    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
-    res.get(0).labelValueOperators(1).operator.shouldEqual("!=")
-  }
+//  it("should get labelValueOps from logicalPlan") {
+//
+//    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName")),
+//      ColumnFilter("instance", NotEquals("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
+//    val periodicSeriesWithWindowing = PeriodicSeriesWithWindowing(rawSeries, 1000, 500, 5000, 100, SumOverTime)
+//
+//    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
+//    res.get.size.shouldEqual(1)
+//    res.get(0).labelValueOperators.size.shouldEqual(2)
+//    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
+//    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
+//    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
+//    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
+//    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
+//    res.get(0).labelValueOperators(1).operator.shouldEqual("!=")
+//  }
 
   it("should get labelValueOps from logicalPlan with filter In") {
 
-    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName")),
+    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("name", Equals("MetricName")),
       ColumnFilter("instance", In(Set("Inst-1", "Inst-0")))), Seq("_name_", "instance"), Some(300000), None)
     val periodicSeriesWithWindowing = PeriodicSeriesWithWindowing(rawSeries, 1000, 500, 5000, 100, SumOverTime)
 
     val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
-    res.get.size.shouldEqual(1)
-    res.get(0).labelValueOperators.size.shouldEqual(2)
-    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
-    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
-    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
-    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
-    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0", "Inst-1"))
-    res.get(0).labelValueOperators(1).operator.shouldEqual("in")
+    res.get.labelValueOperators.size shouldEqual 2
+    res.get.labelValueOperators(0).columnName.shouldEqual("name")
+//    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
+//    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
+//    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
+//    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0", "Inst-1"))
+//    res.get(0).labelValueOperators(1).operator.shouldEqual("in")
   }
 
-  it("should get labelValueOps from BinaryJoin LogicalPlan") {
-
-    val rawSeriesLhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName1")),
-      ColumnFilter("instance", EqualsRegex("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
-    val lhs = PeriodicSeries(rawSeriesLhs, 1000, 500, 50000)
-
-    val rawSeriesRhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("job", Equals("MetricName2")),
-      ColumnFilter("instance", NotEqualsRegex("Inst-1"))), Seq("job", "instance"), Some(300000), None)
-    val rhs = PeriodicSeries(rawSeriesRhs, 1000, 500, 50000)
-
-    val binaryJoin = BinaryJoin(lhs, DIV, OneToOne, rhs)
-
-    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(binaryJoin)
-    res.get.size.shouldEqual(2)
-    res.get(0).labelValueOperators.size.shouldEqual(2)
-    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
-    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName1"))
-    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
-    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
-    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
-    res.get(0).labelValueOperators(1).operator.shouldEqual("=~")
-    res.get(1).labelValueOperators.size.shouldEqual(2)
-    res.get(1).labelValueOperators(0).columnName.shouldEqual("job")
-    res.get(1).labelValueOperators(0).value.shouldEqual(Seq("MetricName2"))
-    res.get(1).labelValueOperators(0).operator.shouldEqual("=")
-    res.get(1).labelValueOperators(1).columnName.shouldEqual("instance")
-    res.get(1).labelValueOperators(1).value.shouldEqual(Seq("Inst-1"))
-    res.get(1).labelValueOperators(1).operator.shouldEqual("!~")
-  }
-
+//  it("should get labelValueOps from BinaryJoin LogicalPlan") {
+//
+//    val rawSeriesLhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName1")),
+//      ColumnFilter("instance", EqualsRegex("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
+//    val lhs = PeriodicSeries(rawSeriesLhs, 1000, 500, 50000)
+//
+//    val rawSeriesRhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("job", Equals("MetricName2")),
+//      ColumnFilter("instance", NotEqualsRegex("Inst-1"))), Seq("job", "instance"), Some(300000), None)
+//    val rhs = PeriodicSeries(rawSeriesRhs, 1000, 500, 50000)
+//
+//    val binaryJoin = BinaryJoin(lhs, DIV, OneToOne, rhs)
+//
+//    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(binaryJoin)
+//    res.get.size.shouldEqual(2)
+//    res.get(0).labelValueOperators.size.shouldEqual(2)
+//    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
+//    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName1"))
+//    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
+//    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
+//    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
+//    res.get(0).labelValueOperators(1).operator.shouldEqual("=~")
+//    res.get(1).labelValueOperators.size.shouldEqual(2)
+//    res.get(1).labelValueOperators(0).columnName.shouldEqual("job")
+//    res.get(1).labelValueOperators(0).value.shouldEqual(Seq("MetricName2"))
+//    res.get(1).labelValueOperators(0).operator.shouldEqual("=")
+//    res.get(1).labelValueOperators(1).columnName.shouldEqual("instance")
+//    res.get(1).labelValueOperators(1).value.shouldEqual(Seq("Inst-1"))
+//    res.get(1).labelValueOperators(1).operator.shouldEqual("!~")
+//  }
+//
   it("should get labelValueOps fail for scalar logicalPlan") {
     val periodicSeriesWithWindowing = ScalarTimeBasedPlan(ScalarFunctionId.Year, RangeParams(1000, 500, 5000))
     val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)

--- a/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
@@ -1,7 +1,7 @@
 package filodb.query
 
 import filodb.core.query.{ColumnFilter, RangeParams}
-import filodb.core.query.Filter.{Equals, In}
+import filodb.core.query.Filter.{Equals, EqualsRegex, In, NotEquals, NotEqualsRegex}
 import filodb.query.BinaryOperator.DIV
 import filodb.query.Cardinality.OneToOne
 import filodb.query.RangeFunctionId.SumOverTime
@@ -9,69 +9,71 @@ import org.scalatest.{FunSpec, Matchers}
 
 class LogicalPlanSpec extends FunSpec with Matchers {
 
-//  it("should get labelValueOps from logicalPlan") {
-//
-//    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName")),
-//      ColumnFilter("instance", NotEquals("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
-//    val periodicSeriesWithWindowing = PeriodicSeriesWithWindowing(rawSeries, 1000, 500, 5000, 100, SumOverTime)
-//
-//    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
-//    res.get.size.shouldEqual(1)
-//    res.get(0).labelValueOperators.size.shouldEqual(2)
-//    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
-//    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
-//    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
-//    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
-//    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
-//    res.get(0).labelValueOperators(1).operator.shouldEqual("!=")
-//  }
+  it("should get labelValueOps from logicalPlan") {
+
+    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName")),
+      ColumnFilter("instance", NotEquals("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
+    val periodicSeriesWithWindowing = PeriodicSeriesWithWindowing(rawSeries, 1000, 500, 5000, 100, SumOverTime)
+
+    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
+    res.get.size.shouldEqual(1)
+    res.get(0).labelValueOperators.size.shouldEqual(2)
+    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
+    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
+    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
+    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
+    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
+    res.get(0).labelValueOperators(1).operator.shouldEqual("!=")
+  }
 
   it("should get labelValueOps from logicalPlan with filter In") {
 
-    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("name", Equals("MetricName")),
+    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName")),
       ColumnFilter("instance", In(Set("Inst-1", "Inst-0")))), Seq("_name_", "instance"), Some(300000), None)
     val periodicSeriesWithWindowing = PeriodicSeriesWithWindowing(rawSeries, 1000, 500, 5000, 100, SumOverTime)
 
     val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
-    res.get.labelValueOperators.size shouldEqual 2
-    res.get.labelValueOperators(0).columnName.shouldEqual("name")
-//    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
-//    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
-//    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
-//    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0", "Inst-1"))
-//    res.get(0).labelValueOperators(1).operator.shouldEqual("in")
+    res.get.size.shouldEqual(1)
+    res.get(0).labelValueOperators.size.shouldEqual(2)
+    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
+    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName"))
+    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
+    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
+    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0", "Inst-1"))
+    res.get(0).labelValueOperators(1).operator.shouldEqual("in")
   }
 
-//  it("should get labelValueOps from BinaryJoin LogicalPlan") {
-//
-//    val rawSeriesLhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName1")),
-//      ColumnFilter("instance", EqualsRegex("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
-//    val lhs = PeriodicSeries(rawSeriesLhs, 1000, 500, 50000)
-//
-//    val rawSeriesRhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("job", Equals("MetricName2")),
-//      ColumnFilter("instance", NotEqualsRegex("Inst-1"))), Seq("job", "instance"), Some(300000), None)
-//    val rhs = PeriodicSeries(rawSeriesRhs, 1000, 500, 50000)
-//
-//    val binaryJoin = BinaryJoin(lhs, DIV, OneToOne, rhs)
-//
-//    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(binaryJoin)
-//    res.get.size.shouldEqual(2)
-//    res.get(0).labelValueOperators.size.shouldEqual(2)
-//    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
-//    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName1"))
-//    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
-//    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
-//    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
-//    res.get(0).labelValueOperators(1).operator.shouldEqual("=~")
-//    res.get(1).labelValueOperators.size.shouldEqual(2)
-//    res.get(1).labelValueOperators(0).columnName.shouldEqual("job")
-//    res.get(1).labelValueOperators(0).value.shouldEqual(Seq("MetricName2"))
-//    res.get(1).labelValueOperators(0).operator.shouldEqual("=")
-//    res.get(1).labelValueOperators(1).columnName.shouldEqual("instance")
-//    res.get(1).labelValueOperators(1).value.shouldEqual(Seq("Inst-1"))
-//    res.get(1).labelValueOperators(1).operator.shouldEqual("!~")
-//  }
-//
+  it("should get labelValueOps from BinaryJoin LogicalPlan") {
+
+    val rawSeriesLhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("_name_", Equals("MetricName1")),
+      ColumnFilter("instance", EqualsRegex("Inst-0"))), Seq("_name_", "instance"), Some(300000), None)
+    val lhs = PeriodicSeries(rawSeriesLhs, 1000, 500, 50000)
+
+    val rawSeriesRhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("job", Equals("MetricName2")),
+      ColumnFilter("instance", NotEqualsRegex("Inst-1"))), Seq("job", "instance"), Some(300000), None)
+    val rhs = PeriodicSeries(rawSeriesRhs, 1000, 500, 50000)
+
+    val binaryJoin = BinaryJoin(lhs, DIV, OneToOne, rhs)
+
+    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(binaryJoin)
+
+    res.get.size.shouldEqual(2)
+    res.get(0).labelValueOperators.size.shouldEqual(2)
+    res.get(0).labelValueOperators(0).columnName.shouldEqual("_name_")
+    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("MetricName1"))
+    res.get(0).labelValueOperators(0).operator.shouldEqual("=")
+    res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
+    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
+    res.get(0).labelValueOperators(1).operator.shouldEqual("=~")
+    res.get(1).labelValueOperators.size.shouldEqual(2)
+    res.get(1).labelValueOperators(1).columnName.shouldEqual("job")
+    res.get(1).labelValueOperators(1).value.shouldEqual(Seq("MetricName2"))
+    res.get(1).labelValueOperators(1).operator.shouldEqual("=")
+    res.get(1).labelValueOperators(0).columnName.shouldEqual("instance")
+    res.get(1).labelValueOperators(0).value.shouldEqual(Seq("Inst-1"))
+    res.get(1).labelValueOperators(0).operator.shouldEqual("!~")
+  }
+
   it("should get labelValueOps fail for scalar logicalPlan") {
     val periodicSeriesWithWindowing = ScalarTimeBasedPlan(ScalarFunctionId.Year, RangeParams(1000, 500, 5000))
     val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
@@ -148,4 +150,61 @@ class LogicalPlanSpec extends FunSpec with Matchers {
     res.get.shouldEqual(Seq("Inst-0", "Inst-1"))
   }
 
+  it("should sort LabelValueOperators when only one group is present") {
+
+    val rawSeries = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("name", Equals("MetricName")),
+      ColumnFilter("instance", NotEquals("Inst-0"))), Seq("name", "instance"), Some(300000), None)
+    val periodicSeriesWithWindowing = PeriodicSeriesWithWindowing(rawSeries, 1000, 500, 5000, 100, SumOverTime)
+
+    val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(periodicSeriesWithWindowing)
+    res.get.size.shouldEqual(1)
+    res.get(0).labelValueOperators.size.shouldEqual(2)
+    res.get(0).labelValueOperators(0).columnName.shouldEqual("instance")
+    res.get(0).labelValueOperators(0).value.shouldEqual(Seq("Inst-0"))
+    res.get(0).labelValueOperators(0).operator.shouldEqual("!=")
+    res.get(0).labelValueOperators(1).columnName.shouldEqual("name")
+    res.get(0).labelValueOperators(1).value.shouldEqual(Seq("MetricName"))
+    res.get(0).labelValueOperators(1).operator.shouldEqual("=")
+  }
+
+  it("should get label values from nested binary join and sort") {
+   val rawSeriesLhs1 = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("app", Equals("Mosaic")),
+     ColumnFilter("instance", EqualsRegex("Inst-1"))), Seq("name", "instance"), Some(300000), None)
+   val lhs1 = PeriodicSeries(rawSeriesLhs1, 1000, 500, 50000)
+
+   val rawSeriesLhs2 = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("app", Equals("Cassandra")),
+     ColumnFilter("instance", EqualsRegex("Inst-0"))), Seq("name", "instance"), Some(300000), None)
+   val lhs2 = PeriodicSeries(rawSeriesLhs2, 1000, 500, 50000)
+
+   val binaryJoin1 = BinaryJoin(lhs1, DIV, OneToOne, lhs2)
+
+   val rawSeriesRhs = RawSeries(IntervalSelector(1000, 3000), Seq(ColumnFilter("app", Equals("Test")),
+     ColumnFilter("instance", NotEqualsRegex("Inst-1"))), Seq("job", "instance"), Some(300000), None)
+   val rhs = PeriodicSeries(rawSeriesRhs, 1000, 500, 50000)
+
+
+   val binaryJoin2 = BinaryJoin(binaryJoin1, DIV, OneToOne, rhs)
+
+   val res = LogicalPlan.getLabelValueOperatorsFromLogicalPlan(binaryJoin2)
+   res.get.size shouldEqual(3)
+   res.get(0).labelValueOperators.size.shouldEqual(2)
+   res.get(0).labelValueOperators(0).columnName.shouldEqual("app")
+   res.get(0).labelValueOperators(0).value.shouldEqual(Seq("Cassandra"))
+   res.get(0).labelValueOperators(0).operator.shouldEqual("=")
+   res.get(0).labelValueOperators(1).columnName.shouldEqual("instance")
+   res.get(0).labelValueOperators(1).value.shouldEqual(Seq("Inst-0"))
+   res.get(0).labelValueOperators(1).operator.shouldEqual("=~")
+   res.get(1).labelValueOperators(0).columnName.shouldEqual("app")
+   res.get(1).labelValueOperators(0).value.shouldEqual(Seq("Mosaic"))
+   res.get(1).labelValueOperators(0).operator.shouldEqual("=")
+   res.get(1).labelValueOperators(1).columnName.shouldEqual("instance")
+   res.get(1).labelValueOperators(1).value.shouldEqual(Seq("Inst-1"))
+   res.get(1).labelValueOperators(1).operator.shouldEqual("=~")
+   res.get(2).labelValueOperators(0).columnName.shouldEqual("app")
+   res.get(2).labelValueOperators(0).value.shouldEqual(Seq("Test"))
+   res.get(2).labelValueOperators(0).operator.shouldEqual("=")
+   res.get(2).labelValueOperators(1).columnName.shouldEqual("instance")
+   res.get(2).labelValueOperators(1).value.shouldEqual(Seq("Inst-1"))
+   res.get(2).labelValueOperators(1).operator.shouldEqual("!~")
+ }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Sort LabelValueOperators present inside a LabelValueOperatorGroup and sort all LabelValueOperatorGroups returned by LogicalPlan.getLabelValueOperatorsFromLogicalPlan