### PR TITLE
feat(parser): Add support to parse LabelValues query filters

### DIFF
--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -23,6 +23,21 @@ class ParserSpec extends AnyFunSpec with Matchers {
     lp.toString shouldEqual queryToLpString._2
   }
 
+  it("labelvalues filter query") {
+    parseLabelValueSuccessfully("job=\"prometheus\", method=\"GET\"")
+    parseLabelValueSuccessfully("job=\"prometheus\", method=\"GET\"")
+    parseLabelValueSuccessfully("job=\"prometheus\", method!=\"GET\"")
+    parseLabelValueError("http_requests_total{job=\"prometheus\", method!=\"GET\"}")
+    parseLabelValueError("{__name__=\"prometheus\"}")
+    parseLabelValueError("job[__name__=\"prometheus\"]")
+    val queryToLpString = ("job=\"prometheus\", method!=\"GET\"" ->
+      "LabelValues(List(_ns_),List(ColumnFilter(job,Equals(prometheus)), ColumnFilter(method,NotEquals(GET))),1524855988000,1524855988000)")
+    val start: Long = 1524855988L
+    val end: Long = 1524855988L
+    val lp = Parser.labelValuesQueryToLogicalPlan(Seq("_ns_"), Some(queryToLpString._1), TimeStepParams(start, -1, end))
+    lp.toString shouldEqual queryToLpString._2
+  }
+
   it("parse basic scalar expressions") {
     parseSuccessfully("1")
     //    parse("+Inf")
@@ -592,6 +607,16 @@ class ParserSpec extends AnyFunSpec with Matchers {
   private def parseError(query: String) = {
     intercept[IllegalArgumentException] {
       Parser.parseQuery(query)
+    }
+  }
+
+  private def parseLabelValueSuccessfully(query: String) = {
+    Parser.parseLabelValueFilter(query)
+  }
+
+  private def parseLabelValueError(query: String) = {
+    intercept[IllegalArgumentException] {
+      Parser.parseLabelValueFilter(query)
     }
   }
 }

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -473,10 +473,10 @@ object LogicalPlan {
 
   def getRawSeriesFilters(logicalPlan: LogicalPlan): Seq[Seq[ColumnFilter]] = {
     LogicalPlan.findLeafLogicalPlans(logicalPlan).map { l =>
-      l match
-      {
-        case lp: RawSeries => lp.filters
-        case _             => Seq.empty
+      l match {
+        case lp: RawSeries    => lp.filters
+        case lp: LabelValues  => lp.filters
+        case _                => Seq.empty
       }
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Added support in Parser to parse LabelValues queries. Also, fixed an issue in `SingleClusterPlanner` where the label value filter materialize did not use `renameMetricFilter`.

Thank you @TanviBhavsar for the help in Parser.