### PR TITLE
bug(query, coordinator):  bug fixes for shard key regex and multipartition queries

### DIFF
--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -131,7 +131,7 @@ akka-bootstrapper {
 
 }
 
-akka.cluster.downing-provider-class = "tanukki.akka.cluster.autodown.QuorumLeaderAutoDowning"
+akka.cluster.downing-provider-class = "org.sisioh.akka.cluster.custom.downing.QuorumLeaderAutoDowning"
 
 custom-downing {
   stable-after = 20s

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -48,7 +48,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
           // Routes are created according to offset but logical plan should have time without offset.
           // Offset logic is handled in ExecPlan
           localPlanner.materialize(
-            copyWithUpdatedTimeRange(rootLogicalPlan, TimeRange(timeRange.startMs + offsetMs,
+            copyLogicalPlanWithUpdatedTimeRange(rootLogicalPlan, TimeRange(timeRange.startMs + offsetMs,
               timeRange.endMs + offsetMs)), qContext)
         }
         case route: RemoteRoute =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -73,6 +73,7 @@ object LogicalPlanParser {
       case d: ScalarFixedDoublePlan   => d.scalar.toString
       case t: ScalarTimeBasedPlan     => s"${t.function.entryName}$OpeningRoundBracket$ClosingRoundBracket"
       case s: ScalarVaryingDoublePlan => convertToQuery(s.vectors)
+      case s: ScalarBinaryOperation   => scalarBinaryOperationToQuery(s)
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -89,10 +89,13 @@ object LogicalPlanUtils {
       case lp: ApplyAbsentFunction         => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
       case lp: ScalarVaryingDoublePlan     => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
       case lp: RawChunkMeta                => lp.rangeSelector match {
-                                              case is: IntervalSelector => lp.copy(rangeSelector = is.copy(
+                                              case is: IntervalSelector  => lp.copy(rangeSelector = is.copy(
                                                                             timeRange.startMs, timeRange.endMs))
-                                              case _ => throw new UnsupportedOperationException("Copy supported only " +
-                                                        "for IntervalSelector")
+                                              case AllChunksSelector |
+                                                   EncodedChunksSelector |
+                                                   InMemoryChunksSelector |
+                                                   WriteBufferSelector     => throw new UnsupportedOperationException(
+                                                                             "Copy supported only for IntervalSelector")
                                             }
       case lp: VectorPlan                  => lp.copy(scalars = copyWithUpdatedTimeRange(lp.scalars, timeRange).
                                             asInstanceOf[ScalarPlan])

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -67,46 +67,48 @@ object LogicalPlanUtils {
   def copyWithUpdatedTimeRange(logicalPlan: PeriodicSeriesPlan,
                                timeRange: TimeRange): PeriodicSeriesPlan = {
     logicalPlan match {
-      case lp: PeriodicSeries => lp.copy(startMs = timeRange.startMs,
-                                         endMs = timeRange.endMs,
-                                         rawSeries = copyNonPeriodicWithUpdatedTimeRange(lp.rawSeries, timeRange)
-                                                     .asInstanceOf[RawSeries])
+      case lp: PeriodicSeries              => lp.copy(startMs = timeRange.startMs,
+                                                     endMs = timeRange.endMs,
+                                                     rawSeries = copyNonPeriodicWithUpdatedTimeRange(lp.rawSeries,
+                                                       timeRange).asInstanceOf[RawSeries])
       case lp: PeriodicSeriesWithWindowing => lp.copy(startMs = timeRange.startMs,
                                                       endMs = timeRange.endMs,
                                                       series = copyNonPeriodicWithUpdatedTimeRange(lp.series,
                                                                timeRange))
-      case lp: ApplyInstantFunction => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
+      case lp: ApplyInstantFunction        => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
 
-      case lp: Aggregate  => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
+      case lp: Aggregate                   => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
 
-      case lp: BinaryJoin => lp.copy(lhs = copyWithUpdatedTimeRange(lp.lhs, timeRange),
-                                     rhs = copyWithUpdatedTimeRange(lp.rhs, timeRange))
-      case lp: ScalarVectorBinaryOperation =>
-                      lp.copy(vector = copyWithUpdatedTimeRange(lp.vector, timeRange))
+      case lp: BinaryJoin                  => lp.copy(lhs = copyWithUpdatedTimeRange(lp.lhs, timeRange),
+                                               rhs = copyWithUpdatedTimeRange(lp.rhs, timeRange))
+      case lp: ScalarVectorBinaryOperation => lp.copy(vector = copyWithUpdatedTimeRange(lp.vector, timeRange))
 
-      case lp: ApplyMiscellaneousFunction =>
-                      lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
+      case lp: ApplyMiscellaneousFunction  => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
 
-      case lp: ApplySortFunction => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
-      case lp: ApplyAbsentFunction => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
-      case lp: ScalarVaryingDoublePlan => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
-      case lp: RawChunkMeta => lp.rangeSelector match {
-        case is: IntervalSelector => lp.copy(rangeSelector = is.copy(timeRange.startMs, timeRange.endMs))
-        case _ => throw new UnsupportedOperationException("Copy supported only for IntervalSelector")
-      }
-      case lp: VectorPlan    => lp.copy(scalars = copyWithUpdatedTimeRange(lp.scalars, timeRange).
-        asInstanceOf[ScalarPlan])
-      case lp: ScalarTimeBasedPlan => lp.copy(rangeParams = RangeParams(timeRange.startMs * 1000,
-        lp.rangeParams.stepSecs, timeRange.endMs * 1000))
-      case lp: ScalarFixedDoublePlan => lp.copy(timeStepParams = RangeParams(timeRange.startMs * 1000,
-        lp.timeStepParams.stepSecs, timeRange.endMs * 1000))
-      case lp: ScalarBinaryOperation =>  val updatedLhs = if (lp.lhs.isRight) Right(copyWithUpdatedTimeRange
-      (lp.lhs.right.get, timeRange).asInstanceOf[ScalarBinaryOperation]) else Left(lp.lhs.left.get)
-        val updatedRhs = if (lp.rhs.isRight) Right(copyWithUpdatedTimeRange(lp.rhs.right.get, timeRange).
-          asInstanceOf[ScalarBinaryOperation]) else Left(lp.rhs.left.get)
-        lp.copy(lhs = updatedLhs, rhs = updatedRhs, rangeParams = RangeParams(timeRange.startMs * 1000,
-          lp.rangeParams.stepSecs, timeRange.endMs * 1000))
-      case _ => throw new UnsupportedOperationException(s"Logical plan not supported for copy: $logicalPlan")
+      case lp: ApplySortFunction           => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
+      case lp: ApplyAbsentFunction         => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
+      case lp: ScalarVaryingDoublePlan     => lp.copy(vectors = copyWithUpdatedTimeRange(lp.vectors, timeRange))
+      case lp: RawChunkMeta                => lp.rangeSelector match {
+                                              case is: IntervalSelector => lp.copy(rangeSelector = is.copy(
+                                                                            timeRange.startMs, timeRange.endMs))
+                                              case _ => throw new UnsupportedOperationException("Copy supported only " +
+                                                        "for IntervalSelector")
+                                            }
+      case lp: VectorPlan                  => lp.copy(scalars = copyWithUpdatedTimeRange(lp.scalars, timeRange).
+                                            asInstanceOf[ScalarPlan])
+      case lp: ScalarTimeBasedPlan         => lp.copy(rangeParams = RangeParams(timeRange.startMs * 1000,
+                                              lp.rangeParams.stepSecs, timeRange.endMs * 1000))
+      case lp: ScalarFixedDoublePlan       => lp.copy(timeStepParams = RangeParams(timeRange.startMs * 1000,
+                                              lp.timeStepParams.stepSecs, timeRange.endMs * 1000))
+      case lp: ScalarBinaryOperation       =>  val updatedLhs = if (lp.lhs.isRight) Right(copyWithUpdatedTimeRange
+                                              (lp.lhs.right.get, timeRange).asInstanceOf[ScalarBinaryOperation]) else
+                                              Left(lp.lhs.left.get)
+                                              val updatedRhs = if (lp.rhs.isRight) Right(copyWithUpdatedTimeRange(
+                                                lp.rhs.right.get, timeRange).asInstanceOf[ScalarBinaryOperation])
+                                              else Left(lp.rhs.left.get)
+                                              lp.copy(lhs = updatedLhs, rhs = updatedRhs, rangeParams =
+                                                RangeParams(timeRange.startMs * 1000, lp.rangeParams.stepSecs,
+                                                  timeRange.endMs * 1000))
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -49,7 +49,7 @@ class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
           val downsampleLp = if (endWithOffsetMs < lastDownsampleSampleTime) {
             logicalPlan
           } else {
-            copyWithUpdatedTimeRange(logicalPlan,
+            copyLogicalPlanWithUpdatedTimeRange(logicalPlan,
               TimeRange(p.startMs, latestDownsampleTimestampFn + offsetMillis))
           }
           downsampleClusterPlanner.materialize(downsampleLp, qContext)
@@ -61,11 +61,11 @@ class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
           val lastDownsampleInstant = p.startMs + numStepsInDownsample * p.stepMs
           val firstInstantInRaw = lastDownsampleInstant + p.stepMs
 
-          val downsampleLp = copyWithUpdatedTimeRange(logicalPlan,
+          val downsampleLp = copyLogicalPlanWithUpdatedTimeRange(logicalPlan,
                                                       TimeRange(p.startMs, lastDownsampleInstant))
           val downsampleEp = downsampleClusterPlanner.materialize(downsampleLp, qContext)
 
-          val rawLp = copyWithUpdatedTimeRange(logicalPlan, TimeRange(firstInstantInRaw, p.endMs))
+          val rawLp = copyLogicalPlanWithUpdatedTimeRange(logicalPlan, TimeRange(firstInstantInRaw, p.endMs))
           val rawEp = rawClusterPlanner.materialize(rawLp, qContext)
           StitchRvsExec(qContext, stitchDispatcher, Seq(rawEp, downsampleEp))
         }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -75,7 +75,6 @@ class SingleClusterPlanner(dsRef: DatasetRef,
 
   }
 
-
   private def shardsFromFilters(filters: Seq[ColumnFilter],
                                 qContext: QueryContext): Seq[Int] = {
 

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -381,7 +381,7 @@ case class ScalarBinaryOperation(operator: BinaryOperator,
   override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan = {
     val updatedLhs = if (lhs.isRight) Right(lhs.right.get.replacePeriodicSeriesFilters(filters).
                       asInstanceOf[ScalarBinaryOperation]) else Left(lhs.left.get)
-    val updatedRhs = if (lhs.isRight) Right(rhs.right.get.replacePeriodicSeriesFilters(filters).
+    val updatedRhs = if (rhs.isRight) Right(rhs.right.get.replacePeriodicSeriesFilters(filters).
                       asInstanceOf[ScalarBinaryOperation]) else Left(rhs.left.get)
     this.copy(lhs = updatedLhs, rhs = updatedRhs)
   }
@@ -408,6 +408,8 @@ object LogicalPlan {
     */
   def findLeafLogicalPlans (logicalPlan: LogicalPlan) : Seq[LogicalPlan] = {
    logicalPlan match {
+     // scalarArg can have vector like scalar(http_requests_total)
+     case lp: ScalarVectorBinaryOperation => findLeafLogicalPlans(lp.vector) ++ findLeafLogicalPlans(lp.scalarArg)
      // Find leaf logical plans for all children and concatenate results
      case lp: NonLeafLogicalPlan => lp.children.flatMap(findLeafLogicalPlans)
      case _                      => Seq(logicalPlan)

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -22,7 +22,6 @@ trait ReduceAggregateExec extends NonLeafExecPlan {
   def children: Seq[ExecPlan] = childAggregates
   def aggrOp: AggregationOperator
   def aggrParams: Seq[Any]
-  def skipMapPhase: Boolean = true
 
   protected def args: String = s"aggrOp=$aggrOp, aggrParams=$aggrParams"
 
@@ -36,7 +35,7 @@ trait ReduceAggregateExec extends NonLeafExecPlan {
     val task = for { schema <- firstSchema }
                yield {
                  val aggregator = RowAggregator(aggrOp, aggrParams, schema)
-                 RangeVectorAggregator.mapReduce(aggregator, skipMapPhase, results, rv => rv.key,
+                 RangeVectorAggregator.mapReduce(aggregator, skipMapPhase = true, results, rv => rv.key,
                    querySession.qContext.groupByCardLimit)
                }
     Observable.fromTask(task).flatten
@@ -64,8 +63,6 @@ final case class MultiPartitionReduceAggregateExec(queryContext: QueryContext,
   // overriden since it can reduce schemas with different vector lengths as long as the columns are same
   override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema =
     IgnoreFixedVectorLenAndColumnNamesSchemaReducer.reduceSchema(rs, resp)
-
-  override def skipMapPhase: Boolean = false
 }
 
 

--- a/query/src/main/scala/filodb/query/exec/aggregator/AvgRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/AvgRowAggregator.scala
@@ -51,6 +51,6 @@ object AvgRowAggregator extends RowAggregator {
   }
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = {
     // drop last column with count
-    reductionSchema.copy(columns = reductionSchema.columns.take(reductionSchema.columns.size-1))
+    reductionSchema.copy(reductionSchema.columns.filterNot(_.name.equals("count")))
   }
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/StddevRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/StddevRowAggregator.scala
@@ -64,6 +64,6 @@ object StddevRowAggregator extends RowAggregator {
   }
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = {
     // drop last two column with mean and count
-    reductionSchema.copy(reductionSchema.columns.dropRight(2))
+    reductionSchema.copy(reductionSchema.columns.filterNot(c => (c.name.equals("mean") || c.name.equals("count"))))
   }
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/StdvarRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/StdvarRowAggregator.scala
@@ -78,6 +78,6 @@ object StdvarRowAggregator extends RowAggregator {
   }
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = {
     // drop last two column with mean and count
-    reductionSchema.copy(reductionSchema.columns.dropRight(2))
+    reductionSchema.copy(reductionSchema.columns.filterNot(c => (c.name.equals("mean") || c.name.equals("count"))))
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

- Stddev, stdvar for shard key regex failing with requirement failed: columnTypes cannot be empty
- Avg for query with shard key regex failing with IndexOutOfBoundsException
- Absent for multipartition queries throwing Logical plan not supported for copy  error
- Scalar binary operation between time() and scalar function on regex does not get converted to child plan without shard key regex

**New behavior :**

- Add copyWithUpdatedTimeRange for all ApplyAbsentFunction  and other logical plans
- Append leaf logical plan of scalar argument for ScalarVectorBinaryOperation for queries like `scalar(http_requests_total)`
- Change skipMapPhase to false for MultiPartitionReduceAggregateExec as reduce for sttdev, stddvar need “mean” and “ count” column 
- In presentationSchem delete column by column names instead of dropping last columns
