### PR TITLE
misc(query): match nonleaf child query parallelism to number of children

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -371,7 +371,7 @@ abstract class NonLeafExecPlan extends ExecPlan {
     // Create tasks for all results.
     // NOTE: It's really important to preserve the "index" of the child task, as joins depend on it
     val childTasks = Observable.fromIterable(children.zipWithIndex)
-                               .mapAsync(Runtime.getRuntime.availableProcessors()) { case (plan, i) =>
+                               .mapAsync(children.length) { case (plan, i) =>
                                  dispatchRemotePlan(plan, parentSpan).map((_, i))
                                }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

Current behavior is to set child query execution parallelism to `availableProcessors`. This is throttling metadata queries where there will be more child execution-plans, since query is dispatched/executed on all the shards. With this change, parallelism is set to number of child plans, so that child query execution will not be throttled.