### PR TITLE
maint(all): Using too many spans; replace with histograms

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -33,6 +33,7 @@ trait QueryPlanner {
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
+    // Dont finish span since this code didnt create it
     Kamon.runWithSpan(parentSpan, false) {
       execPlan.dispatcher.dispatch(execPlan)
     }

--- a/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
+++ b/core/src/main/scala/filodb.core/downsample/ShardDownsampler.scala
@@ -1,7 +1,6 @@
 package filodb.core.downsample
 
 import com.typesafe.scalalogging.StrictLogging
-import kamon.Kamon
 
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesShardStats}
@@ -64,10 +63,6 @@ class ShardDownsampler(datasetName: String,
                                 chunksets: ChunkInfoIterator,
                                 records: Seq[DownsampleRecords]): Unit = {
     if (enabled) {
-      val downsampleTrace = Kamon.spanBuilder("memstore-downsample-records-trace")
-        .asChildOf(Kamon.currentSpan())
-        .tag("dataset", datasetName)
-        .tag("shard", shardNum).start()
       while (chunksets.hasNext) {
         val chunkset = chunksets.nextInfoReader
         val startTime = chunkset.startTime
@@ -103,7 +98,6 @@ class ShardDownsampler(datasetName: String,
           }
         }
       }
-      downsampleTrace.finish()
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -30,6 +30,7 @@ case object InProcessPlanDispatcher extends PlanDispatcher {
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
+    // Dont finish span since this code didnt create it
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       // translate implicit ExecutionContext to monix.Scheduler
       val querySession = QuerySession(plan.queryContext, queryConfig)

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -2,7 +2,6 @@ package filodb.query.exec
 
 import scala.concurrent.Future
 
-import kamon.Kamon
 import kamon.trace.Span
 import monix.execution.Scheduler
 
@@ -60,11 +59,6 @@ case class PromQlRemoteExec(queryEndpoint: String,
   //   schema.  Would need to detect ahead of time to use TransientHistRow(), so we'd need to add schema to output,
   //   and detect it in execute() above.  Need to discuss compatibility issues with Prometheus.
   def toQueryResponse(data: Data, id: String, parentSpan: kamon.trace.Span): QueryResponse = {
-    val span = Kamon.spanBuilder(s"create-queryresponse-${getClass.getSimpleName}")
-      .asChildOf(parentSpan)
-      .tag("query-id", id)
-      .start()
-
     val queryResponse = if (data.result.isEmpty) {
       logger.debug("PromQlRemoteExec generating empty QueryResult as result is empty")
       QueryResult(id, ResultSchema.empty, Seq.empty)
@@ -84,7 +78,6 @@ case class PromQlRemoteExec(queryEndpoint: String,
         }
       }
     }
-    span.finish()
     queryResponse
   }
 

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -57,7 +57,8 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
     val span = Kamon.currentSpan()
-    Kamon.runWithSpan(span, true) {
+    // Dont finish span since this code didnt create it
+    Kamon.runWithSpan(span, false) {
       Task.fromFuture(sendHttpRequest(span, requestTimeoutMs))
     }
   }

--- a/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
@@ -1,6 +1,5 @@
 package filodb.query.exec
 
-import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -57,24 +56,9 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
   override def execute(source: ChunkSource,
                        querySession: QuerySession)
                       (implicit sched: Scheduler): Task[QueryResponse] = {
-    val execPlan2Span = Kamon.spanBuilder(s"execute-${getClass.getSimpleName}")
-      .asChildOf(Kamon.currentSpan())
-      .tag("query-id", queryContext.queryId)
-      .start()
-
     val rangeVectors : Seq[RangeVector] = Seq(ScalarFixedDouble(params, evaluate))
-    // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
-    // across threads. Note that task/observable will not run on the thread where span is present since
-    // kamon uses thread-locals.
-    Kamon.runWithSpan(execPlan2Span, true) {
-      Task {
-        val span = Kamon.spanBuilder(s"transform-${getClass.getSimpleName}")
-          .asChildOf(execPlan2Span)
-          .tag("query-id", queryContext.queryId)
-          .start()
-        span.finish()
-        QueryResult(queryContext.queryId, resultSchema, rangeVectors)
-      }
+    Task {
+      QueryResult(queryContext.queryId, resultSchema, rangeVectors)
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -51,7 +51,8 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
-    Kamon.runWithSpan(Kamon.currentSpan(), true) {
+    // Dont finish span since this code didnt create it
+    Kamon.runWithSpan(Kamon.currentSpan(), false) {
       Task {
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
           val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult)

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -46,27 +46,18 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
   override def execute(source: ChunkSource,
                        querySession: QuerySession)
                       (implicit sched: Scheduler): Task[QueryResponse] = {
-    val execPlan2Span = Kamon.spanBuilder(s"execute-${getClass.getSimpleName}")
-      .asChildOf(Kamon.currentSpan())
-      .tag("query-id", queryContext.queryId)
-      .start()
     val resultSchema = ResultSchema(columns, 1)
     val rangeVectors : Seq[RangeVector] = Seq(ScalarFixedDouble(params, value))
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
-    Kamon.runWithSpan(execPlan2Span, true) {
+    Kamon.runWithSpan(Kamon.currentSpan(), true) {
       Task {
-        val span = Kamon.spanBuilder(s"transform-${getClass.getSimpleName}")
-          .asChildOf(execPlan2Span)
-          .tag("query-id", queryContext.queryId)
-          .start()
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
           val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult)
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          span.finish()
           QueryResult(queryContext.queryId, resultSchema, _)
         })
       }.flatten

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -124,16 +124,15 @@ final case class SelectRawPartitionsExec(queryContext: QueryContext,
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = {
-    val span = Kamon.spanBuilder(s"execute-${getClass.getSimpleName}")
-      .asChildOf(Kamon.currentSpan())
-      .start()
+
+    Kamon.currentSpan().mark(s"doExecute-start-${getClass.getSimpleName}")
     Query.qLogger.debug(s"queryId=${queryContext.queryId} on dataset=$datasetRef shard=" +
       s"${lookupRes.map(_.shard).getOrElse("")} " + s"schema=" +
       s"${dataSchema.map(_.name)} is configured to use columnIDs=$colIds")
     val rvs = dataSchema.map { sch =>
       source.rangeVectors(datasetRef, lookupRes.get, colIds, sch, filterSchemas, querySession)
     }.getOrElse(Observable.empty)
-    span.finish()
+    Kamon.currentSpan().mark(s"doExecute-end-${getClass.getSimpleName}")
     ExecResult(rvs, Task.eval(schemaOfDoExecute()))
   }
 

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -1,6 +1,5 @@
 package filodb.query.exec
 
-import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -124,15 +123,12 @@ final case class SelectRawPartitionsExec(queryContext: QueryContext,
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = {
-
-    Kamon.currentSpan().mark(s"doExecute-start-${getClass.getSimpleName}")
     Query.qLogger.debug(s"queryId=${queryContext.queryId} on dataset=$datasetRef shard=" +
       s"${lookupRes.map(_.shard).getOrElse("")} " + s"schema=" +
       s"${dataSchema.map(_.name)} is configured to use columnIDs=$colIds")
     val rvs = dataSchema.map { sch =>
       source.rangeVectors(datasetRef, lookupRes.get, colIds, sch, filterSchemas, querySession)
     }.getOrElse(Observable.empty)
-    Kamon.currentSpan().mark(s"doExecute-end-${getClass.getSimpleName}")
     ExecResult(rvs, Task.eval(schemaOfDoExecute()))
   }
 

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -60,7 +60,8 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
-    Kamon.runWithSpan(span, true) {
+    // Dont finish span since this code didnt create it
+    Kamon.runWithSpan(span, false) {
       Task {
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
           val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult)

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -44,10 +44,7 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
   override def execute(source: ChunkSource,
                        querySession: QuerySession)
                       (implicit sched: Scheduler): Task[QueryResponse] = {
-    val execPlan2Span = Kamon.spanBuilder(s"execute-${getClass.getSimpleName}")
-      .asChildOf(Kamon.currentSpan())
-      .tag("query-id", queryContext.queryId)
-      .start()
+    val span = Kamon.currentSpan()
     val resultSchema = ResultSchema(columns, 1)
     val rangeVectors : Seq[RangeVector] = function match {
       case Time        => Seq(TimeScalar(params))
@@ -63,18 +60,13 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
-    Kamon.runWithSpan(execPlan2Span, true) {
+    Kamon.runWithSpan(span, true) {
       Task {
-        val span = Kamon.spanBuilder(s"transform-${getClass.getSimpleName}")
-          .asChildOf(execPlan2Span)
-          .tag("query-id", queryContext.queryId)
-          .start()
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
           val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult)
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          span.finish()
           QueryResult(queryContext.queryId, resultSchema, _)
         })
       }.flatten

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -50,11 +50,11 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
   @transient lazy val numRawChunksDownsampled = Kamon.counter("num-raw-chunks-downsampled").withoutTags()
   @transient lazy val numDownsampledChunksWritten = Kamon.counter("num-downsampled-chunks-written").withoutTags()
 
-  @transient val downsampleBatchLatency = Kamon.histogram("downsample-batch-latency",
+  @transient lazy val downsampleBatchLatency = Kamon.histogram("downsample-batch-latency",
                                               MeasurementUnit.time.milliseconds).withoutTags()
-  @transient val downsampleSinglePartLatency = Kamon.histogram("downsample-single-partition-latency",
+  @transient lazy val downsampleSinglePartLatency = Kamon.histogram("downsample-single-partition-latency",
     MeasurementUnit.time.milliseconds).withoutTags()
-  @transient val downsampleBatchPersistLatency = Kamon.histogram("cassandra-downsample-batch-persist-latency",
+  @transient lazy val downsampleBatchPersistLatency = Kamon.histogram("cassandra-downsample-batch-persist-latency",
     MeasurementUnit.time.milliseconds).withoutTags()
 
   @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(settings.cassandraConfig)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.FiniteDuration
 
 import kamon.Kamon
+import kamon.metric.MeasurementUnit
 import monix.reactive.Observable
 import spire.syntax.cfor._
 
@@ -48,6 +49,13 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
   @transient lazy val numRawChunksSkipped = Kamon.counter("num-raw-chunks-skipped").withoutTags()
   @transient lazy val numRawChunksDownsampled = Kamon.counter("num-raw-chunks-downsampled").withoutTags()
   @transient lazy val numDownsampledChunksWritten = Kamon.counter("num-downsampled-chunks-written").withoutTags()
+
+  @transient val downsampleBatchLatency = Kamon.histogram("downsample-batch-latency",
+                                              MeasurementUnit.time.milliseconds).withoutTags()
+  @transient val downsampleSinglePartLatency = Kamon.histogram("downsample-single-partition-latency",
+    MeasurementUnit.time.milliseconds).withoutTags()
+  @transient val downsampleBatchPersistLatency = Kamon.histogram("cassandra-downsample-batch-persist-latency",
+    MeasurementUnit.time.milliseconds).withoutTags()
 
   @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(settings.cassandraConfig)
 
@@ -110,7 +118,6 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
   def downsampleBatch(rawPartsBatch: Seq[RawPartData],
                       userTimeStart: Long,
                       userTimeEndExclusive: Long): Unit = {
-    val batchSpan = Kamon.spanBuilder("downsample-batch-latency").start()
     DownsamplerContext.dsLogger.info(s"Starting to downsample batchSize=${rawPartsBatch.size} partitions " +
       s"rawDataset=${settings.rawDatasetName} for " +
       s"userTimeStart=${java.time.Instant.ofEpochMilli(userTimeStart)} " +
@@ -158,7 +165,7 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
       numBatchesFailed.increment()
       throw e // will be logged by spark
     } finally {
-      batchSpan.finish()
+      downsampleBatchLatency.record(System.currentTimeMillis() - startedAt)
       offHeapMem.free()   // free offheap mem
       pagedPartsToFree.clear()
       downsampledPartsToFree.clear()
@@ -221,7 +228,7 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
             res -> part
         }.toMap
 
-        val downsamplePartSpan = Kamon.spanBuilder("downsample-single-partition-latency").start()
+        val downsamplePartStart = System.currentTimeMillis()
         downsampleChunks(offHeapMem, rawReadablePart, downsamplers, periodMarker, downsampledParts,
                          userTimeStart, userTimeEndExclusive, dsRecordBuilder, shouldTrace)
 
@@ -233,7 +240,7 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
           val newIt = downsampledChunksToPersist(res) ++ dsPartition.makeFlushChunks(offHeapMem.blockMemFactory)
           downsampledChunksToPersist(res) = newIt
         }
-        downsamplePartSpan.finish()
+        downsampleSinglePartLatency.record(System.currentTimeMillis() - downsamplePartStart)
       case None =>
         numPartitionsNoDownsampleSchema.increment()
         DownsamplerContext.dsLogger.debug(s"Skipping downsampling of partition " +
@@ -363,7 +370,7 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
     * Persist chunks in `downsampledChunksToPersist` to Cassandra.
     */
   private def persistDownsampledChunks(downsampledChunksToPersist: MMap[FiniteDuration, Iterator[ChunkSet]]): Int = {
-    val batchWriteSpan = Kamon.spanBuilder("cassandra-downsample-batch-persist-latency").start()
+    val start = System.currentTimeMillis()
     @volatile var numChunks = 0
     // write all chunks to cassandra
     val writeFut = downsampledChunksToPersist.map { case (res, chunks) =>
@@ -385,7 +392,7 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
         DownsamplerContext.dsLogger.error(s"Got response $response when writing to Cassandra")
     }
     numDownsampledChunksWritten.increment(numChunks)
-    batchWriteSpan.finish()
+    downsampleBatchPersistLatency.record(System.currentTimeMillis() - start)
     numChunks
   }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -25,6 +25,8 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
   @transient lazy private val numPartKeysNoDownsampleSchema = Kamon.counter("num-partkeys-no-downsample").withoutTags()
   @transient lazy private val numPartKeysMigrated = Kamon.counter("num-partkeys-migrated").withoutTags()
   @transient lazy private val numPartKeysBlocked = Kamon.counter("num-partkeys-blocked").withoutTags()
+  @transient lazy val perShardIndexMigrationLatency = Kamon.histogram("per-shard-index-migration-latency",
+    MeasurementUnit.time.milliseconds).withoutTags()
 
   @transient lazy private[downsampler] val schemas = Schemas.fromConfig(dsSettings.filodbConfig).get
 
@@ -54,9 +56,6 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
   @transient lazy private val highestDSResolution =
       dsSettings.rawDatasetIngestionConfig.downsampleConfig.resolutions.last
   @transient lazy private val dsDatasetRef = downsampleRefsByRes(highestDSResolution)
-
-  @transient val perShardIndexMigrationLatency = Kamon.histogram("per-shard-index-migration-latency",
-    MeasurementUnit.time.milliseconds).withoutTags()
 
   def updateDSPartKeyIndex(shard: Int, fromHour: Long, toHourExcl: Long, fullIndexMigration: Boolean): Unit = {
     sparkTasksStarted.increment


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

We are creating too many spans adding to GC as well as tracing backend pressure.
Use existing spans and create markers instead.
Replace the metrics spans emit with histograms.

**NOTE: Metric names have changed quite a bit in this PR. Dashboards and alerts need to be updated**
