### PR TITLE
bug(query): add column in Rawseries and params in aggregation operator

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -9,6 +9,7 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
 
   private def parseAndAssertResult(query: String) = {
     val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
+    println("lp:" + lp)
     val res = LogicalPlanParser.convertToQuery(lp)
     res shouldEqual(query)
   }
@@ -50,6 +51,11 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     parseAndAssertResult("""scalar(http_requests_total{job="app",instance="inst-1"})""")
     parseAndAssertResult("""vector(1.5)""")
     parseAndAssertResult("""time()""")
+    parseAndAssertResult("""http_requests_total::count{job="app"}""")
+    parseAndAssertResult("""http_requests_total::sum{job="app"}""")
+    parseAndAssertResult("""topk(2.0,http_requests_total{job="app"})""")
+    parseAndAssertResult("""quantile(0.2,http_requests_total{job="app"})""")
+    parseAndAssertResult("""count_values("freq",http_requests_total{job="app"})""")
   }
 
   it("should generate query from LogicalPlan having offset") {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -9,7 +9,6 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
 
   private def parseAndAssertResult(query: String) = {
     val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
-    println("lp:" + lp)
     val res = LogicalPlanParser.convertToQuery(lp)
     res shouldEqual(query)
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
In Logical plan to query conversion Rawseries column like sum, count is not added. Also params in aggregation function like topk is not added.

**New behavior :**

- Add Rawseries column like sum, count to query to support queries like `http_requests_total::count{job="app"}`
- Add params in aggregation function like `topk(2.0,http_requests_total{job="app"})`
