### PR TITLE
bug(query): binary join with offset queries uses LHS offset for planning

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -100,10 +100,10 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
   override def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
 
     // lazy because we want to fetch failures only if needed
-    lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan).max
+    lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan)
     lazy val periodicSeriesTime = getTimeFromLogicalPlan(logicalPlan)
-    lazy val periodicSeriesTimeWithOffset = TimeRange(periodicSeriesTime.startMs - offsetMillis,
-      periodicSeriesTime.endMs - offsetMillis)
+    lazy val periodicSeriesTimeWithOffset = TimeRange(periodicSeriesTime.startMs - offsetMillis.max,
+      periodicSeriesTime.endMs - offsetMillis.min)
     lazy val lookBackTime = getLookBackMillis(logicalPlan).max
     // Time at which raw data would be retrieved which is used to get failures.
     // It should have time with offset and lookback as we need raw data at time including offset and lookback.

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -55,7 +55,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
   private def routeExecPlanMapper(routes: Seq[Route], rootLogicalPlan: LogicalPlan,
                                   qContext: QueryContext, lookBackTime: Long): ExecPlan = {
 
-    val offsetMs = LogicalPlanUtils.getOffsetMillis(rootLogicalPlan)
+    val offsetMs = LogicalPlanUtils.getOffsetMillis(rootLogicalPlan).max
     val execPlans: Seq[ExecPlan] = routes.map { route =>
       route match {
         case route: LocalRoute => if (route.timeRange.isEmpty)
@@ -100,11 +100,11 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
   override def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
 
     // lazy because we want to fetch failures only if needed
-    lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan)
+    lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan).max
     lazy val periodicSeriesTime = getTimeFromLogicalPlan(logicalPlan)
     lazy val periodicSeriesTimeWithOffset = TimeRange(periodicSeriesTime.startMs - offsetMillis,
       periodicSeriesTime.endMs - offsetMillis)
-    lazy val lookBackTime = getLookBackMillis(logicalPlan)
+    lazy val lookBackTime = getLookBackMillis(logicalPlan).max
     // Time at which raw data would be retrieved which is used to get failures.
     // It should have time with offset and lookback as we need raw data at time including offset and lookback.
     lazy val queryTimeRange = TimeRange(periodicSeriesTimeWithOffset.startMs - lookBackTime,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -173,7 +173,7 @@ object LogicalPlanUtils extends StrictLogging {
       leaf.map { l =>
         l match {
           case lp: RawSeries => lp.offsetMs.getOrElse(0L)
-          case _ => 0L
+          case _             => 0L
         }
       }
     }
@@ -186,7 +186,7 @@ object LogicalPlanUtils extends StrictLogging {
       leaf.map { l =>
         l match {
           case lp: RawSeries => lp.lookbackMs.getOrElse(staleDataLookbackMillis)
-          case _ => 0
+          case _             => 0
         }
       }
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -34,8 +34,8 @@ class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
     logicalPlan match {
       case p: PeriodicSeriesPlan =>
         val earliestRawTime = earliestRawTimestampFn
-        lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan)
-        lazy val lookbackMs = LogicalPlanUtils.getLookBackMillis(logicalPlan)
+        lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan).max
+        lazy val lookbackMs = LogicalPlanUtils.getLookBackMillis(logicalPlan).max
         lazy val startWithOffsetMs = p.startMs - offsetMillis
         lazy val endWithOffsetMs = p.endMs - offsetMillis
         if (!logicalPlan.isRoutable)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -143,7 +143,7 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
                         if (start > (queryParams.endSecs * 1000)) queryParams.endSecs * 1000 else start
                       }
         prevPartitionStart = startMs
-        val endMs = if (isInstantQuery) queryParams.endSecs * 1000 else p.timeRange.endMs + offsetMs.max
+        val endMs = if (isInstantQuery) queryParams.endSecs * 1000 else p.timeRange.endMs + offsetMs.min
         logger.debug(s"partitionInfo=$p; updated startMs=$startMs, endMs=$endMs")
         if (p.partitionName.equals(localPartitionName))
           localPartitionPlanner.materialize(

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -1,7 +1,9 @@
 package filodb.coordinator.queryplanner
 
 import scala.concurrent.duration._
+
 import monix.execution.Scheduler
+
 import filodb.core.DatasetRef
 import filodb.core.query.{QueryContext, QuerySession}
 import filodb.core.store.ChunkSource

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -198,13 +198,12 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers {
     downsampleLp.asInstanceOf[PeriodicSeriesWithWindowing].offsetMs.get shouldEqual(120000)
   }
 
-
   it("should direct overlapping binary join offset queries to both raw & downsample planner and stitch") {
 
     val start = now/1000 - 30.minutes.toSeconds
     val step = 1.minute.toSeconds
     val end = now/1000 - 2.minutes.toSeconds
-    val logicalPlan = Parser.queryRangeToLogicalPlan("sum(foo offset 2m) - sum(foo)",
+    val logicalPlan = Parser.queryRangeToLogicalPlan("sum(foo) - sum(foo offset 2m)",
       TimeStepParams(start, step, end))
       .asInstanceOf[PeriodicSeriesPlan]
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
For queries like `sum(foo) - sum(foo offset 3d)` LongTimeRangePlanner, HighAvailabilityPlanner and MultiPartitionPlanner use offset of head which in this case has value 0

**New behavior :**
Use max offset for above queries
