### PR TITLE
fix(core,memory): Allow blocks to be reclaimed when ODP fails.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -89,6 +89,7 @@ extends RawToPartitionMaker with StrictLogging {
 
           if (!tsPart.chunkmapContains(chunkID)) {
             val chunkPtrs = new ArrayBuffer[BinaryVectorPtr](rawVectors.length)
+            memFactory.startMetaSpan()
             var metaAddr: Long = 0
             try {
               copyToOffHeap(rawVectors, memFactory, chunkPtrs)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -122,7 +122,7 @@ object TimeSeriesShard {
   /**
     * Copies serialized ChunkSetInfo bytes from persistent storage / on-demand paging.
     */
-  def writeMeta(addr: Long, partitionID: Int, bytes: Array[Byte], vectors: Array[BinaryVectorPtr]): Unit = {
+  def writeMeta(addr: Long, partitionID: Int, bytes: Array[Byte], vectors: ArrayBuffer[BinaryVectorPtr]): Unit = {
     UnsafeUtils.setInt(UnsafeUtils.ZeroPointer, addr, partitionID)
     ChunkSetInfo.copy(bytes, addr + 4)
     cforRange { 0 until vectors.size } { i =>

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -319,7 +319,11 @@ class BlockMemFactory(blockStore: BlockManager,
   def discardMetaSpan(): Unit = {
     if (metadataSpanActive) {
       metadataSpan.foreach { blk =>
-        blk.markReclaimable()
+        if (markFullBlocksAsReclaimable) {
+          blk.markReclaimable()
+        } else synchronized {
+          fullBlocks += blk
+        }
       }
       metadataSpan.clear()
       metadataSpanActive = false

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -311,28 +311,6 @@ class BlockMemFactory(blockStore: BlockManager,
     metaAddr
   }
 
-  /**
-    * Discards the current metadata span, to be called when a failure occurs during allocation.
-    * The blocks are then marked as reclaimable, and they are fully reclaimed later by the
-    * headroom task.
-    */
-  def discardMetaSpan(): Unit = {
-    if (metadataSpanActive) {
-      metadataSpan.foreach { blk =>
-        if (blk != metadataSpan.last) {
-          if (markFullBlocksAsReclaimable) {
-            blk.markReclaimable()
-          } else synchronized {
-            fullBlocks += blk
-          }
-        }
-      }
-
-      metadataSpan.clear()
-      metadataSpanActive = false
-    }
-  }
-
   def markUsedBlocksReclaimable(): Unit = synchronized {
     fullBlocks.foreach(_.markReclaimable())
     fullBlocks.clear()

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -319,12 +319,15 @@ class BlockMemFactory(blockStore: BlockManager,
   def discardMetaSpan(): Unit = {
     if (metadataSpanActive) {
       metadataSpan.foreach { blk =>
-        if (markFullBlocksAsReclaimable) {
-          blk.markReclaimable()
-        } else synchronized {
-          fullBlocks += blk
+        if (blk != metadataSpan.last) {
+          if (markFullBlocksAsReclaimable) {
+            blk.markReclaimable()
+          } else synchronized {
+            fullBlocks += blk
+          }
         }
       }
+
       metadataSpan.clear()
       metadataSpanActive = false
     }

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -311,6 +311,21 @@ class BlockMemFactory(blockStore: BlockManager,
     metaAddr
   }
 
+  /**
+    * Discards the current metadata span, to be called when a failure occurs during allocation.
+    * The blocks are then marked as reclaimable, and they are fully reclaimed later by the
+    * headroom task.
+    */
+  def discardMetaSpan(): Unit = {
+    if (metadataSpanActive) {
+      metadataSpan.foreach { blk =>
+        blk.markReclaimable()
+      }
+      metadataSpan.clear()
+      metadataSpanActive = false
+    }
+  }
+
   def markUsedBlocksReclaimable(): Unit = synchronized {
     fullBlocks.foreach(_.markReclaimable())
     fullBlocks.clear()


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
When ODP fails to allocate, it leaves the metadata span open, and the blocks it contains aren't marked as reclaimable. The next time a span is started, the existing blocks within the span are lost.

**New behavior :**
When ODP fails, an explicit discard method is called to mark the blocks as reclaimable.
