### PR TITLE
feat(core): More accurate data sizing for queries on downsample shard

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -222,15 +222,13 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
           // Second iteration is for query result evaluation. Loading everything to heap
           // is expensive, but we do it to handle data sizing for metrics that have
           // continuous churn. See capDataScannedPerShardCheck method.
-          val res = partKeyIndex.partKeyRecordsFromFilters(filters,
-            chunkMethod.startTime,
-            chunkMethod.endTime)
-          val _schema = res.headOption.map { pkRec =>
+          val recs = partKeyIndex.partKeyRecordsFromFilters(filters, chunkMethod.startTime, chunkMethod.endTime)
+          val _schema = recs.headOption.map { pkRec =>
             RecordSchema.schemaID(pkRec.partKey, UnsafeUtils.arayOffset)
           }
           stats.queryTimeRangeMins.record((chunkMethod.endTime - chunkMethod.startTime) / 60000 )
           PartLookupResult(shardNum, chunkMethod, debox.Buffer.empty,
-            _schema, debox.Map.empty, debox.Buffer.empty, res)
+            _schema, debox.Map.empty, debox.Buffer.empty, recs)
         } else {
           throw new UnsupportedOperationException("Cannot have empty filters")
         }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -58,7 +58,7 @@ TimeSeriesShard(ref, schemas, storeConfig, shardNum, bufferMemoryManager, rawSto
       lookup.chunkMethod match {
         case TimeRangeChunkScan(st, end) =>
           val numMatches = lookup.partsInMemory.length + lookup.partIdsNotInMemory.length
-          schemas.ensureQueriedDataSizeWithinLimit(schId, numMatches,
+          schemas.ensureQueriedDataSizeWithinLimitApprox(schId, numMatches,
             storeConfig.flushInterval.toMillis,
             assumedResolution, end - st, storeConfig.maxDataPerShardQuery)
         case _ =>

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -189,7 +189,8 @@ case class PartLookupResult(shard: Int,
                             partsInMemory: debox.Buffer[Int],
                             firstSchemaId: Option[Int] = None,
                             partIdsMemTimeGap: debox.Map[Int, Long] = debox.Map.empty,
-                            partIdsNotInMemory: debox.Buffer[Int] = debox.Buffer.empty)
+                            partIdsNotInMemory: debox.Buffer[Int] = debox.Buffer.empty,
+                            pkRecords: Seq[PartKeyLuceneIndexRecord] = Seq.empty)
 
 final case class SchemaMismatch(expected: String, found: String) extends
 Exception(s"Multiple schemas found, please filter. Expected schema $expected, found schema $found")

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -9,9 +9,10 @@ import filodb.core.GlobalConfig
 import filodb.core.Types._
 import filodb.core.binaryrecord2._
 import filodb.core.downsample.{ChunkDownsampler, DownsamplePeriodMarker}
+import filodb.core.memstore.PartKeyLuceneIndexRecord
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query.ColumnInfo
-import filodb.core.store.ChunkSetInfo
+import filodb.core.store.{ChunkScanMethod, ChunkSetInfo}
 import filodb.memory.BinaryRegion
 import filodb.memory.format._
 import filodb.memory.format.BinaryVector.BinaryVectorPtr
@@ -295,12 +296,12 @@ final case class Schemas(part: PartitionSchema,
     * (b) it also assigns bytes per sample based on schema which is much of a swag. In reality, it would depend on
     *     number of histogram buckets, samples per chunk etc.
     */
-  def ensureQueriedDataSizeWithinLimit(schemaId: Int,
-                                       numTsPartitions: Int,
-                                       chunkDurationMillis: Long,
-                                       resolutionMs: Long,
-                                       queryDurationMs: Long,
-                                       dataSizeLimit: Long): Unit = {
+  def ensureQueriedDataSizeWithinLimitApprox(schemaId: Int,
+                                             numTsPartitions: Int,
+                                             chunkDurationMillis: Long,
+                                             resolutionMs: Long,
+                                             queryDurationMs: Long,
+                                             dataSizeLimit: Long): Unit = {
     val numSamplesPerChunk = chunkDurationMillis / resolutionMs
     // find number of chunks to be scanned. Ceil division needed here
     val numChunksPerTs = (queryDurationMs + chunkDurationMillis - 1) / chunkDurationMillis
@@ -311,6 +312,35 @@ final case class Schemas(part: PartitionSchema,
         s"$dataSizeLimit bytes queried per shard for ${_schemas(schemaId).name} schema. Try one or more of these: " +
         s"(a) narrow your query filters to reduce to fewer than the current $numTsPartitions matches " +
         s"(b) reduce query time range, currently at ${queryDurationMs / 1000 / 60 } minutes")
+  }
+
+  /**
+    * This method estimates data size with much better accuracy than ensureQueriedDataSizeWithinLimitApprox
+    * since it accepts the start/end times of each matching part key. It is able to handle estimation with
+    * time series churn much better
+    */
+  def ensureQueriedDataSizeWithinLimit(schemaId: Int,
+                                       pkRecs: Seq[PartKeyLuceneIndexRecord],
+                                       chunkDurationMillis: Long,
+                                       resolutionMs: Long,
+                                       chunkMethod: ChunkScanMethod,
+                                       dataSizeLimit: Long): Unit = {
+
+    val numSamplesPerChunk = chunkDurationMillis / resolutionMs
+    val bytesPerSample = bytesPerSampleSwag(schemaId)
+    var estDataSize = 0d
+    val quRange = chunkMethod.startTime to chunkMethod.endTime
+    pkRecs.foreach { pkRec =>
+      val intersection = Math.min(chunkMethod.endTime, pkRec.endTime) - Math.max(chunkMethod.startTime, pkRec.startTime)
+      // find number of chunks to be scanned. Ceil division needed here
+      val numChunks = (intersection + chunkDurationMillis - 1) / chunkDurationMillis
+      estDataSize += bytesPerSample * numSamplesPerChunk * numChunks
+    }
+    require(estDataSize < dataSizeLimit,
+      s"With match of ${pkRecs.length} time series, estimate of $estDataSize bytes exceeds limit of " +
+        s"$dataSizeLimit bytes queried per shard for ${_schemas(schemaId).name} schema. Try one or more of these: " +
+        s"(a) narrow your query filters to reduce to fewer than the current ${pkRecs.length} matches " +
+        s"(b) reduce query time range, currently at ${quRange.length / 1000 / 60 } minutes")
   }
 
   /**

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -325,7 +325,6 @@ final case class Schemas(part: PartitionSchema,
                                        resolutionMs: Long,
                                        chunkMethod: ChunkScanMethod,
                                        dataSizeLimit: Long): Unit = {
-
     val numSamplesPerChunk = chunkDurationMillis / resolutionMs
     val bytesPerSample = bytesPerSampleSwag(schemaId)
     var estDataSize = 0d


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

If there is a lot of churn in time series, downsample shard limits queries more aggressively due to assumption that every matching time series is ingesting for entire time range.

Downsample shard can do more accurate sizing estimate by paying cost of index lookup.
This is what this PR does. It looks up start/end times of all matching partitions and then decides to continue the query.
