### PR TITLE
feat(sparkJobs): Regex filter support for Cardinality Buster

### DIFF
--- a/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
@@ -29,7 +29,7 @@ object BusterContext extends StrictLogging {
  * filodb.cardbuster.delete-pk-filters = [
  *  {
  *     _ns_ = "bulk_ns"
- *     _ws_ = "bulk_ws"
+ *     _ws_ = "tag_value_as_regex"
  *  }
  * ]
  * filodb.cardbuster.delete-startTimeGTE = "ISO_TIME"

--- a/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
@@ -23,6 +23,21 @@ object BusterContext extends StrictLogging {
   lazy protected[cardbuster] val log: Logger = logger
 }
 
+/**
+ * Requires following typesafe config properties:
+ *
+ * filodb.cardbuster.delete-pk-filters = [
+ *  {
+ *     _ns_ = "bulk_ns"
+ *     _ws_ = "bulk_ws"
+ *  }
+ * ]
+ * filodb.cardbuster.delete-startTimeGTE = "ISO_TIME"
+ * filodb.cardbuster.delete-startTimeLTE = "ISO_TIME"
+ * filodb.cardbuster.delete-endTimeGTE = "ISO_TIME"
+ * filodb.cardbuster.delete-endTimeLTE = "ISO_TIME"
+ *
+ */
 class CardinalityBuster(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSIndexJobSettings) extends Serializable {
 
   def run(conf: SparkConf): SparkSession = {

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -40,24 +40,21 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
 
   @transient lazy val deleteFilter = dsSettings.filodbConfig
     .as[Seq[Map[String, String]]]("cardbuster.delete-pk-filters").map(_.mapValues(_.r).toSeq)
-  @transient lazy val startTimeGTE = dsSettings.filodbConfig
-    .as[Option[String]]("cardbuster.delete-startTimeGTE").map { str =>
-    Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str)).toEpochMilli
-  }
-  @transient lazy val startTimeLTE = dsSettings.filodbConfig
-    .as[Option[String]]("cardbuster.delete-startTimeLTE").map { str =>
-    Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str)).toEpochMilli
-  }
-  @transient lazy val endTimeGTE = dsSettings.filodbConfig
-    .as[Option[String]]("cardbuster.delete-endTimeGTE").map { str =>
-    Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str)).toEpochMilli
-  }
-  @transient lazy val endTimeLTE = dsSettings.filodbConfig
-    .as[Option[String]]("cardbuster.delete-endTimeLTE").map { str =>
-    Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str)).toEpochMilli
-  }
+
+  @transient lazy val startTimeGTE = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dsSettings.filodbConfig
+    .as[String]("cardbuster.delete-startTimeGTE"))).toEpochMilli
+
+  @transient lazy val startTimeLTE = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dsSettings.filodbConfig
+    .as[String]("cardbuster.delete-startTimeLTE"))).toEpochMilli
+
+  @transient lazy val endTimeGTE = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dsSettings.filodbConfig
+    .as[String]("cardbuster.delete-endTimeGTE"))).toEpochMilli
+
+  @transient lazy val endTimeLTE = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dsSettings.filodbConfig
+    .as[String]("cardbuster.delete-endTimeLTE"))).toEpochMilli
 
   def bustIndexRecords(shard: Int): Unit = {
+    require(deleteFilter.nonEmpty, "cardbuster.delete-pk-filters should be non-empty")
     BusterContext.log.info(s"Busting cardinality in shard=$shard with " +
       s"filter=$deleteFilter " +
       s"inDownsampleTables=$inDownsampleTables " +
@@ -68,10 +65,10 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
     )
     val toDelete = colStore.scanPartKeys(dataset, shard)
       .filter { pkr =>
-        val timeOk = startTimeGTE.forall(pkr.startTime >= _) &&
-                          startTimeLTE.forall(pkr.startTime <= _) &&
-                          endTimeGTE.forall(pkr.endTime >= _) &&
-                          endTimeLTE.forall(pkr.endTime <= _)
+        val timeOk = pkr.startTime >= startTimeGTE &&
+                     pkr.startTime <= startTimeLTE &&
+                     pkr.endTime >= endTimeGTE &&
+                     pkr.endTime <= endTimeLTE
 
         if (timeOk) {
           val pk = pkr.partKey

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -81,7 +81,8 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
             }
           })
           if (willDelete) {
-            BusterContext.log.debug(s"Deleting part key ${schema.partKeySchema.stringify(pk)}")
+            BusterContext.log.info(s"Deleting part key $pkPairs with startTime=${pkr.startTime} and " +
+              s"endTime=${pkr.endTime} from shard=$shard")
             numPartKeysDeleting.increment()
           }
           willDelete

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -81,7 +81,7 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
             }
           })
           if (willDelete) {
-            BusterContext.log.info(s"Deleting part key $pkPairs with startTime=${pkr.startTime} and " +
+            BusterContext.log.debug(s"Deleting part key $pkPairs with startTime=${pkr.startTime} and " +
               s"endTime=${pkr.endTime} from shard=$shard")
             numPartKeysDeleting.increment()
           }

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -753,12 +753,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     sparkConf.setMaster("local[2]")
     val deleteFilterConfig = ConfigFactory.parseString(
       s"""
-         |filodb.cardbuster.delete-pk-filters = [
-         | {
-         |    _ns_ = "bulk_ns"
-         |    _ws_ = "bulk_ws"
-         | }
-         |]
+         |filodb.cardbuster.delete-pk-filters.0._ns_ = bulk_ns
+         |filodb.cardbuster.delete-pk-filters.0._ws_ = "b.*_ws"
          |filodb.cardbuster.delete-startTimeGTE = "${Instant.ofEpochMilli(0).toString}"
          |filodb.cardbuster.delete-endTimeLTE = "${Instant.ofEpochMilli(600).toString}"
          |""".stripMargin)

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -756,6 +756,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
          |filodb.cardbuster.delete-pk-filters.0._ns_ = bulk_ns
          |filodb.cardbuster.delete-pk-filters.0._ws_ = "b.*_ws"
          |filodb.cardbuster.delete-startTimeGTE = "${Instant.ofEpochMilli(0).toString}"
+         |filodb.cardbuster.delete-startTimeLTE = "${Instant.ofEpochMilli(600).toString}"
+         |filodb.cardbuster.delete-endTimeGTE = "${Instant.ofEpochMilli(500).toString}"
          |filodb.cardbuster.delete-endTimeLTE = "${Instant.ofEpochMilli(600).toString}"
          |""".stripMargin)
 
@@ -796,14 +798,18 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   it ("should be able to bust cardinality in both raw and downsample tables with spark job") {
     val sparkConf = new SparkConf(loadDefaults = true)
     sparkConf.setMaster("local[2]")
-    val deleteFilterConfig = ConfigFactory.parseString( """
+    val deleteFilterConfig = ConfigFactory.parseString( s"""
                                                           |filodb.cardbuster.delete-pk-filters = [
                                                           | {
                                                           |    _ns_ = "bulk_ns"
                                                           |    _ws_ = "bulk_ws"
                                                           | }
                                                           |]
-                                                        """.stripMargin)
+                                                          |filodb.cardbuster.delete-startTimeGTE = "${Instant.ofEpochMilli(0).toString}"
+                                                          |filodb.cardbuster.delete-startTimeLTE = "${Instant.ofEpochMilli(10000).toString}"
+                                                          |filodb.cardbuster.delete-endTimeGTE = "${Instant.ofEpochMilli(500).toString}"
+                                                          |filodb.cardbuster.delete-endTimeLTE = "${Instant.ofEpochMilli(10600).toString}"
+                                                          |                                                        """.stripMargin)
     val settings2 = new DownsamplerSettings(deleteFilterConfig.withFallback(conf))
     val dsIndexJobSettings2 = new DSIndexJobSettings(settings2)
     val cardBuster = new CardinalityBuster(settings2, dsIndexJobSettings2)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

With this PR, `delete-pk-filters` filter values can be regex.