### PR TITLE
bug(coord): Extra on-keys should be added only if on is nonEmpty

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -205,8 +205,8 @@ object ExtraOnByKeysUtil {
   def getRealOnLabels(lp: BinaryJoin, addStepKeyTimeRanges: Seq[Seq[Long]]): Seq[String] = {
     if (shouldAddExtraKeys(lp.lhs, addStepKeyTimeRanges: Seq[Seq[Long]]) ||
         shouldAddExtraKeys(lp.rhs, addStepKeyTimeRanges: Seq[Seq[Long]])) {
-      // add extra keys if ignoring clause is not specified
-      if (lp.ignoring.isEmpty) lp.on ++ extraByOnKeys
+      // add extra keys if ignoring clause is not specified and on is specified
+      if (lp.on.nonEmpty) lp.on ++ extraByOnKeys
       else lp.on
     } else {
       lp.on

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
@@ -30,10 +30,10 @@ class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
     getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq("pod") ++ extraByOnKeys
   }
 
-  it("should add extra on keys for binary join when no keys present") {
+  it("should not add extra on keys for binary join when no join keys present") {
     val lp = Parser.queryRangeToLogicalPlan("""foo + bar """,
       TimeStepParams(20000, 100, 30000))
-    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual extraByOnKeys
+    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual Seq.empty
   }
 
   it("should add extra on keys for binary join when on already keys present") {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.9.2"
+version in ThisBuild := "0.9.9.3"


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Query Planner changes to add join key were not done equivalently.
Now adding extra on-keys only if `on` specifier is non-empty already