### PR TITLE
perf(sparkJobs): Reducing cass batch size to make c* queries smaller

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -187,32 +187,37 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     *    handle this case.
     */
   // scalastyle:off parameter.number
-  def getChunksByIngestionTimeRange(datasetRef: DatasetRef,
-                                    splits: Iterator[ScanSplit],
-                                    ingestionTimeStart: Long,
-                                    ingestionTimeEnd: Long,
-                                    userTimeStart: Long,
-                                    endTimeExclusive: Long,
-                                    maxChunkTime: Long,
-                                    batchSize: Int): Observable[Seq[RawPartData]] = {
-    val partKeys = Observable.fromIterator(splits).flatMap {
+  def getChunksByIngestionTimeRangeNoAsync(datasetRef: DatasetRef,
+                                           splits: Iterator[ScanSplit],
+                                           ingestionTimeStart: Long,
+                                           ingestionTimeEnd: Long,
+                                           userTimeStart: Long,
+                                           endTimeExclusive: Long,
+                                           maxChunkTime: Long,
+                                           batchSize: Int): Iterator[Seq[RawPartData]] = {
+    val partKeys = splits.flatMap {
       case split: CassandraTokenRangeSplit =>
         val indexTable = getOrCreateIngestionTimeIndexTable(datasetRef)
         logger.debug(s"Querying cassandra for partKeys for split=$split ingestionTimeStart=$ingestionTimeStart " +
           s"ingestionTimeEnd=$ingestionTimeEnd")
-        indexTable.scanPartKeysByIngestionTime(split.tokens, ingestionTimeStart, ingestionTimeEnd)
+        indexTable.scanPartKeysByIngestionTimeNoAsync(split.tokens, ingestionTimeStart, ingestionTimeEnd)
       case split => throw new UnsupportedOperationException(s"Unknown split type $split seen")
     }
 
     import filodb.core.Iterators._
 
     val chunksTable = getOrCreateChunkTable(datasetRef)
-    partKeys.bufferTumbling(batchSize).map { parts =>
+    partKeys.sliding(batchSize, batchSize).map { parts =>
       logger.debug(s"Querying cassandra for chunks from ${parts.size} partitions userTimeStart=$userTimeStart " +
         s"endTimeExclusive=$endTimeExclusive maxChunkTime=$maxChunkTime")
-      // TODO evaluate if we can increase parallelism here. This needs to be tuneable
-      // based on how much faster downsampling should run, and how much additional read load cassandra can take.
-      chunksTable.readRawPartitionRangeBB(parts, userTimeStart - maxChunkTime, endTimeExclusive).toIterator().toSeq
+      // This could be more parallel, but decision was made to control parallelism at one place: In spark (via its
+      // parallelism configuration. Revisit if needed later.
+      val batchReadSpan = Kamon.spanBuilder("cassandra-per-batch-data-read-latency").start()
+      try {
+        chunksTable.readRawPartitionRangeBBNoAsync(parts, userTimeStart - maxChunkTime, endTimeExclusive)
+      } finally {
+        batchReadSpan.finish()
+      }
     }
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -5,7 +5,6 @@ import java.nio.ByteBuffer
 import scala.concurrent.{ExecutionContext, Future}
 
 import com.datastax.driver.core.{ConsistencyLevel, ResultSet, Row}
-import monix.reactive.Observable
 
 import filodb.cassandra.FiloCassandraConnector
 import filodb.core._
@@ -101,10 +100,10 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
     }
   }
 
-  def scanPartKeysByIngestionTime(tokens: Seq[(String, String)],
-                                  ingestionTimeStart: Long,
-                                  ingestionTimeEnd: Long): Observable[ByteBuffer] = {
-    val it = tokens.iterator.flatMap { case (start, end) =>
+  def scanPartKeysByIngestionTimeNoAsync(tokens: Seq[(String, String)],
+                                         ingestionTimeStart: Long,
+                                         ingestionTimeEnd: Long): Iterator[ByteBuffer] = {
+    tokens.iterator.flatMap { case (start, end) =>
       /*
        * FIXME conversion of tokens to Long works only for Murmur3Partitioner because it generates
        * Long based tokens. If other partitioners are used, this can potentially break.
@@ -117,7 +116,6 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
       session.execute(stmt).iterator.asScala
         .map { row => row.getBytes("partition") }
     }
-    Observable.fromIterator(it).handleObservableErrors
   }
 
   /**

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -205,6 +205,23 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
     } yield rpd
   }
 
+  /**
+    * Not an async call - limit number of partitions queried at a time
+    */
+  def readRawPartitionRangeBBNoAsync(partitions: Seq[ByteBuffer],
+                                     startTime: Long,
+                                     endTimeExclusive: Long): Seq[RawPartData] = {
+    val query = readChunkRangeCql.bind().setList(0, partitions.asJava, classOf[ByteBuffer])
+                                        .setLong(1, chunkID(startTime, 0))
+                                        .setLong(2, chunkID(endTimeExclusive, 0))
+    session.execute(query).iterator().asScala
+            .map { row => (row.getBytes(0), chunkSetFromRow(row, 1)) }
+            .sortedGroupBy(_._1)
+            .map { case (partKeyBuffer, chunkSetIt) =>
+              RawPartData(partKeyBuffer.array, chunkSetIt.map(_._2).toBuffer)
+            }.toSeq
+  }
+
   def scanPartitionsBySplit(tokens: Seq[(String, String)]): Observable[RawPartData] = {
 
     val res: Observable[Future[Iterator[RawPartData]]] = Observable.fromIterable(tokens).map { case (start, end) =>

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -16,8 +16,8 @@ import filodb.core._
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.{Dataset, Schemas}
 import filodb.core.store.{ChunkSet, ChunkSetInfo, ColumnStoreSpec, PartKeyRecord}
-import filodb.memory.BinaryRegionLarge
-import filodb.memory.format.UnsafeUtils
+import filodb.memory.{BinaryRegionLarge, NativeMemoryManager}
+import filodb.memory.format.{TupleRowReader, UnsafeUtils}
 import filodb.memory.format.ZeroCopyUTF8String._
 
 class CassandraColumnStoreSpec extends ColumnStoreSpec {
@@ -26,6 +26,21 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
   lazy val session = new DefaultFiloSessionProvider(config.getConfig("cassandra")).session
   lazy val colStore = new CassandraColumnStore(config, s, session)
   lazy val metaStore = new CassandraMetaStore(config.getConfig("cassandra"), session)
+
+  val nativeMemoryManager = new NativeMemoryManager(100000000L, Map.empty)
+  val promDataset = Dataset("prometheus", Schemas.gauge)
+
+  // First create the tables in C*
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    colStore.initialize(promDataset.ref, 1).futureValue
+    colStore.truncate(promDataset.ref, 1).futureValue
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    nativeMemoryManager.shutdown()
+  }
 
   "getScanSplits" should "return splits from Cassandra" in {
     // Single split, token_start should equal token_end
@@ -223,5 +238,38 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
     parts should have length (1)
     parts(0).chunkSetsTimeOrdered should have length (1)
     parts(0).chunkSetsTimeOrdered(0).vectors.toSeq shouldEqual sourceChunks.head.chunks
+  }
+
+  "getChunksByIngestionTimeRange" should "batch partitions properly" in {
+
+    val gaugeName = "my_gauge"
+    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8)
+    val firstSampleTime = 74373042000L
+    val partBuilder = new RecordBuilder(nativeMemoryManager)
+    val ingestTime = 1594130687316L
+    val rows = Seq(TupleRowReader((Some(firstSampleTime), Some(0.0d))))
+    val chunksets = for { i <- 0 until 1050 } yield {
+      val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, gaugeName + i, seriesTags)
+      ChunkSet(Schemas.gauge.data, partKey, ingestTime, rows, nativeMemoryManager)
+    }
+    colStore.write(promDataset.ref, Observable.fromIterable(chunksets)).futureValue
+
+    val batches = colStore.getChunksByIngestionTimeRange(
+      promDataset.ref,
+      colStore.getScanSplits(promDataset.ref).iterator,
+      ingestTime - 1,
+      ingestTime + 1,
+      firstSampleTime - 1,
+      firstSampleTime + 1,
+      10L,
+      200
+    ).toListL.runAsync.futureValue
+
+    // TODO there seems to be a bug with batch size 100, possibly with the toIterator logic
+
+    batches.size shouldEqual 6 // 200 rows per batch, 1050 rows => 6 batches
+    batches.zipWithIndex.foreach { case (b, i) =>
+      b.size shouldEqual (if (i == 5) 50 else 200)
+    }
   }
 }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -233,10 +233,7 @@ filodb {
     # cass-session-provider-fqcn = fqcn
 
     # Number of time series to operate on at one time. Reduce if there is much less memory available
-    cass-write-batch-size = 10000
-
-    # Maximum time to wait during cassandra reads to form a batch of partitions to downsample
-    cass-write-batch-time = 3s
+    cass-write-batch-size = 500
 
     # amount of parallelism to introduce in the spark job. This controls number of spark partitions
     # increase if the number of splits seen in cassandra reads is low and spark jobs are slow.

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -108,17 +108,15 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
       .mapPartitions { splitIter =>
         Kamon.init()
         KamonShutdownHook.registerShutdownHook()
-        import filodb.core.Iterators._
         val rawDataSource = batchDownsampler.rawCassandraColStore
-        val batchReadSpan = Kamon.spanBuilder("cassandra-raw-data-read-latency").start()
-        val batchIter = rawDataSource.getChunksByIngestionTimeRange(datasetRef = batchDownsampler.rawDatasetRef,
+        val batchIter = rawDataSource.getChunksByIngestionTimeRangeNoAsync(
+          datasetRef = batchDownsampler.rawDatasetRef,
           splits = splitIter, ingestionTimeStart = ingestionTimeStart,
           ingestionTimeEnd = ingestionTimeEnd,
           userTimeStart = userTimeStart, endTimeExclusive = userTimeEndExclusive,
           maxChunkTime = settings.rawDatasetIngestionConfig.storeConfig.maxChunkTime.toMillis,
-          batchSize = settings.batchSize).toIterator()
-        batchReadSpan.finish()
-        batchIter // iterator of batches
+          batchSize = settings.batchSize)
+        batchIter
       }
       .foreach { rawPartsBatch =>
         Kamon.init()

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -116,7 +116,7 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
           ingestionTimeEnd = ingestionTimeEnd,
           userTimeStart = userTimeStart, endTimeExclusive = userTimeEndExclusive,
           maxChunkTime = settings.rawDatasetIngestionConfig.storeConfig.maxChunkTime.toMillis,
-          batchSize = settings.batchSize, batchTime = settings.batchTime).toIterator()
+          batchSize = settings.batchSize).toIterator()
         batchReadSpan.finish()
         batchIter // iterator of batches
       }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -54,8 +54,6 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val batchSize = downsamplerConfig.getInt("cass-write-batch-size")
 
-  @transient lazy val batchTime = downsamplerConfig.as[FiniteDuration]("cass-write-batch-time")
-
   @transient lazy val splitsPerNode = downsamplerConfig.getInt("splits-per-node")
 
   @transient lazy val cassWriteTimeout = downsamplerConfig.as[FiniteDuration]("cassandra-write-timeout")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Reduce downsample batch size from 10k to 500 to reduce cass query size - more queries instead of few very big queries.

Changed spark job to use Sync cass calls since they are single threaded anyway - I was encountering unit test bugs in the observable.toIterator conversion.