### PR TITLE
fix(jmh): A few more fixes to QueryInMemoryBenchmark

### DIFF
--- a/standalone/src/main/java/filodb/standalone/SimpleProfiler.java
+++ b/standalone/src/main/java/filodb/standalone/SimpleProfiler.java
@@ -321,6 +321,11 @@ public class SimpleProfiler {
             return null;
         }
 
+        // XXX: only profile threads which are query scheduler threads
+        // if (!info.getThreadName().startsWith("query-sched")) {
+        //     return null;
+        // }
+
         StackTraceElement[] trace = info.getStackTrace();
 
         // Reject internal threads which have no trace at all.


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

- Ensures all benchmarks are updating the query time in the LogicalPlan before submitting
- Ensures spread is uniform everywhere
- Corrects OperationsPerInvocation
- Starts Kamon