### PR TITLE
feat(repair): spark job to migrate partitionKeys in case of disaster recovery

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
@@ -3,6 +3,7 @@ package filodb.cassandra.columnstore
 import java.lang.{Integer => JInt, Long => JLong}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters.asScalaIteratorConverter
 
 import com.datastax.driver.core.{ConsistencyLevel, Row}
 import monix.eval.Task
@@ -45,6 +46,17 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
     s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ?")
     .setConsistencyLevel(ConsistencyLevel.ONE)
 
+  private lazy val scanCqlWithStartEndTime = session.prepare(
+    s"SELECT partKey, startTime, endTime FROM $tableString " +
+      s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND startTime >= ? AND endTime <= ? " +
+      s"ALLOW FILTERING")
+    .setConsistencyLevel(ConsistencyLevel.ONE)
+
+  private lazy val readCql = session.prepare(
+    s"SELECT partKey, startTime, endTime FROM $tableString " +
+      s"WHERE partKey = ? ")
+    .setConsistencyLevel(ConsistencyLevel.ONE)
+
   private lazy val deleteCql = session.prepare(
     s"DELETE FROM $tableString " +
     s"WHERE partKey = ?"
@@ -74,7 +86,49 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
     } yield pk
   }
 
-  def deletePartKey(pk: Array[Byte], shard: Int): Future[Response] = {
+  /**
+   * Method used by repair job.
+   * Return rows consisting of partKey, start and end time.
+   */
+  def scanRowsByTimeNoAsync(tokens: Seq[(String, String)],
+                                startTime: Long,
+                                endTime: Long): Iterator[Row] = {
+    tokens.iterator.flatMap { case (start, end) =>
+      /*
+       * FIXME conversion of tokens to Long works only for Murmur3Partitioner because it generates
+       * Long based tokens. If other partitioners are used, this can potentially break.
+       * Correct way is to pass Token objects around and bind tokens with stmt.bind().setPartitionKeyToken(token)
+       */
+      val stmt = scanCqlWithStartEndTime.bind(start.toLong: java.lang.Long,
+        end.toLong: java.lang.Long,
+        startTime: java.lang.Long,
+        endTime: java.lang.Long)
+      session.execute(stmt).iterator.asScala
+    }
+  }
+
+  /**
+   * Returns PartKeyRecord for a given partKey bytes.
+   *
+   * @param pk partKey bytes
+   * @return Option[PartKeyRecord]
+   */
+  def readPartKey(pk: Array[Byte]) : Option[PartKeyRecord] = {
+    val iterator = session.execute(readCql.bind().setBytes(0, toBuffer(pk))).iterator()
+    if (iterator.hasNext) {
+      Some(PartitionKeysTable.rowToPartKeyRecord(iterator.next()))
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Deletes PartKeyRecord for a given partKey bytes.
+   *
+   * @param pk partKey bytes
+   * @return Future[Response]
+   */
+  def deletePartKey(pk: Array[Byte]): Future[Response] = {
     val  stmt = deleteCql.bind().setBytes(0, toBuffer(pk)).setConsistencyLevel(writeConsistencyLevel)
     connector.execStmtWithRetries(stmt)
   }

--- a/conf/timeseries-dev-buddy.conf
+++ b/conf/timeseries-dev-buddy.conf
@@ -1,0 +1,109 @@
+dataset = "buddy_prometheus"
+
+# Name of schema used for this dataset stream.  See filodb.schemas in filodb-defaults or any other server conf
+schema = "prom-counter"
+
+# Should not change once dataset has been set up on the server and data has been persisted to cassandra
+num-shards = 4
+
+min-num-nodes = 2
+# Length of chunks to be written, roughly
+sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"
+
+sourceconfig {
+  # Required FiloDB configurations
+  filo-topic-name = "timeseries-dev"
+
+  # Standard kafka configurations, e.g.
+  # This accepts both the standard kafka value of a comma-separated
+  # string and a Typesafe list of String values
+  # EXCEPT: do not populate value.deserializer, as the Kafka format is fixed in FiloDB to be messages of RecordContainer's
+  bootstrap.servers = "localhost:9092"
+  group.id = "filo-db-timeseries-ingestion"
+
+  # For tests - do not shut down and release memory after ingestion stops (with status IngestionStopped)
+  shutdown-ingest-after-stopped = true
+
+  # Values controlling in-memory store chunking, flushing, etc.
+  store {
+    # Interval it takes to flush ALL time series in a shard.  This time is further divided by groups-per-shard
+    flush-interval = 1h
+
+    # TTL for on-disk / C* data.  Data older than this may be purged.
+    disk-time-to-live = 24 hours
+
+    # amount of time paged chunks should be retained in memory.
+    # We need to have a minimum of x hours free blocks or else init won't work.
+    demand-paged-chunk-retention-period = 12 hours
+
+    # maximum userTime range allowed in a single chunk. This needs to be longer than flush interval
+    # to ensure that normal flushes result in only one chunk.
+    # If not specified, max-chunk-time = 1.1 * flush-interval
+    # max-chunk-time = 66 minutes
+
+    max-chunks-size = 400
+
+    # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,
+    # we need a maximum size, not a maximum number of items.
+    max-blob-buffer-size = 15000
+
+    # Number of bytes of offheap mem to allocate to chunk storage in each shard.  Ex. 1000MB, 1G, 2GB
+    # Assume 5 bytes per sample, should be roughly equal to (# samples per time series) * (# time series)
+    shard-mem-size = 512MB
+
+    # Number of bytes of offheap mem to allocate to write buffers for all shards.  Ex. 1000MB, 1G, 2GB
+    ingestion-buffer-mem-size = 200MB
+
+    # Maximum numer of write buffers to retain in each shard's WriteBufferPool.  Any extra buffers are released
+    # back to native memory, which helps memory reuse.
+    # max-buffer-pool-size = 10000
+
+    # Number of time series to evict at a time.
+    # num-partitions-to-evict = 1000
+
+    # Number of subgroups within each shard.  Persistence to a ChunkSink occurs one subgroup at a time, as does
+    # recovery from failure.  This many batches of flushes must occur to cover persistence of every partition
+    groups-per-shard = 20
+
+    # Use a "MultiPartitionScan" or Cassandra MULTIGET for on-demand paging. Might improve performance.
+    multi-partition-odp = false
+
+    # Amount of parallelism during on-demand paging
+    # demand-paging-parallelism = 4
+
+    # Number of retries for IngestionSource/Kafka initialization
+    # failure-retries = 3
+
+    # Amount of time to delay before retrying
+    # retry-delay = 15s
+
+    # Capacity of Bloom filter used to track evicted partitions.
+    # Tune this based on how much time series churn is expected before a FiloDB node
+    # will be restarted for upgrade/maintenance. Do not take into account churn created by
+    # time series that are purged due to retention. When a time series is not ingesting for retention
+    # period, it is purged, not evicted. Purged PartKeys are not added to Bloom Filter.
+    #
+    # To calculate Bloom Filter size:
+    # console> BloomFilter[String](5000000, falsePositiveRate = 0.01).numberOfBits
+    # res9: Long = 47925292
+    # Thats about 6MB
+    evicted-pk-bloom-filter-capacity = 50000
+
+    # Uncomment to log at DEBUG ingested samples matching these filters on Partition Key columns
+    # Only works for StringColumn fields in the partition key. Scope may be expanded later.
+    # trace-filters = {
+    #   metric = "bad-metric-to-log"
+    # }
+
+    # Limits maximum amount of data a single leaf query can scan
+    max-data-per-shard-query = 50 MB
+  }
+  downsample {
+    # Resolutions for downsampled data ** in ascending order **
+    resolutions = [ 1 minute, 5 minutes ]
+    # Retention of downsampled data for the corresponding resolution
+    ttls = [ 30 days, 183 days ]
+    # Raw schemas from which to downsample
+    raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram"]
+  }
+}

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -9,6 +9,7 @@ filodb {
 
   dataset-configs = [
     "conf/timeseries-dev-source.conf"
+    "conf/timeseries-dev-buddy.conf"
   ]
 
   quotas {

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -9,7 +9,8 @@ filodb {
 
   dataset-configs = [
     "conf/timeseries-dev-source.conf"
-    "conf/timeseries-dev-buddy.conf"
+# below conf used for testing DR data repair.
+#   "conf/timeseries-dev-buddy.conf"
   ]
 
   quotas {

--- a/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
@@ -1,0 +1,182 @@
+package filodb.repair
+
+import java.io.File
+import java.lang
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util
+
+import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.scalalogging.StrictLogging
+import monix.execution.Scheduler
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+import filodb.cassandra.FiloSessionProvider
+import filodb.cassandra.columnstore.CassandraColumnStore
+import filodb.core.{DatasetRef, GlobalConfig}
+import filodb.core.store.ScanSplit
+
+class PartitionKeysCopier(conf: SparkConf) {
+
+  private def openConfig(str: String) = {
+    val sysConfig = GlobalConfig.systemConfig.getConfig("filodb")
+    ConfigFactory.parseFile(new File(conf.get(str))).getConfig("filodb").withFallback(sysConfig)
+  }
+
+  def getShardNum: Int = {
+    def getConfig(path: lang.String): Config = {
+      ConfigFactory.parseFile(new File(path))
+    }
+
+    val sourceConfigPaths: util.List[lang.String] = sourceConfig.getStringList("dataset-configs")
+    val datasetConfig: Config = sourceConfigPaths.stream()
+      .map[Config](new util.function.Function[lang.String, Config]() {
+        override def apply(path: lang.String): Config = getConfig(path)
+      })
+      .filter(new util.function.Predicate[Config] {
+        override def test(conf: Config): Boolean = conf.getString("dataset").equals(sourceDataset)
+      })
+      .findFirst()
+      .orElseThrow()
+
+    val numShards = datasetConfig.getInt("num-shards")
+    numShards
+  }
+
+  // Examples: 2019-10-20T12:34:56Z  or  2019-10-20T12:34:56-08:00
+  private def parseDateTime(str: String) = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str))
+
+  // Both "source" and "target" refer to file paths which define config files that have a
+  // top-level "filodb" section and a "cassandra" subsection.
+  private val sourceConfig = openConfig("spark.filodb.partitionkeys.copier.source.configFile")
+  private val targetConfig = openConfig("spark.filodb.partitionkeys.copier.target.configFile")
+  private val sourceCassConfig = sourceConfig.getConfig("cassandra")
+  private val targetCassConfig = targetConfig.getConfig("cassandra")
+  private val sourceDataset = conf.get("spark.filodb.partitionkeys.copier.source.dataset")
+  private val sourceDatasetRef = DatasetRef.fromDotString(sourceDataset)
+  private val targetDatasetRef = DatasetRef.fromDotString(conf.get("spark.filodb.partitionkeys.copier.target.dataset"))
+  private val sourceSession = FiloSessionProvider.openSession(sourceCassConfig)
+  private val targetSession = FiloSessionProvider.openSession(targetCassConfig)
+
+  private val numOfShards: Int = getShardNum
+  private val ingestionTimeStart = parseDateTime(conf.get("spark.filodb.partitionkeys.copier.ingestionTimeStart"))
+  private val ingestionTimeEnd = parseDateTime(conf.get("spark.filodb.partitionkeys.copier.ingestionTimeEnd"))
+  private val diskTimeToLiveSeconds = conf.getTimeAsSeconds("spark.filodb.partitionkeys.copier.diskTimeToLive")
+  private val readSched = Scheduler.io("cass-read-sched")
+  private val writeSched = Scheduler.io("cass-write-sched")
+
+  val sourceCassandraColStore = new CassandraColumnStore(sourceConfig, readSched, sourceSession)(writeSched)
+  val targetCassandraColStore = new CassandraColumnStore(targetConfig, readSched, targetSession)(writeSched)
+
+  // Destructively deletes everything in the target before updating anthing. Is used when chunks aren't aligned.
+  private[repair] val deleteFirst = conf.getBoolean("spark.filodb.partitionkeys.copier.deleteFirst", false)
+  // Disable the copy phase either for fully deleting with no replacement, or for no-op testing.
+  private[repair] val noCopy = conf.getBoolean("spark.filodb.partitionkeys.copier.noCopy", false)
+  private[repair] val splitsPerNode = conf.getInt("spark.filodb.partitionkeys.copier.splitsPerNode", 1)
+
+  private[repair] def getSourceScanSplits = sourceCassandraColStore.getScanSplits(sourceDatasetRef, splitsPerNode)
+  private[repair] def getTargetScanSplits = targetCassandraColStore.getScanSplits(targetDatasetRef, splitsPerNode)
+
+  def copySourceToTarget(splitIter: Iterator[ScanSplit]): Unit = {
+    sourceCassandraColStore.copyOrDeletePartitionKeysByTimeRange(
+      sourceDatasetRef,
+      numOfShards,
+      splitIter,
+      ingestionTimeStart.toEpochMilli(),
+      ingestionTimeEnd.toEpochMilli(),
+      targetCassandraColStore,
+      targetDatasetRef,
+      diskTimeToLiveSeconds.toInt)
+  }
+
+  def deleteFromTarget(splitIter: Iterator[ScanSplit]): Unit = {
+    targetCassandraColStore.copyOrDeletePartitionKeysByTimeRange(
+      targetDatasetRef,
+      numOfShards,
+      splitIter,
+      ingestionTimeStart.toEpochMilli(),
+      ingestionTimeEnd.toEpochMilli(),
+      targetCassandraColStore,
+      targetDatasetRef,
+      0) // ttl 0 is interpreted as delete
+  }
+
+  def shutdown(): Unit = {
+    sourceCassandraColStore.shutdown()
+    targetCassandraColStore.shutdown()
+  }
+}
+
+object PartitionKeysCopier {
+
+  class ByteComparator extends java.util.Comparator[Array[Byte]] {
+    def compare(a: Array[Byte], b: Array[Byte]): Int = java.util.Arrays.compareUnsigned(a, b)
+  }
+
+  val cache = new java.util.TreeMap[Array[Byte], PartitionKeysCopier](new ByteComparator)
+
+  // scalastyle: off null
+  def lookup(conf: SparkConf): PartitionKeysCopier = synchronized {
+    // SparkConf cannot be used as a key, so serialize it instead.
+    val bout = new java.io.ByteArrayOutputStream()
+    val oout = new java.io.ObjectOutputStream(bout)
+    oout.writeObject(conf)
+    oout.close()
+    val key = bout.toByteArray()
+
+    var copier = cache.get(key)
+    if (copier == null) {
+      copier = new PartitionKeysCopier(conf)
+      cache.put(key, copier)
+    }
+    copier
+  }
+
+  // scalastyle: on
+}
+
+/**
+ * For launching the Spark job.
+ */
+object PartitionKeysCopierMain extends App with StrictLogging {
+  run(new SparkConf(loadDefaults = true))
+
+  def run(conf: SparkConf): SparkSession = {
+    logger.info(s"PartitionKeysCopier Spark Job Properties: ${conf.toDebugString}")
+    val copier = PartitionKeysCopier.lookup(conf)
+    val spark = SparkSession.builder()
+      .appName("FiloDBPartitionKeysCopier")
+      .config(conf)
+      .getOrCreate()
+
+    if (copier.deleteFirst) {
+      logger.info("PartitionKeysCopier deleting from target first")
+
+      val splits = copier.getTargetScanSplits
+      logger.info(s"Delete phase cassandra split size: ${splits.size}. We will have this many spark partitions. " +
+        s"Tune splitsPerNode which was ${copier.splitsPerNode} if parallelism is low")
+
+      spark.sparkContext
+        .makeRDD(splits)
+        .foreachPartition(splitIter => PartitionKeysCopier.lookup(conf).deleteFromTarget(splitIter))
+    }
+
+    if (copier.noCopy) {
+      logger.info("PartitionKeysCopier copy phase disabled")
+    } else {
+      val splits = copier.getSourceScanSplits
+
+      logger.info(s"Copy phase cassandra split size: ${splits.size}. We will have this many spark partitions. " +
+        s"Tune splitsPerNode which was ${copier.splitsPerNode} if parallelism is low")
+
+      spark
+        .sparkContext
+        .makeRDD(splits)
+        .foreachPartition(splitIter => PartitionKeysCopier.lookup(conf).copySourceToTarget(splitIter))
+    }
+    logger.info(s"PartitionKeysCopier Driver completed successfully")
+    copier.shutdown()
+    spark
+  }
+}

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -1,0 +1,233 @@
+package filodb.repair
+
+import java.io.File
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+import com.typesafe.config.ConfigFactory
+import monix.reactive.Observable
+import org.apache.spark.SparkConf
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+import filodb.cassandra.DefaultFiloSessionProvider
+import filodb.cassandra.columnstore.CassandraColumnStore
+import filodb.core.GlobalConfig
+import filodb.core.binaryrecord2.RecordBuilder
+import filodb.core.downsample.OffHeapMemory
+import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesShardStats}
+import filodb.core.metadata.{Dataset, Schema, Schemas}
+import filodb.core.store.{PartKeyRecord, StoreConfig}
+import filodb.memory.format.ZeroCopyUTF8String._
+import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
+
+class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+  implicit val defaultPatience = PatienceConfig(timeout = Span(15, Seconds), interval = Span(250, Millis))
+
+  implicit val s = monix.execution.Scheduler.Implicits.global
+
+  val configPath = "conf/timeseries-filodb-server.conf"
+
+  private val sysConfig = GlobalConfig.systemConfig.getConfig("filodb")
+  private val config = ConfigFactory.parseFile(new File(configPath)).getConfig("filodb").withFallback(sysConfig)
+
+  lazy val session = new DefaultFiloSessionProvider(config.getConfig("cassandra")).session
+  lazy val colStore = new CassandraColumnStore(config, s, session)
+
+  var gauge1PartKeyBytes: Array[Byte] = _
+  var gauge2PartKeyBytes: Array[Byte] = _
+  var gauge3PartKeyBytes: Array[Byte] = _
+  var gauge4PartKeyBytes: Array[Byte] = _
+  val rawDataStoreConfig = StoreConfig(ConfigFactory.parseString(
+    """
+      |flush-interval = 1h
+      |shard-mem-size = 1MB
+      |ingestion-buffer-mem-size = 30MB
+                """.stripMargin))
+  val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram, Schemas.untyped),
+    Map.empty, 100, rawDataStoreConfig)
+
+  val datasetName = "prometheus"
+  val targetDatasetName = "buddy_prometheus"
+  val sourceDataset = Dataset(datasetName, Schemas.gauge)
+  val targetDataset = Dataset(targetDatasetName, Schemas.gauge)
+  val shardStats = new TimeSeriesShardStats(sourceDataset.ref, -1)
+
+  val sparkConf = {
+    val conf = new SparkConf(loadDefaults = true)
+    conf.setMaster("local[2]")
+
+    conf.set("spark.filodb.partitionkeys.copier.source.configFile", configPath)
+    conf.set("spark.filodb.partitionkeys.copier.source.dataset", datasetName)
+
+    conf.set("spark.filodb.partitionkeys.copier.target.configFile", configPath)
+    conf.set("spark.filodb.partitionkeys.copier.target.dataset", targetDatasetName)
+
+    conf.set("spark.filodb.partitionkeys.copier.ingestionTimeStart", "2020-10-13T00:00:00Z")
+    conf.set("spark.filodb.partitionkeys.copier.ingestionTimeEnd", "2020-10-13T05:00:00Z")
+    conf.set("spark.filodb.partitionkeys.copier.diskTimeToLive", "7d")
+    conf
+  }
+
+  val numOfShards = PartitionKeysCopier.lookup(sparkConf).getShardNum
+
+  // Examples: 2019-10-20T12:34:56Z  or  2019-10-20T12:34:56-08:00
+  private def parseDateTime(str: String) = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str))
+
+  def getSeriesTags(workspace: String, namespace: String): Map[ZeroCopyUTF8String, ZeroCopyUTF8String] = {
+    Map("_ws_".utf8 -> workspace.utf8, "_ns_".utf8 -> namespace.utf8)
+  }
+
+  override def beforeAll(): Unit = {
+    colStore.initialize(sourceDataset.ref, numOfShards).futureValue
+    colStore.truncate(sourceDataset.ref, numOfShards).futureValue
+
+    colStore.initialize(targetDataset.ref, numOfShards).futureValue
+    colStore.truncate(targetDataset.ref, numOfShards).futureValue
+  }
+
+  override def afterAll(): Unit = {
+    offheapMem.free()
+  }
+
+  it("should write test data to cassandra source table") {
+    def writePartKeys(pk: PartKeyRecord, shard: Int): Unit = {
+      colStore.writePartKeys(sourceDataset.ref, shard, Observable.now(pk), 259200, 0L, false).futureValue
+    }
+
+    def tsPartition(schema: Schema,
+                    gaugeName: String,
+                    seriesTags: Map[ZeroCopyUTF8String, ZeroCopyUTF8String]): TimeSeriesPartition = {
+      val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
+      val partKey = partBuilder.partKeyFromObjects(schema, gaugeName, seriesTags)
+      val part = new TimeSeriesPartition(0, schema, partKey,
+        0, offheapMem.bufferPools(schema.schemaHash), shardStats,
+        offheapMem.nativeMemoryManager, 1)
+      part
+    }
+
+    for (shard <- 0 until numOfShards) {
+      val ws: String = "my_ws_name_" + shard
+      val ns: String = "my_ns_id"
+
+      gauge1PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge1", getSeriesTags(ws + "1", ns + "1")).partKeyBytes
+      writePartKeys(PartKeyRecord(gauge1PartKeyBytes, 1507923801000L, Long.MaxValue, Some(150)), shard) // 2017
+
+      gauge2PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge2", getSeriesTags(ws + "2", ns + "2")).partKeyBytes
+      writePartKeys(PartKeyRecord(gauge2PartKeyBytes, 1539459801000L, Long.MaxValue, Some(150)), shard) // 2018
+
+      gauge3PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge3", getSeriesTags(ws + "3", ns + "3")).partKeyBytes
+      writePartKeys(PartKeyRecord(gauge3PartKeyBytes, 1602554400000L, 1602561600000L, Some(150)), shard) // 2020-10-13 02:00-04:00 GMT
+
+      gauge4PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge4", getSeriesTags(ws + "4", ns + "4")).partKeyBytes
+      writePartKeys(PartKeyRecord(gauge4PartKeyBytes, 1602549000000L, 1602561600000L, Some(150)), shard) // 2020-10-13 00:30-04:00 GMT
+    }
+  }
+
+  it("should run a simple Spark job") {
+    PartitionKeysCopierMain.run(sparkConf).close()
+  }
+
+  it("verify data written onto cassandra target table") {
+    def getWorkspace(map: Map[String, String]): String = {
+      val ws: String = map.get("_ws_").get
+      ws
+    }
+
+    def getNamespace(map: Map[String, String]): String = {
+      val ws: String = map.get("_ns_").get
+      ws
+    }
+
+    def getPartKeyMap(partKeyRecord: PartKeyRecord) : Map[String, String] = {
+      val pk = partKeyRecord.partKey
+      val pkPairs = Schemas.gauge.partKeySchema.toStringPairs(pk, UnsafeUtils.arayOffset)
+      val map = pkPairs.map(a => a._1 -> a._2).toMap
+      map
+    }
+
+    val startTime = parseDateTime(sparkConf.get("spark.filodb.partitionkeys.copier.ingestionTimeStart")).toEpochMilli()
+    val endTime = parseDateTime(sparkConf.get("spark.filodb.partitionkeys.copier.ingestionTimeEnd")).toEpochMilli()
+
+    for (shard <- 0 until numOfShards) {
+      val partKeyRecords = Await.result(colStore.scanPartKeys(targetDataset.ref, shard).toListL.runAsync, Duration(1, "minutes"))
+
+      // because there will be 2 records that meets the copier time period.
+      partKeyRecords.size shouldEqual 2
+
+      for (pkr <- partKeyRecords) {
+        // verify all the records fall in the copier time period.
+        pkr.startTime should be >= startTime
+        pkr.endTime should be <= endTime
+      }
+    }
+
+    // verify workspace/namespace names in shard=0.
+    val shard0 = 0
+    val partKeyRecordsShard0 = Await.result(colStore.scanPartKeys(targetDataset.ref, shard0).toListL.runAsync,
+      Duration(1, "minutes"))
+    partKeyRecordsShard0.size shouldEqual 2
+    for (pkr <- partKeyRecordsShard0) {
+      val map = getPartKeyMap(pkr)
+
+      // verify workspace/namespace value for "my_gauge3" metric
+      if ("my_gauge3".equals(map.get("_metric_").get)) {
+        getWorkspace(map) shouldEqual "my_ws_name_03"
+        getNamespace(map) shouldEqual "my_ns_id3"
+      }
+
+      // verify workspace/namespace value for "my_gauge4" metric
+      if ("my_gauge4".equals(map.get("_metric_").get)) {
+        getWorkspace(map) shouldEqual "my_ws_name_04"
+        getNamespace(map) shouldEqual "my_ns_id4"
+      }
+    }
+
+    // verify workspace/namespace names in shard=2.
+    val shard2 = 2
+    val partKeyRecordsShard2 = Await.result(colStore.scanPartKeys(targetDataset.ref, shard2).toListL.runAsync,
+      Duration(1, "minutes"))
+    partKeyRecordsShard2.size shouldEqual 2
+    for (pkr <- partKeyRecordsShard2) {
+      val map = getPartKeyMap(pkr)
+
+      // verify workspace/namespace value for "my_gauge3" metric
+      if ("my_gauge3".equals(map.get("_metric_").get)) {
+        getWorkspace(map) shouldEqual "my_ws_name_23"
+        getNamespace(map) shouldEqual "my_ns_id3"
+      }
+
+      // verify workspace/namespace value for "my_gauge4" metric
+      if ("my_gauge4".equals(map.get("_metric_").get)) {
+        getWorkspace(map) shouldEqual "my_ws_name_24"
+        getNamespace(map) shouldEqual "my_ns_id4"
+      }
+    }
+  }
+
+  it("verify data deletes on cassandra target table") {
+    val shard0 = 0
+    val partKeyRecordsShard0 = Await.result(colStore.scanPartKeys(targetDataset.ref, shard0).toListL.runAsync,
+      Duration(1, "minutes"))
+    // making sure there is some data in at least one shard before starting the delete job.
+    partKeyRecordsShard0.size shouldEqual 2
+
+    // flag enabled to deleteFirst from target
+    sparkConf.set("spark.filodb.partitionkeys.copier.deleteFirst", "true")
+    sparkConf.set("spark.filodb.partitionkeys.copier.noCopy", "true")
+
+    PartitionKeysCopierMain.run(sparkConf).close()
+
+    for (shard <- 0 until numOfShards) {
+      val partKeyRec = Await.result(colStore.scanPartKeys(targetDataset.ref, shard).toListL.runAsync,
+        Duration(1, "minutes"))
+      partKeyRec.size shouldEqual 0
+    }
+  }
+}


### PR DESCRIPTION
**Modifications**
- Added a Spark job that can be triggered on demand to copy partitionKey records.  
- Time interval can be configured as specified below. Spark job would copy all the records falling in this interval.
```
conf.set("spark.filodb.partitionkeys.copier.ingestionTimeStart", "2020-10-13T00:00:00Z")
conf.set("spark.filodb.partitionkeys.copier.ingestionTimeEnd", "2020-10-13T05:00:00Z")
```
- This job would be useful in cases of disaster recovery or back fills.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
- NA

**New behavior :**
- data repair feature is new. This job would be useful in cases of disaster recovery or back fills.

**BREAKING CHANGES**
- NA

**Other information**: