### PR TITLE
perf(cass): Increase splits for all token scans

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -64,6 +64,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   private val pkByUTNumSplits = cassandraConfig.getInt("pk-by-updated-time-table-num-splits")
   private val pkByUTTtlSeconds = cassandraConfig.getDuration("pk-by-updated-time-table-ttl", TimeUnit.SECONDS).toInt
   private val createTablesEnabled = cassandraConfig.getBoolean("create-tables-enabled")
+  private val numTokenRangeSplitsForScans = cassandraConfig.getInt("num-token-range-splits-for-scans")
 
   val sinkStats = new ChunkSinkStats
 
@@ -316,7 +317,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
    * @param splitsPerNode  - how much parallelism or ways to divide a token range on each node
    * @return each split will have token_start, token_end, replicas filled in
    */
-  def getScanSplits(dataset: DatasetRef, splitsPerNode: Int = 1): Seq[ScanSplit] = {
+  def getScanSplits(dataset: DatasetRef, splitsPerNode: Int = numTokenRangeSplitsForScans): Seq[ScanSplit] = {
     val keyspace = clusterConnector.keyspace
     require(splitsPerNode >= 1, s"Must specify at least 1 splits_per_node, got $splitsPerNode")
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -228,6 +228,12 @@ filodb {
     # Creation of tables is enabled. Do not set to true in production to avoid
     # multiple nodes trying to create table at once
     create-tables-enabled = false
+
+    # amount of parallelism to introduce in the token scan queries. This controls number of spark partitions
+    # increase if the number of splits seen in cassandra reads is low and spark jobs are slow, or
+    # if we see Cassandra read timeouts in token range scans.
+    num-token-range-splits-for-scans = 10
+
   }
 
   downsampler {
@@ -240,11 +246,6 @@ filodb {
 
     # Number of time series to operate on at one time. Reduce if there is much less memory available
     cass-write-batch-size = 250
-
-    # amount of parallelism to introduce in the spark job. This controls number of spark partitions
-    # increase if the number of splits seen in cassandra reads is low and spark jobs are slow, or
-    # if we see Cassandra read timeouts in token range scans.
-    splits-per-node = 10
 
     # Number of rows to read in one fetch. Reduce if we see Cassandra read timeouts
     cass-read-fetch-size = 5000

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -17,6 +17,7 @@ filodb {
     pk-by-updated-time-table-num-splits = 200
     pk-by-updated-time-table-ttl = 1 day
     create-tables-enabled = true
+    num-token-range-splits-for-scans = 1
   }
 
   shard-manager {

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -96,10 +96,9 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
     DownsamplerContext.dsLogger.info(s"To rerun this job add the following spark config: " +
       s""""spark.filodb.downsampler.userTimeOverride": "${java.time.Instant.ofEpochMilli(userTimeInPeriod)}"""")
 
-    val splits = batchDownsampler.rawCassandraColStore.getScanSplits(batchDownsampler.rawDatasetRef,
-                                                                     settings.splitsPerNode)
+    val splits = batchDownsampler.rawCassandraColStore.getScanSplits(batchDownsampler.rawDatasetRef)
     DownsamplerContext.dsLogger.info(s"Cassandra split size: ${splits.size}. We will have this many spark " +
-      s"partitions. Tune splitsPerNode which was ${settings.splitsPerNode} if parallelism is low")
+      s"partitions. Tune num-token-range-splits-for-scans if parallelism is low or latency is high")
 
     KamonShutdownHook.registerShutdownHook()
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -56,8 +56,6 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val cassFetchSize = downsamplerConfig.getInt("cass-read-fetch-size")
 
-  @transient lazy val splitsPerNode = downsamplerConfig.getInt("splits-per-node")
-
   @transient lazy val cassWriteTimeout = downsamplerConfig.as[FiniteDuration]("cassandra-write-timeout")
 
   @transient lazy val widenIngestionTimeRangeBy = downsamplerConfig.as[FiniteDuration]("widen-ingestion-time-range-by")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Now all token scan queries will use the splits configuration defined for the cassandra cluster.
Earlier, splits were being applied only for the downsample scan queries.
This is being done, after discovering that index bootstrap scan CQL queries are also latent if cassandra cluster is overloaded.
