### PR TITLE
bug(query):  head call on empty list in LogicalPlanUtils

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -150,27 +150,36 @@ object LogicalPlanUtils {
     * NOTE: Plan should be PeriodicSeriesPlan
     */
   def getRawSeriesStartTime(logicalPlan: LogicalPlan): Option[Long] = {
-    LogicalPlan.findLeafLogicalPlans(logicalPlan).head match {
-      case lp: RawSeries => lp.rangeSelector match {
-        case rs: IntervalSelector => Some(rs.from)
-        case _ => None
+    val leaf = LogicalPlan.findLeafLogicalPlans(logicalPlan)
+    if (leaf.isEmpty) None else {
+      leaf.head match {
+        case lp: RawSeries => lp.rangeSelector match {
+          case rs: IntervalSelector => Some(rs.from)
+          case _ => None
+        }
+        case _ => throw new BadQueryException(s"Invalid logical plan $logicalPlan")
       }
-      case _                      => throw new BadQueryException(s"Invalid logical plan $logicalPlan")
     }
   }
 
   def getOffsetMillis(logicalPlan: LogicalPlan): Long = {
-    LogicalPlan.findLeafLogicalPlans(logicalPlan).head match {
-      case lp: RawSeries => lp.offsetMs.getOrElse(0)
-      case _             => 0
+    val leaf = LogicalPlan.findLeafLogicalPlans(logicalPlan)
+    if (leaf.isEmpty) 0 else {
+      leaf.head match {
+        case lp: RawSeries => lp.offsetMs.getOrElse(0)
+        case _ => 0
+      }
     }
   }
 
   def getLookBackMillis(logicalPlan: LogicalPlan): Long = {
     val staleDataLookbackMillis = WindowConstants.staleDataLookbackMillis
-    LogicalPlan.findLeafLogicalPlans(logicalPlan).head match {
-      case lp: RawSeries => lp.lookbackMs.getOrElse(staleDataLookbackMillis)
-      case _             => 0
+    val leaf = LogicalPlan.findLeafLogicalPlans(logicalPlan)
+    if (leaf.isEmpty) 0 else {
+      leaf.head match {
+        case lp: RawSeries => lp.lookbackMs.getOrElse(staleDataLookbackMillis)
+        case _ => 0
+      }
     }
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
@@ -58,4 +58,9 @@ class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
     getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq.empty
   }
 
+  it("should not add extra on keys for nested scalar queries") {
+    val lp = Parser.queryRangeToLogicalPlan("""foo + 10/2""",
+      TimeStepParams(20000, 100, 30000))
+    getRealOnLabels(lp.asInstanceOf[BinaryJoin], extraKeysTimeRange) shouldEqual Seq.empty
+  }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ExtraOnByKeysUtilSpec.scala
@@ -58,6 +58,7 @@ class ExtraOnByKeysUtilSpec extends AnyFunSpec with Matchers {
     getRealByLabels(lp.asInstanceOf[Aggregate], extraKeysTimeRange) shouldEqual Seq.empty
   }
 
+// TODO remove test when unnecessary binary join bug is fixed
   it("should not add extra on keys for nested scalar queries") {
     val lp = Parser.queryRangeToLogicalPlan("""foo + 10/2""",
       TimeStepParams(20000, 100, 30000))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.9.3"
+version in ThisBuild := "0.9.9.4"


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Head is called on empty list 

**New behavior :**
Check whether list is empty before calling head