### PR TITLE
bug(query): add quotes to filter value

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -47,14 +47,6 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
     }
   }
 
-  private def getLabelValuesUrlParams(lp: LabelValues, queryParams: PromQlQueryParams) = {
-    val quote = if (queryParams.remoteQueryPath.get.contains("""/v2/label/""")) """"""" else ""
-    // Filter value should be enclosed in quotes for label values v2 endpoint
-    val filters = lp.filters.map{ f => s"""${f.column}${f.filter.operatorString}$quote${f.filter.valuesStrings.
-      head}$quote"""}.mkString(",")
-    Map("filter" -> filters, "labels" -> lp.labelNames.mkString(","))
-  }
-
   /**
     * Converts Route objects returned by FailureProvider to ExecPlan
     */
@@ -85,8 +77,8 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
           val httpEndpoint = remoteHttpEndpoint + queryParams.remoteQueryPath.getOrElse("")
           rootLogicalPlan match {
             case lp: LabelValues         => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-                                            getLabelValuesUrlParams(lp, queryParams), qContext, InProcessPlanDispatcher,
-                                            dsRef, promQlParams)
+                                            PlannerUtil.getLabelValuesUrlParams(lp, queryParams), qContext,
+                                            InProcessPlanDispatcher, dsRef, promQlParams)
             case lp: SeriesKeysByFilters => val urlParams = Map("match[]" -> queryParams.promQl)
                                             MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
                                               urlParams, qContext, InProcessPlanDispatcher, dsRef, promQlParams)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -48,11 +48,10 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
   }
 
   private def getLabelValuesUrlParams(lp: LabelValues, queryParams: PromQlQueryParams) = {
-    val filters = if (queryParams.remoteQueryPath.get.contains("""/v2/label/""")) lp.filters.map{ f =>
-      s"""${f.column}${f.filter.operatorString}"${f.filter.valuesStrings.head}""""}.mkString(",") //Filter value should
-     // be enclosed in quotes
-    else lp.filters.map{ f => f.column + f.filter.operatorString + f.filter.valuesStrings.head }.
-      mkString(",")
+    val quote = if (queryParams.remoteQueryPath.get.contains("""/v2/label/""")) """"""" else ""
+    // Filter value should be enclosed in quotes for label values v2 endpoint
+    val filters = lp.filters.map{ f => s"""${f.column}${f.filter.operatorString}$quote${f.filter.valuesStrings.
+      head}$quote"""}.mkString(",")
     Map("filter" -> filters, "labels" -> lp.labelNames.mkString(","))
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -180,7 +180,7 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
                      // ^^Filter value should be enclosed in quotes
                       else lp.filters.map{ f => f.column + f.filter.operatorString + f.filter.valuesStrings.head }.
                         mkString(",")
-        createMetadataRemoteExec(qContext, queryParams, p,  Map("filter" ->filters, "labels" ->
+        createMetadataRemoteExec(qContext, queryParams, p, Map("filter" -> filters, "labels" ->
           lp.labelNames.mkString(",")))
       }
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -175,11 +175,10 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
       if (p.partitionName.equals(localPartitionName))
         localPartitionPlanner.materialize(lp.copy(startMs = p.timeRange.startMs, endMs = p.timeRange.endMs), qContext)
       else {
-        val filters = if (queryParams.remoteQueryPath.get.contains("""/v2/label/""")) lp.filters.map{ f =>
-                      s"""${f.column}${f.filter.operatorString}"${f.filter.valuesStrings.head}""""}.mkString(",")
-                     // ^^Filter value should be enclosed in quotes
-                      else lp.filters.map{ f => f.column + f.filter.operatorString + f.filter.valuesStrings.head }.
-                        mkString(",")
+        val quote = if (queryParams.remoteQueryPath.get.contains("""/v2/label/""")) """"""" else ""
+        // ^^Filter value should be enclosed in quotes for label values V2 endpoint
+        val filters = lp.filters.map{ f => s"""${f.column}${f.filter.operatorString}$quote${f.filter.
+          valuesStrings.head}$quote"""}.mkString(",")
         createMetadataRemoteExec(qContext, queryParams, p, Map("filter" -> filters, "labels" ->
           lp.labelNames.mkString(",")))
       }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -174,14 +174,8 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
       logger.debug(s"partitionInfo=$p; queryParams=$queryParams")
       if (p.partitionName.equals(localPartitionName))
         localPartitionPlanner.materialize(lp.copy(startMs = p.timeRange.startMs, endMs = p.timeRange.endMs), qContext)
-      else {
-        val quote = if (queryParams.remoteQueryPath.get.contains("""/v2/label/""")) """"""" else ""
-        // ^^Filter value should be enclosed in quotes for label values V2 endpoint
-        val filters = lp.filters.map{ f => s"""${f.column}${f.filter.operatorString}$quote${f.filter.
-          valuesStrings.head}$quote"""}.mkString(",")
-        createMetadataRemoteExec(qContext, queryParams, p, Map("filter" -> filters, "labels" ->
-          lp.labelNames.mkString(",")))
-      }
+      else
+        createMetadataRemoteExec(qContext, queryParams, p, PlannerUtil.getLabelValuesUrlParams(lp, queryParams))
     }
     if (execPlans.size == 1) execPlans.head
     else LabelValuesDistConcatExec(qContext, InProcessPlanDispatcher,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerMaterializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerMaterializer.scala
@@ -3,7 +3,7 @@ package filodb.coordinator.queryplanner
 import java.util.concurrent.ThreadLocalRandom
 
 import filodb.core.metadata.{DatasetOptions, Schemas}
-import filodb.core.query.{QueryContext, RangeParams}
+import filodb.core.query.{PromQlQueryParams, QueryContext, RangeParams}
 import filodb.prometheus.ast.Vectors.PromMetricLabel
 import filodb.query._
 import filodb.query.exec._
@@ -139,4 +139,17 @@ trait  PlannerMaterializer {
         vectors
       }
     }
+}
+
+object PlannerUtil {
+   /**
+   * Returns URL params for label values which is used to create Metadata remote exec plan
+   */
+   def getLabelValuesUrlParams(lp: LabelValues, queryParams: PromQlQueryParams): Map[String, String] = {
+    val quote = if (queryParams.remoteQueryPath.get.contains("""/v2/label/""")) """"""" else ""
+    // Filter value should be enclosed in quotes for label values v2 endpoint
+    val filters = lp.filters.map{ f => s"""${f.column}${f.filter.operatorString}$quote${f.filter.valuesStrings.
+      head}$quote"""}.mkString(",")
+    Map("filter" -> filters, "labels" -> lp.labelNames.mkString(","))
+  }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -5,6 +5,7 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
 import filodb.coordinator.ShardMapper
 import filodb.core.MetricsTestData
 import filodb.core.metadata.Schemas

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -5,7 +5,6 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
 import filodb.coordinator.ShardMapper
 import filodb.core.MetricsTestData
 import filodb.core.metadata.Schemas
@@ -416,6 +415,43 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers {
     remoteExec2.params.processMultiPartition shouldEqual false
     remoteExec2.queryEndpoint shouldEqual "remote-url"
 
+  }
+
+  it ("should generate Exec plan for Metadata Label values query") {
+    def partitions(timeRange: TimeRange): List[PartitionAssignment] =
+      List(PartitionAssignment("remote", "remote-url",
+        TimeRange(startSeconds * 1000, localPartitionStart * 1000 - 1)),
+        PartitionAssignment("local", "local-url", TimeRange(localPartitionStart * 1000, endSeconds * 1000)))
+
+    val partitionLocationProvider = new PartitionLocationProvider {
+      override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] =
+        partitions(timeRange)
+
+      override def getAuthorizedPartitions(timeRange: TimeRange): List[PartitionAssignment] =
+        partitions(timeRange)
+    }
+
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val lp = Parser.labelValuesQueryToLogicalPlan(Seq("""__metric__"""), Some("""_ws_="demo""""), TimeStepParams(startSeconds, step, endSeconds) )
+
+    val promQlQueryParams = PromQlQueryParams(
+      "", startSeconds, step, endSeconds, None, Some("/api/v2/label/values"),
+      processMultiPartition = true)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    execPlan.isInstanceOf[LabelValuesDistConcatExec] shouldEqual (true)
+    execPlan.children(0).isInstanceOf[LabelValuesDistConcatExec] shouldEqual(true)
+    execPlan.children(1).isInstanceOf[MetadataRemoteExec] shouldEqual(true)
+
+    val expectedUrlParams = Map("filter" -> """_ws_="demo"""", "labels" -> "__metric__")
+    execPlan.children(1).asInstanceOf[MetadataRemoteExec].urlParams shouldEqual(expectedUrlParams) // Filter values
+                                                                                                  // should have quotes
+    execPlan.children(1).asInstanceOf[MetadataRemoteExec].params.endSecs shouldEqual(localPartitionStart - 1)
+    execPlan.children(0).asInstanceOf[LabelValuesDistConcatExec].children(0).asInstanceOf[LabelValuesExec].startMs shouldEqual
+      (localPartitionStart * 1000)
+    execPlan.children(0).asInstanceOf[LabelValuesDistConcatExec].children(0).asInstanceOf[LabelValuesExec].endMs shouldEqual
+      (endSeconds * 1000)
   }
 
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Filter value is not enclosed in quotes for Label values v2 endpoint in MultipartitionPlanner and HighAvailabilityPlanner


**New behavior :**
Enclose filter value in quotes
