### PR TITLE
debug(memory): Add additional debug logging when allocMetadata() call fails

### DIFF
--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -371,7 +371,7 @@ class BlockMemFactory(blockStore: BlockManager,
   def shutdown(): Unit = {}
 
   def debugString: String =
-    s"BlockMemFactory($bucketTime) ${tags.map { case (k, v) => s"$k=$v" }.mkString(" ")}"
+    s"BlockMemFactory($bucketTime, $metadataAllocSize) ${tags.map { case (k, v) => s"$k=$v" }.mkString(" ")}"
 }
 
 

--- a/memory/src/test/scala/filodb.memory/BlockSpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockSpec.scala
@@ -65,6 +65,9 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
 
     block.remaining shouldEqual 3822
 
+    //XXX for debugging
+    println(block.detailedDebugString)
+
     block.markReclaimable()
     block.reclaim()
     testReclaimer.reclaimedBytes shouldEqual 70


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

No block information is logged when `allocMetadata` throws an OutOfMemoryException

**New behavior :**

Very detailed statistics on block metadata and BlockMemFactory (the "owner") is printed when `allocMetadata` runs out of room.
