### PR TITLE
bug(query): AND returns LHS row values if corresponding RHS row value is NaN

### DIFF
--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -2,8 +2,10 @@ package filodb.query.exec
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+
 import monix.eval.Task
 import monix.reactive.Observable
+
 import filodb.core.memstore.SchemaMismatch
 import filodb.core.query._
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String => Utf8Str}

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -92,6 +92,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
 
   private def setOpAnd(lhsRvs: List[RangeVector], rhsRvs: List[RangeVector],
                        rhsSchema: ResultSchema): List[RangeVector] = {
+    require(rhsRvs.forall(_.isInstanceOf[SerializedRangeVector]), "RHS should be SerializedRangeVector")
     val rhsMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
     var result = new ListBuffer[RangeVector]()
     rhsRvs.foreach { rv =>
@@ -114,6 +115,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
           override def next(): RowReader = {
             val lhsRow = lhsRows.next()
             val rhsRow = rhsRows.next()
+            // LHS row should not be added to result if corresponding RHS row does not exist
             val res = if (rhsRow.getDouble(1).isNaN) Double.NaN else lhsRow.getDouble(1)
             cur.setValues(lhsRow.getLong(0), res)
             cur

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -2,13 +2,11 @@ package filodb.query.exec
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-
 import monix.eval.Task
 import monix.reactive.Observable
-
 import filodb.core.memstore.SchemaMismatch
 import filodb.core.query._
-import filodb.memory.format.{ZeroCopyUTF8String => Utf8Str}
+import filodb.memory.format.{RowReader, ZeroCopyUTF8String => Utf8Str}
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 import filodb.query.BinaryOperator.{LAND, LOR, LUnless}
@@ -92,20 +90,41 @@ final case class SetOperatorExec(queryContext: QueryContext,
 
   private def setOpAnd(lhsRvs: List[RangeVector], rhsRvs: List[RangeVector],
                        rhsSchema: ResultSchema): List[RangeVector] = {
-    val rhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
+    //val rhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
+    val rhsMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
     var result = new ListBuffer[RangeVector]()
     rhsRvs.foreach { rv =>
       val jk = joinKeys(rv.key)
       // Don't add range vector if it is empty
       if (jk.nonEmpty && !isEmpty(rv, rhsSchema))
-        rhsKeysSet += jk
+        rhsMap.put(jk, rv)
     }
 
     lhsRvs.foreach { lhs =>
       val jk = joinKeys(lhs.key)
       // Add range vectors from lhs which are present in lhs and rhs both or when jk is empty
-      // "up AND ON (dummy) vector(1)" should be equivalent to up as there's no dummy label
-      if (rhsKeysSet.contains(jk) || jk.isEmpty) {
+      if (rhsMap.contains(jk)) {
+        val lhsRows = lhs.rows
+        val rhsRows = rhsMap.get(jk).get.rows
+
+        val rows = new RangeVectorCursor {
+          val cur = new TransientRow()
+          override def hasNext: Boolean = lhsRows.hasNext && rhsRows.hasNext
+          override def next(): RowReader = {
+            val lhsRow = lhsRows.next()
+            val rhsRow = rhsRows.next()
+            val res = if (rhsRow.getDouble(1).isNaN) Double.NaN else lhsRow.getDouble(1)
+            cur.setValues(lhsRow.getLong(0), res)
+            cur
+          }
+          override def close(): Unit = {
+            lhsRows.close()
+            rhsRows.close()
+          }
+        }
+        result += IteratorBackedRangeVector(lhs.key, rows)
+      } else if (jk.isEmpty) {
+        // "up AND ON (dummy) vector(1)" should be equivalent to up as there's no dummy label
         result += lhs
       }
     }

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -90,7 +90,6 @@ final case class SetOperatorExec(queryContext: QueryContext,
 
   private def setOpAnd(lhsRvs: List[RangeVector], rhsRvs: List[RangeVector],
                        rhsSchema: ResultSchema): List[RangeVector] = {
-    //val rhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
     val rhsMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
     var result = new ListBuffer[RangeVector]()
     rhsRvs.foreach { rv =>

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -92,6 +92,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
 
   private def setOpAnd(lhsRvs: List[RangeVector], rhsRvs: List[RangeVector],
                        rhsSchema: ResultSchema): List[RangeVector] = {
+    // isEmpty method consumes rhs range vector
     require(rhsRvs.forall(_.isInstanceOf[SerializedRangeVector]), "RHS should be SerializedRangeVector")
     val rhsMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
     var result = new ListBuffer[RangeVector]()


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
 AND returns LHS row values if corresponding RHS row value is not present which is represented by NaN

**New behavior :**
Add LHS row to result only when corresponding RHS row is not NaN
