### PR TITLE
bug(sparkJobs): Make fetchSize configurable; increase splits

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -194,13 +194,14 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
                                            userTimeStart: Long,
                                            endTimeExclusive: Long,
                                            maxChunkTime: Long,
-                                           batchSize: Int): Iterator[Seq[RawPartData]] = {
+                                           batchSize: Int,
+                                           cassFetchSize: Int): Iterator[Seq[RawPartData]] = {
     val partKeys = splits.flatMap {
       case split: CassandraTokenRangeSplit =>
         val indexTable = getOrCreateIngestionTimeIndexTable(datasetRef)
         logger.debug(s"Querying cassandra for partKeys for split=$split ingestionTimeStart=$ingestionTimeStart " +
           s"ingestionTimeEnd=$ingestionTimeEnd")
-        indexTable.scanPartKeysByIngestionTimeNoAsync(split.tokens, ingestionTimeStart, ingestionTimeEnd)
+        indexTable.scanPartKeysByIngestionTimeNoAsync(split.tokens, ingestionTimeStart, ingestionTimeEnd, cassFetchSize)
       case split => throw new UnsupportedOperationException(s"Unknown split type $split seen")
     }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -103,7 +103,8 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
 
   def scanPartKeysByIngestionTimeNoAsync(tokens: Seq[(String, String)],
                                          ingestionTimeStart: Long,
-                                         ingestionTimeEnd: Long): Iterator[ByteBuffer] = {
+                                         ingestionTimeEnd: Long,
+                                         fetchSize: Int): Iterator[ByteBuffer] = {
     tokens.iterator.flatMap { case (start, end) =>
       /*
        * FIXME conversion of tokens to Long works only for Murmur3Partitioner because it generates
@@ -114,6 +115,7 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
                                end.toLong: java.lang.Long,
                                ingestionTimeStart: java.lang.Long,
                                ingestionTimeEnd: java.lang.Long)
+                         .setFetchSize(fetchSize)
       try {
         session.execute(stmt).iterator.asScala
           .map { row => row.getBytes("partition") }

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -265,7 +265,8 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
       firstSampleTime - 1,
       firstSampleTime + 5,
       10L,
-      100
+      100,
+      5000
     ).toList
 
     batches.size shouldEqual 11 // 100 rows per batch, 1050 rows => 11 batches

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -242,8 +242,12 @@ filodb {
     cass-write-batch-size = 250
 
     # amount of parallelism to introduce in the spark job. This controls number of spark partitions
-    # increase if the number of splits seen in cassandra reads is low and spark jobs are slow.
-    splits-per-node = 1
+    # increase if the number of splits seen in cassandra reads is low and spark jobs are slow, or
+    # if we see Cassandra read timeouts in token range scans.
+    splits-per-node = 10
+
+    # Number of rows to read in one fetch. Reduce if we see Cassandra read timeouts
+    cass-read-fetch-size = 5000
 
     # Amount of time to wait for a Cassandra write to finish before proceeding to next batch of partitions
     cassandra-write-timeout = 10.minutes

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -115,7 +115,8 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
           ingestionTimeEnd = ingestionTimeEnd,
           userTimeStart = userTimeStart, endTimeExclusive = userTimeEndExclusive,
           maxChunkTime = settings.rawDatasetIngestionConfig.storeConfig.maxChunkTime.toMillis,
-          batchSize = settings.batchSize)
+          batchSize = settings.batchSize,
+          cassFetchSize = settings.cassFetchSize)
         batchIter
       }
       .foreach { rawPartsBatch =>

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -54,6 +54,8 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val batchSize = downsamplerConfig.getInt("cass-write-batch-size")
 
+  @transient lazy val cassFetchSize = downsamplerConfig.getInt("cass-read-fetch-size")
+
   @transient lazy val splitsPerNode = downsamplerConfig.getInt("splits-per-node")
 
   @transient lazy val cassWriteTimeout = downsamplerConfig.as[FiniteDuration]("cassandra-write-timeout")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

1. Make cassandra fetchSize configurable so it can be tweaked without new build
2. Increase number of token splits 

Both of these config params address the read timeout during data scans in downsampler.
