### PR TITLE
feat(query): make skipAggregatePresent false when there is single matching value for shard key regex

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -66,8 +66,7 @@ class ShardKeyRegexPlanner(dataset: Dataset,
                                        qContext: QueryContext): Seq[ExecPlan] = {
     val queryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams]
     val shardKeyMatches = shardKeyMatcher(nonMetricShardKeyFilters)
-    // Filters like _ns_ =~ "App" will result in only one sub query
-    val skipAggregatePresentValue= if (shardKeyMatches.length == 1) false else true
+    val skipAggregatePresentValue = if (shardKeyMatches.length == 1) false else true
     shardKeyMatches.map { result =>
         val newLogicalPlan = logicalPlan.replaceFilters(result)
         // Querycontext should just have the part of query which has regex

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -274,7 +274,6 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn)
     the[UnsupportedOperationException] thrownBy {
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
-      execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
     } should have message "Shard Key regex not supported for TopK"
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -249,4 +249,32 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
     execPlan.isInstanceOf[LabelValuesDistConcatExec] shouldEqual (true)
   }
+
+  it("should generate Exec plan for topk query with single matching value for regex") {
+    val lp = Parser.queryToLogicalPlan(s"""topk(2, test{_ws_ = "demo", _ns_ =~ "App-1"})""",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))))
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
+  }
+
+  it("should throw UnsupportedOperationException for topk query with multiple matching values for regex") {
+    val lp = Parser.queryToLogicalPlan(s"""topk(2, test{_ws_ = "demo", _ns_ =~ "App.*"})""",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))))
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn)
+    the[UnsupportedOperationException] thrownBy {
+      val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+      execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
+    } should have message "Shard Key regex not supported for TopK"
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Queries like `topk(2,test{_ws_ = "demo", _ns_ =~ "App"})` has just one matching value for regex. We don't need to skip aggregate present step as this query will result in only one sub query.

**New behavior :**
Make skipAggregatePresent false when there is single matching value for shard key regex
