### PR TITLE
perf(query): Remove logging of plans to reduce Logging I/O

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -145,7 +145,8 @@ final class QueryActor(memStore: MemStore,
           }(queryScheduler).recover { case ex =>
             querySession.close()
             // Unhandled exception in query, should be rare
-            logger.error(s"queryId ${q.queryContext.queryId} Unhandled Query Error: ", ex)
+            logger.error(s"queryId ${q.queryContext.queryId} Unhandled Query Error," +
+              s" query was ${q.queryContext.origQueryParams}", ex)
             queryExecuteSpan.finish()
             replyTo ! QueryError(q.queryContext.queryId, ex)
           }(queryScheduler)

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -162,7 +162,7 @@ trait ExecPlan extends QueryCommand {
               srv
             case rv: RangeVector =>
               // materialize, and limit rows per RV
-              val srv = SerializedRangeVector(rv, builder, recSchema, printTree(false))
+              val srv = SerializedRangeVector(rv, builder, recSchema, queryWithPlanName(queryContext))
               numResultSamples += srv.numRowsInt
               // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
               if (enforceLimit && numResultSamples > queryContext.plannerParams.sampleLimit)
@@ -185,7 +185,8 @@ trait ExecPlan extends QueryCommand {
               // 250 RVs * (250 bytes for RV-Key + 200 samples * 32 bytes per sample)
               // is < 2MB
               qLogger.warn(s"queryId: ${queryContext.queryId} result was large size $numBytes. May need to " +
-                s"tweak limits. ExecPlan was: ${printTree()} ; Limit was: ${queryContext.plannerParams.sampleLimit}")
+                s"tweak limits. Query was: ${queryContext.origQueryParams}" +
+                s"; Limit was: ${queryContext.plannerParams.sampleLimit}")
             }
             span.mark(s"num-result-samples: $numResultSamples")
             span.mark(s"num-range-vectors: ${r.size}")
@@ -196,7 +197,7 @@ trait ExecPlan extends QueryCommand {
       resultTask.onErrorHandle { case ex: Throwable =>
         if (!ex.isInstanceOf[BadQueryException]) // dont log user errors
           qLogger.error(s"queryId: ${queryContext.queryId} Exception during execution of query: " +
-            s"${printTree(false)}", ex)
+            s"${queryContext.origQueryParams}", ex)
         span.fail(ex)
         QueryError(queryContext.queryId, ex)
       }
@@ -204,7 +205,7 @@ trait ExecPlan extends QueryCommand {
     .onErrorRecover { case NonFatal(ex) =>
       if (!ex.isInstanceOf[BadQueryException]) // dont log user errors
         qLogger.error(s"queryId: ${queryContext.queryId} Exception during orchestration of query:" +
-          s" ${printTree(false)}", ex)
+          s" ${queryContext.origQueryParams}", ex)
       QueryError(queryContext.queryId, ex)
     }
 
@@ -243,6 +244,10 @@ trait ExecPlan extends QueryCommand {
     val curNode = curNodeText(nextLevel)
     val childr = children.map(_.printTree(useNewline, nextLevel + 1))
     ((transf :+ curNode) ++ childr).mkString(if (useNewline) "\n" else " @@@ ")
+  }
+
+  protected def queryWithPlanName(queryContext: QueryContext): String = {
+    s"${this.getClass.getSimpleName}-${queryContext.origQueryParams}"
   }
 
   def curNodeText(level: Int): String =
@@ -314,7 +319,7 @@ final case class ExecPlanFuncArgs(execPlan: ExecPlan, timeStepParams: RangeParam
     Observable.fromTask(
       execPlan.dispatcher.dispatch(execPlan).onErrorHandle { case ex: Throwable =>
       qLogger.error(s"queryId: ${execPlan.queryContext.queryId} Execution failed for sub-query" +
-        s" ${execPlan.printTree()}", ex)
+        s" ${execPlan.queryContext.origQueryParams}", ex)
       QueryError(execPlan.queryContext.queryId, ex)
     }.map {
       case QueryResult(_, _, result)  =>  // Result is empty because of NaN so create ScalarFixedDouble with NaN
@@ -372,7 +377,8 @@ abstract class NonLeafExecPlan extends ExecPlan {
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(span, false) {
       plan.dispatcher.dispatch(plan).onErrorHandle { case ex: Throwable =>
-        qLogger.error(s"queryId: ${queryContext.queryId} Execution failed for sub-query ${plan.printTree()}", ex)
+        qLogger.error(s"queryId: ${queryContext.queryId} Execution failed for sub-query " +
+          s"${queryContext.origQueryParams}", ex)
         QueryError(queryContext.queryId, ex)
       }
     }

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -44,7 +44,8 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
       UTF8MapIteratorRowReader(iteratorMap.toIterator))
 
-    val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema, printTree(false)))
+    val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema,
+                        queryWithPlanName(queryContext)))
 
     QueryResult(id, resultSchema, srvSeq)
   }

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -113,7 +113,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
         override def numRows: Option[Int] = Option(samples.size)
 
       }
-      SerializedRangeVector(rv, builder, recordSchema.get("default").get, printTree(false))
+      SerializedRangeVector(rv, builder, recordSchema.get("default").get,
+        queryWithPlanName(queryContext))
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("default").get, rangeVectors)
@@ -147,7 +148,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         override def numRows: Option[Int] = Option(samples.size)
 
       }
-      SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, printTree(false))
+      SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, queryContext.origQueryParams.toString)
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("histogram").get, rangeVectors)
@@ -171,7 +172,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
           }
           override def numRows: Option[Int] = Option(d.aggregateResponse.get.aggregateSampl.size)
         }
-      SerializedRangeVector(rv, builder, recordSchema.get(Avg.entryName).get, printTree(false))
+      SerializedRangeVector(rv, builder, recordSchema.get(Avg.entryName).get,
+        queryWithPlanName(queryContext))
     }
 
     // TODO: Handle stitching with verbose flag
@@ -197,7 +199,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
         }
         override def numRows: Option[Int] = Option(d.aggregateResponse.get.aggregateSampl.size)
       }
-      SerializedRangeVector(rv, builder, recordSchema.get(QueryFunctionConstants.stdVal).get, printTree(false))
+      SerializedRangeVector(rv, builder, recordSchema.get(QueryFunctionConstants.stdVal).get,
+        queryWithPlanName(queryContext))
     }
 
     // TODO: Handle stitching with verbose flag


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

We use printTree that logs plan on errors.
Now that we have original promQL query, we dont need to log full plan - we can log the query.

This reduces logging pressure. We found that in some nodes that are backed on the scheduler, a lot of time is spent logging timeout errors
