### PR TITLE
feat(query): Instrument query scheduler to get metrics

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -100,6 +100,19 @@ final class QueryActor(memStore: MemStore,
   private val resultVectors = Kamon.histogram("queryactor-result-num-rvs").withTags(TagSet.from(tags))
   private val queryErrors = Kamon.counter("queryactor-query-errors").withTags(TagSet.from(tags))
 
+  /**
+    * Instrumentation adds following metrics on the Query Scheduler
+    *
+    * # Counter
+    * executor_tasks_submitted_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    * # Counter
+    * executor_tasks_completed_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    * # Histogram
+    * executor_threads_active{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    * # Histogram
+    * executor_queue_size_count{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    *
+    */
   private def createInstrumentedQueryScheduler(): SchedulerService = {
     val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor")
                                       * sys.runtime.availableProcessors).toInt
@@ -149,7 +162,7 @@ final class QueryActor(memStore: MemStore,
           // Unhandled exception in query, should be rare
           logger.error(s"queryId ${q.queryContext.queryId} Unhandled Query Error: ", ex)
           replyTo ! QueryError(q.queryContext.queryId, ex)
-      }(queryScheduler)
+        }(queryScheduler)
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -1,5 +1,7 @@
 package filodb.coordinator
 
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory}
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.util.control.NonFatal
@@ -8,8 +10,10 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.dispatch.{Envelope, UnboundedStablePriorityMailbox}
 import com.typesafe.config.Config
 import kamon.Kamon
+import kamon.instrumentation.executor.ExecutorInstrumentation
 import kamon.tag.TagSet
 import monix.execution.Scheduler
+import monix.execution.schedulers.SchedulerService
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 
@@ -88,14 +92,36 @@ final class QueryActor(memStore: MemStore,
   val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
   val queryPlanner = new SingleClusterPlanner(dsRef, schemas, shardMapFunc,
                                               earliestRawTimestampFn, queryConfig, functionalSpreadProvider)
-  val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor") * sys.runtime.availableProcessors)
-  val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName-$dsRef", numSchedThreads.toInt)
+  val queryScheduler = createInstrumentedQueryScheduler()
 
   private val tags = Map("dataset" -> dsRef.toString)
   private val lpRequests = Kamon.counter("queryactor-logicalPlan-requests").withTags(TagSet.from(tags))
   private val epRequests = Kamon.counter("queryactor-execplan-requests").withTags(TagSet.from(tags))
   private val resultVectors = Kamon.histogram("queryactor-result-num-rvs").withTags(TagSet.from(tags))
   private val queryErrors = Kamon.counter("queryactor-query-errors").withTags(TagSet.from(tags))
+
+  private def createInstrumentedQueryScheduler(): SchedulerService = {
+    val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor")
+                                      * sys.runtime.availableProcessors).toInt
+    val schedName = s"$QuerySchedName-$dsRef"
+
+    val thFactory = new ThreadFactory {
+      def newThread(r: Runnable) = {
+        val thread = new Thread(r)
+        thread.setName(s"$schedName-${thread.getId}")
+        thread.setDaemon(true)
+        thread.setUncaughtExceptionHandler(
+          new UncaughtExceptionHandler {
+            override def uncaughtException(t: Thread, e: Throwable): Unit =
+              logger.error("Uncaught Exception in Query Scheduler", e)
+          })
+        thread
+      }
+    }
+    // TODO retaining old fixed size pool for now - later change to fork join pool.
+    val executor = new ScheduledThreadPoolExecutor(numSchedThreads, thFactory)
+    Scheduler.apply(ExecutorInstrumentation.instrument(executor, schedName))
+  }
 
   def execPhysicalPlan2(q: ExecPlan, replyTo: ActorRef): Unit = {
     if (checkTimeout(q.queryContext, replyTo)) {
@@ -106,6 +132,7 @@ final class QueryActor(memStore: MemStore,
       q.execute(memStore, querySession)(queryScheduler)
         .foreach { res =>
           FiloSchedulers.assertThreadName(QuerySchedName)
+          querySession.close()
           replyTo ! res
           res match {
             case QueryResult(_, _, vectors) => resultVectors.record(vectors.length)
@@ -118,9 +145,10 @@ final class QueryActor(memStore: MemStore,
               }
           }
         }(queryScheduler).recover { case ex =>
-        // Unhandled exception in query, should be rare
-        logger.error(s"queryId ${q.queryContext.queryId} Unhandled Query Error: ", ex)
-        replyTo ! QueryError(q.queryContext.queryId, ex)
+          querySession.close()
+          // Unhandled exception in query, should be rare
+          logger.error(s"queryId ${q.queryContext.queryId} Unhandled Query Error: ", ex)
+          replyTo ! QueryError(q.queryContext.queryId, ex)
       }(queryScheduler)
     }
   }

--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -1,7 +1,6 @@
 package filodb.query.exec
 
 import kamon.Kamon
-import monix.eval.Task
 import monix.execution.Scheduler
 
 import filodb.core.{DatasetRef, QueryTimeoutException}
@@ -9,7 +8,6 @@ import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, QueryContext, QuerySession}
 import filodb.core.store._
 import filodb.query.Query.qLogger
-import filodb.query.QueryResponse
 
 final case class UnknownSchemaQueryErr(id: Int) extends
   Exception(s"Unknown schema ID $id during query.  This likely means a schema config change happened and " +
@@ -82,18 +80,6 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
                                     None, Some(lookupRes),
                                     schema.isDefined, Nil)
           }
-  }
-
-  /**
-    * Overridden to close the session and release locks after query executes
-    */
-  override def execute(source: ChunkSource,
-                       querySession: QuerySession)
-                      (implicit sched: Scheduler): Task[QueryResponse] = {
-    val child = super.execute(source, querySession)
-    // doOnFinish handles the success and exception case. It does not handle the canceled case
-    child.doOnCancel(Task.now(querySession.close()))
-    child.doOnFinish(_ => Task.now(querySession.close()))
   }
 
   def doExecute(source: ChunkSource,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

1. Removed additional task due to querySession.close and folded it into QueryActor inline.
2. Kamon instrumentation of query scheduler for metrics

Before:
```
QueryInMemoryBenchmark.someOverlapQueries      thrpt   42  1017.285 ± 46.556  ops/s
```

After: 
```
QueryInMemoryBenchmark.someOverlapQueries      thrpt   42  1129.631 ± 33.969  ops/s
```



Relevant new metrics added:
```
# Counter
executor_tasks_submitted_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
# Counter
executor_tasks_completed_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
# Histogram
executor_threads_active{type="ThreadPoolExecutor",name="query-sched-prometheus"} 
# Histogram
executor_queue_size_count{type="ThreadPoolExecutor",name="query-sched-prometheus"}
```