### PR TITLE
perf(query): Reduce RV key heap memory for high-card queries

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/client/FiloKryoSerializers.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/FiloKryoSerializers.scala
@@ -36,7 +36,7 @@ class PartitionRangeVectorKeySerializer extends KryoSerializer[PartitionRangeVec
     val partBytes = BinaryRegionUtils.readLargeRegion(input)
     val schema = kryo.readObject(input, classOf[RecordSchema2])
     val keyCols = kryo.readClassAndObject(input)
-    PartitionRangeVectorKey(partBytes, UnsafeUtils.arayOffset,
+    PartitionRangeVectorKey(Right((partBytes, UnsafeUtils.arayOffset)),
       schema, keyCols.asInstanceOf[Seq[ColumnInfo]], input.readInt, input.readInt, input.readInt, input.readString)
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -127,8 +127,8 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val tuples = (numRawSamples until 0).by(-1).map(n => (now - n * reportingInterval, n.toDouble))
 
     // scalastyle:off null
-    val rvKey = new PartitionRangeVectorKey(null, defaultPartKey, dataset1.partKeySchema,
-                                            Seq(ColumnInfo("string", ColumnType.StringColumn)), 1, 5, 100, dataset1.name)
+    val rvKey = PartitionRangeVectorKey(Right((null, defaultPartKey)), dataset1.partKeySchema,
+                                        Seq(ColumnInfo("string", ColumnType.StringColumn)), 1, 5, 100, dataset1.name)
 
     val rowbuf = tuples.map { t =>
       new SeqRowReader(Seq[Any](t._1, t._2))

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -42,14 +42,22 @@ class SeqMapConsumer extends MapItemConsumer {
 /**
   * Range Vector Key backed by a BinaryRecord v2 partition key, which is basically a pointer to memory on or offheap.
   */
-final case class PartitionRangeVectorKey(partBase: Array[Byte],
-                                         partOffset: Long,
+final case class PartitionRangeVectorKey(partKeyData: Either[ReadablePartition, (Array[Byte], Long)],
                                          partSchema: RecordSchema,
                                          partKeyCols: Seq[ColumnInfo],
                                          sourceShard: Int,
                                          groupNum: Int,
                                          partId: Int,
                                          schemaName: String) extends RangeVectorKey {
+  def partBase: Array[Byte] = partKeyData match {
+    case Left(part) => part.partKeyBase
+    case Right((p, _)) => p
+  }
+  def partOffset: Long = partKeyData match {
+    case Left(part) => part.partKeyOffset
+    case Right((_, off)) => off
+  }
+
   override def sourceShards: Seq[Int] = Seq(sourceShard)
   override def partIds: Seq[Int] = Seq(partId)
   override def schemaNames: Seq[String] = Seq(schemaName)

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -162,7 +162,7 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       stats.incrReadPartitions(1)
       val subgroup = TimeSeriesShard.partKeyGroup(schema.partKeySchema, partition.partKeyBase,
                                                   partition.partKeyOffset, numGroups)
-      val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,
+      val key = new PartitionRangeVectorKey(Left(partition),
                                             schema.partKeySchema, partCols, partition.shard,
                                             subgroup, partition.partID, schema.name)
       RawDataRangeVector(key, partition, lookupRes.chunkMethod, ids)

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -88,9 +88,10 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
     val aggregator = RowAggregator(aggrOp, aggrParams, sourceSchema)
 
     def grouping(rv: RangeVector): RangeVectorKey = {
+      val rvLabelValues = rv.key.labelValues
       val groupBy: Map[ZeroCopyUTF8String, ZeroCopyUTF8String] =
-        if (by.nonEmpty) rv.key.labelValues.filter(lv => byLabels.contains(lv._1))
-        else if (without.nonEmpty) rv.key.labelValues.filterNot(lv =>withoutLabels.contains(lv._1))
+        if (by.nonEmpty) rvLabelValues.filter(lv => byLabels.contains(lv._1))
+        else if (without.nonEmpty) rvLabelValues.filterNot(lv =>withoutLabels.contains(lv._1))
         else Map.empty
       CustomRangeVectorKey(groupBy)
     }

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -61,10 +61,11 @@ final case class HistogramQuantileMapper(funcParams: Seq[FuncArgs]) extends Rang
 
         // sort the bucket range vectors by increasing le tag value
         val sortedBucketRvs = histBuckets._2.toArray.map { bucket =>
-          if (!bucket.key.labelValues.contains(le))
+          val labelValues = bucket.key.labelValues
+          if (!labelValues.contains(le))
             throw new IllegalArgumentException("Cannot calculate histogram quantile" +
               s"because 'le' tag is absent in the time series ${bucket.key.labelValues}")
-          val leStr = bucket.key.labelValues(le).toString
+          val leStr = labelValues(le).toString
           val leDouble = if (leStr == "+Inf") Double.PositiveInfinity else leStr.toDouble
           leDouble -> bucket
         }.sortBy(_._1)

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -58,7 +58,7 @@ final case class SelectChunkInfosExec(queryContext: QueryContext,
             source.stats.incrReadPartitions(1)
             val subgroup = TimeSeriesShard.partKeyGroup(dataSchema.partKeySchema, partition.partKeyBase,
                                                         partition.partKeyOffset, numGroups)
-            val key = new PartitionRangeVectorKey(partition.partKeyBase, partition.partKeyOffset,
+            val key = PartitionRangeVectorKey(Left(partition),
                                                   dataSchema.partKeySchema, partCols, shard,
                                                   subgroup, partition.partID, dataSchema.name)
             ChunkInfoRangeVector(key, partition, chunkMethod, dataColumn)

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -2,4 +2,10 @@
 sbt "jmh/jmh:run -rf json -i 15 -wi 10 -f3 -jvmArgsAppend -XX:MaxInlineLevel=20 \
  -jvmArgsAppend -Xmx4g -jvmArgsAppend -XX:MaxInlineSize=99 \
  -prof jmh.extras.JFR:dir=/tmp/filo-jmh \
- filodb.jmh.QueryHiCardInMemoryBenchmark"
+ filodb.jmh.QueryHiCardInMemoryBenchmark \
+ filodb.jmh.QueryInMemoryBenchmark \
+ filodb.jmh.QueryAndIngestBenchmark \
+ filodb.jmh.IngestionBenchmark \
+ filodb.jmh.QueryOnDemandBenchmark \
+ filodb.jmh.GatewayBenchmark \
+ filodb.jmh.PartKeyIndexBenchmark"

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -2,10 +2,4 @@
 sbt "jmh/jmh:run -rf json -i 15 -wi 10 -f3 -jvmArgsAppend -XX:MaxInlineLevel=20 \
  -jvmArgsAppend -Xmx4g -jvmArgsAppend -XX:MaxInlineSize=99 \
  -prof jmh.extras.JFR:dir=/tmp/filo-jmh \
- filodb.jmh.QueryHiCardInMemoryBenchmark \
- filodb.jmh.QueryInMemoryBenchmark \
- filodb.jmh.QueryAndIngestBenchmark \
- filodb.jmh.IngestionBenchmark \
- filodb.jmh.QueryOnDemandBenchmark \
- filodb.jmh.GatewayBenchmark \
- filodb.jmh.PartKeyIndexBenchmark"
+ filodb.jmh.QueryHiCardInMemoryBenchmark"


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We currently make a copy of partKey from offheap into heap via PartitionRangeVectorKey. This can be done lazily.
The effect is especially significant when aggregating high cardinality metrics where part key labels are not inspected for grouping at all.

