### PR TITLE
bug(query): "next on empty iterator" when using sum over topk result

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -11,10 +11,10 @@ import filodb.coordinator.client.QueryCommands.StaticSpreadProvider
 import filodb.core.{DatasetRef, SpreadProvider}
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.Schemas
-import filodb.core.query.{ColumnFilter, Filter, QueryConfig, QueryContext}
+import filodb.core.query.{ColumnFilter, Filter, PromQlQueryParams, QueryConfig, QueryContext, RangeParams}
 import filodb.core.store.{AllChunkScan, ChunkScanMethod, InMemoryChunkScan, TimeRangeChunkScan, WriteBufferChunkScan}
 import filodb.prometheus.ast.Vectors.{PromMetricLabel, TypeLabel}
-import filodb.prometheus.ast.WindowConstants
+import filodb.prometheus.ast. WindowConstants
 import filodb.query.{exec, _}
 import filodb.query.exec.{LocalPartitionDistConcatExec, _}
 
@@ -258,8 +258,11 @@ class SingleClusterPlanner(dsRef: DatasetRef,
 
     val reduceDispatcher = pickDispatcher(toReduceLevel2)
     val reducer = LocalPartitionReduceAggregateExec(qContext, reduceDispatcher, toReduceLevel2, lp.operator, lp.params)
+    val promQlQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams]
+
     if (!qContext.plannerParams.skipAggregatePresent)
-      reducer.addRangeVectorTransformer(AggregatePresenter(lp.operator, lp.params))
+      reducer.addRangeVectorTransformer(AggregatePresenter(lp.operator, lp.params, RangeParams(
+        promQlQueryParams.startSecs, promQlQueryParams.stepSecs, promQlQueryParams.endSecs)))
     PlanResult(Seq(reducer), false) // since we have aggregated, no stitching
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -122,7 +122,8 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
   val timeMinSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("min", DoubleColumn)), 1)
   val countSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("count", DoubleColumn)), 1)
   val valueSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("value", DoubleColumn)), 1)
-  val qOpt = QueryContext(plannerParams = PlannerParams(shardOverrides = Some(Seq(0))))
+  val qOpt = QueryContext(plannerParams = PlannerParams(shardOverrides = Some(Seq(0))), origQueryParams =
+    PromQlQueryParams("", 1000, 1, 1000))
 
   describe("QueryActor commands and responses") {
     import MachineMetricsData._
@@ -275,7 +276,8 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       // Should return results from both shards
       // shard 1 - timestamps 110000 -< 130000;  shard 2 - timestamps 130000 <- 1400000
-      val queryOpt = QueryContext(plannerParams = PlannerParams(shardOverrides = Some(Seq(0, 1))))
+      val queryOpt = QueryContext(plannerParams = PlannerParams(shardOverrides = Some(Seq(0, 1))),
+        origQueryParams = PromQlQueryParams("", 1000, 1, 1000))
       val series2 = (2 to 4).map(n => s"Series $n").toSet.asInstanceOf[Set[Any]]
       val multiFilter = Seq(ColumnFilter("series", Filter.In(series2)))
       val q2 = LogicalPlan2Query(ref,

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -322,7 +322,8 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val logicalPlan = Parser.queryRangeToLogicalPlan("""sum(rate(foo{job="bar"}[3d]))""",
       TimeStepParams(nowSeconds, 1.minute.toSeconds, nowSeconds))
 
-    val ep = planner.materialize(logicalPlan, QueryContext()).asInstanceOf[LocalPartitionReduceAggregateExec]
+    val ep = planner.materialize(logicalPlan, QueryContext(origQueryParams = PromQlQueryParams
+    ("""sum(rate(foo{job="bar"}[3d]))""",1000, 100, 1000))).asInstanceOf[LocalPartitionReduceAggregateExec]
     val psm = ep.children.head.asInstanceOf[MultiSchemaPartitionsExec]
       .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
     psm.start shouldEqual (nowSeconds * 1000)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
@@ -471,7 +471,8 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
     val logicalPlan = Parser.queryRangeToLogicalPlan("""sum(rate(foo{job="bar"}[3d]))""",
       TimeStepParams(nowSeconds, 1.minute.toSeconds, nowSeconds))
 
-    val ep = planner.materialize(logicalPlan, QueryContext()).asInstanceOf[LocalPartitionReduceAggregateExec]
+    val ep = planner.materialize(logicalPlan, QueryContext(origQueryParams = PromQlQueryParams
+    ("""sum(rate(foo{job="bar"}[3d]))""",1000, 100, 1000))).asInstanceOf[LocalPartitionReduceAggregateExec]
     val psm = ep.children.head.asInstanceOf[MultiSchemaPartitionsExec]
       .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
     psm.start shouldEqual (nowSeconds * 1000)

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -120,6 +120,7 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
 
 final case class AggregatePresenter(aggrOp: AggregationOperator,
                                     aggrParams: Seq[Any],
+                                    rangeParams: RangeParams,
                                     funcParams: Seq[FuncArgs] = Nil) extends RangeVectorTransformer {
 
   protected[exec] def args: String = s"aggrOp=$aggrOp, aggrParams=$aggrParams"
@@ -130,7 +131,7 @@ final case class AggregatePresenter(aggrOp: AggregationOperator,
             sourceSchema: ResultSchema,
             paramResponse: Seq[Observable[ScalarRangeVector]]): Observable[RangeVector] = {
     val aggregator = RowAggregator(aggrOp, aggrParams, sourceSchema)
-    RangeVectorAggregator.present(aggregator, source, limit)
+    RangeVectorAggregator.present(aggregator, source, limit, rangeParams)
   }
 
   override def schema(source: ResultSchema): ResultSchema = {
@@ -184,8 +185,9 @@ object RangeVectorAggregator extends StrictLogging {
     */
   def present(aggregator: RowAggregator,
               source: Observable[RangeVector],
-              limit: Int): Observable[RangeVector] = {
-    source.flatMap(rv => Observable.fromIterable(aggregator.present(rv, limit)))
+              limit: Int,
+              rangeParams: RangeParams): Observable[RangeVector] = {
+    source.flatMap(rv => Observable.fromIterable(aggregator.present(rv, limit, rangeParams)))
   }
 
   private def mapReduceInternal(rvs: List[RangeVector],

--- a/query/src/main/scala/filodb/query/exec/aggregator/AvgRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/AvgRowAggregator.scala
@@ -45,7 +45,7 @@ object AvgRowAggregator extends RowAggregator {
     acc
   }
   // ignore last count column. we rely on schema change
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = {
     source.copy(columns = source.columns :+ ColumnInfo("count", ColumnType.LongColumn))
   }

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
@@ -34,7 +34,7 @@ abstract class CountRowAggregator extends RowAggregator {
       acc.count += aggRes.getDouble(1)
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
@@ -81,7 +81,7 @@ class CountValuesRowAggregator(label: String, limit: Int = 1000) extends RowAggr
     acc
   }
 
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = {
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = {
     val colSchema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
       ColumnInfo("value", ColumnType.DoubleColumn))
     val recSchema = SerializedRangeVector.toSchema(colSchema)

--- a/query/src/main/scala/filodb/query/exec/aggregator/HistMaxSumAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/HistMaxSumAggregator.scala
@@ -1,6 +1,6 @@
 package filodb.query.exec.aggregator
 
-import filodb.core.query.{MutableRowReader, RangeVector, RangeVectorKey, ResultSchema, TransientHistMaxRow}
+import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema, TransientHistMaxRow}
 import filodb.memory.format.RowReader
 
 object HistMaxSumAggregator extends RowAggregator {
@@ -29,7 +29,7 @@ object HistMaxSumAggregator extends RowAggregator {
     acc.m = if (acc.m.isNaN) aggRes.getDouble(2) else Math.max(acc.m, aggRes.getDouble(2))
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/HistSumRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/HistSumRowAggregator.scala
@@ -1,6 +1,6 @@
 package filodb.query.exec.aggregator
 
-import filodb.core.query.{MutableRowReader, RangeVector, RangeVectorKey, ResultSchema, TransientHistRow}
+import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema, TransientHistRow}
 import filodb.memory.format.RowReader
 
 object HistSumRowAggregator extends RowAggregator {
@@ -27,7 +27,7 @@ object HistSumRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/MaxRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/MaxRowAggregator.scala
@@ -27,7 +27,7 @@ object MaxRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/MinRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/MinRowAggregator.scala
@@ -28,7 +28,7 @@ object MinRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
@@ -63,7 +63,7 @@ class QuantileRowAggregator(q: Double) extends RowAggregator {
     acc
   }
 
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = {
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = {
     val mutRow = new TransientRow()
     val result = aggRangeVector.rows.mapRow { r =>
       val qVal = ArrayDigest.fromBytes(r.getBuffer(1)).quantile(q)

--- a/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
@@ -1,7 +1,7 @@
 package filodb.query.exec.aggregator
 
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{MutableRowReader, RangeVector, RangeVectorKey, ResultSchema}
+import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema}
 import filodb.memory.format.RowReader
 import filodb.query.AggregationOperator
 import filodb.query.AggregationOperator._
@@ -97,7 +97,7 @@ trait RowAggregator {
     *              Apply limit only on iterators that are NOT lazy and need to be
     *              materialized.
     */
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector]
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector]
 
   /**
     * Schema of the RowReader returned by toRowReader

--- a/query/src/main/scala/filodb/query/exec/aggregator/StddevRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/StddevRowAggregator.scala
@@ -57,7 +57,7 @@ object StddevRowAggregator extends RowAggregator {
     acc
   }
   // ignore last two column. we rely on schema change
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = {
     source.copy(source.columns :+ ColumnInfo("mean", ColumnType.DoubleColumn)
       :+ ColumnInfo("count", ColumnType.LongColumn))

--- a/query/src/main/scala/filodb/query/exec/aggregator/StdvarRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/StdvarRowAggregator.scala
@@ -71,7 +71,7 @@ object StdvarRowAggregator extends RowAggregator {
     acc
   }
   // ignore last two column. we rely on schema change
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = {
     source.copy(source.columns :+ ColumnInfo("mean", ColumnType.DoubleColumn)
       :+ ColumnInfo("count", ColumnType.LongColumn))

--- a/query/src/main/scala/filodb/query/exec/aggregator/SumRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/SumRowAggregator.scala
@@ -1,6 +1,6 @@
 package filodb.query.exec.aggregator
 
-import filodb.core.query.{MutableRowReader, RangeVector, RangeVectorKey, ResultSchema, TransientRow}
+import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema, TransientRow}
 import filodb.memory.format.RowReader
 /**
   * Map: Every sample is mapped to itself
@@ -26,7 +26,7 @@ object SumRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -366,9 +366,9 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
   it("should return NaN when all values are NaN for a timestamp ") {
 
     val samples: Array[RangeVector] = Array(
-      toRv(Seq((1L, Double.NaN), (2L, 5.6d))),
-      toRv(Seq((1L, Double.NaN), (2L, 4.4d))),
-      toRv(Seq((1L, Double.NaN), (2L, 5.4d)))
+      toRv(Seq((1000L, Double.NaN), (2000L, 5.6d))),
+      toRv(Seq((1000L, Double.NaN), (2000L, 4.4d))),
+      toRv(Seq((1000L, Double.NaN), (2000L, 5.4d)))
     )
 
     // Sum
@@ -409,7 +409,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg5 = RowAggregator(AggregationOperator.BottomK, Seq(2.0), tvSchema)
     val resultObs5a = RangeVectorAggregator.mapReduce(agg5, false, Observable.fromIterable(samples), noGrouping)
     val resultObs5 = RangeVectorAggregator.mapReduce(agg5, true, resultObs5a, rv=>rv.key)
-    val resultObs5b = RangeVectorAggregator.present(agg5, resultObs5, 1000, RangeParams(0,1,0))
+    val resultObs5b = RangeVectorAggregator.present(agg5, resultObs5, 1000, RangeParams(1,1,2))
     val result5 = resultObs5.toListL.runAsync.futureValue
     result5.size shouldEqual 1
     result5(0).key shouldEqual noKey
@@ -419,14 +419,14 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val result5b = resultObs5b.toListL.runAsync.futureValue
     result5b.size shouldEqual 1
     result5b(0).key shouldEqual ignoreKey
-    // present removes the range vector which has all values as Double.Max
-    compareIter(result5b(0).rows.map(_.getDouble(1)), Seq(5.4d, 4.4d).iterator)
+
+    compareIter(result5b(0).rows.map(_.getDouble(1)), Seq(Double.NaN, 5.4d, 4.4d).iterator)
 
     // TopK
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(2.0), tvSchema)
     val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping)
     val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key)
-    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(0,1,0))
+    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1,1,2))
     val result6 = resultObs6.toListL.runAsync.futureValue
     result6.size shouldEqual 1
     result6(0).key shouldEqual noKey
@@ -435,7 +435,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val result6b = resultObs6b.toListL.runAsync.futureValue
     result6b.size shouldEqual 1
     result6b(0).key shouldEqual ignoreKey
-    compareIter(result6b(0).rows.map(_.getDouble(1)), Seq(5.4d,5.6d).iterator)
+    compareIter(result6b(0).rows.map(_.getDouble(1)), Seq(Double.NaN, 5.4d, 5.6d).iterator)
 
     // Stdvar
     val agg8 = RowAggregator(AggregationOperator.Stdvar, Nil, tvSchema)
@@ -460,14 +460,14 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // The value before NaN should not get carried over. Topk result for timestamp 1556744173L should have Double.NaN
     val samples: Array[RangeVector] = Array(
-      toRv(Seq((1556744143L, 42d), (1556744158L, 42d),(1556744173L, Double.NaN)))
+      toRv(Seq((1556744143L, 42d), (1556745158L, 42d),(1556745173L, Double.NaN)))
     )
 
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(5.0), tvSchema)
     val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping)
     val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv
       .key)
-    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744,1,1556744))
+    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744,1,1556745))
     val result6 = resultObs6.toListL.runAsync.futureValue
     result6(0).key shouldEqual noKey
     val result6b = resultObs6b.toListL.runAsync.futureValue


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
If we execute topK query with k as 1 from t1 to t5 we just get max value for every timestamp from all range vectors. So if for a times series only t1 has top value, t2, t3 etc won't be present in final result. When sum is applied on such a query `next on empty iterator` error is thrown as some timestamps are missing.

**New behavior :**
Add NaN for timestamps which do not have any value in topk result
