### PR TITLE
bug(query): stitch vectors in LHS and RHS during binary join with set operator

### DIFF
--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -93,6 +93,8 @@ final case class BinaryJoinExec(queryContext: QueryContext,
       val oneSideMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
       oneSide.foreach { rv =>
         val jk = joinKeys(rv.key)
+        // When spread changes, we need to account for multiple Range Vectors with same key coming from different shards
+        // Each of these range vectors would contain data for different time ranges
         if (oneSideMap.contains(jk)) {
           val rvDupe = oneSideMap(jk)
           if (rv.key.labelValues == rvDupe.key.labelValues) {

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -97,6 +97,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
     else rv.rows.filter(!_.getDouble(1).isNaN).isEmpty
   }
 
+  // scalastyle:off method.length
   private def setOpAnd(lhsRvs: List[RangeVector], rhsRvs: List[RangeVector],
                        rhsSchema: ResultSchema): List[RangeVector] = {
     // isEmpty method consumes rhs range vector
@@ -155,7 +156,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
         }
         val arrayBuffer = result.getOrElse(jk, ArrayBuffer())
         val resRv = IteratorBackedRangeVector(lhs.key, rows)
-        if (index >=0) arrayBuffer.update(index,resRv) else arrayBuffer.append(resRv)
+        if (index >= 0) arrayBuffer.update(index, resRv) else arrayBuffer.append(resRv)
         result.put(jk, arrayBuffer)
       } else if (jk.isEmpty) {
         // "up AND ON (dummy) vector(1)" should be equivalent to up as there's no dummy label
@@ -166,6 +167,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
     }
     result.values.flatten.toList
   }
+  // scalastyle:on method.length
 
   private def setOpOr(lhsRvs: List[RangeVector]
                       , rhsRvs: List[RangeVector]): List[RangeVector] = {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -1,12 +1,14 @@
 package filodb.query.exec
 
 import scala.util.Random
+
 import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
+
 import filodb.core.MetricsTestData
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
@@ -15,9 +17,6 @@ import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
-import scala.List
-
 
 class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Optimally stitching same RVs from multiple shards while performing Binary Join for LAND, OR and LUNLESS