### PR TITLE
feat(coordinator): Revert "Query concurrency limiter + single thread per query (#830)"

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -1,15 +1,18 @@
 package filodb.coordinator
 
-import scala.collection.mutable.{HashMap => mHashMap, Queue => mQueue}
-import scala.concurrent.Future
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
+
 import scala.util.control.NonFatal
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.dispatch.{Envelope, UnboundedStablePriorityMailbox}
 import com.typesafe.config.Config
 import kamon.Kamon
+import kamon.instrumentation.executor.ExecutorInstrumentation
 import kamon.tag.TagSet
 import monix.execution.Scheduler
+import monix.execution.schedulers.SchedulerService
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 
@@ -21,106 +24,6 @@ import filodb.core.query.{QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.CorruptVectorException
 import filodb.query._
 import filodb.query.exec.ExecPlan
-
-
-// A class to manage a queue and a set of currently executing queries, allowing no more than concurrentQueries
-// at a time.  When the query and execplans finishes execution, then they are removed.  This has multiple benefits
-// including limiting memory usage and tracking running queries.
-// concurrentQueries defines the number of current queries where all execPlans belonging to the same queryID
-// is counted as a single query.
-// A queue keeps track of queries for which there is no space.  It is not expected for there to be more than
-// one query in the queue belonging to the same queryID, this is because only high-level ExecPlans spawn more
-// low-level ones, and spawned ones arrive in the Actor mailbox and will go striaght to executing if the parent
-// plan is already executing.
-// A single threaded scheduler is created for each query (all ExecPlans with the same query ID).  This reduces
-// thread contention significantly and reduces task switching overhead, boosting query throughput especially
-// when the tasks are small.
-class QueryScheduler(concurrentQueries: Int, maxQueueLen: Int, tags: Map[String, String]) {
-  //  Currently executing query IDs -> number of execPlans in that query ID.  Used to track when all plans finish
-  //  so that cleanup can be done and more queries can be popped off the stack.
-  val currentIDs = new mHashMap[String, Int]().withDefaultValue(0)
-  //  Queue of queries waiting to be added to currently executing ones
-  val queue = new mQueue[(ExecPlan, ActorRef)]
-  //  Mapping of queryID to scheduler.  Each queryID gets its own scheduler.
-  val idToSched = new mHashMap[String, Scheduler]()
-  //  Queue of schedulers available for future queries
-  val schedulers = new mQueue[Scheduler]()
-
-  // Immediate ExecPlan execution, direct on current pool, no Queue, vs from queue
-  private val countExecImmed = Kamon.counter("query-scheduler-execute-immediate").withTags(TagSet.from(tags))
-  private val countExecQueue = Kamon.counter("query-scheduler-execute-queue").withTags(TagSet.from(tags))
-  private val countAddQueue  = Kamon.counter("query-scheduler-add-queue").withTags(TagSet.from(tags))
-  private val countQueueFull = Kamon.counter("query-scheduler-reject-queue-full").withTags(TagSet.from(tags))
-  private val queueLen = Kamon.gauge("query-scheduler-queue-length").withTags(TagSet.from(tags))
-
-  // Given a plan and replyTo, executes the plan if there is room or it is a currently executing query.
-  // If there isn't room, add it to the queue.  If the queue has no room, return false; otherwise true.
-  def execOrWait(plan: ExecPlan,
-                 replyTo: ActorRef,
-                 newPlanFunc: (ExecPlan, ActorRef, Scheduler) => Future[Unit]): Boolean = synchronized {
-    val id = plan.queryContext.queryId
-    if ((currentIDs contains id) || currentIDs.size < concurrentQueries) {
-      countExecImmed.increment()
-      execute(plan, replyTo, newPlanFunc)
-      true
-    } else if (queueSize < maxQueueLen) {
-      countAddQueue.increment()
-      queue.enqueue((plan, replyTo))
-      true
-    } else {
-      countQueueFull.increment()
-      false
-    }
-  }
-
-  // Length of queue - not synchronized, so data might not be consistent.
-  def queueSize: Int = queue.length
-
-  // Pop next item(s?) off top of queue so long as there is room to execute another query.
-  def tryPop(newPlanFunc: (ExecPlan, ActorRef, Scheduler) => Future[Unit]): Unit = synchronized {
-    if (currentIDs.size < concurrentQueries && queue.nonEmpty) {
-      val (nextPlan, replyTo) = queue.dequeue
-      countExecQueue.increment()
-      execute(nextPlan, replyTo, newPlanFunc)
-    }
-  }
-
-  // Executes newPlanFunc, updating currentIDs/plans as needed
-  // The closure is called in the current thread, but the callback when Future/plan is completed will not be.
-  // Note that an appropriate single threaded scheduler is pulled off the stack and used.
-  private def execute(newPlan: ExecPlan,
-                      replyTo: ActorRef,
-                      newPlanFunc: (ExecPlan, ActorRef, Scheduler) => Future[Unit]): Unit = {
-    val queryId = newPlan.queryContext.queryId
-
-    // Add plan to data structures and obtain scheduler
-    val sched = synchronized {
-      currentIDs(queryId) += 1
-      idToSched.getOrElseUpdate(queryId, {
-        if (schedulers.nonEmpty) schedulers.dequeue
-        else Scheduler.singleThread(s"${FiloSchedulers.QuerySchedName}-${currentIDs.size}")
-      })
-    }
-
-    val planFut = newPlanFunc(newPlan, replyTo, sched)
-
-    // Remove plan on Future complete.  If a slot opens up, recursively call myself to open up a new slot
-    planFut.onComplete {
-      case _ => synchronized {
-                  currentIDs(queryId) -= 1
-                  if (currentIDs(queryId) == 0) {
-                    currentIDs.remove(queryId)
-                    schedulers.enqueue(idToSched.remove(queryId).get)
-                    queueLen.update(queueSize)
-                    tryPop(newPlanFunc)
-                  }
-                }
-    }(sched)
-  }
-
-  // Currently active query IDs.  Not synchronized, so data might not be consistent.
-  def currentQueryIDs: Set[String] = currentIDs.keySet.toSet
-}
 
 object QueryCommandPriority extends java.util.Comparator[Envelope] {
   override def compare(o1: Envelope, o2: Envelope): Int = {
@@ -185,6 +88,7 @@ final class QueryActor(memStore: MemStore,
   val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
   val queryPlanner = new SingleClusterPlanner(dsRef, schemas, shardMapFunc,
                                               earliestRawTimestampFn, queryConfig, functionalSpreadProvider)
+  val queryScheduler = createInstrumentedQueryScheduler()
 
   private val tags = Map("dataset" -> dsRef.toString)
   private val lpRequests = Kamon.counter("queryactor-logicalPlan-requests").withTags(TagSet.from(tags))
@@ -192,16 +96,47 @@ final class QueryActor(memStore: MemStore,
   private val resultVectors = Kamon.histogram("queryactor-result-num-rvs").withTags(TagSet.from(tags))
   private val queryErrors = Kamon.counter("queryactor-query-errors").withTags(TagSet.from(tags))
 
-  val numSchedThreads = Math.ceil(queryConfig.threadsFactor * sys.runtime.availableProcessors).toInt
-  val sched = new QueryScheduler(numSchedThreads, queryConfig.maxQueueLen, tags)
+  /**
+    * Instrumentation adds following metrics on the Query Scheduler
+    *
+    * # Counter
+    * executor_tasks_submitted_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    * # Counter
+    * executor_tasks_completed_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    * # Histogram
+    * executor_threads_active{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    * # Histogram
+    * executor_queue_size_count{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+    *
+    */
+  private def createInstrumentedQueryScheduler(): SchedulerService = {
+    val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor")
+                                      * sys.runtime.availableProcessors).toInt
+    val schedName = s"$QuerySchedName-$dsRef"
+    val exceptionHandler = new UncaughtExceptionHandler {
+      override def uncaughtException(t: Thread, e: Throwable): Unit =
+        logger.error("Uncaught Exception in Query Scheduler", e)
+    }
+    val threadFactory = new ForkJoinPool.ForkJoinWorkerThreadFactory {
+      def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
+        val thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
+        thread.setDaemon(true)
+        thread.setUncaughtExceptionHandler(exceptionHandler)
+        thread.setName(s"$schedName-${thread.getPoolIndex}")
+        thread
+      }
+    }
+    val executor = new ForkJoinPool( numSchedThreads, threadFactory, exceptionHandler, true)
+    Scheduler.apply(ExecutorInstrumentation.instrument(executor, schedName))
+  }
 
-  def execPhysicalPlan2(q: ExecPlan, replyTo: ActorRef, sched: Scheduler): Future[Unit] = {
+  def execPhysicalPlan2(q: ExecPlan, replyTo: ActorRef): Unit = {
     if (checkTimeout(q.queryContext, replyTo)) {
       epRequests.increment()
       Kamon.currentSpan().tag("query", q.getClass.getSimpleName)
       Kamon.currentSpan().tag("query-id", q.queryContext.queryId)
       val querySession = QuerySession(q.queryContext, queryConfig)
-      q.execute(memStore, querySession)(sched)
+      q.execute(memStore, querySession)(queryScheduler)
         .foreach { res =>
           FiloSchedulers.assertThreadName(QuerySchedName)
           querySession.close()
@@ -216,14 +151,12 @@ final class QueryActor(memStore: MemStore,
                 case t: Throwable =>
               }
           }
-        }(sched).recover { case ex =>
+        }(queryScheduler).recover { case ex =>
           querySession.close()
           // Unhandled exception in query, should be rare
           logger.error(s"queryId ${q.queryContext.queryId} Unhandled Query Error: ", ex)
           replyTo ! QueryError(q.queryContext.queryId, ex)
-        }(sched)
-    } else {
-      Future.successful(())
+        }(queryScheduler)
     }
   }
 
@@ -284,8 +217,7 @@ final class QueryActor(memStore: MemStore,
                                       processLogicalPlan2Query(q, replyTo)
     case q: ExplainPlan2Query      => val replyTo = sender()
                                       processExplainPlanQuery(q, replyTo)
-    case q: ExecPlan               => if (!sched.execOrWait(q, sender(), execPhysicalPlan2))
-                                        sender() ! QueryQueueFull
+    case q: ExecPlan              =>  execPhysicalPlan2(q, sender())
 
     case GetIndexNames(ref, limit, _) =>
       sender() ! memStore.indexNames(ref, limit).map(_._1).toBuffer

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -77,5 +77,4 @@ object QueryCommands {
   final case class BadArgument(msg: String) extends ErrorResponse with QueryResponse
   final case class BadQuery(msg: String) extends ErrorResponse with QueryResponse
   final case class WrongNumberOfArgs(actual: Int, expected: Int) extends ErrorResponse with QueryResponse
-  case object QueryQueueFull extends ErrorResponse with QueryResponse
 }

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -244,7 +244,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       memStore.refreshIndexForTesting(dataset1.ref)
 
-      val numQueries = 30   // Want to make sure more queries than default concurrent limit in Query Scheduler
+      val numQueries = 6
 
       val series2 = (2 to 4).map(n => s"Series $n").toSet.asInstanceOf[Set[Any]]
       val multiFilter = Seq(ColumnFilter("series", Filter.In(series2)))

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -160,10 +160,7 @@ filodb {
     min-step = 5 seconds
 
     # Parallelism (query threadpool per dataset) ... ceil(available processors * factor)
-    threads-factor = 1.5
-
-    # Maximum number of queries the query queue can hold.  If the queue is full, new ExecPlans will be rejected.
-    max-queue-length = 25000
+    threads-factor = 1.0
 
     # Maximum number of steps/windows to use the RangeVectorAggregator.fastReduce aggregators.  This aggregator
     # uses memory proportional to the # of windows, rather than the # of time series aggregated; it can speed up

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -525,9 +525,9 @@ akka {
     # Auto downing is turned off by default.  See
     # http://doc.akka.io/docs/akka/2.3.16/scala/cluster-usage.html#Automatic_vs__Manual_Downing
     # Instead, we use this repo to provide smarter downing solutions:
-    # https://github.com/TanUkkii007/akka-cluster-custom-downing
+    # https://github.com/sisioh/akka-cluster-custom-downing
     # Note that this strategy should work well but for fixed size clusters QuorumLeader might be better
-    downing-provider-class = "tanukki.akka.cluster.autodown.MajorityLeaderAutoDowning"
+    downing-provider-class = "org.sisioh.akka.cluster.custom.downing.MajorityLeaderAutoDowning"
 
     metrics.enabled = off
     failure-detector {

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -15,8 +15,6 @@ class QueryConfig(queryConfig: Config) {
   lazy val minStepMs = queryConfig.getDuration("min-step").toMillis
   lazy val fastReduceMaxWindows = queryConfig.getInt("fastreduce-max-windows")
   lazy val routingConfig = queryConfig.getConfig("routing")
-  lazy val threadsFactor = queryConfig.getDouble("threads-factor")
-  lazy val maxQueueLen = queryConfig.getInt("max-queue-length")
 
   /**
    * Feature flag test: returns true if the config has an entry with "true", "t" etc

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,7 +112,7 @@ object Dependencies {
     // Redirect minlog logs to SLF4J
     "com.dorkbox"            % "MinLog-SLF4J"                 % "1.12",
     "com.opencsv"            % "opencsv"                      % "3.3",
-    "com.github.TanUkkii007" %% "akka-cluster-custom-downing" % "0.0.12",
+    "org.sisioh"             %% "akka-cluster-custom-downing" % "0.0.21",
     "com.typesafe.akka"      %% "akka-testkit"                % akkaVersion % Test,
     "com.typesafe.akka"      %% "akka-multi-node-testkit"     % akkaVersion % Test
   )

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -242,10 +242,6 @@ object FiloSettings {
 
 
   lazy val moduleSettings = Seq(
-    resolvers ++= Seq(
-      "Velvia Bintray" at "https://dl.bintray.com/velvia/maven"
-    ),
-    resolvers += Resolver.bintrayRepo("tanukkii007", "maven"),
 
     cancelable in Global := true,
 


### PR DESCRIPTION
This reverts commit 8e7b14c59ec60ca0f9cead014ee189242af030f6.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
PR #830 (commit 8e7b14c59ec60ca0f9cead014ee189242af030f6)  Caused a regression when running stress tests. In particular, it causes small queries to get stuck behind slow ones in the queue. One workaround is to increase the number of concurrent queries allowed, but then this effectively defeats the queue.

**New behavior :**
Revert the change and rely on original scheduler for now.
