### PR TITLE
fix(core): move status from recovery to active if there is no data to read from ingestion source

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -2,6 +2,7 @@ package filodb.core.downsample
 
 import scala.collection.mutable.HashMap
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
@@ -149,7 +150,8 @@ extends MemStore with StrictLogging {
   override def recoverStream(dataset: DatasetRef, shard: Int,
                              stream: Observable[SomeData],
                              startOffset: Long, endOffset: Long, checkpoints: Map[Int, Long],
-                             reportingInterval: Long): Observable[Long] = throw new UnsupportedOperationException()
+                             reportingInterval: Long) (implicit timeout: FiniteDuration)
+                              : Observable[Long] = throw new UnsupportedOperationException()
 
   override def numPartitions(dataset: DatasetRef, shard: Int): Int = throw new UnsupportedOperationException()
 

--- a/core/src/main/scala/filodb.core/memstore/MemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/MemStore.scala
@@ -1,6 +1,7 @@
 package filodb.core.memstore
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 import monix.eval.Task
 import monix.execution.{CancelableFuture, Scheduler}
@@ -131,7 +132,7 @@ trait MemStore extends ChunkSource {
                     startOffset: Long,
                     endOffset: Long,
                     checkpoints: Map[Int, Long],
-                    reportingInterval: Long): Observable[Long]
+                    reportingInterval: Long) (implicit timeout: FiniteDuration = 60.seconds): Observable[Long]
 
   /**
    * Returns the names of tags or columns that are indexed at the partition level, across

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -161,8 +161,8 @@ extends MemStore with StrictLogging {
       }
         // Nothing to read from source, blocking indefinitely. In such cases, 60sec timeout causes it
         // to return endOffset, making recovery complete and to start normal ingestion.
-        .timeoutOnSlowUpstreamTo(timeout, Observable.now(endOffset))
-        .collect {
+      .timeoutOnSlowUpstreamTo(timeout, Observable.now(endOffset))
+      .collect {
         case offset: Long if offset >= endOffset => // last offset reached
           offset
         case offset: Long if offset > targetOffset => // reporting interval reached

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -2,6 +2,7 @@ package filodb.core.memstore
 
 import scala.collection.mutable.HashMap
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
@@ -15,8 +16,7 @@ import filodb.core.downsample.{DownsampleConfig, DownsamplePublisher}
 import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, QuerySession}
 import filodb.core.store._
-import filodb.memory.MemFactory
-import filodb.memory.NativeMemoryManager
+import filodb.memory.{MemFactory, NativeMemoryManager}
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 
 class TimeSeriesMemStore(config: Config,
@@ -139,7 +139,7 @@ extends MemStore with StrictLogging {
                     startOffset: Long,
                     endOffset: Long,
                     checkpoints: Map[Int, Long],
-                    reportingInterval: Long): Observable[Long] = {
+                    reportingInterval: Long) (implicit timeout: FiniteDuration = 60.seconds): Observable[Long] = {
     val shard = getShardE(dataset, shardNum)
     shard.setGroupWatermarks(checkpoints)
     if (endOffset < startOffset) Observable.empty
@@ -158,7 +158,11 @@ extends MemStore with StrictLogging {
           startOffsetValidated = true
         }
         shard.ingest(r)
-      }.collect {
+      }
+        // Nothing to read from source, blocking indefinitely. In such cases, 60sec timeout causes it
+        // to return endOffset, making recovery complete and to start normal ingestion.
+        .timeoutOnSlowUpstreamTo(timeout, Observable.now(endOffset))
+        .collect {
         case offset: Long if offset >= endOffset => // last offset reached
           offset
         case offset: Long if offset > targetOffset => // reporting interval reached

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -170,7 +170,7 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     memStore.ingest(dataset1.ref, 0, data)
     memStore.refreshIndexForTesting(dataset1.ref)
 
-    val filter =  ColumnFilter("series", Filter.Equals("Series 1".utf8))
+    val filter = ColumnFilter("series", Filter.Equals("Series 1".utf8))
     val split = memStore.getScanSplits(dataset1.ref, 1).head
     val q2 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(split, Seq(filter)))
     q2.map(_.getDouble(0)).toSeq should equal (Seq(2.0, 12.0))
@@ -384,6 +384,20 @@ class TimeSeriesMemStoreSpec extends FunSpec with Matchers with BeforeAndAfter w
     val data1 = memStore.scanRows(dataset1, Seq(1), FilteredPartitionScan(splits.head))
                         .map(_.getDouble(0)).toSeq
     data1.length shouldEqual 47
+  }
+
+  it("should recoverStream after timeout, returns endOffset to start normal ingestion") {
+    memStore.setup(dataset1.ref, schemas1, 0, TestData.storeConf)
+    val checkpoints = Map(0 -> 2L, 1 -> 21L, 2 -> 6L, 3 -> 8L)
+
+    val stream = Observable.never // "never" to mimic no data in stream source
+    val startOffset = checkpoints.values.min
+    val endOffset = checkpoints.values.max
+    // recover from checkpoints.min to checkpoints.max - timeout after 1sec
+    val offsets = memStore.recoverStream(dataset1.ref, 0, stream, startOffset, endOffset, checkpoints, 4L)(1.second)
+      .until(_ >= 21L).toListL.runAsync.futureValue
+
+    offsets shouldEqual Seq(checkpoints.values.max) // should equal end offset
   }
 
   it("should truncate shards properly") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

Currently if there are checkpoints for a dataset and there is no data at InputSource, recovery process waits indefinitely for data to arrive, and in turn Shard status gets stuck at `StatusRecovery(0)`.
This PR is to 
 - timeout when there is no data to read `.timeoutOnSlowUpstreamTo(timeout, Observable.now(endOffset))`
 - return endOffset to complete recovery
 - mark the status as active
 - enable normal ingestion