### PR TITLE
misc(core): drop duplicate & out-of-order samples

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -137,7 +137,7 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
              maxChunkTime: Long = Long.MaxValue): Unit = {
     // NOTE: lastTime is not persisted for recovery.  Thus the first sample after recovery might still be out of order.
     val ts = schema.timestamp(row)
-    if (ts < timestampOfLatestSample) {
+    if (ts <= timestampOfLatestSample) {
       shardStats.outOfOrderDropped.increment()
       return
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

During ingestion, drop duplicate and out-of-order samples