### PR TITLE
perf(sparkJobs): Repartition in downsampler to address jobs with skewed cass partitions

### DIFF
--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -537,6 +537,16 @@ class ParserSpec extends FunSpec with Matchers {
     }
   }
 
+  it("should error instant queries without step when step multiple notation is used") {
+    val q = "sum(rate(foo{job=\"SNRT-App-0\"}[5i]))"
+    val qts: Long = 1524855988L
+    val step = 0
+    info(s"Parsing $q")
+    intercept[IllegalArgumentException] {
+      Parser.queryToLogicalPlan(q, qts, step)
+    }
+  }
+
   private def printBinaryJoin( lp: LogicalPlan, level: Int = 0) : scala.Unit =  {
     if (!lp.isInstanceOf[BinaryJoin]) {
       info(s"${"  "*level}" + lp.toString)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -124,7 +124,7 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
       // needed since original number of partitions (cassandra splits) can have unbalanced data sizes
       // and caused long tails and increase job times. Hence repartition. This can cause shuffle,
       // but since part keys are small and we use kryo for serialization, we should be ok
-      .repartition(sparkParallelism * 4)
+      .repartition(sparkParallelism * 3)
       .foreach { rawPartsBatch =>
         Kamon.init()
         KamonShutdownHook.registerShutdownHook()


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

We are seeing jobs with long tails where one executor runs for a very long time indicating that original cassandra split based spark partitions were skewed. This PR will shuffle part keys amongst executors and even out data.