### PR TITLE
Revert "bug(query): Stitch and uniqify LHS and RHS before binary join

### DIFF
--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -83,9 +83,8 @@ final case class BinaryJoinExec(queryContext: QueryContext,
       // NOTE: We can't require this any more, as multischema queries may result in not a QueryResult if the
       //       filter returns empty results.  The reason is that the schema will be undefined.
       // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
-      // Stitch results and uniquify LHS and RHS vectors - there could be dupes because of spread increase
-      val lhsRvs = StitchRvsExec.stitchAndUnique(resp.filter(_._2 < lhs.size).flatMap(_._1))
-      val rhsRvs = StitchRvsExec.stitchAndUnique(resp.filter(_._2 >= lhs.size).flatMap(_._1))
+      val lhsRvs = resp.filter(_._2 < lhs.size).flatMap(_._1)
+      val rhsRvs = resp.filter(_._2 >= lhs.size).flatMap(_._1)
       // figure out which side is the "one" side
       val (oneSide, otherSide, lhsIsOneSide) =
         if (cardinality == Cardinality.OneToMany) (lhsRvs, rhsRvs, true)

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -67,12 +67,12 @@ final case class SetOperatorExec(queryContext: QueryContext,
       //       filter returns empty results.  The reason is that the schema will be undefined.
       // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
       // Resp is segregated based on index of child plans
-      val lhsRvs = StitchRvsExec.stitchAndUnique(resp.filter(_._3 < lhs.size).flatMap(_._2))
+      val lhsRvs = resp.filter(_._3 < lhs.size).flatMap(_._2)
       val rhsResp = resp.filter(_._3 >= lhs.size)
-      val rhsRvs = StitchRvsExec.stitchAndUnique(rhsResp.flatMap(_._2))
+      val rhsRvs = rhsResp.flatMap(_._2)
 
       val results: List[RangeVector] = binaryOp match {
-        case LAND    => val rhsSchema = rhsResp.headOption.map(_._1).getOrElse(ResultSchema.empty)
+        case LAND    => val rhsSchema = if (rhsResp.map(_._1).nonEmpty) rhsResp.map(_._1).head else ResultSchema.empty
                         setOpAnd(lhsRvs, rhsRvs, rhsSchema)
         case LOR     => setOpOr(lhsRvs, rhsRvs)
         case LUnless => setOpUnless(lhsRvs, rhsRvs)
@@ -97,7 +97,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
     else rv.rows.filter(!_.getDouble(1).isNaN).isEmpty
   }
 
-  private def setOpAnd(lhsRvs: Iterable[RangeVector], rhsRvs: Iterable[RangeVector],
+  private def setOpAnd(lhsRvs: List[RangeVector], rhsRvs: List[RangeVector],
                        rhsSchema: ResultSchema): List[RangeVector] = {
     // isEmpty method consumes rhs range vector
     require(rhsRvs.forall(_.isInstanceOf[SerializedRangeVector]), "RHS should be SerializedRangeVector")
@@ -142,8 +142,8 @@ final case class SetOperatorExec(queryContext: QueryContext,
     result.toList
   }
 
-  private def setOpOr(lhsRvs: Iterable[RangeVector]
-                      , rhsRvs: Iterable[RangeVector]): List[RangeVector] = {
+  private def setOpOr(lhsRvs: List[RangeVector]
+                      , rhsRvs: List[RangeVector]): List[RangeVector] = {
     val lhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
     var result = new ListBuffer[RangeVector]()
     // Add everything from left hand side range vector
@@ -162,8 +162,8 @@ final case class SetOperatorExec(queryContext: QueryContext,
     result.toList
   }
 
-  private def setOpUnless(lhsRvs: Iterable[RangeVector]
-                          , rhsRvs: Iterable[RangeVector]): List[RangeVector] = {
+  private def setOpUnless(lhsRvs: List[RangeVector]
+                          , rhsRvs: List[RangeVector]): List[RangeVector] = {
     val rhsKeysSet = new mutable.HashSet[Map[Utf8Str, Utf8Str]]()
     var result = new ListBuffer[RangeVector]()
     rhsRvs.foreach { rv =>

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -188,8 +188,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       .toListL.runAsync.futureValue
 
     result.size shouldEqual 2
-    result(0).key.labelValues.contains("_step_".utf8) shouldEqual true
-    result(1).key.labelValues.contains("_pi_".utf8) shouldEqual true
+    result(0).key.labelValues.contains("_pi_".utf8) shouldEqual true
+    result(1).key.labelValues.contains("_step_".utf8) shouldEqual true
 
   }
 
@@ -257,8 +257,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
     result.size shouldEqual 4
     Seq("_pi_".utf8, "tag1".utf8).forall(result(0).key.labelValues.contains) shouldEqual true
-    Seq("_pi_".utf8, "tag1".utf8).forall(result(1).key.labelValues.contains) shouldEqual true
-    Seq("_step_".utf8, "tag1".utf8).forall(result(2).key.labelValues.contains) shouldEqual true
+    Seq("_step_".utf8, "tag1".utf8).forall(result(1).key.labelValues.contains) shouldEqual true
+    Seq("_pi_".utf8, "tag1".utf8).forall(result(2).key.labelValues.contains) shouldEqual true
     Seq("_step_".utf8, "tag1".utf8).forall(result(3).key.labelValues.contains) shouldEqual true
   }
 
@@ -527,46 +527,5 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     thrown.getCause.getClass shouldEqual classOf[BadQueryException]
     thrown.getCause.getMessage shouldEqual "This query results in more than 1 join cardinality." +
       " Try applying more filters."
-  }
-
-  it ("should remove dupes and stitch before joining") {
-
-    def dataRows = Stream.from(0).map(n => new TransientRow(n.toLong, n.toDouble))
-
-    val queryContext = QueryContext(plannerParams = PlannerParams(joinQueryCardLimit = 10)) // set join card limit to 1
-    val execPlan = BinaryJoinExec(queryContext, dummyDispatcher,
-      Array(dummyPlan), // cannot be empty as some compose's rely on the schema
-      new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
-      BinaryOperator.ADD,
-      Cardinality.OneToOne,
-      Nil, Nil, Nil, "__name__")
-
-    val lhsRv = new RangeVector {
-      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
-      import NoCloseCursor._
-      val rows: RangeVectorCursor = dataRows.take(20).iterator
-    }
-
-    val lhsRvDupe = new RangeVector {
-      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
-      import NoCloseCursor._
-      val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
-    }
-
-    val rhsRv = new RangeVector {
-      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
-      import NoCloseCursor._
-      val rows: RangeVectorCursor = dataRows.take(30).iterator
-    }
-
-    val lhs = QueryResult("someId", null, Seq(lhsRv, lhsRvDupe).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema)))
-
-    val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
-      .toListL.runAsync.futureValue
-
-    result.size shouldEqual 1
-    result.head.key.labelValues shouldEqual Map("tag".utf8 -> s"value1".utf8)
-    result.head.rows().map(_.getLong(0)).toList shouldEqual (0L until 30).toList
   }
 }

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -211,20 +211,19 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runAsync.futureValue
 
-    val expectedLabels = List(
-      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("def"),
-        ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
-        ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("idle")
-      ),
-      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("def"),
+    val expectedLabels = List(Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
+      ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
+      ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("idle")
+    ),
+      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
         ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
         ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("user")
-      ),
-      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
+    ),
+      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("def"),
         ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
         ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("idle")
       ),
-      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("abc"),
+      Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("def"),
         ZeroCopyUTF8String("job") -> ZeroCopyUTF8String("node"),
         ZeroCopyUTF8String("mode") -> ZeroCopyUTF8String("user")
       )
@@ -232,10 +231,10 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     result.size shouldEqual 4
     result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
 
-    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
-    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
-    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
-    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
+    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
+    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
+    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
+    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
   }
 
   it("copy sample role to node using group right ") {
@@ -309,12 +308,12 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       )
     )
     result.size shouldEqual 4
-    result.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
+    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
 
-    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
-    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
-    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
-    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
+    result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
+    result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
+    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
+    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
   }
 
   it("should have metric name when operator is not MathOperator") {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -489,8 +489,9 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       .toListL.runAsync.futureValue
 
     result.size shouldEqual 8
-    result.map(rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet shouldEqual
-      sampleHttpRequests.map( rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet
+    result.map(_.key.labelValues) sameElements (sampleHttpRequests.map(_.key.labelValues).toList) shouldEqual true
+    sampleHttpRequests.flatMap(_.rows.map(_.getDouble(1)).toList).
+      sameElements(result.flatMap(_.rows.map(_.getDouble(1)).toList)) shouldEqual true
   }
 
   it("should return Lhs when LAND is done with vector having no labels and ignoring is used om Lhs labels") {
@@ -510,8 +511,9 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       .toListL.runAsync.futureValue
 
     result.size shouldEqual 8
-    result.map(rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet shouldEqual
-      sampleHttpRequests.map( rv => (rv.key.labelValues, rv.rows.map(_.getDouble(1)).toList)).toSet
+    result.map(_.key.labelValues) sameElements (sampleHttpRequests.map(_.key.labelValues)) shouldEqual true
+    sampleHttpRequests.flatMap(_.rows.map(_.getDouble(1)).toList).
+      sameElements(result.flatMap(_.rows.map(_.getDouble(1)).toList)) shouldEqual true
   }
 
   it("should join many-to-many with or") {
@@ -662,14 +664,14 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     )
 
     result2.size shouldEqual 6
-    result2.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
+    result2.map(_.key.labelValues) sameElements (expectedLabels) shouldEqual true
 
-    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(401)
-    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(301)
-    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(801)
-    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(701)
-    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(200)
-    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(100)
+    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(301)
+    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(401)
+    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(701)
+    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(801)
+    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(100)
+    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(200)
   }
 
   it("should excludes everything that has instance=0/1 but includes entries without " +
@@ -733,14 +735,14 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     )
 
     result2.size shouldEqual 6
-    result2.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
+    result2.map(_.key.labelValues) sameElements (expectedLabels) shouldEqual true
 
-    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(401)
-    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(301)
-    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(801)
-    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(701)
-    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(200)
-    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(100)
+    result2(0).rows.map(_.getDouble(1)).toList shouldEqual List(301)
+    result2(1).rows.map(_.getDouble(1)).toList shouldEqual List(401)
+    result2(2).rows.map(_.getDouble(1)).toList shouldEqual List(701)
+    result2(3).rows.map(_.getDouble(1)).toList shouldEqual List(801)
+    result2(4).rows.map(_.getDouble(1)).toList shouldEqual List(100)
+    result2(5).rows.map(_.getDouble(1)).toList shouldEqual List(200)
   }
 
   it("should join many-to-many with unless") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This reverts commit 76b822675099c3a5bceef5eeb032553f6f6bc404.
Cost of stitching before Binary Join is too much and not feasible. We need alternative solution.