### PR TITLE
measure(query): Measure latency of scans separately

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -150,7 +150,7 @@ trait ExecPlan extends QueryCommand {
               srv
             case rv: RangeVector =>
               // materialize, and limit rows per RV
-              val srv = SerializedRangeVector(rv, builder, recSchema, printTree(false))
+              val srv = SerializedRangeVector(rv, builder, recSchema, getClass.getSimpleName, span)
               numResultSamples += srv.numRowsInt
               // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
               if (enforceLimit && numResultSamples > queryContext.sampleLimit)

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -48,7 +48,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
       new UTF8MapIteratorRowReader(iteratorMap.toIterator))
 
-    val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema, printTree(false)))
+    val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema, this.getClass.getSimpleName, span))
 
     span.finish()
     QueryResult(id, resultSchema, srvSeq)

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -162,7 +162,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         override def numRows: Option[Int] = Option(samples.size)
 
       }
-      SerializedRangeVector(rv, builder, defaultRecSchema, printTree(useNewline = false))
+      SerializedRangeVector(rv, builder, defaultRecSchema, "PromQlRemoteExec-default")
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, defaultResultSchema, rangeVectors)
@@ -196,7 +196,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         override def numRows: Option[Int] = Option(samples.size)
 
       }
-      SerializedRangeVector(rv, builder, histRecSchema, printTree(useNewline = false))
+      SerializedRangeVector(rv, builder, histRecSchema, "PromQlRemoteExec-hist")
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, histResultSchema, rangeVectors)

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -279,7 +279,7 @@ final case class SortFunctionMapper(function: SortFunctionId) extends RangeVecto
 
       // Create SerializedRangeVector so that sorting does not consume rows iterator
       val resultRv = source.toListL.map { rvs =>
-         rvs.map(SerializedRangeVector(_, builder, recSchema, "sortExecPlan")).
+         rvs.map(SerializedRangeVector(_, builder, recSchema, getClass.getSimpleName)).
            sortBy { rv => if (rv.rows.hasNext) rv.rows.next().getDouble(1) else Double.NaN
         }(ordering)
 

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
@@ -2,6 +2,8 @@ package filodb.query.exec.aggregator
 
 import scala.collection.mutable
 
+import kamon.Kamon
+
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.FiloSchedulers
 import filodb.core.memstore.FiloSchedulers.QuerySchedName
@@ -86,6 +88,7 @@ class CountValuesRowAggregator(label: String, limit: Int = 1000) extends RowAggr
       ColumnInfo("value", ColumnType.DoubleColumn))
     val recSchema = SerializedRangeVector.toSchema(colSchema)
     val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
+    val span = Kamon.spanBuilder(s"execplan-scan-latency-TopBottomK").start()
     try {
       FiloSchedulers.assertThreadName(QuerySchedName)
       // aggRangeVector.rows.take below triggers the ChunkInfoIterator which requires lock/release
@@ -108,6 +111,7 @@ class CountValuesRowAggregator(label: String, limit: Int = 1000) extends RowAggr
       aggRangeVector.rows.close()
       ChunkMap.releaseAllSharedLocks()
     }
+    span.finish()
     resRvs.map { case (key, builder) =>
       val numRows = builder.allContainers.map(_.countRecords()).sum
       new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0)

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -2,6 +2,8 @@ package filodb.query.exec.aggregator
 
 import scala.collection.mutable
 
+import kamon.Kamon
+
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.FiloSchedulers
 import filodb.core.memstore.FiloSchedulers.QuerySchedName
@@ -86,6 +88,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
       ColumnInfo("value", ColumnType.DoubleColumn))
     val recSchema = SerializedRangeVector.toSchema(colSchema)
     val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
+    val span = Kamon.spanBuilder(s"execplan-scan-latency-TopBottomK").start()
     try {
       FiloSchedulers.assertThreadName(QuerySchedName)
       ChunkMap.validateNoSharedLocks()
@@ -108,6 +111,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator {
       aggRangeVector.rows().close()
       ChunkMap.releaseAllSharedLocks()
     }
+    span.finish()
     resRvs.map { case (key, builder) =>
       val numRows = builder.allContainers.map(_.countRecords).sum
       new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Step2 latency measured includes monix task wait time in queue

**New behavior :**

We need to measure scan latency separately. This is the non-asynchronous part of the query processing which should ideally remain the same (per sample scanned) irrespective of spread changes.

