### PR TITLE
bug(coord): Use localpartitioner only if required

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -111,7 +111,7 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
         prevPartitionStart = startMs
         val endMs = if (isInstantQuery) queryParams.endSecs * 1000 else p.timeRange.endMs + offsetMs
         logger.debug(s"partitionInfo=$p; updated startMs=$startMs, endMs=$endMs")
-        if (p.partitionName.equals(localPartitionName))
+        if (partitions.size == 1 && p.partitionName.equals(localPartitionName))
           localPartitionPlanner.materialize(
             copyLogicalPlanWithUpdatedTimeRange(logicalPlan, TimeRange(startMs, endMs)), qContext)
         else {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
When there are multiple partitions to query and if one of the partition is local to the queryEngine partition that received the request, it will use one localPartitionPlanner and remoteExec for rest of the planners. This results in schema related issues.

**New behavior :**
Use local partition planner only when there is one partition to query.