### PR TITLE
bug(memory): Faster-Rate bugfix mutating counter correction vectors

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -344,7 +344,14 @@ extends DoubleVectorDataReader {
     try {
       correctionMeta match {
         // corrected value + any carryover correction
+        // GOTCHA: There is a possibility that n is > length of corrected array if this
+        // vector is in a mutable write buffer. Can happen if a sample was ingested after
+        // corrected array was initialized
+        // In such cases, just retain last counter value
+        // should be ok since it is the latest value which is mutating continuously
+        case DoubleCorrection(_, corr) if n >= corrected.length => corrected.last + corr
         case DoubleCorrection(_, corr) => corrected(n) + corr
+        case NoCorrection if n >= corrected.length => corrected.last
         case NoCorrection => corrected(n)
       }
     } catch { case e: ArrayIndexOutOfBoundsException =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Counter correction in write buffer vectors was encountering ArrayIndexOutOfBoundsException