### PR TITLE
bug(query):  shard key regex query returns partial  results when remote query throws an exception

### DIFF
--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -1,6 +1,7 @@
 package filodb.query
 
 import enumeratum.{Enum, EnumEntry}
+
 import filodb.core.{DatasetRef, NodeCommand, NodeResponse}
 import filodb.core.query.{RangeVector, ResultSchema}
 

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -1,7 +1,6 @@
 package filodb.query
 
 import enumeratum.{Enum, EnumEntry}
-
 import filodb.core.{DatasetRef, NodeCommand, NodeResponse}
 import filodb.core.query.{RangeVector, ResultSchema}
 
@@ -19,16 +18,25 @@ final case class QueryError(id: String, t: Throwable) extends QueryResponse with
     t.getStackTrace.map(_.toString).mkString("\n")
 }
 
-final case class RemoteQueryError(id: String,
-                                  errorResponse: RemoteErrorResponse,
-                                  statusCode: Int) extends QueryResponse {
-  override def toString: String = s"RemoteQueryError id=$id RemoteErrorResponse=$errorResponse StatusCode=$statusCode"
-}
 /**
   * Use this exception to raise user errors when inside the context of an observable.
   * Currently no other way to raise user errors when returning an observable
   */
 class BadQueryException(message: String) extends RuntimeException(message)
+
+case class RemoteQueryFailureException(statusCode: Int, requestStatus: String, errorType: String, errorMessage: String )
+  extends RuntimeException {
+  override def getMessage: String = {
+    val sb = new StringBuilder(64)
+    sb.append("[").append(this.requestStatus).append("] ").append(this.statusCode)
+    if (this.errorType != null) sb.append(" (").append(this.errorType).append(")")
+    if (this.errorMessage != null) sb.append(" - \"").append(this.errorMessage).append("\"")
+    val cause = getCause
+    if (cause == null) return sb.toString
+    sb.append("; ").append("nested exception is ").append(cause)
+    sb.toString
+  }
+}
 
 sealed trait QueryResultType extends EnumEntry
 object QueryResultType extends Enum[QueryResultType] {

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -55,7 +55,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
         // as response status code is not 2xx
         if (response.body.isLeft) {
           parser.decode[RemoteErrorResponse](response.body.left.get) match {
-              case Right(errorResponse) => RemoteQueryError(queryContext.queryId, errorResponse, response.code.toInt)
+              case Right(errorResponse) => QueryError(queryContext.queryId,
+                RemoteQueryFailureException(response.code.toInt, errorResponse.status, errorResponse.errorType,
+                  errorResponse.error))
               case Left(ex)             => QueryError(queryContext.queryId, ex)
             }
         }


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Shard key regex query returns partial  results when remote query throws an exception

**New behavior :**
Create QueryError with RemoteQueryFailureException when remote query throws an exception. The parent plan will throw exception even when one of the child plans returns QueryError
