### PR TITLE
feat(query): return error response and status code for remote query

### DIFF
--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -73,4 +73,16 @@ object PromCirceSupport {
       } yield  AggregateResponse(functionName, sample)
     }
   }
+
+  implicit val decodeRemoteErrorResponse: Decoder[RemoteErrorResponse] = new Decoder[RemoteErrorResponse] {
+    final def apply(c: HCursor): Decoder.Result[RemoteErrorResponse] = {
+      for {
+        status    <- c.downField("status").as[String]
+        errorType <- c.downField("errorType").as[String]
+        error     <- c.downField("error").as[String]
+      } yield {
+        RemoteErrorResponse(status, errorType, error)
+      }
+    }
+  }
 }

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -4,6 +4,8 @@ sealed trait PromQueryResponse {
   def status: String
 }
 
+final case class RemoteErrorResponse(status: String, errorType: String, error: String) extends PromQueryResponse
+
 final case class ErrorResponse(errorType: String, error: String, status: String = "error") extends PromQueryResponse
 
 final case class SuccessResponse(data: Data, status: String = "success") extends PromQueryResponse

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -22,7 +22,7 @@ final case class QueryError(id: String, t: Throwable) extends QueryResponse with
 final case class RemoteQueryError(id: String,
                                   errorResponse: RemoteErrorResponse,
                                   statusCode: Int) extends QueryResponse {
-  override def toString: String = s"RemoteQueryError id=$id RemoteErrorResponse=$errorResponse"
+  override def toString: String = s"RemoteQueryError id=$id RemoteErrorResponse=$errorResponse StatusCode=$statusCode"
 }
 /**
   * Use this exception to raise user errors when inside the context of an observable.

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -19,6 +19,11 @@ final case class QueryError(id: String, t: Throwable) extends QueryResponse with
     t.getStackTrace.map(_.toString).mkString("\n")
 }
 
+final case class RemoteQueryError(id: String,
+                                  errorResponse: RemoteErrorResponse,
+                                  statusCode: Int) extends QueryResponse {
+  override def toString: String = s"RemoteQueryError id=$id RemoteErrorResponse=$errorResponse"
+}
 /**
   * Use this exception to raise user errors when inside the context of an observable.
   * Currently no other way to raise user errors when returning an observable

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -51,8 +51,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
     remoteExecHttpClient.httpGet(queryContext.plannerParams.applicationId, queryEndpoint,
       requestTimeoutMs, queryContext.submitTime, getUrlParams())
       .map { response =>
-        if (response.body.isLeft)
-        {
+        // Error response from remote partition is a nested json present in response.body
+        // as response status code is not 2xx
+        if (response.body.isLeft) {
           parser.decode[RemoteErrorResponse](response.body.left.get) match {
               case Right(errorResponse) => RemoteQueryError(queryContext.queryId, errorResponse, response.code.toInt)
               case Left(ex)             => QueryError(queryContext.queryId, ex)

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -43,7 +43,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
   override val urlParams = Map("query" -> promQlQueryParams.promQl)
 
-  override def sendHttpRequest(execPlan2Span: Span, pTimeoutMs: Long)
+  override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
                               (implicit sched: Scheduler): Future[QueryResponse] = {
 
     import PromCirceSupport._

--- a/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
+++ b/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
@@ -161,4 +161,19 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
        case Left(ex) => throw ex
      }
   }
+
+  it("should parse remote error response") {
+    val input = """[{
+                  |  "status" : "error",
+                  |  "data" : null,
+                  |  "errorType" : "query_materialization_failed",
+                  |  "error" : "Shard: 2 is not available"
+                  |}]""".stripMargin
+
+    parser.decode[List[RemoteErrorResponse]](input) match {
+      case Right(errorResponse) => errorResponse.head shouldEqual(RemoteErrorResponse("error",
+                                   "query_materialization_failed", "Shard: 2 is not available"))
+      case Left(ex)             => throw ex
+    }
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Parse remote query error response and return RemoteQueryError object having status code, error type, and error message