### PR TITLE
debug(query): Marking spans when dispatch of child plan is done

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -410,7 +410,9 @@ abstract class NonLeafExecPlan extends ExecPlan {
     // NOTE: It's really important to preserve the "index" of the child task, as joins depend on it
     val childTasks = Observable.fromIterable(children.zipWithIndex)
                                .mapAsync(parallelism) { case (plan, i) =>
-                                 dispatchRemotePlan(plan, span).map((_, i))
+                                 val task = dispatchRemotePlan(plan, span).map((_, i))
+                                 span.mark(s"plan-dispatched-${plan.getClass.getSimpleName}")
+                                 task
                                }
 
     // The first valid schema is returned as the Task.  If all results are empty, then return


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

