### PR TITLE
bug(cass): Retry with exponential backoff when scanning

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/Util.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/Util.scala
@@ -3,9 +3,11 @@ package filodb.cassandra
 import java.nio.ByteBuffer
 
 import scala.concurrent.{Future, Promise}
+import scala.util.Random
 
 import com.datastax.driver.core._
-import com.datastax.driver.core.exceptions.DriverException
+import com.datastax.driver.core.exceptions.{DriverException, ReadTimeoutException}
+import com.typesafe.scalalogging.StrictLogging
 import monix.reactive.Observable
 
 import filodb.core._
@@ -84,4 +86,35 @@ object Util {
   def toBuffer(key: Array[Byte]): ByteBuffer = ByteBuffer.wrap(key)
 
   def toHex(bb: ByteBuffer): String = com.datastax.driver.core.utils.Bytes.toHexString(bb)
+}
+
+/**
+ * Quick & Dirty synchronous exponential backoff that sleeps.
+ * Use only for synchronous API calls
+ */
+class RetryWithExpBackOffIterator(inner: Iterator[Row]) extends Iterator[Row] with StrictLogging{
+  val callStack = new RuntimeException()
+  override def hasNext: Boolean = inner.hasNext
+
+  //scalastyle:off null
+  override def next(): Row = {
+    var retries = 0
+    val maxRetries = 5 // Hardcode maxRetries for now. If needed make it a config later.
+    var nxt: Row = null
+    while (retries < maxRetries && nxt == null) {
+      try {
+        nxt = inner.next()
+      } catch {
+        case e: ReadTimeoutException =>
+          retries += 1
+          if (retries == 5) throw e
+          val jitter = Random.nextInt(3000)
+          val sleepTime = Math.pow(2, retries + 1).toLong * 1000 + jitter
+          logger.error("Got ReadTimeoutException when invoking next on " +
+            s"cassandra's paged iterator. RetriesFinished=$retries sleepingForMs=$sleepTime", callStack)
+          Thread.sleep(sleepTime)
+      }
+    }
+    nxt
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Token scan from ingestion index table during downsample use paged iterator, and this sometimes times out causing entire task to repeat causing more writes, more compaction on cassandra, and more read timeouts.

Putting in place retry with exponential backoff.

