### PR TITLE
bug(query): Fast Reduce closed RV in a different thread

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -1,7 +1,5 @@
 package filodb.query.exec
 
-import scala.collection.mutable.ArrayBuffer
-
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
 import monix.reactive.Observable

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -270,10 +270,12 @@ object RangeVectorAggregator extends StrictLogging {
       }
     }
 
+    // convert the aggregations to range vectors
     aggObs.flatMap { _ =>
       if (count > 0) {
-        import NoCloseCursor._ // The base range vectors are already closed
-        Observable.now(IteratorBackedRangeVector(CustomRangeVectorKey.empty, accs.toIterator.map(_.toRowReader)))
+        import NoCloseCursor._ // The base range vectors are already closed, so no close propagation needed
+        Observable.now(IteratorBackedRangeVector(CustomRangeVectorKey.empty,
+          NoCloseCursor(accs.toIterator.map(_.toRowReader))))
       } else {
         Observable.empty
       }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Range vector locks were released in a different thread than the one where it was acquired. This leads to lock state corruption. Closing immediately in same lambda.