### PR TITLE
fix(query): Fix class cast exception when using absent function over an aggregate

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -58,6 +58,8 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     parseAndAssertResult("""timestamp(http_requests_total{job="app"})""")
     parseAndAssertResult("""absent(http_requests_total{job="app"})""")
     parseAndAssertResult("""absent(sum(http_requests_total{job="app"}))""")
+    parseAndAssertResult("""absent(sum_over_time(http_requests_total{job="app"}[5s]))""")
+    parseAndAssertResult("""absent(rate(http_requests_total{job="app"}[5s] offset 200s))""")
   }
 
   it("should generate query from LogicalPlan having offset") {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -57,6 +57,7 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     parseAndAssertResult("""count_values("freq",http_requests_total{job="app"})""")
     parseAndAssertResult("""timestamp(http_requests_total{job="app"})""")
     parseAndAssertResult("""absent(http_requests_total{job="app"})""")
+    parseAndAssertResult("""absent(sum(http_requests_total{job="app"}))""")
   }
 
   it("should generate query from LogicalPlan having offset") {

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -1,6 +1,6 @@
 package filodb.prometheus.ast
 
-import filodb.core.query.RangeParams
+import filodb.core.query.{ColumnFilter, RangeParams}
 import filodb.query._
 import filodb.query.RangeFunctionId.Timestamp
 
@@ -165,7 +165,8 @@ trait Functions extends Base with Operators with Vectors {
         val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toSeriesPlan(timeParams)
         ApplySortFunction(periodicSeriesPlan, sortFunctionId)
       } else if (absentFunctionIdOpt.isDefined) {
-        val columnFilter = seriesParam.asInstanceOf[InstantExpression].columnFilters
+        val columnFilter = if (seriesParam.isInstanceOf[InstantExpression])
+          seriesParam.asInstanceOf[InstantExpression].columnFilters else Seq.empty[ColumnFilter]
         val periodicSeriesPlan = seriesParam.asInstanceOf[PeriodicSeries].toSeriesPlan(timeParams)
         ApplyAbsentFunction(periodicSeriesPlan, columnFilter, RangeParams(timeParams.start, timeParams.step,
           timeParams.end))

--- a/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
@@ -143,6 +143,7 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
 
   it("should not have keys when ColumnFilter is empty") {
     val columnFilter = Seq.empty[ColumnFilter]
+    val expectedRows = List(1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
     val absentFunctionMapper = exec.AbsentFunctionMapper(columnFilter, RangeParams(1, 2, 11), "metric")
     val resultObs = absentFunctionMapper(Observable.fromIterable(emptySample), querySession, 1000, resultSchema, Nil)
     val result = resultObs.toListL.runAsync.futureValue
@@ -150,6 +151,7 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
     val keys = result.map(_.key.labelValues)
     val rows = result.flatMap(_.rows.map(_.getDouble(1)).toList)
     keys.head.isEmpty shouldEqual true
+    rows shouldEqual expectedRows
   }
 
 }

--- a/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
@@ -140,4 +140,16 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
     keys.head shouldEqual expectedKeys
     rows shouldEqual expectedRows
   }
+
+  it("should not have keys when ColumnFilter is empty") {
+    val columnFilter = Seq.empty[ColumnFilter]
+    val absentFunctionMapper = exec.AbsentFunctionMapper(columnFilter, RangeParams(1, 2, 11), "metric")
+    val resultObs = absentFunctionMapper(Observable.fromIterable(emptySample), querySession, 1000, resultSchema, Nil)
+    val result = resultObs.toListL.runAsync.futureValue
+    result.size shouldEqual (1)
+    val keys = result.map(_.key.labelValues)
+    val rows = result.flatMap(_.rows.map(_.getDouble(1)).toList)
+    keys.head.isEmpty shouldEqual true
+  }
+
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Queries like absent(sum(http_requests_total{job="myjob"})) throw a class cast exception.

**New behavior :**
Use an empty column filter when passing an aggregate result into the absent function.

