### PR TITLE
bug(core): Mark ingestion blocks reclaimable on cassandra failure

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -30,7 +30,7 @@ import filodb.core.metadata.{Schema, Schemas}
 import filodb.core.query.{ColumnFilter, QuerySession}
 import filodb.core.store._
 import filodb.memory._
-import filodb.memory.data.ChunkMap
+import filodb.memory.data.Shutdown
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 import filodb.memory.format.BinaryVector.BinaryVectorPtr
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -332,7 +332,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   private[memstore] final val reclaimLock = blockStore.reclaimLock
 
   // Requires blockStore.
-  startHeadroomTask(ingestSched)
+  private val headroomTask = startHeadroomTask(ingestSched)
 
   // Each shard has a single ingestion stream at a time.  This BlockMemFactory is used for buffer overflow encoding
   // strictly during ingest() and switchBuffers().
@@ -951,8 +951,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     val result = Future.sequence(Seq(writeChunksFuture, writeDirtyPartKeysFuture, pubDownsampleFuture)).map {
       _.find(_.isInstanceOf[ErrorResponse]).getOrElse(Success)
     }.flatMap {
-      case Success           => blockHolder.markUsedBlocksReclaimable()
-                                commitCheckpoint(ref, shardNum, flushGroup)
+      case Success           => commitCheckpoint(ref, shardNum, flushGroup)
       case er: ErrorResponse => Future.successful(er)
     }.recover { case e =>
       logger.error(s"Internal Error when persisting chunks in dataset=$ref shard=$shardNum - should " +
@@ -962,6 +961,10 @@ class TimeSeriesShard(val ref: DatasetRef,
     result.onComplete { resp =>
       assertThreadName(IngestSchedName)
       try {
+        // Mark used blocks as reclaimable even on failure. Even if cassandra write fails or other errors occur,
+        // we cannot leave blocks as not reclaimable and also release the factory back into pool.
+        // Can try out tracking unreclaimed blockMemFactories without releasing, but it needs to be separate PR.
+        blockHolder.markUsedBlocksReclaimable()
         blockFactoryPool.release(blockHolder)
         flushDoneTasks(flushGroup, resp)
         tracer.finish()
@@ -1499,7 +1502,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     })
   }
 
-  private def startHeadroomTask(sched: Scheduler): Unit = {
+  private def startHeadroomTask(sched: Scheduler) = {
     sched.scheduleWithFixedDelay(1, 1, TimeUnit.MINUTES, new Runnable {
       var numFailures = 0
 
@@ -1510,9 +1513,8 @@ class TimeSeriesShard(val ref: DatasetRef,
         } else {
           numFailures += 1
           if (numFailures >= 5) {
-            logger.error(s"Headroom task was unable to free memory for $numFailures consecutive attempts. " +
-              s"Shutting down process. shard=$shardNum")
-            ChunkMap.haltAndCatchFire()
+            Shutdown.haltAndCatchFire(new RuntimeException(s"Headroom task was unable to free memory " +
+              s"for $numFailures consecutive attempts. Shutting down process. shard=$shardNum"))
           }
         }
       }
@@ -1556,6 +1558,7 @@ class TimeSeriesShard(val ref: DatasetRef,
        method to ensure that no threads are accessing the memory before it's freed.
     blockStore.releaseBlocks()
     */
+    headroomTask.cancel()
     ingestSched.shutdown()
   }
 }

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -316,6 +316,7 @@ class BlockMemFactory(blockStore: BlockManager,
     fullBlocks.clear()
   }
 
+
   protected def ensureCapacity(forSize: Long): Block = synchronized {
     var block = accessCurrentBlock()
     if (block.hasCapacity(forSize)) {
@@ -325,12 +326,10 @@ class BlockMemFactory(blockStore: BlockManager,
       }
     } else {
       val newBlock = requestBlock()
-      if (!metadataSpanActive) {
-        if (markFullBlocksAsReclaimable) {
-          block.markReclaimable()
-        } else {
-          fullBlocks += block
-        }
+      if (markFullBlocksAsReclaimable) {
+        block.markReclaimable()
+      } else {
+        fullBlocks += block
       }
       block = newBlock
       currentBlock = block

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -316,7 +316,6 @@ class BlockMemFactory(blockStore: BlockManager,
     fullBlocks.clear()
   }
 
-
   protected def ensureCapacity(forSize: Long): Block = synchronized {
     var block = accessCurrentBlock()
     if (block.hasCapacity(forSize)) {
@@ -326,10 +325,12 @@ class BlockMemFactory(blockStore: BlockManager,
       }
     } else {
       val newBlock = requestBlock()
-      if (markFullBlocksAsReclaimable) {
-        block.markReclaimable()
-      } else {
-        fullBlocks += block
+      if (!metadataSpanActive) {
+        if (markFullBlocksAsReclaimable) {
+          block.markReclaimable()
+        } else {
+          fullBlocks += block
+        }
       }
       block = newBlock
       currentBlock = block

--- a/memory/src/main/scala/filodb.memory/data/Shutdown.scala
+++ b/memory/src/main/scala/filodb.memory/data/Shutdown.scala
@@ -5,9 +5,7 @@ import com.typesafe.scalalogging.StrictLogging
 object Shutdown extends StrictLogging {
 
   def haltAndCatchFire(e: Exception, unitTest: Boolean = false): Unit = {
-    if (unitTest) {
-      throw new Error(e)
-    }
+    if (unitTest) throw e
     logger.error(s"Shutting down process since it may be in an unstable/corrupt state", e)
     Runtime.getRuntime.halt(189)
   }

--- a/memory/src/main/scala/filodb.memory/data/Shutdown.scala
+++ b/memory/src/main/scala/filodb.memory/data/Shutdown.scala
@@ -1,10 +1,13 @@
 package filodb.memory.data
 
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
 
 object Shutdown extends StrictLogging {
 
+  val forcedShutdowns = Kamon.counter("forced-shutdowns").withoutTags()
   def haltAndCatchFire(e: Exception, unitTest: Boolean = false): Unit = {
+    forcedShutdowns.increment()
     if (unitTest) throw e
     logger.error(s"Shutting down process since it may be in an unstable/corrupt state", e)
     Runtime.getRuntime.halt(189)

--- a/memory/src/main/scala/filodb.memory/data/Shutdown.scala
+++ b/memory/src/main/scala/filodb.memory/data/Shutdown.scala
@@ -1,0 +1,15 @@
+package filodb.memory.data
+
+import com.typesafe.scalalogging.StrictLogging
+
+object Shutdown extends StrictLogging {
+
+  def haltAndCatchFire(e: Exception, unitTest: Boolean = false): Unit = {
+    if (unitTest) {
+      throw new Error(e)
+    }
+    logger.error(s"Shutting down process since it may be in an unstable/corrupt state", e)
+    Runtime.getRuntime.halt(189)
+  }
+
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

* Blocks are not marked reclaimable if there is a cassandra error, but they are released back to pool where they will never be marked as reclaimable.
* When we run out of memory in ingestion pipeline, we continue without cleanup

**New behavior :**

* Mark blocks as reclaimable even though the chunks are not completely flushed. 
* Shutdown process if we run out of ingestion memory.
