### PR TITLE
bug(query): NumberFormatException for +Inf bucket value

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -64,5 +64,4 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     // Converted query has time in seconds
     res shouldEqual("http_requests_total{job=\"app\"} offset 300s")
   }
-
 }

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -183,7 +183,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
           samples.iterator.collect { case v: HistSampl =>
             row.setLong(0, v.timestamp * 1000)
-            val sortedBucketsWithValues = v.buckets.toArray.map(x => (x._1.toDouble, x._2)).sortBy(_._1)
+            val sortedBucketsWithValues = v.buckets.toArray.map { h =>
+              if (h._1.toLowerCase.equals("+inf")) (Double.PositiveInfinity, h._2) else (h._1.toDouble, h._2)
+            }.sortBy(_._1)
             val hist = MutableHistogram(CustomBuckets(sortedBucketsWithValues.map(_._1)),
               sortedBucketsWithValues.map(_._2))
             row.setValues(v.timestamp * 1000, hist)

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -4,13 +4,15 @@ import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import filodb.core.metadata.{Dataset, DatasetOptions}
 import filodb.core.query.{PromQlQueryParams, QueryContext}
+import filodb.memory.format.vectors.{MutableHistogram}
 import filodb.query
-import filodb.query.{Data, QueryResponse, QueryResult, Sampl}
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
+import filodb.query.{Data, HistSampl, QueryResponse, QueryResult, Sampl}
+
 
 class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val timeseriesDataset = Dataset.make("timeseries",
@@ -28,20 +30,20 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   it ("should convert matrix Data to QueryResponse ") {
     val expectedResult = List((1000000, 1.0), (2000000, 2.0), (3000000, 3.0))
     val exec = PromQlRemoteExec("", 60000, queryContext, dummyDispatcher, timeseriesDataset.ref, params)
-    val result = query.Result (Map("instance" ->"inst1"), Some(Seq(Sampl(1000, 1), Sampl(2000, 2), Sampl(3000, 3))), None)
+    val result = query.Result (Map("instance" -> "inst1"), Some(Seq(Sampl(1000, 1), Sampl(2000, 2), Sampl(3000, 3))),
+      None)
     val res = exec.toQueryResponse(Data("vector", Seq(result)), "id", Kamon.currentSpan())
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     queryResult.result(0).numRows.get shouldEqual(3)
     val data = queryResult.result.flatMap(x=>x.rows.map{ r => (r.getLong(0) , r.getDouble(1)) }.toList)
     data.shouldEqual(expectedResult)
-
   }
 
   it ("should convert vector Data to QueryResponse ") {
     val expectedResult = List((1000000, 1.0))
     val exec = PromQlRemoteExec("", 60000, queryContext, dummyDispatcher, timeseriesDataset.ref, params)
-    val result = query.Result (Map("instance" ->"inst1"), None, Some(Sampl(1000, 1)))
+    val result = query.Result (Map("instance" -> "inst1"), None, Some(Sampl(1000, 1)))
     val res = exec.toQueryResponse(Data("vector", Seq(result)), "id", Kamon.currentSpan())
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
@@ -71,8 +73,24 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     val res = exec.toQueryResponse(Seq(map1, map2), "id", Kamon.currentSpan())
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
-    val data = queryResult.result.flatMap(x=>x.rows.map{ r => r.getAny(0) }.toList)
+    val data = queryResult.result.flatMap(x => x.rows.map(r => r.getAny(0)).toList)
     data(0) shouldEqual(map1)
     data(1) shouldEqual(map2)
+  }
+
+  it ("should convert histogram to QueryResponse ") {
+    val exec = PromQlRemoteExec("", 60000, queryContext, dummyDispatcher, timeseriesDataset.ref, params)
+    val result = query.Result (Map("instance" -> "inst1"), None, Some(HistSampl(1000, Map("1" -> 2, "+Inf" -> 3))))
+    val res = exec.toQueryResponse(Data("vector", Seq(result)), "id", Kamon.currentSpan())
+    res.isInstanceOf[QueryResult] shouldEqual true
+    val queryResult = res.asInstanceOf[QueryResult]
+    queryResult.result(0).numRows.get shouldEqual(1)
+    val data = queryResult.result.flatMap(x => x.rows.map{r => (r.getLong(0) , r.getHistogram(1))}.toList)
+    val hist = data.head._2.asInstanceOf[MutableHistogram]
+    data.head._1 shouldEqual 1000000
+    hist.buckets.allBucketTops shouldEqual Array(1, Double.PositiveInfinity)
+    hist.numBuckets shouldEqual(2)
+    hist.bucketValue(0) shouldEqual(2.0)
+    hist.bucketValue(1) shouldEqual(3)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
java.lang.NumberFormatException is thrown when bucket  value is +Inf

**New behavior :**
When bucket value is +Inf use Double.PositiveInfinity instead of converting string using toDouble
