### PR TITLE
bug(memory): Mask out high bit of lockState to get shared lock count

### DIFF
--- a/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
@@ -105,7 +105,7 @@ object ChunkMap extends StrictLogging {
           var lockState = 0
           do {
             lockState = UnsafeUtils.getIntVolatile(inst, lockStateOffset)
-            if (lockState - amt < 0) {
+            if ((lockState & Int.MaxValue) - amt < 0) {
               _logger.error(s"Negative lock state while releasing all shared locks for pk: $inst, amount=$amt " +
                 s"Contents of execPlanTracker for current thread: ${execPlanTracker.get(Thread.currentThread())}",
                 new RuntimeException)
@@ -404,7 +404,7 @@ class ChunkMap(val memFactory: NativeMemoryManager, var capacity: Int) {
     var lockState = 0
     do {
       lockState = UnsafeUtils.getIntVolatile(this, lockStateOffset)
-      if (lockState - 1 < 0) {
+      if ((lockState & Int.MaxValue) - 1 < 0) {
         _logger.error(s"Negative lock state while releasing single shared lock for pk: $this " +
           s"Contents of execPlanTracker for current thread: ${execPlanTracker.get(Thread.currentThread())}",
           new RuntimeException)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Invalid warning seen because the lock loop may be observing a write lock.
Mask the high bit of lockState to get shared lock count.