### PR TITLE
fix(query): fix resets function to set the counter to NaN outside window

### DIFF
--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
@@ -129,9 +129,10 @@ class ResetsFunction extends RangeFunction {
   }
 
   def removedFromWindow(row: TransientRow, window: Window): Unit = {
-    if (window.size > 0 && row.value > window.head.value) {
+    if (window.size > 0 && row.value > window.head.value)
       resets -= 1
-    }
+    else if (window.size == 0)
+      resets = Double.NaN
   }
 
   def apply(startTimestamp: Long,

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -316,7 +316,7 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
     }
 
     resetsFunction.apply(startTs, endTs, gaugeWindowForReset, toEmit, queryConfig)
-    Math.abs(toEmit.value - expected) should be < errorOk
+    toEmit.value shouldEqual expected
 
     // Window sliding case
     val expected2 = 1
@@ -327,8 +327,18 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
       toEmit2 = q3.remove
       resetsFunction.removedFromWindow(toEmit2, gaugeWindowForReset)// old items being evicted for new window items
     }
-    resetsFunction.apply(startTs, endTs, gaugeWindow, toEmit2, queryConfig)
-    Math.abs(toEmit2.value - expected2) should be < errorOk
+    resetsFunction.apply(startTs, endTs, gaugeWindowForReset, toEmit2, queryConfig)
+    toEmit2.value shouldEqual expected2
+
+    // Remove all the elements from the window - window is outside of data range
+    // Expectation is to not emit outside window
+    while(q3.size > 0) {
+      val toEmit2 = q3.remove()
+      resetsFunction.removedFromWindow(toEmit2, gaugeWindowForReset)
+    }
+    resetsFunction.apply(startTs, endTs, gaugeWindowForReset, toEmit2, queryConfig)
+
+    toEmit2.value.isNaN shouldBe true //window is empty, so resets is not defined
   }
 
   it ("deriv should work when start and end are outside window") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

- fix the bug in `resets` function to set the counter to NaN once all rows from window are removed. This fixes an issue where even if there is no data to emit, `resets` function still returns `0`