### PR TITLE
bug(core): Overflow BlockMemFactory is not reclaimed correctly after flush

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -788,7 +788,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     // Rapidly switch all of the input buffers for a particular group
     logger.debug(s"Switching write buffers for group $groupNum in dataset=$ref shard=$shardNum")
     InMemPartitionIterator(partitionGroups(groupNum).intIterator)
-      .foreach(_.switchBuffers(blockFactoryPool.fetchForOverflow(groupNum)))
+      .foreach(_.switchBuffers(blockFactoryPool.checkoutForOverflow(groupNum)))
 
     val dirtyPartKeys = if (groupNum == dirtyPartKeysFlushGroup) {
       logger.debug(s"Switching dirty part keys in dataset=$ref shard=$shardNum out for flush. ")
@@ -1206,7 +1206,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         val tsp = part.asInstanceOf[TimeSeriesPartition]
         brRowReader.schema = schema.ingestionSchema
         brRowReader.recordOffset = recordOff
-        tsp.ingest(ingestionTime, brRowReader, blockFactoryPool.fetchForOverflow(group),
+        tsp.ingest(ingestionTime, brRowReader, blockFactoryPool.checkoutForOverflow(group),
           storeConfig.timeAlignedChunksEnabled, flushBoundaryMillis, acceptDuplicateSamples, maxChunkTime)
         // Below is coded to work concurrently with logic in updateIndexWithEndTime
         // where we try to de-activate an active time series

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -70,7 +70,7 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
 
     //Evict partition "0"
     val shard = memStore.getShardE(timeseriesDataset.ref, 0)
-    val blockFactory = shard.overflowBlockFactory
+    val blockFactory = shard.blockFactoryPool.fetchForOverflow(0)
     val part = shard.partitions.get(0)
     part.switchBuffers(blockFactory, encode = true)
     shard.updatePartEndTimeInIndex(part, part.timestampOfLatestSample)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -70,7 +70,7 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
 
     //Evict partition "0"
     val shard = memStore.getShardE(timeseriesDataset.ref, 0)
-    val blockFactory = shard.blockFactoryPool.fetchForOverflow(0)
+    val blockFactory = shard.blockFactoryPool.checkoutForOverflow(0)
     val part = shard.partitions.get(0)
     part.switchBuffers(blockFactory, encode = true)
     shard.updatePartEndTimeInIndex(part, part.timestampOfLatestSample)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -423,7 +423,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   // used for testing only
   def markPartitionsForEviction(partIDs: Seq[Int]): Long = {
     val shard = memStore.getShardE(dataset1.ref, 0)
-    val blockFactory = shard.blockFactoryPool.fetchForOverflow(0)
+    val blockFactory = shard.blockFactoryPool.checkoutForOverflow(0)
     var endTime = 0L
     for { n <- partIDs } {
       val part = shard.partitions.get(n)
@@ -613,7 +613,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
       val afterIngestFree = shard.bufferMemoryManager.numFreeBytes
 
       // Switch buffers, encode and release/return buffers for all partitions
-      val blockFactory = shard.blockFactoryPool.fetchForOverflow(0)
+      val blockFactory = shard.blockFactoryPool.checkoutForOverflow(0)
       for { n <- 0 until numSeries } {
         val part = shard.partitions.get(n)
         part.switchBuffers(blockFactory, encode = true)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -423,7 +423,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   // used for testing only
   def markPartitionsForEviction(partIDs: Seq[Int]): Long = {
     val shard = memStore.getShardE(dataset1.ref, 0)
-    val blockFactory = shard.overflowBlockFactory
+    val blockFactory = shard.blockFactoryPool.fetchForOverflow(0)
     var endTime = 0L
     for { n <- partIDs } {
       val part = shard.partitions.get(n)
@@ -613,7 +613,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
       val afterIngestFree = shard.bufferMemoryManager.numFreeBytes
 
       // Switch buffers, encode and release/return buffers for all partitions
-      val blockFactory = shard.overflowBlockFactory
+      val blockFactory = shard.blockFactoryPool.fetchForOverflow(0)
       for { n <- 0 until numSeries } {
         val part = shard.partitions.get(n)
         part.switchBuffers(blockFactory, encode = true)

--- a/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
+++ b/memory/src/main/scala/filodb.memory/BlockMemFactoryPool.scala
@@ -1,5 +1,7 @@
 package filodb.memory
 
+import scala.collection.mutable
+
 import com.typesafe.scalalogging.StrictLogging
 
 /**
@@ -15,32 +17,54 @@ class BlockMemFactoryPool(blockStore: BlockManager,
                           metadataAllocSize: Int,
                           baseTags: Map[String, String]) extends StrictLogging {
   private val factoryPool = new collection.mutable.Queue[BlockMemFactory]()
+  private val checkedOut = new mutable.HashMap[Int, BlockMemFactory]()
 
   def poolSize: Int = factoryPool.length
 
   /**
-   * Checks out a BlockMemFactory, optionally adding in extra tags for this particular BMF
+   * Allocates (if needed) and returns new block mem factory from the pool for the given
+   * flush group. Subsequent calls to fetch will return the same block mem factory
+   * until the flush group is checked out for flush
    */
-  def checkout(moreTags: Map[String, String] = Map.empty): BlockMemFactory = synchronized {
-    val fact = if (factoryPool.nonEmpty) {
-      logger.debug(s"Checking out BlockMemFactory from pool.  poolSize=$poolSize")
-      factoryPool.dequeue
+  def fetchForOverflow(flushGroup: Int): BlockMemFactory = synchronized {
+    if (checkedOut.contains(flushGroup)) {
+      checkedOut(flushGroup)
     } else {
-      logger.debug(s"Nothing in BlockMemFactory pool.  Creating a new one")
-      new BlockMemFactory(blockStore, metadataAllocSize, baseTags)
+      val fact = if (factoryPool.nonEmpty) {
+        logger.debug(s"Checking out BlockMemFactory from pool for flushGroup=$flushGroup poolSize=$poolSize")
+        factoryPool.dequeue
+      } else {
+        logger.debug(s"Nothing in BlockMemFactory pool.  Creating a new one for flushGroup=$flushGroup")
+        new BlockMemFactory(blockStore, metadataAllocSize, baseTags)
+      }
+      fact.tags = baseTags + ("flushGroup" -> flushGroup.toString)
+      checkedOut(flushGroup) = fact
+      fact
     }
-    fact.tags = baseTags ++ moreTags
-    fact
   }
 
+  /**
+   * Checks out a BlockMemFactory for flush. Subsequent call for fetch for this
+   * flush group will return new BlockMemFactory
+   */
+  def checkoutForFlush(flushGroup: Int): BlockMemFactory = synchronized {
+    checkedOut.remove(flushGroup).getOrElse(fetchForOverflow(flushGroup))
+  }
+
+  /**
+   * Release factory back to pool. It should have been checked out for flush
+   * @param factory
+   */
   def release(factory: BlockMemFactory): Unit = synchronized {
     logger.debug(s"Returning factory $factory to the pool.  New size ${poolSize + 1}")
     factoryPool += factory
   }
 
-  def blocksContainingPtr(ptr: BinaryRegion.NativePointer): Seq[Block] =
+  def blocksContainingPtr(ptr: BinaryRegion.NativePointer): Seq[Block] = synchronized {
     factoryPool.flatMap { bmf =>
       val blocks = bmf.fullBlocksToBeMarkedAsReclaimable ++ Option(bmf.currentBlock).toList
       BlockDetective.containsPtr(ptr, blocks)
     }
+  }
+
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Overflow BlockMemFactory in TimeSeriesShard today depends on ODP blocks and hence is not correctly reclaimed after flush of chunks placed in it.

This PR removes overflow BMF in the shard and makes the BlockMemFactory pool track the flush group for which the
BMF is used. Subsequent use in overflow chunks will retrieve same BMF, until the BMF is checked out for flush in the FlushEvent for the group. At that point, it is removed from the map and future calls for overflow BMF will yield a new BMF.
Once the BMF checked out for flush is released after flush to Cassandra, the BMF is put back into free pool.

