### PR TITLE
bug(memory): Blocks need to be marked reclaimable correctly

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -929,7 +929,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         // as reclaimable. But the factory could be used for a different flush group. Not the same one. It can
         // succeed, and the wrong blocks can be marked as reclaimable.
         // Can try out tracking unreclaimed blockMemFactories without releasing, but it needs to be separate PR.
-        blockHolder.markUsedBlocksReclaimable()
+        blockHolder.markFullBlocksReclaimable()
         blockFactoryPool.release(blockHolder)
         flushDoneTasks(flushGroup, resp)
         tracer.finish()

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -255,7 +255,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part.unflushedChunksets shouldEqual 1
 
      val currBlock = blockHolder.currentBlock // hang on to these; we'll later test reclaiming them manually
-     blockHolder.markUsedBlocksReclaimable()
+     blockHolder.markFullBlocksReclaimable()
 
      // Now, switch buffers and flush again, ingesting 5 more rows
      // There should now be 3 chunks total, the current write buffers plus the two flushed ones

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -398,7 +398,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
   }
 
   //scalastyle:off
-  protected def tryReclaim(num: Int): Unit = {
+  protected[memory] def tryReclaim(num: Int): Int = {
     var reclaimed = 0
 
     // First reclaim time-ordered blocks which are marked as reclaimable.
@@ -456,6 +456,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
       }
       removed
     }
+    reclaimed
   }
   //scalastyle:on
 

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -40,7 +40,7 @@ class BlockMemFactoryPool(blockStore: BlockManager,
 
   def blocksContainingPtr(ptr: BinaryRegion.NativePointer): Seq[Block] =
     factoryPool.flatMap { bmf =>
-      val blocks = bmf.fullBlocks ++ Option(bmf.currentBlock).toList
+      val blocks = bmf.fullBlocksToBeMarkedAsReclaimable ++ Option(bmf.currentBlock).toList
       BlockDetective.containsPtr(ptr, blocks)
     }
 }

--- a/memory/src/test/scala/filodb.memory/BlockMemFactorySpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockMemFactorySpec.scala
@@ -1,0 +1,49 @@
+package filodb.memory
+
+import scala.collection.JavaConverters._
+
+import com.kenai.jffi.PageManager
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.memory.PageAlignedBlockManagerSpec.testReclaimer
+
+class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
+
+  val pageSize = PageManager.getInstance().pageSize()
+
+  it should "Mark all blocks of BlockMemFactory as reclaimable when used as done in ingestion pipeline" in {
+    val stats = new MemoryStats(Map("test1" -> "test1"))
+    val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1)
+    val bmf = new BlockMemFactory(blockManager, None, 50, Map("test" -> "val"), false)
+
+    // simulate encoding of multiple ts partitions in flush group
+
+    for { flushGroup <- 0 to 1 } {
+      for {tsParts <- 0 to 5} {
+        bmf.startMetaSpan()
+        for {chunks <- 0 to 3} {
+          bmf.allocateOffheap(1000)
+        }
+        bmf.endMetaSpan(d => {}, 45)
+      }
+      // full blocks are tracked as they are allocated
+      flushGroup match {
+        case 0 => bmf.fullBlocksToBeMarkedAsReclaimable.size shouldEqual 5
+        case 1 => bmf.fullBlocksToBeMarkedAsReclaimable.size shouldEqual 6
+      }
+      // full blocks are marked as reclaimable
+      bmf.markFullBlocksReclaimable()
+    }
+
+    // only the current block is not reclaimable
+    blockManager.usedBlocks.asScala.count(!_.canReclaim) shouldEqual 1
+
+    blockManager.usedBlocks.size shouldEqual 12
+    blockManager.tryReclaim(3) shouldEqual 3
+    blockManager.usedBlocks.size shouldEqual 9 // 3 are reclaimed
+
+    blockManager.releaseBlocks()
+  }
+
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Address cases where blocks were not being marked as reclaimable in ingestion pipeline causing blocks to leak.
Pulling some of the fixes from https://github.com/filodb/FiloDB/pull/918 so non-contentious bug fixes can go in quickly.
Unit tests will come in that PR.