### PR TITLE
bug(coord): Add extra by and on keys in QueryPlanner

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import com.typesafe.scalalogging.StrictLogging
 
+import filodb.coordinator.queryplanner.LogicalPlanUtils.{getLookBackMillis, getTimeFromLogicalPlan}
 import filodb.core.query.{QueryContext, RangeParams}
 import filodb.prometheus.ast.Vectors.PromMetricLabel
 import filodb.prometheus.ast.WindowConstants
@@ -234,5 +235,54 @@ object LogicalPlanUtils extends StrictLogging {
     } else {
       Seq(lp)
     }
+  }
+}
+
+/**
+ * Temporary utility to modify plan to add extra join-on keys or group-by keys
+ * for specific time ranges.
+ */
+object ExtraOnByKeysUtil {
+
+  def getRealOnLabels(lp: BinaryJoin, addStepKeyTimeRanges: Seq[Seq[Long]]): Seq[String] = {
+    if (shouldAddExtraKeys(lp.lhs, addStepKeyTimeRanges: Seq[Seq[Long]]) ||
+        shouldAddExtraKeys(lp.rhs, addStepKeyTimeRanges: Seq[Seq[Long]])) {
+      // add extra keys if ignoring clause is not specified
+      if (lp.ignoring.isEmpty) lp.on ++ extraByOnKeys
+      else lp.on
+    } else {
+      lp.on
+    }
+  }
+
+  def getRealByLabels(lp: Aggregate, addStepKeyTimeRanges: Seq[Seq[Long]]): Seq[String] = {
+    if (shouldAddExtraKeys(lp, addStepKeyTimeRanges)) {
+      // add extra keys if ignoring clause is not specified
+      if (lp.without.isEmpty) lp.by ++ extraByOnKeys
+      else lp.by
+    } else {
+      lp.by
+    }
+  }
+
+  private def shouldAddExtraKeys(lp: LogicalPlan, addStepKeyTimeRanges: Seq[Seq[Long]]): Boolean = {
+    // need to check if raw time range in query overlaps with configured addStepKeyTimeRanges
+    val range = getTimeFromLogicalPlan(lp)
+    val lookback = getLookBackMillis(lp)
+    queryTimeRangeRequiresExtraKeys(range.startMs - lookback, range.endMs, addStepKeyTimeRanges)
+  }
+
+  val extraByOnKeys = Seq("_pi_", "_step_")
+  /**
+   * Returns true if two time ranges (x1, x2) and (y1, y2) overlap
+   */
+  private def rangeOverlaps(x1: Long, x2: Long, y1: Long, y2: Long): Boolean = {
+    Math.max(x1, y1) <= Math.min(x2, y2)
+  }
+
+  private def queryTimeRangeRequiresExtraKeys(rawStartMs: Long,
+                                              rawEndMs: Long,
+                                              addStepKeyTimeRanges: Seq[Seq[Long]]): Boolean = {
+    addStepKeyTimeRanges.exists { r => rangeOverlaps(rawStartMs, rawEndMs, r(0), r(1)) }
   }
 }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -257,7 +257,7 @@ object ExtraOnByKeysUtil {
 
   def getRealByLabels(lp: Aggregate, addStepKeyTimeRanges: Seq[Seq[Long]]): Seq[String] = {
     if (shouldAddExtraKeys(lp, addStepKeyTimeRanges)) {
-      // add extra keys if ignoring clause is not specified
+      // add extra keys if without clause is not specified
       if (lp.without.isEmpty) lp.by ++ extraByOnKeys
       else lp.by
     } else {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerMaterializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerMaterializer.scala
@@ -1,8 +1,6 @@
 package filodb.coordinator.queryplanner
 
-import com.typesafe.scalalogging.StrictLogging
 import java.util.concurrent.ThreadLocalRandom
-import kamon.Kamon
 
 import filodb.core.metadata.{DatasetOptions, Schemas}
 import filodb.core.query.{QueryContext, RangeParams}
@@ -140,24 +138,4 @@ trait  PlannerMaterializer {
         vectors
       }
     }
-}
-
-object PlannerUtil extends StrictLogging {
-
-  val bjBetweenAggAndNonAgg = Kamon.counter("join-between-agg-non-agg").withoutTags()
-
-  def validateBinaryJoin(lhs: Seq[ExecPlan], rhs: Seq[ExecPlan], queryContext: QueryContext): Any = {
-
-    if (lhs.exists(_.isInstanceOf[LocalPartitionReduceAggregateExec]) &&
-      !rhs.exists(_.isInstanceOf[LocalPartitionReduceAggregateExec])) {
-      logger.info(s"Saw Binary Join between aggregate(lhs) and non-aggregate (rhs). ${queryContext.origQueryParams}")
-      bjBetweenAggAndNonAgg.increment()
-    }
-
-    if (!lhs.exists(_.isInstanceOf[LocalPartitionReduceAggregateExec]) &&
-      rhs.exists(_.isInstanceOf[LocalPartitionReduceAggregateExec])) {
-      logger.info(s"Saw Binary Join between non-aggregate(lhs) and aggregate(rhs): ${queryContext.origQueryParams}")
-      bjBetweenAggAndNonAgg.increment()
-    }
-  }
 }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -202,8 +202,7 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     val stitchedRhs = if (rhs.needsStitch) Seq(StitchRvsExec(qContext, pickDispatcher(rhs.plans), rhs.plans))
     else rhs.plans
 
-
-    PlannerUtil.validateBinaryJoin(lhs.plans, rhs.plans, qContext)
+    val onKeysReal = ExtraOnByKeysUtil.getRealOnLabels(lp, queryConfig.addStepKeyTimeRanges)
 
     // TODO Currently we create separate exec plan node for stitching.
     // Ideally, we can go one step further and add capability to NonLeafNode plans to pre-process
@@ -214,11 +213,11 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     val targetActor = pickDispatcher(stitchedLhs ++ stitchedRhs)
     val joined = if (lp.operator.isInstanceOf[SetOperator])
       Seq(exec.SetOperatorExec(qContext, targetActor, stitchedLhs, stitchedRhs, lp.operator,
-        LogicalPlanUtils.renameLabels(lp.on, dsOptions.metricColumn),
+        LogicalPlanUtils.renameLabels(onKeysReal, dsOptions.metricColumn),
         LogicalPlanUtils.renameLabels(lp.ignoring, dsOptions.metricColumn), dsOptions.metricColumn))
     else
       Seq(BinaryJoinExec(qContext, targetActor, stitchedLhs, stitchedRhs, lp.operator, lp.cardinality,
-        LogicalPlanUtils.renameLabels(lp.on, dsOptions.metricColumn),
+        LogicalPlanUtils.renameLabels(onKeysReal, dsOptions.metricColumn),
         LogicalPlanUtils.renameLabels(lp.ignoring, dsOptions.metricColumn),
         LogicalPlanUtils.renameLabels(lp.include, dsOptions.metricColumn), dsOptions.metricColumn))
     PlanResult(joined, false)
@@ -227,6 +226,8 @@ class SingleClusterPlanner(dsRef: DatasetRef,
   private def materializeAggregate(qContext: QueryContext,
                                    lp: Aggregate): PlanResult = {
     val toReduceLevel1 = walkLogicalPlanTree(lp.vectors, qContext)
+    val byKeysReal = ExtraOnByKeysUtil.getRealByLabels(lp, queryConfig.addStepKeyTimeRanges)
+
     // Now we have one exec plan per shard
     /*
      * Note that in order for same overlapping RVs to not be double counted when spread is increased,
@@ -242,7 +243,7 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     toReduceLevel1.plans.foreach {
       _.addRangeVectorTransformer(AggregateMapReduce(lp.operator, lp.params,
         LogicalPlanUtils.renameLabels(lp.without, dsOptions.metricColumn),
-        LogicalPlanUtils.renameLabels(lp.by, dsOptions.metricColumn)))
+        LogicalPlanUtils.renameLabels(byKeysReal, dsOptions.metricColumn)))
     }
 
     val toReduceLevel2 =

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -202,7 +202,7 @@ class SingleClusterPlanner(dsRef: DatasetRef,
     val stitchedRhs = if (rhs.needsStitch) Seq(StitchRvsExec(qContext, pickDispatcher(rhs.plans), rhs.plans))
     else rhs.plans
 
-    val onKeysReal = ExtraOnByKeysUtil.getRealOnLabels(lp, queryConfig.addStepKeyTimeRanges)
+    val onKeysReal = ExtraOnByKeysUtil.getRealOnLabels(lp, queryConfig.addExtraOnByKeysTimeRanges)
 
     // TODO Currently we create separate exec plan node for stitching.
     // Ideally, we can go one step further and add capability to NonLeafNode plans to pre-process
@@ -226,7 +226,7 @@ class SingleClusterPlanner(dsRef: DatasetRef,
   private def materializeAggregate(qContext: QueryContext,
                                    lp: Aggregate): PlanResult = {
     val toReduceLevel1 = walkLogicalPlanTree(lp.vectors, qContext)
-    val byKeysReal = ExtraOnByKeysUtil.getRealByLabels(lp, queryConfig.addStepKeyTimeRanges)
+    val byKeysReal = ExtraOnByKeysUtil.getRealByLabels(lp, queryConfig.addExtraOnByKeysTimeRanges)
 
     // Now we have one exec plan per shard
     /*

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
@@ -60,7 +60,7 @@ class SinglePartitionPlanner(planners: Map[String, QueryPlanner],
       case _             => getPlanner(logicalPlan.rhs).materialize(logicalPlan.rhs, rhsQueryContext)
     }
 
-    val onKeysReal = ExtraOnByKeysUtil.getRealOnLabels(logicalPlan, queryConfig.addStepKeyTimeRanges)
+    val onKeysReal = ExtraOnByKeysUtil.getRealOnLabels(logicalPlan, queryConfig.addExtraOnByKeysTimeRanges)
 
     if (logicalPlan.operator.isInstanceOf[SetOperator])
       SetOperatorExec(qContext, InProcessPlanDispatcher, Seq(lhsExec), Seq(rhsExec), logicalPlan.operator,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
@@ -1,6 +1,6 @@
 package filodb.coordinator.queryplanner
 
-import filodb.core.query.{PromQlQueryParams, QueryContext}
+import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext}
 import filodb.query.{BinaryJoin, LabelValues, LogicalPlan, SeriesKeysByFilters, SetOperator}
 import filodb.query.exec._
 
@@ -12,8 +12,10 @@ import filodb.query.exec._
   * @param plannerSelector a function that selects the planner name given the metric name
   *
   */
-class SinglePartitionPlanner(planners: Map[String, QueryPlanner], plannerSelector: String => String,
-                             datasetMetricColumn: String)
+class SinglePartitionPlanner(planners: Map[String, QueryPlanner],
+                             plannerSelector: String => String,
+                             datasetMetricColumn: String,
+                             queryConfig: QueryConfig)
   extends QueryPlanner {
 
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
@@ -58,15 +60,15 @@ class SinglePartitionPlanner(planners: Map[String, QueryPlanner], plannerSelecto
       case _             => getPlanner(logicalPlan.rhs).materialize(logicalPlan.rhs, rhsQueryContext)
     }
 
-    PlannerUtil.validateBinaryJoin(Seq(lhsExec), Seq(rhsExec), qContext)
+    val onKeysReal = ExtraOnByKeysUtil.getRealOnLabels(logicalPlan, queryConfig.addStepKeyTimeRanges)
 
     if (logicalPlan.operator.isInstanceOf[SetOperator])
       SetOperatorExec(qContext, InProcessPlanDispatcher, Seq(lhsExec), Seq(rhsExec), logicalPlan.operator,
-        LogicalPlanUtils.renameLabels(logicalPlan.on, datasetMetricColumn),
+        LogicalPlanUtils.renameLabels(onKeysReal, datasetMetricColumn),
         LogicalPlanUtils.renameLabels(logicalPlan.ignoring, datasetMetricColumn), datasetMetricColumn)
     else
       BinaryJoinExec(qContext, InProcessPlanDispatcher, Seq(lhsExec), Seq(rhsExec), logicalPlan.operator,
-        logicalPlan.cardinality, LogicalPlanUtils.renameLabels(logicalPlan.on, datasetMetricColumn),
+        logicalPlan.cardinality, LogicalPlanUtils.renameLabels(onKeysReal, datasetMetricColumn),
         LogicalPlanUtils.renameLabels(logicalPlan.ignoring, datasetMetricColumn),
         LogicalPlanUtils.renameLabels(logicalPlan.include, datasetMetricColumn), datasetMetricColumn)
   }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
@@ -53,4 +53,9 @@ class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
     getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual extraByOnKeys
   }
 
+  it("should not add extra keys when no overlap with configured time ranges") {
+    val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m]))""", TimeStepParams(40000L, 100, 50000))
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq.empty
+  }
+
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
@@ -15,7 +15,7 @@ class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
 
   it("should add extra by keys for aggregate when no keys present") {
     val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m]))""", TimeStepParams(20000, 100, 30000))
-    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual ExtraOnByKeysUtil.extraByOnKeys
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual extraByOnKeys
   }
 
   it("should not add extra by keys for aggregate when without present") {
@@ -27,19 +27,19 @@ class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
   it("should add extra by keys for aggregate when on already keys present") {
     val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m])) by (pod)""",
       TimeStepParams(20000, 100, 30000))
-    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq("pod", "_pi_", "_step_")
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq("pod") ++ extraByOnKeys
   }
 
   it("should add extra on keys for binary join when no keys present") {
     val lp = Parser.queryRangeToLogicalPlan("""foo + bar """,
       TimeStepParams(20000, 100, 30000))
-    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual ExtraOnByKeysUtil.extraByOnKeys
+    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual extraByOnKeys
   }
 
   it("should add extra on keys for binary join when on already keys present") {
     val lp = Parser.queryRangeToLogicalPlan("""foo + on(pod) bar """,
       TimeStepParams(20000, 100, 30000))
-    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual Seq("pod", "_pi_", "_step_")
+    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual Seq("pod") ++ extraByOnKeys
   }
 
   it("should not add extra on keys for binary join when ignoring present") {
@@ -50,7 +50,7 @@ class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
 
   it("should add extra keys even with overlap is inside of the first lookback range") {
     val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m]))""", TimeStepParams(30005L, 100, 40000))
-    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual ExtraOnByKeysUtil.extraByOnKeys
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual extraByOnKeys
   }
 
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
@@ -1,0 +1,56 @@
+package filodb.coordinator.queryplanner
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.prometheus.ast.TimeStepParams
+import filodb.prometheus.parse.Parser
+import filodb.query.{Aggregate, BinaryJoin}
+
+class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
+
+  import ExtraOnByKeysUtil._
+
+  val extraKeysTimeRange = Seq(Seq(25000000L, 30000000L))
+
+  it("should add extra by keys for aggregate when no keys present") {
+    val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m]))""", TimeStepParams(20000, 100, 30000))
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual ExtraOnByKeysUtil.extraByOnKeys
+  }
+
+  it("should not add extra by keys for aggregate when without present") {
+    val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m])) without (pod)""",
+                               TimeStepParams(20000, 100, 30000))
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq.empty
+  }
+
+  it("should add extra by keys for aggregate when on already keys present") {
+    val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m])) by (pod)""",
+      TimeStepParams(20000, 100, 30000))
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq("pod", "_pi_", "_step_")
+  }
+
+  it("should add extra on keys for binary join when no keys present") {
+    val lp = Parser.queryRangeToLogicalPlan("""foo + bar """,
+      TimeStepParams(20000, 100, 30000))
+    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual ExtraOnByKeysUtil.extraByOnKeys
+  }
+
+  it("should add extra on keys for binary join when on already keys present") {
+    val lp = Parser.queryRangeToLogicalPlan("""foo + on(pod) bar """,
+      TimeStepParams(20000, 100, 30000))
+    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual Seq("pod", "_pi_", "_step_")
+  }
+
+  it("should not add extra on keys for binary join when ignoring present") {
+    val lp = Parser.queryRangeToLogicalPlan("""foo + ignoring(pod) bar """,
+      TimeStepParams(20000, 100, 30000))
+    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual Seq.empty
+  }
+
+  it("should add extra keys even with overlap is inside of the first lookback range") {
+    val lp = Parser.queryRangeToLogicalPlan("""sum(rate(foo[5m]))""", TimeStepParams(30005L, 100, 40000))
+    getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual ExtraOnByKeysUtil.extraByOnKeys
+  }
+
+}

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -4,10 +4,11 @@ import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import monix.execution.Scheduler
+
 import filodb.coordinator.ShardMapper
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
-import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query.{EmptyQueryConfig, PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.ChunkSource
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
@@ -80,7 +81,7 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
   val plannerSelector = (metricName: String) => { if (metricName.equals("rr1")) "rules1"
   else if (metricName.equals("rr2")) "rules2" else "local" }
 
-  val engine = new SinglePartitionPlanner(planners, plannerSelector, "_metric_")
+  val engine = new SinglePartitionPlanner(planners, plannerSelector, "_metric_", EmptyQueryConfig)
 
   it("should generate Exec plan for simple query") {
     val lp = Parser.queryToLogicalPlan("test{job = \"app\"}", 1000, 1000)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -8,7 +8,7 @@ import monix.execution.Scheduler
 import filodb.coordinator.ShardMapper
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
-import filodb.core.query.{EmptyQueryConfig, PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.ChunkSource
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
@@ -81,7 +81,7 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
   val plannerSelector = (metricName: String) => { if (metricName.equals("rr1")) "rules1"
   else if (metricName.equals("rr2")) "rules2" else "local" }
 
-  val engine = new SinglePartitionPlanner(planners, plannerSelector, "_metric_", EmptyQueryConfig)
+  val engine = new SinglePartitionPlanner(planners, plannerSelector, "_metric_", queryConfig)
 
   it("should generate Exec plan for simple query") {
     val lp = Parser.queryToLogicalPlan("test{job = \"app\"}", 1000, 1000)

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -174,6 +174,12 @@ filodb {
     # Enable faster rate/increase/delta calculations. Depends on drop detection in chunks (detectDrops=true)
     faster-rate = true
 
+    # Time ranges for which additional join/by keys need to be added implicitly. Add as a 2D array, example:
+    # [
+    #   [1600224662, 1600229662],
+    #   [1600204662, 1600209662]
+    # ]
+    add-step-key-time-ranges = []
   }
 
   shard-manager {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -179,7 +179,7 @@ filodb {
     #   [1600224662, 1600229662],
     #   [1600204662, 1600209662]
     # ]
-    add-step-key-time-ranges = []
+    add-extra-by-on-key-time-ranges = []
   }
 
   shard-manager {

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -15,6 +15,11 @@ class QueryConfig(queryConfig: Config) {
   lazy val minStepMs = queryConfig.getDuration("min-step").toMillis
   lazy val fastReduceMaxWindows = queryConfig.getInt("fastreduce-max-windows")
   lazy val routingConfig = queryConfig.getConfig("routing")
+  lazy val addStepKeyTimeRanges = {
+    val v = queryConfig.as[Seq[Seq[Long]]]("add-step-key-time-ranges")
+    require(v.forall(r => r.size == 2 && r(0) < r(1)))
+    v
+  }
 
   /**
    * Feature flag test: returns true if the config has an entry with "true", "t" etc

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -15,8 +15,8 @@ class QueryConfig(queryConfig: Config) {
   lazy val minStepMs = queryConfig.getDuration("min-step").toMillis
   lazy val fastReduceMaxWindows = queryConfig.getInt("fastreduce-max-windows")
   lazy val routingConfig = queryConfig.getConfig("routing")
-  lazy val addStepKeyTimeRanges = {
-    val v = queryConfig.as[Seq[Seq[Long]]]("add-step-key-time-ranges")
+  lazy val addExtraOnByKeysTimeRanges = {
+    val v = queryConfig.as[Seq[Seq[Long]]]("add-extra-by-on-key-time-ranges")
     require(v.forall(r => r.size == 2 && r(0) < r(1)))
     v
   }

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -63,6 +63,8 @@ filodb {
     min-step = 1 ms
     faster-rate = true
     fastreduce-max-windows = 50
+    add-step-key-time-ranges = []
+
   }
 
   spread-default = 1

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -63,8 +63,7 @@ filodb {
     min-step = 1 ms
     faster-rate = true
     fastreduce-max-windows = 50
-    add-step-key-time-ranges = []
-
+    add-extra-by-on-key-time-ranges = []
   }
 
   spread-default = 1

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -52,8 +52,6 @@ final case class BinaryJoinExec(queryContext: QueryContext,
   require(!on.contains(metricColumn), "On cannot contain metric name")
 
   val onLabels = on.map(Utf8Str(_)).toSet
-  // publishInterval and step tags always needs to be included in join key
-  val withExtraOnLabels = onLabels ++ Seq("_pi_".utf8, "_step_".utf8)
   val ignoringLabels = ignoring.map(Utf8Str(_)).toSet
   val ignoringLabelsForJoin = ignoringLabels + metricColumn.utf8
   // if onLabels is non-empty, we are doing matching based on on-label, otherwise we are
@@ -125,7 +123,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
   }
 
   private def joinKeys(rvk: RangeVectorKey): Map[Utf8Str, Utf8Str] = {
-    if (onLabels.nonEmpty) rvk.labelValues.filter(lv => withExtraOnLabels.contains(lv._1))
+    if (onLabels.nonEmpty) rvk.labelValues.filter(lv => onLabels.contains(lv._1))
     else rvk.labelValues.filterNot(lv => ignoringLabelsForJoin.contains(lv._1))
   }
 
@@ -136,9 +134,8 @@ final case class BinaryJoinExec(queryContext: QueryContext,
     if (binaryOp.isInstanceOf[MathOperator]) result = result - Utf8Str(metricColumn)
 
     if (cardinality == Cardinality.OneToOne) {
-      result =
-        if (onLabels.nonEmpty) result.filter(lv => withExtraOnLabels.contains(lv._1)) // retain what is in onLabel list
-        else result.filterNot(lv => ignoringLabels.contains(lv._1)) // remove the labels in ignoring label list
+      result = if (onLabels.nonEmpty) result.filter(lv => onLabels.contains(lv._1)) // retain what is in onLabel list
+               else result.filterNot(lv => ignoringLabels.contains(lv._1)) // remove the labels in ignoring label list
     } else if (cardinality == Cardinality.OneToMany || cardinality == Cardinality.ManyToOne) {
       // For group_left/group_right add labels in include from one side. Result should have all keys from many side
       include.foreach { x =>

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -41,8 +41,6 @@ final case class SetOperatorExec(queryContext: QueryContext,
   require(!on.contains(metricColumn), "On cannot contain metric name")
 
   val onLabels = on.map(Utf8Str(_)).toSet
-  // TODO Add unit tests for automatic inclusion of _pi_ and _step_ in the join key
-  val withExtraOnLabels = onLabels ++ Seq("_pi_".utf8, "_step_".utf8)
   val ignoringLabels = ignoring.map(Utf8Str(_)).toSet + metricColumn.utf8
   // if onLabels is non-empty, we are doing matching based on on-label, otherwise we are
   // doing matching based on ignoringLabels even if it is empty
@@ -83,7 +81,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
   }
 
   private def joinKeys(rvk: RangeVectorKey): Map[Utf8Str, Utf8Str] = {
-    if (onLabels.nonEmpty) rvk.labelValues.filter(lv => withExtraOnLabels.contains(lv._1))
+    if (onLabels.nonEmpty) rvk.labelValues.filter(lv => onLabels.contains(lv._1))
     else rvk.labelValues.filterNot(lv => ignoringLabels.contains(lv._1))
   }
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -143,7 +143,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     result.map(_.key).toSet.size shouldEqual 100
   }
 
-  it("should implictly add step and pi tag as join key on OneToOne joins") {
+  it("should deal with additional step and pi tag as join key on OneToOne joins") {
     val lhs1: RangeVector = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
         Map("__name__".utf8 -> s"someMetricLhs".utf8, "_pi_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))
@@ -177,7 +177,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Array(dummyPlan), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Nil, Nil, "__name__")
+      Seq("_step_", "_pi_"), Nil, Nil, "__name__")
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema)))
@@ -193,7 +193,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
   }
 
-  it("should implictly add step and pi tag as join key on OneToMany joins") {
+  it("should deal with implictly added step and pi tag as join key on OneToMany joins") {
     val lhs1: RangeVector = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
         Map("__name__".utf8 -> s"someMetricLhs".utf8, "_pi_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Extra join-on or group-by keys are added during planning time and not during runtime.
* Keys are added only if query overlaps with configured time ranges
* Keeps code clean, and improves unit testability
