### PR TITLE
feat(repair): Add downsample index repair

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -260,7 +260,8 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       )
       val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
       Await.result(
-        writePartKeys(targetDatasetRef, shard, Observable.fromIterable(partKeys), diskTimeToLiveSeconds, updateHour),
+        target.writePartKeys(targetDatasetRef,
+          shard, Observable.fromIterable(partKeys), diskTimeToLiveSeconds, updateHour),
         5.minutes
       )
     }

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -236,7 +236,6 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
                                    repairStartTime: Long,
                                    repairEndTime: Long,
                                    target: CassandraColumnStore,
-                                   targetDatasetRef: DatasetRef,
                                    partKeyHashFn: PartKeyRecord => Option[Int],
                                    diskTimeToLiveSeconds: Int): Unit = {
     def pkRecordWithHash(pkRecord: PartKeyRecord) = {
@@ -260,7 +259,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       )
       val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
       Await.result(
-        target.writePartKeys(targetDatasetRef,
+        target.writePartKeys(datasetRef,
           shard, Observable.fromIterable(partKeys), diskTimeToLiveSeconds, updateHour),
         5.minutes
       )
@@ -270,7 +269,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     for (split <- splits; shard <- 0 until numOfShards) {
       val tokens = split.asInstanceOf[CassandraTokenRangeSplit].tokens
       val srcPartKeysTable = getOrCreatePartitionKeysTable(datasetRef, shard)
-      val targetPartKeysTable = target.getOrCreatePartitionKeysTable(targetDatasetRef, shard)
+      val targetPartKeysTable = target.getOrCreatePartitionKeysTable(datasetRef, shard)
       // CQL does not support OR operator. So we need to query separately to get the timeSeries partitionKeys
       // which were born or died during the data loss period (aka repair window).
       val rowsByStartTime = srcPartKeysTable.scanRowsByStartTimeRangeNoAsync(tokens, repairStartTime, repairEndTime)

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -9,8 +9,6 @@ filodb {
 
   dataset-configs = [
     "conf/timeseries-dev-source.conf"
-# below conf used for testing DR data repair.
-#   "conf/timeseries-dev-buddy.conf"
   ]
 
   quotas {

--- a/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
@@ -18,13 +18,13 @@ import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.core.{DatasetRef, GlobalConfig}
 import filodb.core.metadata.Schemas
 import filodb.core.store.{PartKeyRecord, ScanSplit}
+import filodb.downsampler.chunk.DownsamplerSettings
 import filodb.memory.format.UnsafeUtils
 
 class PartitionKeysCopier(conf: SparkConf) {
 
   private def openConfig(str: String) = {
-    val sysConfig = GlobalConfig.systemConfig.getConfig("filodb")
-    ConfigFactory.parseFile(new File(conf.get(str))).getConfig("filodb").withFallback(sysConfig)
+    ConfigFactory.parseFile(new File(conf.get(str))).withFallback(GlobalConfig.systemConfig)
   }
 
   def datasetConfig(mainConfig: Config): Config = {
@@ -49,15 +49,18 @@ class PartitionKeysCopier(conf: SparkConf) {
 
   // Both "source" and "target" refer to file paths which define config files that have a
   // top-level "filodb" section and a "cassandra" subsection.
-  private val sourceConfig = openConfig("spark.filodb.partitionkeys.copier.source.configFile")
-  private val targetConfig = openConfig("spark.filodb.partitionkeys.copier.target.configFile")
+  private val rawSourceConfig = openConfig("spark.filodb.partitionkeys.copier.source.configFile")
+  private val rawTargetConfig = openConfig("spark.filodb.partitionkeys.copier.target.configFile")
+  private val sourceConfig = rawSourceConfig.getConfig("filodb")
+  private val targetConfig = rawTargetConfig.getConfig("filodb")
   private val sourceCassConfig = sourceConfig.getConfig("cassandra")
   private val targetCassConfig = targetConfig.getConfig("cassandra")
   private val sourceDataset = conf.get("spark.filodb.partitionkeys.copier.source.dataset")
+  private val targetDataset = conf.get("spark.filodb.partitionkeys.copier.target.dataset")
   private val sourceDatasetConfig = datasetConfig(sourceConfig)
   private val targetDatasetConfig = datasetConfig(targetConfig)
   private val sourceDatasetRef = DatasetRef.fromDotString(sourceDataset)
-  private val targetDatasetRef = DatasetRef.fromDotString(conf.get("spark.filodb.partitionkeys.copier.target.dataset"))
+  private val targetDatasetRef = DatasetRef.fromDotString(targetDataset)
   private val sourceSession = FiloSessionProvider.openSession(sourceCassConfig)
   private val targetSession = FiloSessionProvider.openSession(targetCassConfig)
 
@@ -66,15 +69,26 @@ class PartitionKeysCopier(conf: SparkConf) {
     Option(schemas.part.binSchema.partitionHash(partKey.partKey, UnsafeUtils.arayOffset))
 
   val numOfShards: Int = sourceDatasetConfig.getInt("num-shards")
+  private val isDownsampleRepair = conf.getBoolean("spark.filodb.partitionkeys.copier.copyDownsample", false)
   private val repairStartTime = parseDateTime(conf.get("spark.filodb.partitionkeys.copier.repairStartTime"))
   private val repairEndTime = parseDateTime(conf.get("spark.filodb.partitionkeys.copier.repairEndTime"))
-  private val diskTimeToLiveSeconds = targetDatasetConfig.getConfig("sourceconfig.store")
-    .as[FiniteDuration]("disk-time-to-live").toSeconds.toInt
+  private val diskTimeToLiveSeconds = if (isDownsampleRepair) {
+    val dsSettings = new DownsamplerSettings(rawSourceConfig)
+    val highestDSResolution = dsSettings.rawDatasetIngestionConfig.downsampleConfig.resolutions.last
+    dsSettings.ttlByResolution(highestDSResolution)
+  } else {
+    targetDatasetConfig.getConfig("sourceconfig.store")
+      .as[FiniteDuration]("disk-time-to-live").toSeconds.toInt
+  }
   private val readSched = Scheduler.io("cass-read-sched")
   private val writeSched = Scheduler.io("cass-write-sched")
 
-  val sourceCassandraColStore = new CassandraColumnStore(sourceConfig, readSched, sourceSession)(writeSched)
-  val targetCassandraColStore = new CassandraColumnStore(targetConfig, readSched, targetSession)(writeSched)
+  val sourceCassandraColStore = new CassandraColumnStore(
+    sourceConfig, readSched, sourceSession, isDownsampleRepair
+  )(writeSched)
+  val targetCassandraColStore = new CassandraColumnStore(
+    targetConfig, readSched, targetSession, isDownsampleRepair
+  )(writeSched)
 
   // Disable the copy phase either for fully deleting with no replacement, or for no-op testing.
   private[repair] val noCopy = conf.getBoolean("spark.filodb.partitionkeys.copier.noCopy", false)

--- a/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
@@ -69,7 +69,7 @@ class PartitionKeysCopier(conf: SparkConf) {
     Option(schemas.part.binSchema.partitionHash(partKey.partKey, UnsafeUtils.arayOffset))
 
   val numOfShards: Int = sourceDatasetConfig.getInt("num-shards")
-  private val isDownsampleRepair = conf.getBoolean("spark.filodb.partitionkeys.copier.copyDownsample", false)
+  private val isDownsampleRepair = conf.getBoolean("spark.filodb.partitionkeys.copier.isDownsampleCopy", false)
   private val repairStartTime = parseDateTime(conf.get("spark.filodb.partitionkeys.copier.repairStartTime"))
   private val repairEndTime = parseDateTime(conf.get("spark.filodb.partitionkeys.copier.repairEndTime"))
   private val diskTimeToLiveSeconds = if (isDownsampleRepair) {

--- a/spark-jobs/src/test/resources/timeseries-filodb-buddy-server.conf
+++ b/spark-jobs/src/test/resources/timeseries-filodb-buddy-server.conf
@@ -1,0 +1,8 @@
+include required("../../../../conf/timeseries-filodb-server.conf")
+
+filodb {
+  cassandra {
+    keyspace = "filodb_buddy"
+    downsample-keyspace = "filodb_buddy_downsample"
+  }
+}

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -31,12 +31,15 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
   implicit val s = monix.execution.Scheduler.Implicits.global
 
-  val configPath = "conf/timeseries-filodb-server.conf"
+  val sourceConfigPath = "conf/timeseries-filodb-server.conf"
+  val targetConfigPath = "spark-jobs/src/test/resources/timeseries-filodb-buddy-server.conf"
 
   private val sysConfig = GlobalConfig.systemConfig.getConfig("filodb")
-  private val config = ConfigFactory.parseFile(new File(configPath)).getConfig("filodb").withFallback(sysConfig)
+  private val sourceConfig = ConfigFactory.parseFile(new File(sourceConfigPath)).getConfig("filodb").withFallback(sysConfig)
+  private val targetConfig = ConfigFactory.parseFile(new File(targetConfigPath)).getConfig("filodb").withFallback(sysConfig)
 
-  lazy val session = new DefaultFiloSessionProvider(config.getConfig("cassandra")).session
+  lazy val sourceSession = new DefaultFiloSessionProvider(sourceConfig.getConfig("cassandra")).session
+  val targetSession = new DefaultFiloSessionProvider(targetConfig.getConfig("cassandra")).session
 
   var gauge1PartKeyBytes: Array[Byte] = _
   var gauge2PartKeyBytes: Array[Byte] = _
@@ -54,20 +57,17 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
     Map.empty, 100, rawDataStoreConfig)
 
   val datasetName = "prometheus"
-  val targetDatasetName = "buddy_prometheus"
-  val sourceDataset = Dataset(datasetName, Schemas.gauge)
-  val targetDataset = Dataset(targetDatasetName, Schemas.gauge)
-  val shardStats = new TimeSeriesShardStats(sourceDataset.ref, -1)
+  val dataset = Dataset(datasetName, Schemas.gauge)
+  val shardStats = new TimeSeriesShardStats(dataset.ref, -1)
 
   val sparkConf = {
     val conf = new SparkConf(loadDefaults = true)
     conf.setMaster("local[2]")
 
-    conf.set("spark.filodb.partitionkeys.copier.source.configFile", configPath)
-    conf.set("spark.filodb.partitionkeys.copier.source.dataset", datasetName)
+    conf.set("spark.filodb.partitionkeys.copier.source.configFile", sourceConfigPath)
+    conf.set("spark.filodb.partitionkeys.copier.target.configFile", targetConfigPath)
 
-    conf.set("spark.filodb.partitionkeys.copier.target.configFile", configPath)
-    conf.set("spark.filodb.partitionkeys.copier.target.dataset", targetDatasetName)
+    conf.set("spark.filodb.partitionkeys.copier.dataset", datasetName)
 
     conf.set("spark.filodb.partitionkeys.copier.repairStartTime", "2020-10-13T00:00:00Z")
     conf.set("spark.filodb.partitionkeys.copier.repairEndTime", "2020-10-13T05:00:00Z")
@@ -85,34 +85,36 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
   describe("raw data repair") {
     it("should copy data for repair window") {
-      val colStore = new CassandraColumnStore(config, s, session)
-      truncateColStore(colStore)
-      prepareTestData(colStore)
+      val sourceColStore = new CassandraColumnStore(sourceConfig, s, sourceSession)
+      val targetColStore = new CassandraColumnStore(targetConfig, s, targetSession)
+      truncateColStore(sourceColStore)
+      truncateColStore(targetColStore)
+      prepareTestData(sourceColStore)
 
       PartitionKeysCopierMain.run(sparkConf).close()
 
-      validateRepairData(colStore)
+      validateRepairData(targetColStore)
     }
   }
 
   describe("downsample data repair") {
     it("should copy data for repair window") {
       sparkConf.set("spark.filodb.partitionkeys.copier.isDownsampleCopy", "true")
-      val colStore = new CassandraColumnStore(config, s, session, true)
-      truncateColStore(colStore)
-      prepareTestData(colStore)
+      val sourceColStore = new CassandraColumnStore(sourceConfig, s, sourceSession, true)
+      val targetColStore = new CassandraColumnStore(targetConfig, s, targetSession, true)
+      truncateColStore(sourceColStore)
+      truncateColStore(targetColStore)
+      prepareTestData(sourceColStore)
 
       PartitionKeysCopierMain.run(sparkConf).close()
 
-      validateRepairData(colStore)
+      validateRepairData(targetColStore)
     }
   }
 
   def truncateColStore(colStore: CassandraColumnStore): Unit = {
-    colStore.initialize(sourceDataset.ref, numOfShards).futureValue
-    colStore.truncate(sourceDataset.ref, numOfShards).futureValue
-    colStore.initialize(targetDataset.ref, numOfShards).futureValue
-    colStore.truncate(targetDataset.ref, numOfShards).futureValue
+    colStore.initialize(dataset.ref, numOfShards).futureValue
+    colStore.truncate(dataset.ref, numOfShards).futureValue
   }
 
   override def afterAll(): Unit = {
@@ -121,7 +123,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
   def prepareTestData(colStore: CassandraColumnStore): Unit = {
     def writePartKeys(pk: PartKeyRecord, shard: Int): Unit = {
-      colStore.writePartKeys(sourceDataset.ref, shard, Observable.now(pk), 259200, 0L, false).futureValue
+      colStore.writePartKeys(dataset.ref, shard, Observable.now(pk), 259200, 0L, false).futureValue
     }
 
     def tsPartition(schema: Schema,
@@ -195,7 +197,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
     // verify data in index table.
     for (shard <- 0 until numOfShards) {
-      val partKeyRecords = Await.result(colStore.scanPartKeys(targetDataset.ref, shard).toListL.runAsync, Duration(1, "minutes"))
+      val partKeyRecords = Await.result(colStore.scanPartKeys(dataset.ref, shard).toListL.runAsync, Duration(1, "minutes"))
       // because there will be 3 records that meets the copier time period.
       partKeyRecords.size shouldEqual 3
       for (pkr <- partKeyRecords) {
@@ -215,7 +217,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
     // verify data in pk_by_update_time table
     val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
     for (shard <- 0 until numOfShards) {
-      val partKeyRecords = Await.result(colStore.getPartKeysByUpdateHour(targetDataset.ref, shard, updateHour).toListL.runAsync, Duration(1, "minutes"))
+      val partKeyRecords = Await.result(colStore.getPartKeysByUpdateHour(dataset.ref, shard, updateHour).toListL.runAsync, Duration(1, "minutes"))
       // because there will be 3 records that meets the copier time period.
       partKeyRecords.size shouldEqual 3
       for (pkr <- partKeyRecords) {
@@ -234,7 +236,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
     // verify workspace/namespace names in shard=0.
     val shard0 = 0
-    val partKeyRecordsShard0 = Await.result(colStore.scanPartKeys(targetDataset.ref, shard0).toListL.runAsync,
+    val partKeyRecordsShard0 = Await.result(colStore.scanPartKeys(dataset.ref, shard0).toListL.runAsync,
       Duration(1, "minutes"))
     partKeyRecordsShard0.size shouldEqual 3
     for (pkr <- partKeyRecordsShard0) {
@@ -253,7 +255,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
     // verify workspace/namespace names in shard=2.
     val shard2 = 2
-    val partKeyRecordsShard2 = Await.result(colStore.scanPartKeys(targetDataset.ref, shard2).toListL.runAsync,
+    val partKeyRecordsShard2 = Await.result(colStore.scanPartKeys(dataset.ref, shard2).toListL.runAsync,
       Duration(1, "minutes"))
     partKeyRecordsShard2.size shouldEqual 3
     for (pkr <- partKeyRecordsShard2) {

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -97,7 +97,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
   describe("downsample data repair") {
     it("should copy data for repair window") {
-      sparkConf.set("spark.filodb.partitionkeys.copier.copyDownsample", "true")
+      sparkConf.set("spark.filodb.partitionkeys.copier.isDownsampleCopy", "true")
       val colStore = new CassandraColumnStore(config, s, session, true)
       truncateColStore(colStore)
       prepareTestData(colStore)


### PR DESCRIPTION
Follow up to #993. Add index repair for downsampled data via `spark.filodb.partitionkeys.copier.copyDownsample`

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

