### PR TITLE
Remove scalaxy dependency

### DIFF
--- a/core/src/main/scala/filodb.core/KeyType.scala
+++ b/core/src/main/scala/filodb.core/KeyType.scala
@@ -6,7 +6,7 @@ import scala.language.postfixOps
 import scala.math.Ordering
 
 import org.joda.time.DateTime
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.format.{vectors => bv, RowReader, ZeroCopyUTF8String}
 import filodb.memory.format.RowReader._

--- a/core/src/main/scala/filodb.core/KeyType.scala
+++ b/core/src/main/scala/filodb.core/KeyType.scala
@@ -60,7 +60,7 @@ abstract class SingleKeyTypeBase[K : Ordering : TypedFieldExtractor] extends Key
 case class CompositeOrdering(atomTypes: Seq[SingleKeyType]) extends Ordering[Seq[_]] {
   override def compare(x: Seq[_], y: Seq[_]): Int = {
     if (x.length == y.length && x.length == atomTypes.length) {
-      for { i <- 0 until x.length optimized } {
+      cforRange { 0 until x.length } { i =>
         val keyType = atomTypes(i)
         val res = keyType.ordering.compare(x(i).asInstanceOf[keyType.T],
                                            y(i).asInstanceOf[keyType.T])
@@ -76,7 +76,7 @@ case class CompositeReaderOrdering(atomTypes: Seq[SingleKeyType]) extends Orderi
   private final val extractors = atomTypes.map(_.extractor).toArray
   private final val numAtoms = atomTypes.length
   def compare(a: RowReader, b: RowReader): Int = {
-    for { i <- 0 until numAtoms optimized } {
+    cforRange { 0 until numAtoms } { i =>
       val res = extractors(i).compare(a, b, i)
       if (res != 0) return res
     }

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -615,7 +615,7 @@ object RecordBuilder {
   final def sortAndComputeHashes(pairs: java.util.ArrayList[(String, String)]): Array[Int] = {
     pairs.sort(stringPairComparator)
     val hashes = new Array[Int](pairs.size)
-    for { i <- 0 until pairs.size optimized } {
+    cforRange { 0 until pairs.size } { i =>
       val (k, v) = pairs.get(i)
       // This is not very efficient, we have to convert String to bytes first to get the hash
       // TODO: work on different API which is far more efficient and saves memory allocation
@@ -644,7 +644,7 @@ object RecordBuilder {
                                  hashes: Array[Int],
                                  excludeKeys: Set[String]): Int = {
     var hash = 7
-    for { i <- 0 until sortedPairs.size optimized } {
+    cforRange { 0 until sortedPairs.size } { i =>
       if (!(excludeKeys contains sortedPairs.get(i)._1))
         hash = combineHash(hash, hashes(i))
     }

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -2,7 +2,7 @@ package filodb.core.binaryrecord2
 
 import com.typesafe.scalalogging.StrictLogging
 import org.agrona.DirectBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.binaryrecord2.RecordSchema.schemaID
 import filodb.core.metadata.{Column, DatasetOptions, PartitionSchema, Schema, Schemas}

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
@@ -1,6 +1,6 @@
 package filodb.core.binaryrecord2
 
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.format.UnsafeUtils
 

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordComparator.scala
@@ -130,7 +130,7 @@ final class RecordComparator(ingestSchema: RecordSchema) {
 
     // adjust offsets to var fields
     val adjustment = partVarAreaOffset - ingestVarAreaOffset
-    for { i <- 0 until fixedAreaNumWords optimized } {
+    cforRange { 0 until fixedAreaNumWords } { i =>
       if ((compareBitmap & (1 << i)) == 0) {    // not a primitive field, but an offset to String or Map
         builder.adjustFieldOffset(i, adjustment)
       }

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -430,7 +430,7 @@ object RecordSchema {
   // Creates a Long from a byte array
   private def eightBytesToLong(bytes: Array[Byte], index: Int, len: Int): Long = {
     var num = 0L
-    for { i <- 0 until len optimized } {
+    cforRange { 0 until len } { i =>
       num = (num << 8) ^ (bytes(index + i) & 0x00ff)
     }
     num

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.agrona.DirectBuffer
 import org.agrona.concurrent.UnsafeBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.metadata.{Column, Schemas}
 import filodb.core.metadata.Column.ColumnType.{LongColumn, MapColumn, TimestampColumn}

--- a/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsamplePeriodMarker.scala
@@ -1,7 +1,7 @@
 package filodb.core.downsample
 
 import enumeratum.{Enum, EnumEntry}
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.metadata.DataSchema
 import filodb.core.store.{ChunkSetInfoReader, ReadablePartition}

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
@@ -2,7 +2,7 @@ package filodb.core.legacy.binaryrecord
 
 import com.typesafe.scalalogging.StrictLogging
 import org.agrona.DirectBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.metadata.{Column, Dataset}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, LongColumn, MapColumn, StringColumn}

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordBuilder.scala
@@ -557,7 +557,7 @@ object RecordBuilder {
   final def sortAndComputeHashes(pairs: java.util.ArrayList[(String, String)]): Array[Int] = {
     pairs.sort(stringPairComparator)
     val hashes = new Array[Int](pairs.size)
-    for { i <- 0 until pairs.size optimized } {
+    cforRange { 0 until pairs.size } { i =>
       val (k, v) = pairs.get(i)
       // This is not very efficient, we have to convert String to bytes first to get the hash
       // TODO: work on different API which is far more efficient and saves memory allocation
@@ -586,7 +586,7 @@ object RecordBuilder {
                                  hashes: Array[Int],
                                  excludeKeys: Set[String]): Int = {
     var hash = 7
-    for { i <- 0 until sortedPairs.size optimized } {
+    cforRange { 0 until sortedPairs.size } { i =>
       if (!(excludeKeys contains sortedPairs.get(i)._1))
         hash = combineHash(hash, hashes(i))
     }

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
@@ -1,6 +1,6 @@
 package filodb.core.legacy.binaryrecord
 
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.format.UnsafeUtils
 

--- a/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
+++ b/core/src/main/scala/filodb.core/legacy/binaryrecord/RecordComparator.scala
@@ -129,7 +129,7 @@ final class RecordComparator(ingestSchema: RecordSchema) {
 
     // adjust offsets to var fields
     val adjustment = partVarAreaOffset - ingestVarAreaOffset
-    for { i <- 0 until fixedAreaNumWords optimized } {
+    cforRange { 0 until fixedAreaNumWords } { i =>
       if ((compareBitmap & (1 << i)) == 0) {    // not a primitive field, but an offset to String or Map
         builder.adjustFieldOffset(i, adjustment)
       }

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -21,7 +21,7 @@ import org.apache.lucene.search.BooleanClause.Occur
 import org.apache.lucene.store.MMapDirectory
 import org.apache.lucene.util.{BytesRef, InfoStream}
 import org.apache.lucene.util.automaton.RegExp
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.{concurrentCache, DatasetRef}
 import filodb.core.Types.PartitionKey

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -184,7 +184,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     */
   def removePartKeys(partIds: debox.Buffer[Int]): Unit = {
     val terms = new util.ArrayList[BytesRef]()
-    for { i <- 0 until partIds.length optimized } {
+    cforRange { 0 until partIds.length } { i =>
       terms.add(new BytesRef(partIds(i).toString.getBytes))
     }
     indexWriter.deleteDocuments(new TermInSetQuery(PART_ID, terms))
@@ -317,7 +317,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     // Currently there is a bit of leak in abstraction of Binary Record processing in this class.
 
     luceneDocument.set(document) // threadlocal since we are not able to pass the document into mapconsumer
-    for { i <- 0 until numPartColumns optimized } {
+    cforRange { 0 until numPartColumns } { i =>
       indexers(i).fromPartKey(partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset), partId)
     }
     // partId

--- a/core/src/main/scala/filodb.core/memstore/PartitionKeyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionKeyIndex.scala
@@ -3,7 +3,7 @@ package filodb.core.memstore
 import com.googlecode.javaewah.{EWAHCompressedBitmap, IntIterator}
 import com.typesafe.scalalogging.StrictLogging
 import org.jctools.maps.NonBlockingHashMap
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.Types.PartitionKey
 import filodb.core.binaryrecord2.MapItemConsumer

--- a/core/src/main/scala/filodb.core/memstore/PartitionKeyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionKeyIndex.scala
@@ -71,7 +71,7 @@ class PartitionKeyIndex(dataset: Dataset) extends StrictLogging {
    * Adds fields from a partition key to the index
    */
   def addPartKey(base: Any, offset: Long, partIndex: Int): Unit = {
-    for { i <- 0 until numPartColumns optimized } {
+    cforRange { 0 until numPartColumns } { i =>
       indexers(i).fromPartKey(base, offset, partIndex)
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -1,7 +1,7 @@
 package filodb.core.memstore
 
 import com.typesafe.scalalogging.StrictLogging
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.DatasetRef
 import filodb.core.Types._

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -21,7 +21,7 @@ import monix.execution.{Scheduler, UncaughtExceptionReporter}
 import monix.execution.atomic.AtomicBoolean
 import monix.reactive.Observable
 import org.jctools.maps.NonBlockingHashMapLong
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.{ErrorResponse, _}
 import filodb.core.binaryrecord2._

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -114,7 +114,7 @@ object TimeSeriesShard {
   def writeMeta(addr: Long, partitionID: Int, info: ChunkSetInfo, vectors: Array[BinaryVectorPtr]): Unit = {
     UnsafeUtils.setInt(UnsafeUtils.ZeroPointer, addr, partitionID)
     ChunkSetInfo.copy(info, addr + 4)
-    for { i <- 0 until vectors.size optimized } {
+    cforRange { 0 until vectors.size } { i =>
       ChunkSetInfo.setVectorPtr(addr + 4, i, vectors(i))
     }
   }
@@ -125,7 +125,7 @@ object TimeSeriesShard {
   def writeMeta(addr: Long, partitionID: Int, bytes: Array[Byte], vectors: Array[BinaryVectorPtr]): Unit = {
     UnsafeUtils.setInt(UnsafeUtils.ZeroPointer, addr, partitionID)
     ChunkSetInfo.copy(bytes, addr + 4)
-    for { i <- 0 until vectors.size optimized } {
+    cforRange { 0 until vectors.size } { i =>
       ChunkSetInfo.setVectorPtr(addr + 4, i, vectors(i))
     }
   }
@@ -135,7 +135,7 @@ object TimeSeriesShard {
     */
   def writeMetaWithoutPartId(addr: Long, bytes: Array[Byte], vectors: Array[BinaryVectorPtr]): Unit = {
     ChunkSetInfo.copy(bytes, addr)
-    for { i <- 0 until vectors.size optimized } {
+    cforRange { 0 until vectors.size } { i =>
       ChunkSetInfo.setVectorPtr(addr, i, vectors(i))
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/WriteBufferPool.scala
+++ b/core/src/main/scala/filodb.core/memstore/WriteBufferPool.scala
@@ -2,7 +2,7 @@ package filodb.core.memstore
 
 import com.typesafe.scalalogging.StrictLogging
 import org.jctools.queues.MpscUnboundedArrayQueue
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.metadata.DataSchema
 import filodb.core.store.{ChunkSetInfo, StoreConfig}

--- a/core/src/main/scala/filodb.core/query/KeyFilter.scala
+++ b/core/src/main/scala/filodb.core/query/KeyFilter.scala
@@ -121,7 +121,7 @@ object KeyFilter {
   //   val funcs = positionsAndFuncs.collect { case (pos, func) if pos >= 0 => func }.toArray
 
   //   def partFunc(p: PartitionKey): Boolean = {
-  //     for { i <- 0 until positions.size optimized } {
+  //     cforRange { 0 until positions.size } { i =>
   //       val bool = funcs(i)(p.getAny(positions(i)))
   //       // Short circuit when any filter returns false
   //       if (!bool) return false

--- a/core/src/main/scala/filodb.core/query/PartitionTimeRangeReader.scala
+++ b/core/src/main/scala/filodb.core/query/PartitionTimeRangeReader.scala
@@ -1,6 +1,6 @@
 package filodb.core.query
 
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.metadata.Dataset
 import filodb.core.store.{ChunkInfoIterator, ChunkSetInfoReader, ReadablePartition}

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
@@ -169,7 +169,7 @@ object InfluxProtocolParser extends StrictLogging {
   // relies on offsets being in the same order as keys
   def parseKeyValues(bytes: Array[Byte], offsets: Buffer[Int], endOffset: Int, visitor: KVVisitor): Unit = {
     val last = offsets.length - 1
-    for { i <- 0 to last optimized } {
+    cforRange { 0 to last } { i =>
       val fieldEnd = if (i < last) keyOffset(offsets(i + 1)) - 1 else endOffset
       val curOffsetInt = offsets(i)
       val valueOffset = valOffset(curOffsetInt)

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxProtocolParser.scala
@@ -5,7 +5,7 @@ import scala.language.postfixOps
 import com.typesafe.scalalogging.StrictLogging
 import debox.Buffer
 import org.jboss.netty.buffer.ChannelBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.memory.format.UnsafeUtils

--- a/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
@@ -3,7 +3,7 @@ package filodb.gateway.legacy.conversion
 import scala.language.postfixOps
 
 import remote.RemoteStorage.TimeSeries
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.legacy.binaryrecord.RecordBuilder
 import filodb.core.metadata.Dataset

--- a/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/legacy/conversion/InputRecord.scala
@@ -79,7 +79,7 @@ case class PrometheusInputRecord(tags: Map[String, String],
     val metricBytes = metric.getBytes
     builder.addMapKeyValueHash(dataset.options.metricBytes, dataset.options.metricHash,
                                metricBytes, 0, metricBytes.size)
-    for { i <- 0 until javaTags.size optimized } {
+    cforRange { 0 until javaTags.size } { i =>
       val (k, v) = javaTags.get(i)
       builder.addMapKeyValue(k.getBytes, v.getBytes)
       builder.updatePartitionHash(hashes(i))

--- a/jmh/src/main/scala/filodb.jmh/BasicFiloBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/BasicFiloBenchmark.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 import scala.language.postfixOps
 
 import org.openjdk.jmh.annotations._
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format.MemoryReader._

--- a/jmh/src/main/scala/filodb.jmh/BasicFiloBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/BasicFiloBenchmark.scala
@@ -62,7 +62,7 @@ class BasicFiloBenchmark {
   def sumAllLongsApply(): Long = {
     var total = 0L
     val acc2 = acc // local variable to make the scala compiler not use virtual invoke
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       total += ivReader(acc2, iv, i)
     }
     total
@@ -74,7 +74,7 @@ class BasicFiloBenchmark {
   def sumAllLongsIterate(): Long = {
     var total = 0L
     val it = ivReader.iterate(acc, iv)
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       total += it.next
     }
     total
@@ -107,7 +107,7 @@ class BasicFiloBenchmark {
   def sumTimeSeriesBytesApply(): Long = {
     var total = 0L
     val acc2 = acc // local variable to make the scala compiler not use virtual invoke
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       total += byteReader(acc2, byteVect, i)
     }
     total
@@ -119,7 +119,7 @@ class BasicFiloBenchmark {
   def sumTimeSeriesBytesIterate(): Long = {
     var total = 0L
     val it = byteReader.iterate(acc, byteVect)
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       total += it.next
     }
     total

--- a/jmh/src/main/scala/filodb.jmh/DictStringBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/DictStringBenchmark.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 import scala.language.postfixOps
 
 import org.openjdk.jmh.annotations._
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._

--- a/jmh/src/main/scala/filodb.jmh/DictStringBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/DictStringBenchmark.scala
@@ -58,7 +58,7 @@ class DictStringBenchmark {
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   def rawStringLengthTotal(): Int = {
     var totalLen = 0
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       totalLen += scNoNA(i).length
     }
     totalLen
@@ -75,7 +75,7 @@ class DictStringBenchmark {
 
     val reader = UTF8Vector(acc, scNAPtr)
     val it = reader.iterate(acc, scNAPtr)
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       totalLen += it.next.length
     }
     totalLen

--- a/jmh/src/main/scala/filodb.jmh/EncodingBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/EncodingBenchmark.scala
@@ -8,7 +8,7 @@ import org.openjdk.jmh.annotations.{Mode, Scope, State}
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.OutputTimeUnit
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._

--- a/jmh/src/main/scala/filodb.jmh/EncodingBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/EncodingBenchmark.scala
@@ -53,7 +53,7 @@ class EncodingBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   def newIntVectorEncoding(): Unit = {
     val cb = IntBinaryVector.appendingVector(memFactory, numValues)
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       cb.addData(intArray(i))
     }
     cb.optimize(memFactory)
@@ -69,7 +69,7 @@ class EncodingBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   def growableIntVectorAddData(): Unit = {
     cbAdder.reset()
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       cbAdder.addData(intArray(i))
     }
   }
@@ -81,7 +81,7 @@ class EncodingBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   def noNAIntVectorAddData(): Unit = {
     noNAAdder.reset()
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       noNAAdder.addData(intArray(i))
     }
   }
@@ -93,7 +93,7 @@ class EncodingBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   def newUtf8VectorEncoding(): Unit = {
     val cb = UTF8Vector.appendingVector(memFactory, numValues, maxStringLength * numUniqueStrings)
-    for { i <- 0 until numValues optimized } {
+    cforRange { 0 until numValues } { i =>
       cb.addData(utf8strings(i))
     }
     cb.optimize(memFactory)
@@ -102,7 +102,7 @@ class EncodingBenchmark {
   // TODO: RowReader based vector building
 
   val utf8cb = UTF8Vector.appendingVector(memFactory, numValues, maxStringLength * numUniqueStrings)
-  for { i <- 0 until numValues optimized } {
+  cforRange { 0 until numValues } { i =>
     utf8cb.addData(utf8strings(i))
   }
 

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.ConfigFactory
 import org.agrona.{ExpandableArrayBuffer, ExpandableDirectByteBuffer}
 import org.agrona.concurrent.UnsafeBuffer
 import org.openjdk.jmh.annotations.{Level => JMHLevel, _}
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.{MachineMetricsData, MetricsTestData, TestData}
 import filodb.core.binaryrecord2.RecordBuilder

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -188,7 +188,7 @@ class HistogramIngestBenchmark {
     ddsink.writePos = 0
     java.util.Arrays.fill(ddsink.lastHistDeltas, 0)
     var lastPos = 0
-    for { i <- 0 until numInputs optimized } {
+    cforRange { 0 until numInputs } { i =>
       ddSlice.wrap(increasingBuf, lastPos, increasingHistPos(i) - lastPos)
       val res = NibblePack.unpackToSink(ddSlice, ddsink, inputs.size)
       require(res == NibblePack.Ok)

--- a/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
@@ -52,7 +52,7 @@ class IntSumReadBenchmark {
   def applyVectorScan(): Int = {
     var total = 0
     val acc2 = acc // local variable to make the scala compiler not use virtual invoke
-    for { i <- 0 until NumRows optimized } {
+    cforRange { 0 until NumRows } { i =>
       total += intReader(acc2, intVectAddr, i)
     }
     total
@@ -67,7 +67,7 @@ class IntSumReadBenchmark {
   def iterateScan(): Int = {
     val it = intReader.iterate(acc, intVectAddr, 0)
     var sum = 0
-    for { i <- 0 until NumRows optimized } {
+    cforRange { 0 until NumRows } { i =>
       sum += it.next
     }
     sum

--- a/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
@@ -6,7 +6,7 @@ import scala.language.postfixOps
 
 import ch.qos.logback.classic.{Level, Logger}
 import org.openjdk.jmh.annotations._
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.{NamesTestData, TestData}
 import filodb.core.metadata.{Dataset, DatasetOptions}

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -7,7 +7,7 @@ import scala.language.postfixOps
 
 import ch.qos.logback.classic.{Level, Logger}
 import org.openjdk.jmh.annotations._
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.DatasetRef
 import filodb.core.binaryrecord2.RecordBuilder

--- a/jmh/src/main/scala/filodb.jmh/PartitionListBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartitionListBenchmark.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 import scala.language.postfixOps
 
 import org.openjdk.jmh.annotations._
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 /**
  * Microbenchmark involving comparison of data structures for holding partition lists in a shard.
@@ -18,7 +18,7 @@ import scalaxy.loops._
 @State(Scope.Thread)
 class PartitionListBenchmark {
   val lhm = new collection.mutable.LinkedHashMap[Int, String]
-  for { i <- 0 until 1000000 optimized } { lhm(i) = "shoo" }
+  cForRange { 0 until 1000000 } { i => lhm(i) = "shoo" }
 
   val jlhm = new java.util.LinkedHashMap[Int, String]
   for { i <- 0 until 1000000 optimized } { jlhm.put(i, "shoo") }

--- a/jmh/src/main/scala/filodb.jmh/PartitionListBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartitionListBenchmark.scala
@@ -18,10 +18,10 @@ import spire.syntax.cfor._
 @State(Scope.Thread)
 class PartitionListBenchmark {
   val lhm = new collection.mutable.LinkedHashMap[Int, String]
-  cForRange { 0 until 1000000 } { i => lhm(i) = "shoo" }
+  cforRange { 0 until 1000000 } { i => lhm(i) = "shoo" }
 
   val jlhm = new java.util.LinkedHashMap[Int, String]
-  for { i <- 0 until 1000000 optimized } { jlhm.put(i, "shoo") }
+  cforRange { 0 until 1000000 } { i => jlhm.put(i, "shoo") }
 
   val abuf = collection.mutable.ArrayBuffer.fill(1000000)("shoo")
 
@@ -52,7 +52,7 @@ class PartitionListBenchmark {
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   def javaLinkedMapRemove100(): Unit = {
-    for { i <- 5100 to 5199 optimized } {
+    cforRange { 5100 to 5199 } { i =>
       jlhm.remove(i)
     }
   }

--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -331,7 +331,7 @@ trait BinaryAppendableVector[@specialized(Int, Long, Double, Boolean) A] {
    * The default implementation is generic but inefficient: does not take advantage of data layout
    */
   def addVector(other: BinaryAppendableVector[A]): Unit = {
-    for { i <- 0 until other.length optimized } {
+    cforRange { 0 until other.length } { i =>
       if (other.isAvailable(i)) { addData(other(i))}
       else                      { addNA() }
     }
@@ -571,7 +571,7 @@ extends OptimizingPrimitiveAppender[A] {
       // Optimization: this vector does not support NAs so just add the data
       require(numBytes + (nbits * v.length / 8) <= maxBytes,
              s"Not enough space to add ${v.length} elems; nbits=$nbits; need ${maxBytes-numBytes} bytes")
-      for { i <- 0 until v.length optimized } { addData(v(i)) }
+      cforRange { 0 until v.length } { i => addData(v(i)) }
   }
 
   final def isAllNA: Boolean = (length == 0)
@@ -669,7 +669,7 @@ extends BinaryAppendableVector[A] {
   }
 
   final def isAllNA: Boolean = {
-    for { word <- 0 until curBitmapOffset/8 optimized } {
+    cforRange { 0 until curBitmapOffset/8 } { word =>
       if (nativePtrReader.getLong(bitmapOffset + word * 8) != -1L) return false
     }
     val naMask = curMask - 1
@@ -677,7 +677,7 @@ extends BinaryAppendableVector[A] {
   }
 
   final def noNAs: Boolean = {
-    for { word <- 0 until curBitmapOffset/8 optimized } {
+    cforRange { 0 until curBitmapOffset/8 } { word =>
       if (nativePtrReader.getLong(bitmapOffset + word * 8) != 0) return false
     }
     val naMask = curMask - 1

--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -3,7 +3,7 @@ package filodb.memory.format
 import java.nio.ByteBuffer
 
 import debox.Buffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{BinaryRegion, MemFactory}
 import filodb.memory.format.Encodings._

--- a/memory/src/main/scala/filodb.memory/format/NibblePack.scala
+++ b/memory/src/main/scala/filodb.memory/format/NibblePack.scala
@@ -3,7 +3,7 @@ package filodb.memory.format
 import java.nio.ByteOrder.LITTLE_ENDIAN
 
 import org.agrona.{DirectBuffer, MutableDirectBuffer}
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 /**
  * An implementation of the NibblePack algorithm for efficient encoding, see [compression.md](doc/compression.md).

--- a/memory/src/main/scala/filodb.memory/format/NibblePack.scala
+++ b/memory/src/main/scala/filodb.memory/format/NibblePack.scala
@@ -56,7 +56,7 @@ object NibblePack {
   @inline
   private def packRemainder(input: Array[Long], buf: MutableDirectBuffer, pos: Int, i: Int): Int =
     if (i % 8 != 0) {
-      for { j <- (i % 8) until 8 optimized } { input(j) = 0 }
+      cforRange { (i % 8) until 8 } { j => input(j) = 0 }
       pack8(input, buf, pos)
     } else {
       pos
@@ -87,7 +87,7 @@ object NibblePack {
 
     // Flush remainder - if any left
     if (i % 8 != 0) {
-      for { j <- (i % 8) until 8 optimized } { inputArray(j) = 0 }
+      cforRange { (i % 8) until 8 } { j => inputArray(j) = 0 }
       pos = pack8(inputArray, buf, pos)
     }
 
@@ -108,7 +108,7 @@ object NibblePack {
 
     var bitmask = 0
     // Figure out which words are nonzero, pack bitmask
-    for { i <- 0 until 8 optimized } {
+    cforRange { 0 until 8 } { i =>
       if (input(i) != 0) bitmask |= 1 << i
     }
     buf.putByte(bufpos, bitmask.toByte)
@@ -118,7 +118,7 @@ object NibblePack {
       // figure out min # of nibbles to represent nonzero words
       var minLeadingZeros = 64
       var minTrailingZeros = 64
-      for { i <- 0 until 8 optimized } {
+      cforRange { 0 until 8 } { i =>
         minLeadingZeros = Math.min(minLeadingZeros, java.lang.Long.numberOfLeadingZeros(input(i)))
         minTrailingZeros = Math.min(minTrailingZeros, java.lang.Long.numberOfTrailingZeros(input(i)))
       }
@@ -145,7 +145,7 @@ object NibblePack {
     var outWord = 0L
     var bitCursor = 0
 
-    for { i <- 0 until 8 optimized } {
+    cforRange { 0 until 8 } { i =>
       val input = inputs(i)
       if (input != 0) {
         val remaining = 64 - bitCursor
@@ -210,7 +210,7 @@ object NibblePack {
       // user might not intuitively allocate output arrays in elements of 8.
       val numElems = Math.min(outArray.size - i, 8)
       require(numElems > 0)
-      for { n <- 0 until numElems optimized } {
+      cforRange { 0 until numElems } { n =>
         current += data(n)
         outArray(i + n) = current
       }
@@ -227,7 +227,7 @@ object NibblePack {
     private var pos: Int = 1
     def process(data: Array[Long]): Unit = {
       val numElems = Math.min(outArray.size - pos, 8)
-      for { n <- 0 until numElems optimized } {
+      cforRange { 0 until numElems } { n =>
         val nextBits = lastBits ^ data(n)
         outArray(pos + n) = java.lang.Double.longBitsToDouble(nextBits)
         lastBits = nextBits
@@ -271,7 +271,7 @@ object NibblePack {
 
     final def process(data: Array[Long]): Unit = {
       val numElems = Math.min(lastHistDeltas.size - i, 8)
-      for { n <- 0 until numElems optimized } {
+      cforRange { 0 until numElems } { n =>
         val diff = data(n) - lastHistDeltas(i + n)
         if (diff < 0) valueDropped = true
         packArray(n) = diff
@@ -310,7 +310,7 @@ object NibblePack {
 
     final def process(data: Array[Long]): Unit = {
       val numElems = Math.min(numBuckets - i, 8)
-      for { n <- 0 until numElems optimized } {
+      cforRange { 0 until numElems } { n =>
         if (data(n) < lastHistDeltas(i + n)) valueDropped = true
         packArray(n) = data(n) - originalDeltas(i + n)
       }
@@ -389,7 +389,7 @@ object NibblePack {
       var inWord = readLong(compressed, bufIndex)
       bufIndex += 8
 
-      for { bit <- 0 until 8 optimized } {
+      cforRange { 0 until 8 } { bit =>
         if ((nonzeroMask & (1 << bit)) != 0) {
           val remaining = 64 - bitCursor
 

--- a/memory/src/main/scala/filodb.memory/format/RowReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowReader.scala
@@ -8,7 +8,7 @@ import scala.reflect.ClassTag
 import org.agrona.DirectBuffer
 import org.agrona.concurrent.UnsafeBuffer
 import org.joda.time.DateTime
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.format.vectors.Histogram
 

--- a/memory/src/main/scala/filodb.memory/format/RowReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowReader.scala
@@ -88,7 +88,7 @@ trait SchemaRowReader extends RowReader {
   // or slow functional code here.
   override def hashCode: Int = {
     var hash = 0
-    for { i <- 0 until extractors.size optimized } {
+    cforRange { 0 until extractors.size } { i =>
       hash ^= extractors(i).getField(this, i).hashCode
     }
     hash
@@ -96,7 +96,7 @@ trait SchemaRowReader extends RowReader {
 
   override def equals(other: Any): Boolean = other match {
     case reader: RowReader =>
-      for { i <- 0 until extractors.size optimized } {
+      cforRange { 0 until extractors.size } { i =>
         if (extractors(i).compare(this, reader, i) != 0) return false
       }
       true

--- a/memory/src/main/scala/filodb.memory/format/RowToVectorBuilder.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowToVectorBuilder.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import scala.language.existentials
 
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.MemFactory
 import filodb.memory.format.Encodings.{AutoDetect, EncodingHint}

--- a/memory/src/main/scala/filodb.memory/format/RowToVectorBuilder.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowToVectorBuilder.scala
@@ -73,7 +73,7 @@ class RowToVectorBuilder(schema: Seq[VectorInfo], memFactory: MemFactory) {
     * @param row the row of data to transpose.  Each column will be added to the right Builders.
     */
   def addRow(row: RowReader): Unit = {
-    for { i <- 0 until numColumns optimized } {
+    cforRange { 0 until numColumns } { i =>
       builders(i).addFromReader(row, i)
     }
   }

--- a/memory/src/main/scala/filodb.memory/format/UnsafeUtils.scala
+++ b/memory/src/main/scala/filodb.memory/format/UnsafeUtils.scala
@@ -4,8 +4,6 @@ import java.nio.ByteBuffer
 
 import com.kenai.jffi.MemoryIO
 import org.agrona.DirectBuffer
-import scalaxy.loops._
-
 // scalastyle:off number.of.methods
 object UnsafeUtils {
   val unsafe = scala.concurrent.util.Unsafe.instance
@@ -145,7 +143,7 @@ object UnsafeUtils {
     if (wordComp == 0) {
       var pointer1 = offset1 + minLenAligned
       var pointer2 = offset2 + minLenAligned
-      for { i <- minLenAligned until minLen optimized } {
+      for { i <- minLenAligned until minLen } {
         val res = (getByte(base1, pointer1) & 0xff) - (getByte(base2, pointer2) & 0xff)
         if (res != 0) return res
         pointer1 += 1

--- a/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
+++ b/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
@@ -1,7 +1,7 @@
 package filodb.memory.format
 
 import net.jpountz.xxhash.XXHashFactory
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{MemFactory, UTF8StringMedium}
 

--- a/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
+++ b/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
@@ -29,7 +29,7 @@ trait ZeroCopyBinary extends Ordered[ZeroCopyBinary] {
     val minLenAligned = minLen & -4
     val wordComp = UnsafeUtils.wordCompare(base, offset, other.base, other.offset, minLenAligned)
     if (wordComp == 0) {
-      for { i <- minLenAligned until minLen optimized } {
+      cforRange { minLenAligned until minLen } { i =>
         val res = getByte(i) - other.getByte(i)
         if (res != 0) return res
       }
@@ -174,7 +174,7 @@ final class ZeroCopyUTF8String(val base: Any, val offset: Long, val numBytes: In
     if (substring.numBytes == 0) { true }
     else {
       val firstByte = substring.getByte(0)
-      for { i <- 0 to (numBytes - substring.numBytes) optimized } {
+      cforRange { 0 to (numBytes - substring.numBytes) } { i =>
         if (getByte(i) == firstByte && matchAt(substring, i)) return true
       }
       false

--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -119,7 +119,7 @@ object DeltaDeltaVector {
     var baseValue: Long = inputVect(0)
     var max = Int.MinValue
     var min = Int.MaxValue
-    for { i <- 1 until inputVect.length optimized } {
+    cforRange { 1 until inputVect.length } { i =>
       baseValue += slope
       val delta = inputVect(i) - baseValue
       if (delta > Int.MaxValue || delta < Int.MinValue) return None   // will not fit in 32 bits, just quit
@@ -216,7 +216,7 @@ object DeltaDeltaDataReader extends LongVectorDataReader {
       val itr = iterate(acc, vector, start)
       var prevVector: Long = prev
       var changes = 0
-      for {i <- start until end + 1 optimized} {
+      cforRange { start until end + 1 } { i =>
         val cur = itr.next
         if (i == start && ignorePrev) //Initialize prev
           prevVector = cur

--- a/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DeltaDeltaVector.scala
@@ -1,7 +1,7 @@
 package filodb.memory.format.vectors
 
 import debox.Buffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{BinaryRegion, MemFactory}
 import filodb.memory.format._

--- a/memory/src/main/scala/filodb.memory/format/vectors/DictUTF8Vector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DictUTF8Vector.scala
@@ -46,7 +46,7 @@ object DictUTF8Vector {
     val codeVect = IntBinaryVector.appendingVectorNoNA(memFactory, sourceLen)
     dictVect.addNA()   // first code point 0 == NA
 
-    for { i <- 0 until sourceLen optimized } {
+    cforRange { 0 until sourceLen } { i =>
       if (sourceVector.isAvailable(i)) {
         val item = sourceVector(i)
         val newCode = codeMap.size + 1

--- a/memory/src/main/scala/filodb.memory/format/vectors/DictUTF8Vector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DictUTF8Vector.scala
@@ -2,7 +2,7 @@ package filodb.memory.format.vectors
 
 import java.util.HashMap
 
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.MemFactory
 import filodb.memory.format._

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -3,7 +3,7 @@ package filodb.memory.format.vectors
 import java.nio.ByteBuffer
 
 import debox.Buffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{BinaryRegion, MemFactory}
 import filodb.memory.format._

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -167,7 +167,7 @@ trait DoubleVectorDataReader extends CounterVectorReader {
     val dataIt = iterate(acc, vector, startElement)
     val availIt = iterateAvailable(acc, vector, startElement)
     val len = length(acc, vector)
-    for { n <- startElement until len optimized } {
+    cforRange { startElement until len } { n =>
       val item = dataIt.next
       if (availIt.next) newBuf += item
     }
@@ -320,7 +320,7 @@ extends DoubleVectorDataReader {
     val _corrected = new Array[Double](length(acc, vect))
     val it = iterate(acc, vect, 0)
     var last = Double.MinValue
-    for { pos <- 0 until length(acc, vect) optimized } {
+    cforRange { 0 until length(acc, vect) } { pos =>
       val nextVal = it.next
       if (nextVal < last) {   // reset!
         _correction += last
@@ -400,7 +400,7 @@ extends PrimitiveAppendableVector[Double](addr, maxBytes, 64, true) {
   final def minMax: (Double, Double) = {
     var min = Double.MaxValue
     var max = Double.MinValue
-    for { index <- 0 until length optimized } {
+    cforRange { 0 until length } { index =>
       val data = apply(index)
       if (data < min) min = data
       if (data > max) max = data
@@ -457,7 +457,7 @@ BitmapMaskAppendableVector[Double](addr, maxElements) with OptimizingPrimitiveAp
   final def minMax: (Double, Double) = {
     var min = Double.MaxValue
     var max = Double.MinValue
-    for { index <- 0 until length optimized } {
+    cforRange { 0 until length } { index =>
       if (isAvailable(index)) {
         val data = subVect.apply(index)
         if (data < min) min = data
@@ -489,7 +489,7 @@ extends AppendableVectorWrapper[Long, Double] {
   val MaxLongDouble = Long.MaxValue.toDouble
   final def nonIntegrals: Int = {
     var nonInts = 0
-    for { index <- 0 until length optimized } {
+    cforRange { 0 until length } { index =>
       if (inner.isAvailable(index)) {
         val data = inner.apply(index)
         if (data > MaxLongDouble || (Math.rint(data) != data)) nonInts += 1

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -3,7 +3,7 @@ package filodb.memory.format.vectors
 import java.nio.ByteOrder.LITTLE_ENDIAN
 
 import org.agrona.{DirectBuffer, MutableDirectBuffer}
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.format._
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -93,10 +93,10 @@ trait Histogram extends Ordered[Histogram] {
    */
   def compare(other: Histogram): Int = {
     if (numBuckets != other.numBuckets) return topBucketValue compare other.topBucketValue
-    for { b <- 0 until numBuckets optimized } {
+    cforRange { 0 until numBuckets } { b =>
       if (bucketTop(b) != other.bucketTop(b)) return topBucketValue compare other.topBucketValue
     }
-    for { b <- (numBuckets - 1) to 0 by -1 optimized } {
+    cforRange { (numBuckets - 1) to 0 by -1 } {b =>
       val countComp = bucketValue(b) compare other.bucketValue(b)
       if (countComp != 0) return countComp
     }
@@ -113,7 +113,7 @@ trait Histogram extends Ordered[Histogram] {
 
   override def hashCode: Int = {
     var hash = 7.0
-    for { b <- 0 until numBuckets optimized } {
+    cforRange { 0 until numBuckets } { b =>
       hash = (31 * bucketTop(b) + hash) * 31 + bucketValue(b)
     }
     java.lang.Double.doubleToLongBits(hash).toInt
@@ -130,7 +130,7 @@ trait HistogramWithBuckets extends Histogram {
   final def bucketTop(no: Int): Double = buckets.bucketTop(no)
   final def valueArray: Array[Double] = {
     val values = new Array[Double](numBuckets)
-    for { b <- 0 until numBuckets optimized } {
+    cforRange { 0 until numBuckets } { b =>
       values(b) = bucketValue(b)
     }
     values
@@ -155,7 +155,7 @@ final case class LongHistogram(buckets: HistogramBuckets, values: Array[Long]) e
    */
   final def add(other: LongHistogram): Unit = {
     assert(other.buckets == buckets)
-    for { b <- 0 until numBuckets optimized } {
+    cforRange { 0 until numBuckets } { b =>
       values(b) += other.values(b)
     }
   }
@@ -208,7 +208,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
       case m: MutableHistogram =>
         System.arraycopy(m.values, 0, values, 0, values.size)
       case l: LongHistogram    =>
-        for { n <- 0 until values.size optimized } {
+        cforRange { 0 until values.size } { n =>
           values(n) = l.values(n).toDouble
         }
     }
@@ -225,7 +225,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
     if (buckets.similarForMath(other.buckets)) {
       // If it was NaN before, reset to 0 to sum another hist
       if (values(0).isNaN) java.util.Arrays.fill(values, 0.0)
-      for { b <- 0 until numBuckets optimized } {
+      cforRange { 0 until numBuckets } { b =>
         values(b) += other.bucketValue(b)
       }
     } else {
@@ -234,7 +234,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
       // NOTE: there are two issues here: below add picks the existing bucket scheme (not commutative)
       //       and the newer different buckets are lost (one may want more granularity)
       // var ourBucketNo = 0
-      // for { b <- 0 until other.numBuckets optimized } {
+      // cforRange { 0 until other.numBuckets } { b =>
       //   // Find our first bucket greater than or equal to their bucket
       //   while (ourBucketNo < numBuckets && bucketTop(ourBucketNo) < other.bucketTop(b)) ourBucketNo += 1
       //   if (ourBucketNo < numBuckets) {
@@ -260,7 +260,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
     */
   final def makeMonotonic(): Unit = {
     var max = 0d
-    for { b <- 0 until values.size optimized } {
+    cforRange { 0 until values.size } { b =>
       // When bucket no longer used NaN will be seen. Non-increasing values can be seen when
       // newer buckets are introduced and not all instances are updated with that bucket.
       if (values(b) < max || values(b).isNaN) values(b) = max // assign previous max
@@ -345,7 +345,7 @@ sealed trait HistogramBuckets {
    */
   final def allBucketTops: Array[Double] = {
     val tops = new Array[Double](numBuckets)
-    for { b <- 0 until numBuckets optimized } {
+    cforRange { 0 until numBuckets } { b =>
       tops(b) = bucketTop(b)
     }
     tops
@@ -353,7 +353,7 @@ sealed trait HistogramBuckets {
 
   final def bucketSet: debox.Set[Double] = {
     val tops = debox.Set.empty[Double]
-    for { b <- 0 until numBuckets optimized } {
+    cforRange { 0 until numBuckets } { b =>
       tops += bucketTop(b)
     }
     tops

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
@@ -4,7 +4,7 @@ import scala.io.Source
 
 import org.agrona.{ExpandableArrayBuffer, ExpandableDirectByteBuffer}
 import org.agrona.concurrent.UnsafeBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramCompressor.scala
@@ -157,7 +157,7 @@ object HistogramIngestBench extends App with CompressorAnalyzer {
     ddsink.writePos = 0
     java.util.Arrays.fill(ddsink.lastHistDeltas, 0)
     var lastPos = 0
-    for { i <- 0 until numHist optimized } {
+    cforRange { 0 until numHist } { i =>
       ddSlice.wrap(increasingBuf, lastPos, increasingHistPos(i) - lastPos)
       val res = NibblePack.unpackToSink(ddSlice, ddsink, bucketDef.numBuckets)
       require(res == NibblePack.Ok)
@@ -189,7 +189,7 @@ object PromCompressor extends App with CompressorAnalyzer {
 
   histograms.foreach { h =>
     numRecords += 1
-    for { b <- 0 until bucketDef.numBuckets optimized } {
+    cforRange { 0 until bucketDef.numBuckets } { b =>
       appenders(b).addData(h.values(b)) match {
         case Ack =>    // data added, no problem
         case VectorTooSmall(_, _) =>   // not enough space.   Encode, aggregate, and add to a new appender

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -544,7 +544,7 @@ class RowHistogramReader(val acc: MemoryReader, histVect: Ptr.U8) extends Histog
   final def sum(start: Int, end: Int): MutableHistogram = {
     require(length > 0 && start >= 0 && end < length)
     val summedHist = MutableHistogram.empty(buckets)
-    for { i <- start to end optimized } {
+    cforRange { start to end } { i =>
       summedHist.addNoCorrection(apply(i))
     }
     summedHist

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.StrictLogging
 import debox.Buffer
 import org.agrona.{DirectBuffer, ExpandableArrayBuffer, MutableDirectBuffer}
 import org.agrona.concurrent.UnsafeBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{BinaryRegion, MemFactory}
 import filodb.memory.format._

--- a/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
@@ -3,7 +3,7 @@ package filodb.memory.format.vectors
 import java.nio.ByteBuffer
 
 import debox.Buffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{BinaryRegion, MemFactory}
 import filodb.memory.format._

--- a/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
@@ -295,7 +295,7 @@ trait IntVectorDataReader extends VectorDataReader {
     val dataIt = iterate(acc, vector, startElement)
     val availIt = iterateAvailable(acc, vector, startElement)
     val len = length(acc, vector)
-    for { n <- startElement until len optimized } {
+    cforRange { startElement until len } { n =>
       val item = dataIt.next
       if (availIt.next) newBuf += item
     }
@@ -490,7 +490,7 @@ extends PrimitiveAppendableVector[Int](addr, maxBytes, nbits, signed) {
   final def minMax: (Int, Int) = {
     var min = Int.MaxValue
     var max = Int.MinValue
-    for { index <- 0 until length optimized } {
+    cforRange { 0 until length } { index =>
       val data = reader.apply(nativePtrReader, addr, index)
       if (data < min) min = data
       if (data > max) max = data
@@ -523,7 +523,7 @@ BitmapMaskAppendableVector[Int](addr, maxElements) with OptimizingPrimitiveAppen
   final def minMax: (Int, Int) = {
     var min = Int.MaxValue
     var max = Int.MinValue
-    for { index <- 0 until length optimized } {
+    cforRange { 0 until length } { index =>
       if (isAvailable(index)) {
         val data = subVect.apply(index)
         if (data < min) min = data

--- a/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
@@ -178,7 +178,7 @@ trait LongVectorDataReader extends VectorDataReader {
     val dataIt = iterate(acc, vector, startElement)
     val availIt = iterateAvailable(acc, vector, startElement)
     val len = length(acc, vector)
-    for { n <- startElement until len optimized } {
+    cforRange { startElement until len } { n =>
       val item = dataIt.next
       if (availIt.next) newBuf += item
     }
@@ -313,7 +313,7 @@ extends PrimitiveAppendableVector[Long](addr, maxBytes, 64, true) {
   final def minMax: (Long, Long) = {
     var min = Long.MaxValue
     var max = Long.MinValue
-    for { index <- 0 until length optimized } {
+    cforRange { 0 until length } { index =>
       val data = apply(index)
       if (data < min) min = data
       if (data > max) max = data
@@ -355,7 +355,7 @@ BitmapMaskAppendableVector[Long](addr, maxElements) with OptimizingPrimitiveAppe
   final def minMax: (Long, Long) = {
     var min = Long.MaxValue
     var max = Long.MinValue
-    for { index <- 0 until length optimized } {
+    cforRange { 0 until length } { index =>
       if (isAvailable(index)) {
         val data = subVect.apply(index)
         if (data < min) min = data

--- a/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
@@ -3,7 +3,7 @@ package filodb.memory.format.vectors
 import java.nio.ByteBuffer
 
 import debox.Buffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{BinaryRegion, MemFactory}
 import filodb.memory.format._

--- a/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
@@ -132,7 +132,7 @@ trait UTF8VectorDataReader extends VectorDataReader {
     val dataIt = iterate(acc, vector, startElement)
     val availIt = iterateAvailable(acc, vector, startElement)
     val len = length(acc, vector)
-    for { n <- startElement until len optimized } {
+    cforRange { startElement until len } { n =>
       val item = dataIt.next
       if (availIt.next) newBuf += item
     }
@@ -286,7 +286,7 @@ class UTF8AppendableVector(val addr: BinaryRegion.NativePointer,
   final def minMaxStrLen: (Int, Int) = {
     var min = Int.MaxValue
     var max = 0
-    for {index <- 0 until _len optimized} {
+    cforRange { 0 until _len } { index =>
       val fixedData = UnsafeUtils.getInt(addr + 12 + index * 4)
       if (fixedData != NABlob) {
         val utf8len = if (fixedData < 0) fixedData & MaxSmallLen else UnsafeUtils.getInt(addr + fixedData)
@@ -332,7 +332,7 @@ class UTF8AppendableVector(val addr: BinaryRegion.NativePointer,
 
   // WARNING: no checking for if delta pushes small offsets out.  Intended for compactions only.
   private def adjustOffsets(newBase: Any, newOff: Long, delta: Int): Unit = {
-    for {i <- 0 until _len optimized} {
+    cforRange { 0 until _len } { i =>
       val fixedData = UnsafeUtils.getInt(newBase, newOff + 12 + i * 4)
       val newData = if (fixedData < 0) {
         if (fixedData == NABlob) {

--- a/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
@@ -3,7 +3,7 @@ package filodb.memory.format.vectors
 import java.nio.ByteBuffer
 
 import debox.Buffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.{BinaryRegion, MemFactory}
 import filodb.memory.format._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,8 +47,6 @@ object Dependencies {
     scalaTestPlus % Test
   )
 
-  lazy val scalaxyDep = "com.nativelibs4java"  %% "scalaxy-loops"     % "0.3.3" % "provided"
-
   lazy val memoryDeps = commonDeps ++ Seq(
     "com.github.jnr"       %  "jnr-ffi"          % "2.1.6",
     "joda-time"            % "joda-time"         % "2.2" withJavadoc(),
@@ -57,8 +55,7 @@ object Dependencies {
     "org.agrona"           %  "agrona"           % "0.9.35",
     "org.jctools"          % "jctools-core"      % "2.0.1" withJavadoc(),
     "org.spire-math"       %% "debox"            % "0.8.0" withJavadoc(),
-    scalaLoggingDep,
-    scalaxyDep
+    scalaLoggingDep
   )
 
   lazy val coreDeps = commonDeps ++ Seq(
@@ -74,16 +71,14 @@ object Dependencies {
     "com.github.rholder.fauxflake" % "fauxflake-core"     % "1.1.0",
     "org.scalactic"                %% "scalactic"         % "3.2.0" withJavadoc(),
     "org.apache.lucene"            % "lucene-core"        % "7.3.0" withJavadoc(),
-    "com.github.alexandrnikitin"   %% "bloom-filter"      % "0.11.0",
-    scalaxyDep
+    "com.github.alexandrnikitin"   %% "bloom-filter"      % "0.11.0"
   )
 
   lazy val sparkJobsDeps = commonDeps ++ Seq(
     "org.apache.spark"       %%      "spark-core" % sparkVersion % Provided,
     "org.apache.spark"       %%      "spark-sql"  % sparkVersion % Provided,
     "org.apache.spark"       %%      "spark-core" % sparkVersion % Test excludeAll(excludeNetty),
-    "org.apache.spark"       %%      "spark-sql"  % sparkVersion % Test excludeAll(excludeNetty),
-    scalaxyDep
+    "org.apache.spark"       %%      "spark-sql"  % sparkVersion % Test excludeAll(excludeNetty)
   )
 
   lazy val cassDeps = commonDeps ++ Seq(
@@ -99,8 +94,7 @@ object Dependencies {
     "com.softwaremill.sttp" %% "circe"                                % sttpVersion ,
     "com.softwaremill.sttp" %% "async-http-client-backend-future"     % sttpVersion,
     "com.softwaremill.sttp" %% "core"                                 % sttpVersion,
-    circeGeneric,
-    scalaxyDep
+    circeGeneric
   )
 
   lazy val coordDeps = commonDeps ++ Seq(
@@ -137,7 +131,6 @@ object Dependencies {
   )
 
   lazy val gatewayDeps = commonDeps ++ Seq(
-    scalaxyDep,
     logbackDep,
     "io.monix"   %% "monix-kafka-1x" % monixKafkaVersion,
     "org.rogach" %% "scallop"        % "3.1.1"
@@ -190,7 +183,6 @@ object Dependencies {
   //  )
 
   lazy val jmhDeps = Seq(
-    scalaxyDep,
     "org.apache.spark" %% "spark-sql" % sparkVersion excludeAll(excludeSlf4jLog4j, excludeZK, excludeJersey)
   )
 

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -246,7 +246,7 @@ object RangeVectorAggregator extends StrictLogging {
         count += 1
         val rowIter = rv.rows
         toClose += rowIter
-        for { i <- 0 until outputLen optimized } {
+        cforRange { 0 until outputLen } { i =>
           accs(i) = rowAgg.reduceAggregate(accs(i), rowIter.next)
         }
         accs
@@ -257,7 +257,7 @@ object RangeVectorAggregator extends StrictLogging {
         count += 1
         val rowIter = rv.rows
         toClose += rowIter
-        for { i <- 0 until outputLen optimized } {
+        cforRange { 0 until outputLen } { i =>
           val mapped = rowAgg.map(rv.key, rowIter.next, mapIntos(i))
           accs(i) = rowAgg.reduceMappedRow(accs(i), mapped)
         }

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable.ArrayBuffer
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
 import monix.reactive.Observable
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.query._
 import filodb.memory.format.ZeroCopyUTF8String

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -79,7 +79,7 @@ final case class HistogramQuantileMapper(funcParams: Seq[FuncArgs]) extends Rang
           val row = new TransientRow()
           override def hasNext: Boolean = samples.forall(_.hasNext)
           override def next(): RowReader = {
-            for { i <- 0 until samples.size optimized } {
+            cforRange { 0 until samples.size } { i =>
               val nxt = samples(i).next()
               buckets(i).rate = nxt.getDouble(1)
               row.timestamp = nxt.getLong(0)

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -2,7 +2,7 @@ package filodb.query.exec
 
 import monix.reactive.Observable
 import org.agrona.MutableDirectBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.query._
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String}

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -442,7 +442,7 @@ final case class HistToPromSeriesMapper(sch: PartitionSchema) extends RangeVecto
       }
 
       timestamps += row.getLong(0)
-      for { b <- 0 until hist.numBuckets optimized } {
+      cforRange { 0 until hist.numBuckets } { b =>
         buckets(hist.bucketTop(b)) += hist.bucketValue(b)
       }
       emptyBuckets.foreach { b => buckets(b) += Double.NaN }

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -2,7 +2,7 @@ package filodb.query.exec
 
 import monix.reactive.Observable
 import scala.collection.mutable.ListBuffer
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.PartitionSchema

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -2,7 +2,7 @@ package filodb.query.exec.rangefn
 
 import java.time.{Instant, LocalDateTime, YearMonth, ZoneId, ZoneOffset}
 
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.memory.format.vectors.{Histogram, MaxHistogram, MutableHistogram}
 import filodb.query.InstantFunctionId

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -372,7 +372,7 @@ final case class HistogramBucketImpl() extends HistToDoubleIFunction {
       if (value.bucketTop(value.numBuckets - 1) == Double.PositiveInfinity) value.topBucketValue
       else throw new IllegalArgumentException(s"+Inf bucket not in the last position!")
     } else {
-      for { b <- 0 until value.numBuckets optimized } {
+      cforRange { 0 until value.numBuckets } { b =>
         // This comparison does not work for +Inf
         if (Math.abs(value.bucketTop(b) - bucket) <= 1E-10) return value.bucketValue(b)
       }

--- a/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
@@ -1,6 +1,6 @@
 package filodb.query.exec.rangefn
 
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.core.query.{QueryConfig, TransientHistRow, TransientRow}
 import filodb.memory.format.{CounterVectorReader, MemoryReader}

--- a/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
@@ -272,7 +272,7 @@ abstract class HistogramRateFunctionBase extends CounterChunkedRangeFunction[Tra
       // TODO: handle case where schemas are different and we need to interpolate schemas
       if (highestValue.buckets == lowestValue.buckets) {
         val rateArray = new Array[Double](lowestValue.numBuckets)
-        for { b <- 0 until rateArray.size optimized } {
+        cforRange { 0 until rateArray.size } { b =>
           rateArray(b) = RateFunctions.extrapolatedRate(
                            windowStart - 1, windowEnd, numSamples,
                            lowestTime, lowestValue.bucketValue(b),

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import kamon.Kamon
 import monix.reactive.Observable
-import scalaxy.loops._
+import spire.syntax.cfor._
 
 import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.core.{DatasetRef, ErrorResponse, Instance}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Scalaxy is not maintained for Scala 2.12 (#457), so I propose to use spire's `cfor` and `cforRange` loops. They are also macro based. In benchmarks on my machine they give very similar results, but please run all microbenchmarks on some reliable machine.



