### PR TITLE
bug(core): Revert _step_ predefined key since we already use it; fix binary joins

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -25,9 +25,12 @@ filodb {
     columns = ["_metric_:string", "tags:map"]
 
     # Predefined keys allow space to be saved for over the wire tags with the given keys
-    # WARN: It is suggested to only ADD to predefined keys.
-    #       Changing/Renaming existing keys will cause incorrect tags to be reported and probably require a clean wipe.
-    predefined-keys = ["_ws_", "_ns_", "app", "__name__", "instance", "dc", "le", "job", "exporter", "_step_"]
+    # WARN: 1. It is suggested to only ADD to predefined keys that are not used already,
+    #          which means only new tags with underscore prefixed and suffixed.
+    #       2. Changing/Renaming existing keys will cause incorrect tags to be reported and probably require a clean wipe.
+    #       3. Even when adding new keys, be careful. If that tag is already being used, there is no
+    #          equality of partKeys between old and new time series.
+    predefined-keys = ["_ws_", "_ns_", "app", "__name__", "instance", "dc", "le", "job", "exporter", "_pi_"]
 
     options {
       # Copy tags can be used to create a new labelPair from one of the existing labelPair in a TimeSeries.

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -31,6 +31,7 @@ filodb {
     #       3. Even when adding new keys, be careful. If that tag is already being used, there is no
     #          equality of partKeys between old and new time series.
     predefined-keys = ["_ws_", "_ns_", "app", "__name__", "instance", "dc", "le", "job", "exporter", "_pi_"]
+    # FYI: _pi_ stands for publish interval; _ws_ stands for workspace, _ns_ stands for namespace
 
     options {
       # Copy tags can be used to create a new labelPair from one of the existing labelPair in a TimeSeries.

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -51,11 +51,11 @@ final case class BinaryJoinExec(queryContext: QueryContext,
   require(!on.contains(metricColumn), "On cannot contain metric name")
 
   val onLabels = on.map(Utf8Str(_)).toSet
+  val withExtraOnLabels = onLabels ++ Seq("_pi_", "_step_") // needed since these are internal tags
   val ignoringLabels = ignoring.map(Utf8Str(_)).toSet
   val ignoringLabelsForJoin = ignoringLabels + metricColumn.utf8
   // if onLabels is non-empty, we are doing matching based on on-label, otherwise we are
   // doing matching based on ignoringLabels even if it is empty
-  val onMatching = onLabels.nonEmpty
 
   def children: Seq[ExecPlan] = lhs ++ rhs
 
@@ -120,7 +120,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
   }
 
   private def joinKeys(rvk: RangeVectorKey): Map[Utf8Str, Utf8Str] = {
-    if (onLabels.nonEmpty) rvk.labelValues.filter(lv => onLabels.contains(lv._1))
+    if (onLabels.nonEmpty) rvk.labelValues.filter(lv => withExtraOnLabels.contains(lv._1))
     else rvk.labelValues.filterNot(lv => ignoringLabelsForJoin.contains(lv._1))
   }
 
@@ -131,8 +131,9 @@ final case class BinaryJoinExec(queryContext: QueryContext,
     if (binaryOp.isInstanceOf[MathOperator]) result = result - Utf8Str(metricColumn)
 
     if (cardinality == Cardinality.OneToOne) {
-      result = if (onLabels.nonEmpty) result.filter(lv => onLabels.contains(lv._1)) // retain what is in onLabel list
-               else result.filterNot(lv => ignoringLabels.contains(lv._1)) // remove the labels in ignoring label list
+      result =
+        if (onLabels.nonEmpty) result.filter(lv => withExtraOnLabels.contains(lv._1)) // retain what is in onLabel list
+        else result.filterNot(lv => ignoringLabels.contains(lv._1)) // remove the labels in ignoring label list
     } else if (cardinality == Cardinality.OneToMany || cardinality == Cardinality.ManyToOne) {
       // For group_left/group_right add labels in include from one side. Result should have all keys from many side
       include.foreach { x =>

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -51,7 +51,8 @@ final case class BinaryJoinExec(queryContext: QueryContext,
   require(!on.contains(metricColumn), "On cannot contain metric name")
 
   val onLabels = on.map(Utf8Str(_)).toSet
-  val withExtraOnLabels = onLabels ++ Seq("_pi_", "_step_") // needed since these are internal tags
+  // publishInterval and step tags always needs to be included in join key
+  val withExtraOnLabels = onLabels ++ Seq("_pi_", "_step_")
   val ignoringLabels = ignoring.map(Utf8Str(_)).toSet
   val ignoringLabelsForJoin = ignoringLabels + metricColumn.utf8
   // if onLabels is non-empty, we are doing matching based on on-label, otherwise we are

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -245,7 +245,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Array(dummyPlan), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToMany,
-      Nil, ignoring = Seq("tag1"), Nil, "__name__")
+      Nil, ignoring = Seq("tag1"), include = Seq("tag2"), "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema)))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

`_step_` tag was earlier introduced as predefined tag. As a result new partKeys are created which aren't equivalent to old ones. In addition, binary joins have issues since the one-side in OneToOne or OneToMany joins now have duplicate join keys.

**New behavior :**

* Rename `_step_` tag with unused `_pi_` (stands for publish interval). Test case included to ensure name update works fine.
* Include tags like `_step_` and `_pi_` in the `on` specifier of joins

