### PR TITLE
bug(query): Stitch and uniqify LHS and RHS before binary join

### DIFF
--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -83,8 +83,9 @@ final case class BinaryJoinExec(queryContext: QueryContext,
       // NOTE: We can't require this any more, as multischema queries may result in not a QueryResult if the
       //       filter returns empty results.  The reason is that the schema will be undefined.
       // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
-      val lhsRvs = resp.filter(_._2 < lhs.size).flatMap(_._1)
-      val rhsRvs = resp.filter(_._2 >= lhs.size).flatMap(_._1)
+      // Stitch results and uniquify LHS and RHS vectors - there could be dupes because of spread increase
+      val lhsRvs = StitchRvsExec.stitchAndUnique(resp.filter(_._2 < lhs.size).flatMap(_._1))
+      val rhsRvs = StitchRvsExec.stitchAndUnique(resp.filter(_._2 >= lhs.size).flatMap(_._1))
       // figure out which side is the "one" side
       val (oneSide, otherSide, lhsIsOneSide) =
         if (cardinality == Cardinality.OneToMany) (lhsRvs, rhsRvs, true)

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -12,7 +12,27 @@ import filodb.query.Query.qLogger
 
 object StitchRvsExec {
 
-  def merge(vectors: Seq[RangeVectorCursor]): RangeVectorCursor = {
+  /**
+   * Use this method to make RVs unique if there is a possibility of
+   * dupes from different shards. Cost: iteration is not lazy and will
+   * bring vectors to memory like in Binary Joins
+   */
+  def stitchAndUnique(vectors: Iterable[RangeVector]): Iterable[RangeVector] = {
+    vectors
+      .groupBy(_.key.labelValues)
+      .values
+      .map { toMerge =>
+      if (toMerge.size > 1) {
+        val rows = StitchRvsExec.merge(toMerge.map(_.rows))
+        val key = toMerge.head.key
+        IteratorBackedRangeVector(key, rows)
+      } else {
+        toMerge.head
+      }
+    }
+  }
+
+  def merge(vectors: Iterable[RangeVectorCursor]): RangeVectorCursor = {
     // This is an n-way merge without using a heap.
     // Heap is not used since n is expected to be very small (almost always just 1 or 2)
     new RangeVectorCursor {
@@ -73,12 +93,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
       case (QueryResult(_, _, result), _) => result
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map(_.flatten).map { srvs =>
-      val groups = srvs.groupBy(_.key.labelValues)
-      groups.mapValues { toMerge =>
-        val rows = StitchRvsExec.merge(toMerge.map(_.rows))
-        val key = toMerge.head.key
-        IteratorBackedRangeVector(key, rows)
-      }.values
+      StitchRvsExec.stitchAndUnique(srvs)
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten
   }
@@ -99,12 +114,7 @@ final case class StitchRvsMapper() extends RangeVectorTransformer {
             sourceSchema: ResultSchema, paramResponse: Seq[Observable[ScalarRangeVector]]): Observable[RangeVector] = {
     qLogger.debug(s"StitchRvsMapper: Stitching results:")
     val stitched = source.toListL.map { rvs =>
-      val groups = rvs.groupBy(_.key)
-      groups.mapValues { toMerge =>
-        val rows = StitchRvsExec.merge(toMerge.map(_.rows))
-        val key = toMerge.head.key
-        IteratorBackedRangeVector(key, rows)
-      }.values
+      StitchRvsExec.stitchAndUnique(rvs)
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten
   }

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -22,14 +22,14 @@ object StitchRvsExec {
       .groupBy(_.key.labelValues)
       .values
       .map { toMerge =>
-      if (toMerge.size > 1) {
-        val rows = StitchRvsExec.merge(toMerge.map(_.rows))
-        val key = toMerge.head.key
-        IteratorBackedRangeVector(key, rows)
-      } else {
-        toMerge.head
+        if (toMerge.size > 1) {
+          val rows = StitchRvsExec.merge(toMerge.map(_.rows))
+          val key = toMerge.head.key
+          IteratorBackedRangeVector(key, rows)
+        } else {
+          toMerge.head
+        }
       }
-    }
   }
 
   def merge(vectors: Iterable[RangeVectorCursor]): RangeVectorCursor = {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -188,8 +188,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       .toListL.runAsync.futureValue
 
     result.size shouldEqual 2
-    result(0).key.labelValues.contains("_pi_".utf8) shouldEqual true
-    result(1).key.labelValues.contains("_step_".utf8) shouldEqual true
+    result(0).key.labelValues.contains("_step_".utf8) shouldEqual true
+    result(1).key.labelValues.contains("_pi_".utf8) shouldEqual true
 
   }
 
@@ -257,8 +257,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
     result.size shouldEqual 4
     Seq("_pi_".utf8, "tag1".utf8).forall(result(0).key.labelValues.contains) shouldEqual true
-    Seq("_step_".utf8, "tag1".utf8).forall(result(1).key.labelValues.contains) shouldEqual true
-    Seq("_pi_".utf8, "tag1".utf8).forall(result(2).key.labelValues.contains) shouldEqual true
+    Seq("_pi_".utf8, "tag1".utf8).forall(result(1).key.labelValues.contains) shouldEqual true
+    Seq("_step_".utf8, "tag1".utf8).forall(result(2).key.labelValues.contains) shouldEqual true
     Seq("_step_".utf8, "tag1".utf8).forall(result(3).key.labelValues.contains) shouldEqual true
   }
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -211,14 +211,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runAsync.futureValue
 
-    val expectedLabels = List(Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
-      ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
-      ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("idle")
-    ),
-      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
-        ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
-        ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("user")
-    ),
+    val expectedLabels = List(
       Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("def"),
         ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
         ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("idle")
@@ -226,15 +219,23 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("def"),
         ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
         ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("user")
+      ),
+      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
+        ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
+        ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("idle")
+      ),
+      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
+        ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
+        ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("user")
       )
     )
     result.size shouldEqual 4
     result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
 
-    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
-    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
-    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
-    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
+    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
+    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
   }
 
   it("copy sample role to node using group right ") {
@@ -308,12 +309,12 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       )
     )
     result.size shouldEqual 4
-    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
+    result.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
 
-    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
-    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
-    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
-    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
+    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
+    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
   }
 
   it("should have metric name when operator is not MathOperator") {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -489,9 +489,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       .toListL.runAsync.futureValue
 
     result.size shouldEqual 8
-    result.map(_.key.labelValues) sameElements (sampleHttpRequests.map(_.key.labelValues).toList) shouldEqual true
-    sampleHttpRequests.flatMap(_.rows.map(_.getDouble(1)).toList).
-      sameElements(result.flatMap(_.rows.map(_.getDouble(1)).toList)) shouldEqual true
+    result.map(rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet shouldEqual
+      sampleHttpRequests.map( rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet
   }
 
   it("should return Lhs when LAND is done with vector having no labels and ignoring is used om Lhs labels") {
@@ -511,9 +510,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       .toListL.runAsync.futureValue
 
     result.size shouldEqual 8
-    result.map(_.key.labelValues) sameElements (sampleHttpRequests.map(_.key.labelValues)) shouldEqual true
-    sampleHttpRequests.flatMap(_.rows.map(_.getDouble(1)).toList).
-      sameElements(result.flatMap(_.rows.map(_.getDouble(1)).toList)) shouldEqual true
+    result.map(rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet shouldEqual
+      sampleHttpRequests.map( rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet
   }
 
   it("should join many-to-many with or") {
@@ -664,14 +662,14 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     )
 
     result2.size shouldEqual 6
-    result2.map(_.key.labelValues) sameElements (expectedLabels) shouldEqual true
+    result2.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
 
-    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(301)
-    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(401)
-    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(701)
-    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(801)
-    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(100)
-    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(200)
+    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(401)
+    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(301)
+    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(801)
+    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(701)
+    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(200)
+    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(100)
   }
 
   it("should excludes everything that has instance=0/1 but includes entries without " +
@@ -735,14 +733,14 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     )
 
     result2.size shouldEqual 6
-    result2.map(_.key.labelValues) sameElements (expectedLabels) shouldEqual true
+    result2.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
 
-    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(301)
-    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(401)
-    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(701)
-    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(801)
-    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(100)
-    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(200)
+    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(401)
+    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(301)
+    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(801)
+    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(701)
+    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(200)
+    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(100)
   }
 
   it("should join many-to-many with unless") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Range Vectors need to be stitched and made distinct before joins because duplicates can exist due to spread changes. Duplicates cause errors in join matching.