### PR TITLE
fix(memory): Blocks shouldn't be reclaimable until after metadata is …

### DIFF
--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -295,7 +295,7 @@ class BlockMemFactory(blockStore: BlockManager,
       if (blk != metadataSpan.last) {
         if (markFullBlocksAsReclaimable) {
           blk.markReclaimable()
-        } else {
+        } else synchronized {
           fullBlocks += blk
         }
       }

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -292,6 +292,13 @@ class BlockMemFactory(blockStore: BlockManager,
     metadataSpan.foreach { blk =>
       metaAddr = blk.allocMetadata(metaSize)
       metadataWriter(metaAddr)
+      if (blk != metadataSpan.last) {
+        if (markFullBlocksAsReclaimable) {
+          blk.markReclaimable()
+        } else {
+          fullBlocks += blk
+        }
+      }
     }
 
     metadataSpan.clear()
@@ -318,10 +325,12 @@ class BlockMemFactory(blockStore: BlockManager,
       }
     } else {
       val newBlock = requestBlock()
-      if (markFullBlocksAsReclaimable) {
-        block.markReclaimable()
-      } else {
-        fullBlocks += block
+      if (!metadataSpanActive) {
+        if (markFullBlocksAsReclaimable) {
+          block.markReclaimable()
+        } else {
+          fullBlocks += block
+        }
       }
       block = newBlock
       currentBlock = block
@@ -339,7 +348,7 @@ class BlockMemFactory(blockStore: BlockManager,
     * @param allocateSize Request memory allocation size in bytes
     * @return Memory which has a base, offset and a length
     */
-  def allocateOffheap(size: Int, zero: Boolean = false): BinaryRegion.NativePointer = {
+  def allocateOffheap(size: Int, zero: Boolean = false): BinaryRegion.NativePointer = synchronized {
     require(!zero, "BlockMemFactory cannot zero memory at allocation")
     val block = ensureCapacity(size + metadataAllocSize + 2)
     block.own()


### PR DESCRIPTION
…filled in. Also, minor thread safety improvement (currently not an issue).

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
A potential race exists when allocating over multiple blocks. The blocks can be reclaimed before metadata has been written. The thread which is filling in the metadata can run concurrently with any thread performing reclamation.

**New behavior :**
Don't make full blocks reclaimable until after the metadata has been filled in.
