### PR TITLE
bug(query): logical plan parser for timestamp generates query with window 0s

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -101,8 +101,10 @@ object LogicalPlanParser {
   }
 
   private def periodicSeriesWithWindowingToQuery(lp: PeriodicSeriesWithWindowing): String = {
-    val rawSeriesQueryWithWindow = s"${rawSeriesLikeToQuery(lp.series)}$OpeningSquareBracket${lp.window/1000}s" +
-      s"$ClosingSquareBracket${lp.offsetMs.map(o => Space + Offset + Space + (o / 1000).toString + "s").getOrElse("")}"
+    val rawSeries = rawSeriesLikeToQuery(lp.series)
+    val rawSeriesQueryWithWindow = if (lp.window == 0) rawSeries else s"${rawSeries}$OpeningSquareBracket" +
+      s"${lp.window/1000}s$ClosingSquareBracket${lp.offsetMs.map(o => s"$Space$Offset$Space${(o / 1000).toString}s")
+        .getOrElse("")}"
     val prefix = lp.function.entryName + OpeningRoundBracket
     if (lp.functionArgs.isEmpty) s"$prefix$rawSeriesQueryWithWindow$ClosingRoundBracket"
     else {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -55,6 +55,8 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     parseAndAssertResult("""topk(2.0,http_requests_total{job="app"})""")
     parseAndAssertResult("""quantile(0.2,http_requests_total{job="app"})""")
     parseAndAssertResult("""count_values("freq",http_requests_total{job="app"})""")
+    parseAndAssertResult("""timestamp(http_requests_total{job="app"})""")
+    parseAndAssertResult("""absent(http_requests_total{job="app"})""")
   }
 
   it("should generate query from LogicalPlan having offset") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Logical plan parser generates query with window 0s for timestamp function

**New behavior :**
Don't append window when the PeriodicSeriesWithWindowing.window is 0
