### PR TITLE
misc(query): make assumedResolution configurable

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -100,6 +100,10 @@
 
         # Set to true to enable metering of time series. Used for rate-limiting
         metering-enabled = true
+
+        # Approx ingested data resolution. This is used in estimating/capping the number of samples that will be scanned
+        # during a query execution. specified in milliseconds. default is 60sec.
+        ingest-resolution = 60000
       }
       downsample {
         # Resolutions for downsampled data ** in ascending order **

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -103,7 +103,7 @@
 
         # Approx ingested data resolution. This is used in estimating/capping the number of samples that will be scanned
         # during a query execution. specified in milliseconds. default is 60sec.
-        ingest-resolution = 60000
+        ingest-resolution-millis = 60000
       }
       downsample {
         # Resolutions for downsampled data ** in ascending order **

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -49,8 +49,6 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
     .tag("shard", shardNum)
     .start()
 
-  val assumedResolution = 20000 // for now hard-code and assume 30ms as reporting interval
-
   private def capDataScannedPerShardCheck(lookup: PartLookupResult): Unit = {
     lookup.firstSchemaId.foreach { schId =>
       lookup.chunkMethod match {
@@ -58,7 +56,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
           val numMatches = lookup.partsInMemory.length + lookup.partIdsNotInMemory.length
           schemas.ensureQueriedDataSizeWithinLimitApprox(schId, numMatches,
             storeConfig.flushInterval.toMillis,
-            assumedResolution, end - st, storeConfig.maxDataPerShardQuery)
+            storeConfig.resolution, end - st, storeConfig.maxDataPerShardQuery)
         case _ =>
       }
     }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -56,7 +56,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
           val numMatches = lookup.partsInMemory.length + lookup.partIdsNotInMemory.length
           schemas.ensureQueriedDataSizeWithinLimitApprox(schId, numMatches,
             storeConfig.flushInterval.toMillis,
-            storeConfig.resolution, end - st, storeConfig.maxDataPerShardQuery)
+            storeConfig.estimatedIngestResolution, end - st, storeConfig.maxDataPerShardQuery)
         case _ =>
       }
     }

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -56,7 +56,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
           val numMatches = lookup.partsInMemory.length + lookup.partIdsNotInMemory.length
           schemas.ensureQueriedDataSizeWithinLimitApprox(schId, numMatches,
             storeConfig.flushInterval.toMillis,
-            storeConfig.estimatedIngestResolution, end - st, storeConfig.maxDataPerShardQuery)
+            storeConfig.estimatedIngestResolutionMillis, end - st, storeConfig.maxDataPerShardQuery)
         case _ =>
       }
     }

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -42,7 +42,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              meteringEnabled: Boolean,
                              // approx data resolution, used for estimating the size of data to be scanned for
                              // answering queries, specified in milliseconds
-                             estimatedIngestResolution: Int) {
+                             estimatedIngestResolutionMillis: Int) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -69,7 +69,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
                                "ensure-headroom-percent" -> ensureHeadroomPercent,
                                "metering-enabled" -> meteringEnabled,
-                               "ingest-resolution" -> estimatedIngestResolution).asJava)
+                               "ingest-resolution-millis" -> estimatedIngestResolutionMillis).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -107,7 +107,7 @@ object StoreConfig {
                                            |trace-filters = {}
                                            |metering-enabled = false
                                            |time-aligned-chunks-enabled = false
-                                           |ingest-resolution = 60000
+                                           |ingest-resolution-millis = 60000
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -150,7 +150,7 @@ object StoreConfig {
                 config.as[Map[String, String]]("trace-filters"),
                 config.getMemorySize("max-data-per-shard-query").toBytes,
                 config.getBoolean("metering-enabled"),
-                config.getInt("ingest-resolution"))
+                config.getInt("ingest-resolution-millis"))
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -41,8 +41,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              maxDataPerShardQuery: Long,
                              meteringEnabled: Boolean,
                              // approx data resolution, used for estimating the size of data to be scanned for
-                             // answering queries
-                             resolution: Int) {
+                             // answering queries, specified in milliseconds
+                             estimatedIngestResolution: Int) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -69,7 +69,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
                                "ensure-headroom-percent" -> ensureHeadroomPercent,
                                "metering-enabled" -> meteringEnabled,
-                               "resolution" -> resolution).asJava)
+                               "ingest-resolution" -> estimatedIngestResolution).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -107,7 +107,7 @@ object StoreConfig {
                                            |trace-filters = {}
                                            |metering-enabled = false
                                            |time-aligned-chunks-enabled = false
-                                           |resolution = 60000
+                                           |ingest-resolution = 60000
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -150,7 +150,7 @@ object StoreConfig {
                 config.as[Map[String, String]]("trace-filters"),
                 config.getMemorySize("max-data-per-shard-query").toBytes,
                 config.getBoolean("metering-enabled"),
-                config.getInt("resolution"))
+                config.getInt("ingest-resolution"))
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

make `assumedResolution` configurable, as datasets can have different resolution data.