### PR TITLE
bug(query): Optimally stitch vectors in LHS and RHS during binary join

### DIFF
--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -12,7 +12,12 @@ import filodb.query.Query.qLogger
 
 object StitchRvsExec {
 
-  def merge(vectors: Seq[RangeVectorCursor]): RangeVectorCursor = {
+  def stitch(v1: RangeVector, v2: RangeVector): RangeVector = {
+    val rows = StitchRvsExec.merge(Seq(v1.rows(), v2.rows()))
+    IteratorBackedRangeVector(v1.key, rows)
+  }
+
+  def merge(vectors: Iterable[RangeVectorCursor]): RangeVectorCursor = {
     // This is an n-way merge without using a heap.
     // Heap is not used since n is expected to be very small (almost always just 1 or 2)
     new RangeVectorCursor {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -188,8 +188,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       .toListL.runAsync.futureValue
 
     result.size shouldEqual 2
-    result(0).key.labelValues.contains("_pi_".utf8) shouldEqual true
-    result(1).key.labelValues.contains("_step_".utf8) shouldEqual true
+    result(1).key.labelValues.contains("_pi_".utf8) shouldEqual true
+    result(0).key.labelValues.contains("_step_".utf8) shouldEqual true
 
   }
 
@@ -257,8 +257,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
     result.size shouldEqual 4
     Seq("_pi_".utf8, "tag1".utf8).forall(result(0).key.labelValues.contains) shouldEqual true
-    Seq("_step_".utf8, "tag1".utf8).forall(result(1).key.labelValues.contains) shouldEqual true
-    Seq("_pi_".utf8, "tag1".utf8).forall(result(2).key.labelValues.contains) shouldEqual true
+    Seq("_pi_".utf8, "tag1".utf8).forall(result(1).key.labelValues.contains) shouldEqual true
+    Seq("_step_".utf8, "tag1".utf8).forall(result(2).key.labelValues.contains) shouldEqual true
     Seq("_step_".utf8, "tag1".utf8).forall(result(3).key.labelValues.contains) shouldEqual true
   }
 
@@ -528,4 +528,92 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     thrown.getCause.getMessage shouldEqual "This query results in more than 1 join cardinality." +
       " Try applying more filters."
   }
+
+  it ("should remove dupes in LHS and stitch before joining") {
+
+    def dataRows = Stream.from(0).map(n => new TransientRow(n.toLong, n.toDouble))
+
+    val queryContext = QueryContext(plannerParams = PlannerParams(joinQueryCardLimit = 10)) // set join card limit to 1
+    val execPlan = BinaryJoinExec(queryContext, dummyDispatcher,
+      Array(dummyPlan), // cannot be empty as some compose's rely on the schema
+      new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
+      BinaryOperator.ADD,
+      Cardinality.OneToOne,
+      Nil, Nil, Nil, "__name__")
+
+    import NoCloseCursor._
+    val lhsRv = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(20).iterator
+    }
+
+    val lhsRvDupe = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+    }
+
+    val lhsRvDupe2 = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+    }
+
+    val rhsRv = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(40).iterator
+    }
+
+    val lhs = QueryResult("someId", null, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema)))
+
+    val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
+      .toListL.runAsync.futureValue
+
+    result.size shouldEqual 1
+    result.head.key.labelValues shouldEqual Map("tag".utf8 -> s"value1".utf8)
+    result.head.rows().map(_.getLong(0)).toList shouldEqual (0L until 40).toList
+  }
+
+  it ("should remove dupes in RHS and stitch before joining") {
+
+    def dataRows = Stream.from(0).map(n => new TransientRow(n.toLong, n.toDouble))
+
+    val queryContext = QueryContext(plannerParams = PlannerParams(joinQueryCardLimit = 10)) // set join card limit to 1
+    val execPlan = BinaryJoinExec(queryContext, dummyDispatcher,
+      Array(dummyPlan), // cannot be empty as some compose's rely on the schema
+      new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
+      BinaryOperator.ADD,
+      Cardinality.OneToOne,
+      Nil, Nil, Nil, "__name__")
+
+    import NoCloseCursor._
+    val rhsRv = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(20).iterator
+    }
+
+    val rhsRvDupe = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+    }
+    val rhsRvDupe2 = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+    }
+
+    val lhsRv = new RangeVector {
+      val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
+      val rows: RangeVectorCursor = dataRows.take(40).iterator
+    }
+
+    val lhs = QueryResult("someId", null, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, Seq(rhsRv, rhsRvDupe, rhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
+
+    val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
+      .toListL.runAsync.futureValue
+
+    result.size shouldEqual 1
+    result.head.key.labelValues shouldEqual Map("tag".utf8 -> s"value1".utf8)
+    result.head.rows().map(_.getLong(0)).toList shouldEqual (0L until 40).toList
+  }
+
 }

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -229,12 +229,12 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       )
     )
     result.size shouldEqual 4
-    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
+    result.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
 
     result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
     result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
-    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
-    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
   }
 
   it("copy sample role to node using group right ") {
@@ -308,12 +308,12 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       )
     )
     result.size shouldEqual 4
-    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
+    result.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
 
     result(0).rows.map(_.getDouble(1)).toList shouldEqual List(0.75)
     result(1).rows.map(_.getDouble(1)).toList shouldEqual List(0.25)
-    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
-    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(2).rows.map(_.getDouble(1)).toList shouldEqual List(0.2)
+    result(3).rows.map(_.getDouble(1)).toList shouldEqual List(0.8)
   }
 
   it("should have metric name when operator is not MathOperator") {
@@ -387,7 +387,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     )
 
     result.size shouldEqual 2
-    result.map(_.key.labelValues) sameElements(expectedLabels) shouldEqual true
+    result.map(_.key.labelValues).toSet shouldEqual expectedLabels.toSet
   }
 
   it("should throw BadQueryException - many-to-one with on - cardinality limit 1") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Optimally stitching same RVs from multiple shards while performing Binary Join.
This is better than previous attempt since it uses less memory and also less steps to finish the job.