### PR TITLE
misc(query): add user-agent to remote query headers

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -350,9 +350,10 @@ object CliMain extends FilodbClusterNode {
     val ref = DatasetRef(dataset)
     val spreadProvider: Option[SpreadProvider] = options.spread.map(s => StaticSpreadProvider(SpreadChange(0, s)))
 
-    val qOpts = QueryContext(origQueryParams = tsdbQueryParams, plannerParams = PlannerParams(spreadOverride =
-      spreadProvider, sampleLimit = options.sampleLimit, queryTimeoutMillis = options.timeout.toMillis.toInt, shardOverrides =
-      options.shardOverrides))
+    val qOpts = QueryContext(origQueryParams = tsdbQueryParams,
+      plannerParams = PlannerParams(applicationId = "filodb-cli", spreadOverride = spreadProvider,
+        sampleLimit = options.sampleLimit, queryTimeoutMillis = options.timeout.toMillis.toInt,
+        shardOverrides = options.shardOverrides))
     println(s"Sending query command to server for $ref with options $qOpts...")
     println(s"Query Plan:\n$plan")
     options.everyN match {

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -16,7 +16,8 @@ case class PromQlQueryParams(promQl: String, startSecs: Long, stepSecs: Long, en
 
 case object UnavailablePromQlQueryParams extends TsdbQueryParams
 
-case class PlannerParams(spread: Option[Int] = None,
+case class PlannerParams(applicationId: String = "filodb",
+                        spread: Option[Int] = None,
                         spreadOverride: Option[SpreadProvider] = None,
                         shardOverrides: Option[Seq[Int]] = None,
                         queryTimeoutMillis: Int = 30000,

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -28,7 +28,8 @@ case class MetadataRemoteExec(queryEndpoint: String,
 
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
                               (implicit sched: Scheduler): Future[QueryResponse] = {
-    remoteExecHttpClient.httpMetadataGet(queryEndpoint, httpTimeoutMs, queryContext.submitTime, getUrlParams())
+    remoteExecHttpClient.httpMetadataGet(queryContext.plannerParams.applicationId, queryEndpoint,
+      httpTimeoutMs, queryContext.submitTime, getUrlParams())
       .map { response =>
         response.unsafeBody match {
           case Left(error) => QueryError(queryContext.queryId, error.error)

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -43,7 +43,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
                               (implicit sched: Scheduler): Future[QueryResponse] = {
-    remoteExecHttpClient.httpGet(queryEndpoint, requestTimeoutMs, queryContext.submitTime, getUrlParams())
+    remoteExecHttpClient.httpGet(queryContext.plannerParams.applicationId, queryEndpoint,
+      requestTimeoutMs, queryContext.submitTime, getUrlParams())
       .map { response =>
         response.unsafeBody match {
           case Left(error) => QueryError(queryContext.queryId, error.error)

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -93,11 +93,13 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
  */
 trait RemoteExecHttpClient extends StrictLogging {
 
-  def httpGet(httpEndpoint: String, httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+  def httpGet(applicationId: String, httpEndpoint: String,
+              httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
              (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], SuccessResponse]]]
 
-  def httpMetadataGet(httpEndpoint: String, httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+  def httpMetadataGet(applicationId: String, httpEndpoint: String,
+                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
                      (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], MetadataSuccessResponse]]]
 
@@ -115,7 +117,8 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
 
   ShutdownHookThread(shutdown())
 
-  def httpGet(httpEndpoint: String, httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+  def httpGet(applicationId: String, httpEndpoint: String,
+              httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
              (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], SuccessResponse]]] = {
     val queryTimeElapsed = System.currentTimeMillis() - submitTime
@@ -123,13 +126,15 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
     val url = uri"$httpEndpoint?$urlParams"
     logger.debug("promQlExec url={}", url)
     sttp
+      .header(HeaderNames.UserAgent, applicationId)
       .get(url)
       .readTimeout(readTimeout)
       .response(asJson[SuccessResponse])
       .send()
   }
 
-  def httpMetadataGet(httpEndpoint: String, httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+  def httpMetadataGet(applicationId: String, httpEndpoint: String,
+                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
                      (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], MetadataSuccessResponse]]] = {
     val queryTimeElapsed = System.currentTimeMillis() - submitTime
@@ -137,6 +142,7 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
     val url = uri"$httpEndpoint?$urlParams"
     logger.debug("promMetadataExec url={}", url)
     sttp
+      .header(HeaderNames.UserAgent, applicationId)
       .get(url)
       .readTimeout(readTimeout)
       .response(asJson[MetadataSuccessResponse])


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Without a user-agent in query header, it is difficult to identify and track who is sending the requests.