### PR TITLE
bug(query): changes return non zero result when input has constant value

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -528,6 +528,6 @@ object DoubleLongWrapDataReader extends DoubleVectorDataReader {
     val ignorePrev = if (prev.isNaN) true
     else false
     val changes = LongBinaryVector(acc, vector).changes(acc, vector, start, end, prev.toLong, ignorePrev)
-    (changes._1.toDouble, changes._1.toDouble)
+    (changes._1.toDouble, changes._2.toDouble)
   }
 }

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -707,4 +707,15 @@ class AggrOverTimeFunctionsSpec extends RawDataWindowingSpec {
       aggregated shouldEqual List((100000, 0.0), (120000, 2.0), (140000, 2.0))
     } should have message "Query timeout in filodb.core.store.WindowedChunkIterator after 180 seconds"
   }
+
+  it("should return 0 for changes on constant value") {
+    val data = List.fill(1000)(1.586365307E9)
+    val startTS = 1599071100L
+    val tuples = data.zipWithIndex.map { case (d, t) => (startTS + t * 15, d) }
+    val rv = timeValueRVPk(tuples)
+    val chunkedIt = new ChunkedWindowIteratorD(rv, 1599073500L, 300000,  1599678300L, 10800000,
+      new ChangesChunkedFunctionD(), querySession)
+    val aggregated = chunkedIt.map(x => (x.getLong(0), x.getDouble(1))).toList
+    aggregated.foreach(x => x._2 shouldEqual(0))
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Incorrect prev value returned by DoubleLongWrapDataReader.changes

**New behavior :**
Return correct value
