### PR TITLE
feat(coordinator): Query concurrency limiter + single thread per query

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -24,7 +24,8 @@ import filodb.query.exec.ExecPlan
 
 
 // A class to manage a queue and a set of currently executing queries, allowing no more than concurrentQueries
-// at a time.  When the query and execplans finishes execution, then they are removed.
+// at a time.  When the query and execplans finishes execution, then they are removed.  This has multiple benefits
+// including limiting memory usage and tracking running queries.
 // concurrentQueries defines the number of current queries where all execPlans belonging to the same queryID
 // is counted as a single query.
 // A queue keeps track of queries for which there is no space.  It is not expected for there to be more than

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -77,4 +77,5 @@ object QueryCommands {
   final case class BadArgument(msg: String) extends ErrorResponse with QueryResponse
   final case class BadQuery(msg: String) extends ErrorResponse with QueryResponse
   final case class WrongNumberOfArgs(actual: Int, expected: Int) extends ErrorResponse with QueryResponse
+  case object QueryQueueFull extends ErrorResponse with QueryResponse
 }

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -244,7 +244,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       memStore.refreshIndexForTesting(dataset1.ref)
 
-      val numQueries = 6
+      val numQueries = 30   // Want to make sure more queries than default concurrent limit in Query Scheduler
 
       val series2 = (2 to 4).map(n => s"Series $n").toSet.asInstanceOf[Set[Any]]
       val multiFilter = Seq(ColumnFilter("series", Filter.In(series2)))

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -160,7 +160,7 @@ filodb {
     min-step = 5 seconds
 
     # Parallelism (query threadpool per dataset) ... ceil(available processors * factor)
-    threads-factor = 1.0
+    threads-factor = 1.5
 
     # Maximum number of queries the query queue can hold.  If the queue is full, new ExecPlans will be rejected.
     max-queue-length = 25000

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -162,6 +162,9 @@ filodb {
     # Parallelism (query threadpool per dataset) ... ceil(available processors * factor)
     threads-factor = 1.0
 
+    # Maximum number of queries the query queue can hold.  If the queue is full, new ExecPlans will be rejected.
+    max-queue-length = 25000
+
     # Maximum number of steps/windows to use the RangeVectorAggregator.fastReduce aggregators.  This aggregator
     # uses memory proportional to the # of windows, rather than the # of time series aggregated; it can speed up
     # high cardinality aggregations in particular.

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -15,6 +15,8 @@ class QueryConfig(queryConfig: Config) {
   lazy val minStepMs = queryConfig.getDuration("min-step").toMillis
   lazy val fastReduceMaxWindows = queryConfig.getInt("fastreduce-max-windows")
   lazy val routingConfig = queryConfig.getConfig("routing")
+  lazy val threadsFactor = queryConfig.getDouble("threads-factor")
+  lazy val maxQueueLen = queryConfig.getInt("max-queue-length")
 
   /**
    * Feature flag test: returns true if the config has an entry with "true", "t" etc


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, when ExecPlans come into the QueryActor mailbox, they are processed immediately, and Tasks for actual query plan execution are then added onto a Scheduler.   This results in some issues when a flood of ExecPlans comes to a QueryActor:
1) As the scheduler is used as a queue, and Tasks and associated state use up significant memory, this results in `OutOfMemoryError`s and significant GC pressure, leading to host restarts or much longer latencies
2) A very large number of concurrent tasks from different queries leads to high overhead and thread switching / Monix task management overhead costs, which can be seen in profiler output.

**New behavior :**

This PR introduces a new class, the `QueryScheduler`.  

The `QueryScheduler` allows only n concurrent queries to be executed at the same time; all ExecPlans belonging to the same queryID may be then converted into Tasks and executed; only n concurrent queryIDs are allowed at once.   Incoming ExecPlans which do not belong in one of the currently executing queryIDs are put into a queue, and only when a query finishes executing is a new query allowed into the task pool.  Limiting concurrent queries is designed to address 1) the OOM and memory issues primarily.  It also has other benefits including tracking of and potential cancellation of running queries.

At the same time, the `QueryScheduler` will assign a single-threaded scheduler to each running query (rather all ExecPlans belonging to the same queryID).  This is designed to reduce the task and thread switching overhead, and in fact does appear to boost performance significantly, approximately 2x over the original design.

JMH performance measurements, QueryInMemoryBenchmark.someOverlapQueries:

Original QueryActor with fixed thread pool:
```
[info] Benchmark                                   Mode  Cnt     Score    Error  Units
[info] QueryInMemoryBenchmark.someOverlapQueries  thrpt   20  1217.110 ± 31.830  ops/s
```

Original QueryActor with ForkJoinPool:
```
[info] Benchmark                                   Mode  Cnt     Score    Error  Units
[info] QueryInMemoryBenchmark.someOverlapQueries  thrpt   20  1622.374 ± 91.850  ops/s
```

QueryScheduler with single-threaded pool per query (this PR):
```
[info] Benchmark                                   Mode  Cnt     Score    Error  Units
[info] QueryInMemoryBenchmark.someOverlapQueries  thrpt   20  2458.496 ± 44.633  ops/s
```
