### PR TITLE
bug(query):  binary join remote query children have original query

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
@@ -1,6 +1,6 @@
 package filodb.coordinator.queryplanner
 
-import filodb.core.query.QueryContext
+import filodb.core.query.{PromQlQueryParams, QueryContext}
 import filodb.query.{BinaryJoin, LabelValues, LogicalPlan, SeriesKeysByFilters, SetOperator}
 import filodb.query.exec._
 
@@ -43,14 +43,19 @@ class SinglePartitionPlanner(planners: Map[String, QueryPlanner], plannerSelecto
 
   private def materializeBinaryJoin(logicalPlan: BinaryJoin, qContext: QueryContext): ExecPlan = {
 
+    val lhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].
+      copy(promQl = LogicalPlanParser.convertToQuery(logicalPlan.lhs)))
+    val rhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].
+      copy(promQl = LogicalPlanParser.convertToQuery(logicalPlan.rhs)))
+
     val lhsExec = logicalPlan.lhs match {
-      case b: BinaryJoin => materializeBinaryJoin(b, qContext)
-      case _             => getPlanner(logicalPlan.lhs).materialize(logicalPlan.lhs, qContext)
+      case b: BinaryJoin => materializeBinaryJoin(b, lhsQueryContext)
+      case _             => getPlanner(logicalPlan.lhs).materialize(logicalPlan.lhs, lhsQueryContext)
     }
 
     val rhsExec = logicalPlan.rhs match {
-      case b: BinaryJoin => materializeBinaryJoin(b, qContext)
-      case _             => getPlanner(logicalPlan.rhs).materialize(logicalPlan.rhs, qContext)
+      case b: BinaryJoin => materializeBinaryJoin(b, rhsQueryContext)
+      case _             => getPlanner(logicalPlan.rhs).materialize(logicalPlan.rhs, rhsQueryContext)
     }
 
     if (logicalPlan.operator.isInstanceOf[SetOperator])

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -4,7 +4,6 @@ import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import monix.execution.Scheduler
-
 import filodb.coordinator.ShardMapper
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
@@ -48,7 +47,7 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
   val failureProvider = new FailureProvider {
     override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
       Seq(FailureTimeRange("local", datasetRef,
-        TimeRange(100, 10000), false))
+        TimeRange(300000, 400000), false))
     }
   }
 
@@ -160,5 +159,19 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
     execPlan.isInstanceOf[TimeScalarGeneratorExec] shouldEqual true
   }
 
+  it("should generate BinaryJoin Exec with remote exec's having lhs or rhs query") {
+    val lp = Parser.queryRangeToLogicalPlan("""test1{job = "app"} + test2{job = "app"}""", TimeStepParams(300, 20, 500))
+
+    val promQlQueryParams = PromQlQueryParams("test1{job = \"app\"} + test2{job = \"app\"}", 300, 20, 500)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    println(execPlan.printTree())
+    execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
+    execPlan.children(0).isInstanceOf[PromQlRemoteExec] shouldEqual(true)
+    execPlan.children(1).isInstanceOf[PromQlRemoteExec] shouldEqual(true)
+
+    // LHS should have only LHS query and RHS should have oly RHS query
+    execPlan.children(0).asInstanceOf[PromQlRemoteExec].params.promQl shouldEqual("""test1{job="app"}""")
+    execPlan.children(1).asInstanceOf[PromQlRemoteExec].params.promQl shouldEqual("""test2{job="app"}""")
+  }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Remote Exec for LHS and RHS of binary join have original query

**New behavior :**
Generate LHS/RHS query by converting LHS/RHS logical plan to query and use it to create QueryContext 

