### PR TITLE
debug(core): Log details if onReclaim blockMetaSize assertion fails, and halt process proactively

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -281,8 +281,18 @@ class TimeSeriesShard(val ref: DatasetRef,
       val partID = UnsafeUtils.getInt(metaAddr)
       val partition = partitions.get(partID)
       if (partition != UnsafeUtils.ZeroPointer) {
-        assert(numBytes == partition.schema.data.blockMetaSize)
+        // The number of bytes passed in is the metadata size which depends on schema.  It should match the
+        // TSPartition's blockMetaSize; if it doesn't that is a flag for possible corruption, and we should halt
+        // the process to be safe and log details for further debugging.
         val chunkID = UnsafeUtils.getLong(metaAddr + 4)
+        if (numBytes != partition.schema.data.blockMetaSize) {
+          logger.error(f"POSSIBLE CORRUPTION DURING onReclaim(metaAddr=0x$metaAddr%08x, numBytes=$numBytes)" +
+                       s"Expected meta size: ${partition.schema.data.blockMetaSize} for schema=${partition.schema}" +
+                       s"  Reclaiming chunk chunkID=$chunkID from shard=$shardNum " +
+                       s"partID=$partID ${partition.stringPartition}")
+          logger.warn("Halting FiloDB...")
+          sys.exit(33)   // Special onReclaim corruption exit code
+        }
         partition.removeChunksAt(chunkID)
         logger.debug(s"Reclaiming chunk chunkID=$chunkID from shard=$shardNum " +
           s"partID=$partID ${partition.stringPartition}")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Assertion in onReclaim handler can fail with no debug info

**New behavior :**

Add debug info and proactively halt process.  This causes a restart automatically to clean up state.
