### PR TITLE
misc(memory): Remove unnecessary objects.

### DIFF
--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -351,7 +351,6 @@ class BlockMemFactory(blockStore: BlockManager,
   def allocateOffheap(size: Int, zero: Boolean = false): BinaryRegion.NativePointer = synchronized {
     require(!zero, "BlockMemFactory cannot zero memory at allocation")
     val block = ensureCapacity(size + metadataAllocSize + 2)
-    block.own()
     val preAllocationPosition = block.position()
     val newAddress = block.address + preAllocationPosition
     val postAllocationPosition = preAllocationPosition + size

--- a/memory/src/test/scala/filodb.memory/BlockSpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockSpec.scala
@@ -21,7 +21,6 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
 
   it should "allocate metadata and report remaining bytes accurately" in {
     val block = blockManager.requestBlock(None).get
-    block.own()
     block.capacity shouldEqual 4096
     block.remaining shouldEqual 4096
 
@@ -36,7 +35,6 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
 
   it should "return null when allocate metadata if not enough space" in {
     val block = blockManager.requestBlock(None).get
-    block.own()
     block.capacity shouldEqual 4096
     block.remaining shouldEqual 4096
 
@@ -48,14 +46,12 @@ class BlockSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAn
 
   it should "not reclaim when block has not been marked reclaimable" in {
     val block = blockManager.requestBlock(None).get
-    block.own()
 
     intercept[IllegalStateException] { block.reclaim() }
   }
 
   it should "call reclaimListener with address of all allocated metadatas" in {
     val block = blockManager.requestBlock(None).get
-    block.own()
     block.capacity shouldEqual 4096
     block.remaining shouldEqual 4096
 

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerConcurrentSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerConcurrentSpec.scala
@@ -25,7 +25,6 @@ with ConductorFixture with Matchers with BeforeAndAfterAll {
         val blocks = blockManager.requestBlocks(pageSize, None)
         blocks.size should be(1)
         val block = blocks.head
-        block.own()
         block.position(block.position() + 1)
         waitForBeat(1)
       }
@@ -34,7 +33,6 @@ with ConductorFixture with Matchers with BeforeAndAfterAll {
         val blocks = blockManager.requestBlocks(2 * pageSize, None)
         blocks.size should be(2)
         val block = blocks.head
-        block.own()
         block.position(block.position() + 1)
         waitForBeat(1)
       }
@@ -43,7 +41,6 @@ with ConductorFixture with Matchers with BeforeAndAfterAll {
         val blocks = blockManager.requestBlocks(3 * pageSize, None)
         blocks.size should be(3)
         val block = blocks.head
-        block.own()
         block.position(block.position() + 1)
         waitForBeat(1)
       }

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -82,7 +82,6 @@ class PageAlignedBlockManagerSpec extends FlatSpec with Matchers with BeforeAndA
     //used 2 out of 2
     firstRequest.size should be(2)
     //simulate writing to the block
-    firstRequest.head.own()
     firstRequest.head.position(blockSize.toInt - 1)
     //mark them as reclaimable
     firstRequest.foreach(_.markReclaimable())


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Lots of AtomicReferences, AtomicBooleans, and Loggers found in a heap dump. Most were from the Block class.

**New behavior :**
Removed all of these useless objects. Note that block ownership feature was never truly used. The call to "own" a block and to check ownership was always performed in the same thread, in the BlockMemFactory.allocateOffheap method.
