### PR TITLE
bug(query): use multipartitionPlanner for shard key regex metadata queries

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -56,6 +56,8 @@ class ShardKeyRegexPlanner(dataset: Dataset,
       case lp: VectorPlan                  => materializeVectorPlan(qContext, lp)
       case lp: Aggregate                   => materializeAggregate(lp, qContext)
       case lp: BinaryJoin                  => materializeBinaryJoin(lp, qContext)
+      case lp: LabelValues                 => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
+      case lp: SeriesKeysByFilters         => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
       case _                               => materializeOthers(logicalPlan, qContext)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Metadata queries are not handled in shard key regex planner

**New behavior :**
Return multipartitionPlanner.materialize for shard key regex metadata queries
