### PR TITLE
misc(query): Move time-split query planning config to QueryContext

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -3,6 +3,8 @@ package filodb.core.query
 import java.util.UUID
 import java.util.concurrent.locks.Lock
 
+import scala.concurrent.duration._
+
 import filodb.core.{SpreadChange, SpreadProvider}
 
 trait TsdbQueryParams
@@ -24,6 +26,9 @@ case class PlannerParams(applicationId: String = "filodb",
                         sampleLimit: Int = 1000000,
                         groupByCardLimit: Int = 100000,
                         joinQueryCardLimit: Int = 100000,
+                        timeSplitEnabled: Boolean = false,
+                        minTimeRangeForSplitMs: Long = 1.day.toMillis,
+                        splitSizeMs: Long = 1.day.toMillis,
                         skipAggregatePresent: Boolean = false,
                         processFailure: Boolean = true,
                         processMultiPartition: Boolean = false)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

Move time-split query planning config to `PlanParameters`, so that it can be controlled/tuned during `materialze`.