### PR TITLE
feat(core): add addititional condition to create chunks at flush interval boundary, only when enabled

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
@@ -82,7 +82,7 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
 
     MachineMetricsData.records(dataset, rawSamples).records.foreach { case (base, offset) =>
       val rr = new BinaryRecordRowReader(Schemas.gauge.ingestionSchema, base, offset)
-      part.ingest( System.currentTimeMillis(), rr, offheapMem.blockMemFactory)
+      part.ingest( System.currentTimeMillis(), rr, offheapMem.blockMemFactory, false, Option.empty)
       part.switchBuffers(offheapMem.blockMemFactory, true)
     }
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1184,7 +1184,8 @@ class TimeSeriesShard(val ref: DatasetRef,
         val tsp = part.asInstanceOf[TimeSeriesPartition]
         brRowReader.schema = schema.ingestionSchema
         brRowReader.recordOffset = recordOff
-        tsp.ingest(ingestionTime, brRowReader, overflowBlockFactory, maxChunkTime)
+        tsp.ingest(ingestionTime, brRowReader, overflowBlockFactory,
+          storeConfig.createChunkAtFlushBoundary, Option(flushBoundaryMillis), maxChunkTime)
         // Below is coded to work concurrently with logic in updateIndexWithEndTime
         // where we try to de-activate an active time series
         if (!tsp.ingesting) {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -407,12 +407,12 @@ class TimeSeriesShard(val ref: DatasetRef,
   // Flush groups when ingestion time is observed to cross a time boundary (typically an hour),
   // plus a group-specific offset. This simplifies disaster recovery -- chunks can be copied
   // without concern that they may overlap in time.
-  private val flushBoundaryMillis = storeConfig.flushInterval.toMillis
+  private val flushBoundaryMillis = Option(storeConfig.flushInterval.toMillis)
 
   // Defines the group-specific flush offset, to distribute the flushes around such they don't
   // all flush at the same time. With an hourly boundary and 60 flush groups, flushes are
   // scheduled once a minute.
-  private val flushOffsetMillis = flushBoundaryMillis / numGroups
+  private val flushOffsetMillis = flushBoundaryMillis.get / numGroups
 
   private[memstore] val evictedPartKeys =
     BloomFilter[PartKey](storeConfig.evictedPkBfCapacity, falsePositiveRate = 0.01)(new CanGenerateHashFrom[PartKey] {
@@ -837,7 +837,7 @@ class TimeSeriesShard(val ref: DatasetRef,
            As written the code the same thing but with fewer operations. It's also a bit
            shorter, but you also had to read this comment...
          */
-        if (oldTimestamp / flushBoundaryMillis != newTimestamp / flushBoundaryMillis) {
+        if (oldTimestamp / flushBoundaryMillis.get != newTimestamp / flushBoundaryMillis.get) {
           // Flush out the group before ingesting records for a new hour (by group offset).
           tasks += createFlushTask(prepareFlushGroup(group))
         }
@@ -1185,7 +1185,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         brRowReader.schema = schema.ingestionSchema
         brRowReader.recordOffset = recordOff
         tsp.ingest(ingestionTime, brRowReader, overflowBlockFactory,
-          storeConfig.createChunkAtFlushBoundary, Option(flushBoundaryMillis), maxChunkTime)
+          storeConfig.timeAlignedChunksEnabled, flushBoundaryMillis, maxChunkTime)
         // Below is coded to work concurrently with logic in updateIndexWithEndTime
         // where we try to de-activate an active time series
         if (!tsp.ingesting) {

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -109,7 +109,7 @@ object StoreConfig {
     val config = storeConfig.withFallback(defaults)
     val flushInterval = config.as[FiniteDuration]("flush-interval")
 
-    // createChunkAtFlushBoundary - switch buffers and create chunk when current sample's timestamp crosses flush boundary
+    // switch buffers and create chunk when current sample's timestamp crosses flush boundary.
     // e.g. for a flush-interval of 1hour, if new sample falls in different hour than last sample, then switch buffers
     // and create chunk. This helps in aligning chunks across Active/Active HA clusters and facilitates chunk migration
     // between the clusters during disaster recovery.

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -10,7 +10,7 @@ import filodb.core.{DatasetRef, IngestionKeys}
 import filodb.core.downsample.DownsampleConfig
 
 final case class StoreConfig(flushInterval: FiniteDuration,
-                             createChunkAtFlushBoundary: Boolean,
+                             timeAlignedChunksEnabled: Boolean,
                              diskTTLSeconds: Int,
                              demandPagedRetentionPeriod: FiniteDuration,
                              maxChunksSize: Int,
@@ -43,7 +43,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
-                               "create-chunk-at-flush-boundary" -> createChunkAtFlushBoundary,
+                               "time-aligned-chunks-enabled" -> timeAlignedChunksEnabled,
                                "disk-time-to-live" -> (diskTTLSeconds + "s"),
                                "demand-paged-chunk-retention-period" -> (demandPagedRetentionPeriod.toSeconds + "s"),
                                "max-chunks-size" -> maxChunksSize,
@@ -102,7 +102,7 @@ object StoreConfig {
                                            |ensure-headroom-percent = 5.0
                                            |trace-filters = {}
                                            |metering-enabled = false
-                                           |create-chunk-at-flush-boundary = false
+                                           |time-aligned-chunks-enabled = false
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -114,14 +114,14 @@ object StoreConfig {
     // and create chunk. This helps in aligning chunks across Active/Active HA clusters and facilitates chunk migration
     // between the clusters during disaster recovery.
     // Note: Enabling this might result into creation of smaller suboptimal chunks.
-    val createChunkAtFlushInterval = config.getBoolean("create-chunk-at-flush-boundary")
+    val timeAlignedChunksEnabled = config.getBoolean("time-aligned-chunks-enabled")
 
     // maxChunkTime should atleast be length of flush interval to accommodate all data within one chunk.
     // better to be slightly greater so if more samples arrive within that flush period, two chunks are not created.
     val fallbackMaxChunkTime = (flushInterval.toMillis * 1.1).toLong.millis
     val maxChunkTime = config.as[Option[FiniteDuration]]("max-chunk-time").getOrElse(fallbackMaxChunkTime)
     StoreConfig(flushInterval,
-                createChunkAtFlushInterval,
+                timeAlignedChunksEnabled,
                 config.as[FiniteDuration]("disk-time-to-live").toSeconds.toInt,
                 config.as[FiniteDuration]("demand-paged-chunk-retention-period"),
                 config.getInt("max-chunks-size"),

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -412,7 +412,8 @@ object MachineMetricsData {
     val histData = linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets, infBucket).take(numSamples)
     val container = records(ds, histData).records
     val part = TimeSeriesPartitionSpec.makePart(0, ds, partKey=histPartKey, bufferPool=pool)
-    container.iterate(ds.ingestionSchema).foreach { row => part.ingest(0, row, histIngestBH, 1.hour.toMillis) }
+    container.iterate(ds.ingestionSchema).foreach { row => part.ingest(0, row, histIngestBH,
+      false, Option.empty, 1.hour.toMillis) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(histIngestBH, encode = true)
     (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 3)))  // select timestamp and histogram columns only
@@ -426,7 +427,8 @@ object MachineMetricsData {
     val histData = histMax(linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets)).take(numSamples)
     val container = records(histMaxDS, histData).records
     val part = TimeSeriesPartitionSpec.makePart(0, histMaxDS, partKey=histPartKey, bufferPool=histMaxBP)
-    container.iterate(histMaxDS.ingestionSchema).foreach { row => part.ingest(0, row, histMaxBH, 1.hour.toMillis) }
+    container.iterate(histMaxDS.ingestionSchema).foreach { row => part.ingest(0, row, histMaxBH, false,
+      Option.empty, 1.hour.toMillis) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(histMaxBH, encode = true)
     // Select timestamp, hist, max

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -74,7 +74,7 @@ class ShardDownsamplerSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
   def timeValueRV(tuples: Seq[(Long, Double)]): RawDataRangeVector = {
     val part = TimeSeriesPartitionSpec.makePart(0, promDataset, partKeyOffset, bufferPool = tsBufferPool)
     val readers = tuples.map { case (ts, d) => TupleRowReader((Some(ts), Some(d))) }
-    readers.foreach { row => part.ingest(0, row, ingestBlockHolder) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder, false, Option.empty) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder, encode = true)
 //    part.encodeAndReleaseBuffers(ingestBlockHolder)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -24,7 +24,7 @@ object TimeSeriesPartitionSpec {
 
   val maxChunkSize = TestData.storeConf.maxChunksSize
   private val flushIntervalMillis = Option(TestData.storeConf.flushInterval.toMillis)
-  private val chunkAtFlushBoundary = TestData.storeConf.createChunkAtFlushBoundary
+  private val timeAlignedChunksEnabled = TestData.storeConf.timeAlignedChunksEnabled
   protected val myBufferPool = new WriteBufferPool(memFactory, schema1.data, TestData.storeConf)
 
   def makePart(partNo: Int, dataset: Dataset,
@@ -84,7 +84,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
   it("should be able to read immediately after ingesting one row") {
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(5)
-    part.ingest(0, data(0), ingestBlockHolder, chunkAtFlushBoundary,
+    part.ingest(0, data(0), ingestBlockHolder, timeAlignedChunksEnabled,
       flushIntervalMillis = flushIntervalMillis)   // just one row
     part.numChunks shouldEqual 1
     part.appendingChunkLen shouldEqual 1
@@ -100,7 +100,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val minData = data.map(_.getDouble(1))
     val initTS = data(0).getLong(0)
     data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
 
     val origPoolSize = myBufferPool.poolSize
 
@@ -123,7 +123,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
     data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
     val chunkSets = flushFut.futureValue
 
     // After flush, the old writebuffers should be returned to pool, but new one allocated for ingesting
@@ -153,19 +153,19 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part = makePart(0, dataset1)
     // user time maximum is not enforced, so just one chunk
     singleSeriesReaders().take(35).foreach { r => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
     part.numChunks shouldEqual 1
 
     part = makePart(0, dataset1)
     // 11 samples per chunk since maxChunkTime is 10 seconds
     singleSeriesReaders().take(33).foreach { r => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary, maxChunkTime = 10000) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled, maxChunkTime = 10000) }
     part.numChunks shouldEqual 3
 
     part = makePart(0, dataset1)
     // 11 samples per chunk since maxChunkTime is 10 seconds
     singleSeriesReaders().take(34).foreach { r => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary, maxChunkTime = 10000) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled, maxChunkTime = 10000) }
     part.numChunks shouldEqual 4
   }
 
@@ -176,7 +176,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part = makePart(0, dataset1)
     // chunk creation on crossing flush boundary is not enforced, so will create 1 chunk
     timeAlignedSeriesReaders().take(70).foreach { r => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
     part.numChunks shouldEqual 1
 
     // chunk creation on crossing flush boundary is enabled with flushInterval of 1 min.
@@ -208,7 +208,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val appendingTS = data.last.getLong(0)
     val minData = data.map(_.getDouble(1))
     data.take(10).foreach { r => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
 
     // First 10 rows ingested. Now flush in a separate Future while ingesting the remaining row
     part.switchBuffers(ingestBlockHolder)
@@ -218,7 +218,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     // Task needs to fully iterate over the chunks, to release the shared lock.
     val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
     data.drop(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
 
     // there should be a frozen chunk of 10 records plus 1 record in currently appending chunks
     part.numChunks shouldEqual 2
@@ -266,7 +266,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      val data = singleSeriesReaders().take(21)
      val minData = data.map(_.getDouble(1))
      data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-       flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+       flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
 
      val origPoolSize = myBufferPool.poolSize
 
@@ -277,7 +277,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut = Future(part.makeFlushChunks(blockHolder).toBuffer)
      data.drop(10).take(6).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-       flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+       flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
      val chunkSets = flushFut.futureValue
 
      // After flush, the old writebuffers should be returned to pool, but new one allocated too
@@ -309,7 +309,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
      // Task needs to fully iterate over the chunks, to release the shared lock.
      val flushFut2 = Future(part.makeFlushChunks(holder2).toBuffer)
      data.drop(16).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-       flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+       flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
      val chunkSets2 = flushFut2.futureValue
 
      part.numChunks shouldEqual 3
@@ -330,7 +330,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(11)
     data.zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
     part.numChunks shouldEqual 1
     part.appendingChunkLen shouldEqual 11
 
@@ -366,7 +366,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     }
     (0 to 9).foreach { i =>
       data.foreach { case d => partitions(i).ingest(0, d, ingestBlockHolder,
-        flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+        flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
       partitions(i).numChunks shouldEqual 1
       partitions(i).appendingChunkLen shouldEqual 10
       val infos = partitions(i).infos(AllChunkScan)
@@ -388,7 +388,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     (0 until 4).foreach { n =>
       (0 to 9).foreach { i =>
         moreData.drop(n*10).take(10).foreach { case d => partitions(i).ingest(0, d, ingestBlockHolder,
-          flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+          flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
         partitions(i).appendingChunkLen shouldEqual 10
         partitions(i).switchBuffers(ingestBlockHolder, true)
       }
@@ -397,7 +397,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     // Now ingest again but don't switch buffers.  Ensure appendingChunkLen is appropriate.
     (0 to 9).foreach { i =>
       moreData.drop(40).foreach { case d => partitions(i).ingest(0, d, ingestBlockHolder,
-        flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+        flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
       partitions(i).appendingChunkLen shouldEqual 10
     }
   }
@@ -409,7 +409,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     part = makePart(0, dataset1)
     val data = singleSeriesReaders().take(maxChunkSize + 10)
     data.take(maxChunkSize - 10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
     part.numChunks shouldEqual 1
     part.appendingChunkLen shouldEqual (maxChunkSize - 10)
     part.unflushedChunksets shouldEqual 1
@@ -418,7 +418,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     // Now ingest 20 more.  Verify new chunks encoded.  10 rows after switch at 100. Verify can read everything.
     data.drop(maxChunkSize - 10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
     part.numChunks shouldEqual 2
     part.appendingChunkLen shouldEqual 10
     part.unflushedChunksets shouldEqual 2
@@ -446,21 +446,21 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     // Ingest first 5, then: 8th, 6th, 7th, 9th, 10th
     data.take(5).foreach { r => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
     part.ingest(0, data(7), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
     part.ingest(0, data(5), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
     part.ingest(0, data(6), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
     part.ingest(0, data(8), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
     part.ingest(0, data(9), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
 
     // Try ingesting old sample now at the end.  Verify that end time of chunkInfo is not incorrectly changed.
     part.ingest(0, data(2), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
     // 8 of first 10 ingested, 2 should be dropped.  Switch buffers, and try ingesting out of order again.
     part.appendingChunkLen shouldEqual 8
     part.infoLast.numRows shouldEqual 8
@@ -471,12 +471,12 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
 
     // Now try ingesting an old smaple again at first element of next chunk.
     part.ingest(0, data(8), ingestBlockHolder, flushIntervalMillis = flushIntervalMillis,
-      createChunkAtFlushBoundary = chunkAtFlushBoundary)   // This one should be dropped
+      createChunkAtFlushBoundary = timeAlignedChunksEnabled)   // This one should be dropped
     part.appendingChunkLen shouldEqual 0
     part.ingest(0, data(10), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
     part.ingest(0, data(11), ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary)
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled)
 
     // there should be a frozen chunk of 10 records plus 2 records in currently appending chunks
     part.numChunks shouldEqual 2
@@ -494,7 +494,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
     val minData = data.map(_.getDouble(1))
     val initTS = data(0).getLong(0)
     data.take(10).zipWithIndex.foreach { case (r, i) => part.ingest(0, r, ingestBlockHolder,
-      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = chunkAtFlushBoundary) }
+      flushIntervalMillis = flushIntervalMillis, createChunkAtFlushBoundary = timeAlignedChunksEnabled) }
 
     val origPoolSize = myBufferPool.poolSize
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -154,7 +154,8 @@ trait RawDataWindowingSpec extends AnyFunSpec with Matchers with BeforeAndAfter 
                     partKey: NativePointer = defaultPartKey): RawDataRangeVector = {
     val part = TimeSeriesPartitionSpec.makePart(0, timeseriesDatasetWithMetric, partKey, bufferPool = tsBufferPool)
     val readers = tuples.map { case (ts, d) => TupleRowReader((Some(ts), Some(d))) }
-    readers.foreach { row => part.ingest(0, row, ingestBlockHolder) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder, createChunkAtFlushBoundary = false,
+      flushIntervalMillis = Option.empty) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder, encode = true)
     // part.encodeAndReleaseBuffers(ingestBlockHolder)
@@ -167,7 +168,8 @@ trait RawDataWindowingSpec extends AnyFunSpec with Matchers with BeforeAndAfter 
     val readers = tuples.map { case (ts, d1, d2, d3, d4, d5) =>
       TupleRowReader((Some(ts), Some(d1), Some(d2), Some(d3), Some(d4), Some(d5)))
     }
-    readers.foreach { row => part.ingest(0, row, ingestBlockHolder2) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder2, createChunkAtFlushBoundary = false,
+      flushIntervalMillis = Option.empty) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder2, encode = true)
     // part.encodeAndReleaseBuffers(ingestBlockHolder)
@@ -184,7 +186,8 @@ trait RawDataWindowingSpec extends AnyFunSpec with Matchers with BeforeAndAfter 
     val part = rv.partition.asInstanceOf[TimeSeriesPartition]
     val startingNumChunks = part.numChunks
     val readers = tuples.map { case (ts, d) => TupleRowReader((Some(ts), Some(d))) }
-    readers.foreach { row => part.ingest(0, row, ingestBlockHolder) }
+    readers.foreach { row => part.ingest(0, row, ingestBlockHolder, createChunkAtFlushBoundary = false,
+      flushIntervalMillis = Option.empty) }
     part.switchBuffers(ingestBlockHolder, encode = true)
     part.numChunks shouldEqual (startingNumChunks + 1)
   }

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -227,7 +227,8 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
     val dropData = data.map(d => (d.head.asInstanceOf[Long] + 70000L) +: d.drop(1))
     val container = MachineMetricsData.records(promHistDS, dropData).records
     val bh = MachineMetricsData.histIngestBH
-    container.iterate(promHistDS.ingestionSchema).foreach { row => part.ingest(0, row, bh) }
+    container.iterate(promHistDS.ingestionSchema).foreach { row => part.ingest(0, row, bh,
+      createChunkAtFlushBoundary = false, flushIntervalMillis = Option.empty) }
     part.switchBuffers(bh, encode = true)
 
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -328,7 +328,8 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
               for {c <- dsRecordBuilder.allContainers
                    row <- c.iterate(part.schema.ingestionSchema)
               } {
-                part.ingest(userTimeEndExclusive, row, offHeapMem.blockMemFactory)
+                part.ingest(userTimeEndExclusive, row, offHeapMem.blockMemFactory, createChunkAtFlushBoundary = false,
+                  flushIntervalMillis = Option.empty)
               }
             } catch {
               case e: Exception =>

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -132,7 +132,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
       val rr = new BinaryRecordRowReader(Schemas.untyped.ingestionSchema, base, offset)
-      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+      part.ingest(lastSampleTime, rr, offheapMem.blockMemFactory, createChunkAtFlushBoundary = false,
+        flushIntervalMillis = Option.empty)
     }
     part.switchBuffers(offheapMem.blockMemFactory, true)
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
@@ -174,7 +175,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
       val rr = new BinaryRecordRowReader(Schemas.gauge.ingestionSchema, base, offset)
-      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory, createChunkAtFlushBoundary = false,
+        flushIntervalMillis = Option.empty)
     }
     part.switchBuffers(offheapMem.blockMemFactory, true)
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
@@ -214,7 +216,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
       val rr = new BinaryRecordRowReader(Schemas.gauge.ingestionSchema, base, offset)
-      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory, createChunkAtFlushBoundary = false,
+        flushIntervalMillis = Option.empty)
     }
     part.switchBuffers(offheapMem.blockMemFactory, true)
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
@@ -260,7 +263,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
       val rr = new BinaryRecordRowReader(Schemas.promCounter.ingestionSchema, base, offset)
-      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory, createChunkAtFlushBoundary = false,
+        flushIntervalMillis = Option.empty)
     }
     part.switchBuffers(offheapMem.blockMemFactory, true)
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
@@ -307,7 +311,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
     MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
       val rr = new BinaryRecordRowReader(Schemas.promHistogram.ingestionSchema, base, offset)
-      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory)
+      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory, createChunkAtFlushBoundary = false,
+        flushIntervalMillis = Option.empty)
     }
     part.switchBuffers(offheapMem.blockMemFactory, true)
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

switch buffers and create an encoded chunk when current sample's timestamp crosses flush boundary.  e.g. for a flush-interval of 1hour, if new sample falls in different hour than last sample, then switch buffers and create chunk. This helps in aligning chunks across Active/Active HA clusters and facilitates chunk migration between the clusters during disaster recovery.
Note: Enabling this feature might result into creation of smaller suboptimal chunks.