### PR TITLE
bug(query): Remove span per result RV; add spans/markers to track child plans

### DIFF
--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -48,24 +48,15 @@ kamon {
     port = 9095
   }
   modules {
-    metriclog-reporter {
-      enabled = true
-      name = "MetricLog Reporter"
-      description = "Log all Metrics"
-      factory = "filodb.coordinator.KamonLogger$MetricsLogFactory"
-    }
-    spanlog-reporter {
-      enabled = true
-      name = "SpanLog Reporter"
-      description = "Log all traced Spans"
-      factory = "filodb.coordinator.KamonLogger$SpanLogFactory"
-    }
-    status-page {
-      enabled = false
-    }
-    zipkin-reporter {
-      enabled = false
-    }
+    zipkin-reporter.enabled = false
+    prometheus-reporter.enabled = false
+    status-page.enabled = false
+  }
+
+  zipkin {
+    url = "https://localhost:9411/api/v2/spans"
+    max.requests = 128
+    message.max.bytes = 131072
   }
 
   metric.tick-interval = 60s

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -50,7 +50,7 @@ class RangeVectorSpec  extends AnyFunSpec with Matchers {
     val builder = SerializedRangeVector.newBuilder()
 
     // Sharing one builder across multiple input RangeVectors
-    val srvs = rvs.map(rv => SerializedRangeVector(rv, builder, schema, "Unit-test"))
+    val srvs = rvs.map(rv => SerializedRangeVector(rv, builder, schema))
 
     // Now verify each of them
     val observedTs = srvs(0).rows.toSeq.map(_.getLong(0))

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -3,6 +3,7 @@ package filodb.query.exec
 import scala.collection.mutable
 
 import kamon.Kamon
+import kamon.metric.MeasurementUnit
 import monix.eval.Task
 import monix.reactive.Observable
 
@@ -65,6 +66,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
   protected[exec] def compose(childResponses: Observable[(QueryResponse, Int)],
                               firstSchema: Task[ResultSchema],
                               querySession: QuerySession): Observable[RangeVector] = {
+    val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
       case (QueryResult(_, _, result), _)
         if (result.size  > queryContext.plannerParams.joinQueryCardLimit && cardinality == Cardinality.OneToOne) =>
@@ -73,9 +75,11 @@ final case class BinaryJoinExec(queryContext: QueryContext,
       case (QueryResult(_, _, result), i) => (result, i)
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map { resp =>
-      Kamon.histogram("query-execute-time-elapsed-step2-child-results-available")
+      span.mark("binary-join-child-results-available")
+      Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",
+        MeasurementUnit.time.milliseconds)
         .withTag("plan", getClass.getSimpleName)
-        .record(System.currentTimeMillis - queryContext.submitTime)
+        .record(Math.max(0, System.currentTimeMillis - queryContext.submitTime))
       // NOTE: We can't require this any more, as multischema queries may result in not a QueryResult if the
       //       filter returns empty results.  The reason is that the schema will be undefined.
       // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -119,17 +119,16 @@ trait ExecPlan extends QueryCommand {
         Kamon.histogram("query-execute-time-elapsed-step1-done",
           MeasurementUnit.time.milliseconds)
           .withTag("plan", getClass.getSimpleName)
-          .record(System.currentTimeMillis - startExecute)
+          .record(Math.max(0, System.currentTimeMillis - startExecute))
         doEx
       }
     }
 
     // Step 2: Run connect monix pipeline to transformers, materialize the result
     def step2(res: ExecResult) = res.schema.map { resSchema =>
-      Kamon.histogram("query-execute-time-elapsed-step2-start",
-        MeasurementUnit.time.milliseconds)
+      Kamon.histogram("query-execute-time-elapsed-step2-start", MeasurementUnit.time.milliseconds)
         .withTag("plan", getClass.getSimpleName)
-        .record(System.currentTimeMillis - startExecute)
+        .record(Math.max(0, System.currentTimeMillis - startExecute))
       val span = Kamon.spanBuilder(s"execute-step2-${getClass.getSimpleName}")
         .asChildOf(parentSpan)
         .tag("query-id", queryContext.queryId)
@@ -144,7 +143,6 @@ trait ExecPlan extends QueryCommand {
         Task.eval(QueryResult(queryContext.queryId, resSchema, Nil))
       } else {
         val finalRes = allTransformers.foldLeft((res.rvs, resSchema)) { (acc, transf) =>
-          span.mark(transf.getClass.getSimpleName)
           val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult)
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
@@ -153,10 +151,12 @@ trait ExecPlan extends QueryCommand {
         Kamon.histogram("query-execute-time-elapsed-step2-transformer-pipeline-setup",
                     MeasurementUnit.time.milliseconds)
           .withTag("plan", getClass.getSimpleName)
-          .record(System.currentTimeMillis - startExecute)
+          .record(Math.max(0, System.currentTimeMillis - startExecute))
+        span.mark("step2-transformer-pipeline-setup")
         val builder = SerializedRangeVector.newBuilder()
         @volatile var numResultSamples = 0 // BEWARE - do not modify concurrently!!
         finalRes._1
+          .doOnStart(_ => span.mark("before-first-materialized-result-rv"))
           .map {
             case srv: SerializableRangeVector =>
               numResultSamples += srv.numRowsInt
@@ -167,7 +167,7 @@ trait ExecPlan extends QueryCommand {
               srv
             case rv: RangeVector =>
               // materialize, and limit rows per RV
-              val srv = SerializedRangeVector(rv, builder, recSchema, getClass.getSimpleName, span)
+              val srv = SerializedRangeVector(rv, builder, recSchema)
               numResultSamples += srv.numRowsInt
               // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
               if (enforceLimit && numResultSamples > queryContext.plannerParams.sampleLimit)
@@ -175,12 +175,13 @@ trait ExecPlan extends QueryCommand {
                   sampleLimit} samples. Try applying more filters or reduce time range.")
               srv
           }
+          .doOnTerminate(_ => span.mark("after-last-materialized-result-rv"))
           .toListL
           .map { r =>
             Kamon.histogram("query-execute-time-elapsed-step2-result-materialized",
-              MeasurementUnit.time.milliseconds)
+                  MeasurementUnit.time.milliseconds)
               .withTag("plan", getClass.getSimpleName)
-              .record(System.currentTimeMillis - startExecute)
+              .record(Math.max(0, System.currentTimeMillis - startExecute))
             val numBytes = builder.allContainers.map(_.numBytes).sum
             SerializedRangeVector.queryResultBytes.record(numBytes)
             span.mark(s"num-bytes: $numBytes")
@@ -393,6 +394,11 @@ abstract class NonLeafExecPlan extends ExecPlan {
                      (implicit sched: Scheduler): ExecResult = {
     val parentSpan = Kamon.currentSpan()
 
+    val span = Kamon.spanBuilder(s"execute-step1-child-result-composition-${getClass.getSimpleName}")
+      .asChildOf(parentSpan)
+      .tag("query-id", queryContext.queryId)
+      .start()
+
     // whether child tasks need to be executed sequentially.
     // parallelism 1 means, only one worker thread to process underlying tasks.
     val parallelism: Int = if (parallelChildTasks)
@@ -404,13 +410,16 @@ abstract class NonLeafExecPlan extends ExecPlan {
     // NOTE: It's really important to preserve the "index" of the child task, as joins depend on it
     val childTasks = Observable.fromIterable(children.zipWithIndex)
                                .mapAsync(parallelism) { case (plan, i) =>
-                                 dispatchRemotePlan(plan, parentSpan).map((_, i))
+                                 dispatchRemotePlan(plan, span).map((_, i))
                                }
 
     // The first valid schema is returned as the Task.  If all results are empty, then return
     // an empty schema.  Validate that the other schemas are the same.  Skip over empty schemas.
     var sch = ResultSchema.empty
-    val processedTasks = childTasks.collect {
+    val processedTasks = childTasks
+      .doOnStart(_ => span.mark("first-child-result-received"))
+      .doOnTerminate(_ => span.mark("last-child-result-received"))
+      .collect {
       case (res @ QueryResult(_, schema, _), i) if schema != ResultSchema.empty =>
         sch = reduceSchemas(sch, res)
         (res, i.toInt)
@@ -422,8 +431,11 @@ abstract class NonLeafExecPlan extends ExecPlan {
     val outputSchema = processedTasks.collect {
       case (QueryResult(_, schema, _), _) => schema
     }.firstOptionL.map(_.getOrElse(ResultSchema.empty))
-    val outputRvs = compose(processedTasks, outputSchema, querySession)
-    ExecResult(outputRvs, outputSchema)
+      Kamon.runWithSpan(span, false) {
+        val outputRvs = compose(processedTasks, outputSchema, querySession)
+          .doOnTerminate(_ => span.finish())
+        ExecResult(outputRvs, outputSchema)
+      }
   }
 
   /**

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -49,7 +49,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
       new UTF8MapIteratorRowReader(iteratorMap.toIterator))
 
-    val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema, this.getClass.getSimpleName, span))
+    val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema))
 
     span.finish()
     QueryResult(id, resultSchema, srvSeq)

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -115,7 +115,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         override def numRows: Option[Int] = Option(samples.size)
 
       }
-      SerializedRangeVector(rv, builder, recordSchema.get("default").get, "PromQlRemoteExec-default")
+      SerializedRangeVector(rv, builder, recordSchema.get("default").get)
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("default").get, rangeVectors)
@@ -149,7 +149,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         override def numRows: Option[Int] = Option(samples.size)
 
       }
-      SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, "PromQlRemoteExec-hist")
+      SerializedRangeVector(rv, builder, recordSchema.get("histogram").get)
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("histogram").get, rangeVectors)
@@ -173,7 +173,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
           }
           override def numRows: Option[Int] = Option(d.aggregateResponse.get.aggregateSampl.size)
         }
-      SerializedRangeVector(rv, builder, recordSchema.get(Avg.entryName).get, "PromQlRemoteExec-avg")
+      SerializedRangeVector(rv, builder, recordSchema.get(Avg.entryName).get)
     }
 
         // TODO: Handle stitching with verbose flag

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -279,7 +279,7 @@ final case class SortFunctionMapper(function: SortFunctionId) extends RangeVecto
 
       // Create SerializedRangeVector so that sorting does not consume rows iterator
       val resultRv = source.toListL.map { rvs =>
-         rvs.map(SerializedRangeVector(_, builder, recSchema, getClass.getSimpleName)).
+         rvs.map(SerializedRangeVector(_, builder, recSchema)).
            sortBy { rv => if (rv.rows.hasNext) rv.rows.next().getDouble(1) else Double.NaN
         }(ordering)
 

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 import kamon.Kamon
+import kamon.metric.MeasurementUnit
 import monix.eval.Task
 import monix.reactive.Observable
 
@@ -52,13 +53,16 @@ final case class SetOperatorExec(queryContext: QueryContext,
   protected[exec] def compose(childResponses: Observable[(QueryResponse, Int)],
                               firstSchema: Task[ResultSchema],
                               querySession: QuerySession): Observable[RangeVector] = {
+    val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
       case (QueryResult(_, schema, result), i) => (schema, result, i)
       case (QueryError(_, ex), _)              => throw ex
     }.toListL.map { resp =>
-      Kamon.histogram("query-execute-time-elapsed-step2-child-results-available")
+      span.mark("binary-join-child-results-available")
+      Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",
+        MeasurementUnit.time.milliseconds)
         .withTag("plan", getClass.getSimpleName)
-        .record(System.currentTimeMillis - queryContext.submitTime)
+        .record(Math.max(0, System.currentTimeMillis - queryContext.submitTime))
       // NOTE: We can't require this any more, as multischema queries may result in not a QueryResult if the
       //       filter returns empty results.  The reason is that the schema will be undefined.
       // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -287,7 +287,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val recSchema = SerializedRangeVector.toSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                                          ColumnInfo("tdig", ColumnType.StringColumn)))
     val builder = SerializedRangeVector.newBuilder()
-    val srv = SerializedRangeVector(result7(0), builder, recSchema, "Unit-Test")
+    val srv = SerializedRangeVector(result7(0), builder, recSchema)
 
     val resultObs7b = RangeVectorAggregator.present(agg7, Observable.now(srv), 1000)
     val finalResult = resultObs7b.toListL.runAsync.futureValue

--- a/scripts/schema-truncate.sh
+++ b/scripts/schema-truncate.sh
@@ -39,7 +39,7 @@ done
 
 if [[ "${KEYSP}" != "${FILO_DOWNSAMPLE_KEYSPACE}" ]]; then
 cat << EOF
-TRUNCATE ${KEYSP}.${DSET}_pks_by_update_time
+TRUNCATE ${KEYSP}.${DSET}_pks_by_update_time;
 EOF
 fi
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Removed scan span which was per result RV. It created too many spans - was not intended earlier.
* Added spans and markers to track scans, and child result retrieval.