### PR TITLE
bug(core): Error due to missing impl while counting queried chunks

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PagedReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/PagedReadablePartition.scala
@@ -72,7 +72,7 @@ class PagedReadablePartition(override val schema: Schema,
       private val iter = partData.chunkSetsTimeOrdered.iterator
       override def close(): Unit = {}
       override def hasNext: Boolean = iter.hasNext
-      override def nextInfo = ??? // intentionally not implemented since users dont bother with off-heap
+      override def nextInfo = ??? // intentionally not implemented since callers dont use off-heap chunkInfo
       override def nextInfoReader: ChunkSetInfoReader = {
         val nxt = iter.next()
         ChunkSetInfoOnHeap(nxt.infoBytes, nxt.vectors)

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -246,10 +246,7 @@ final case class RawDataRangeVector(key: RangeVectorKey,
 
   // Obtain ChunkSetInfos from specific window of time from partition
   def chunkInfos(windowStart: Long, windowEnd: Long): ChunkInfoIterator = {
-    partition.infos(windowStart, windowEnd).filter { c =>
-      chunksQueriedMetric.increment()
-      true
-    }
+    new CountingChunkInfoIterator(partition.infos(windowStart, windowEnd), chunksQueriedMetric)
   }
 
   // the query engine is based around one main data column to query, so it will always be the second column passed in

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -32,7 +32,7 @@ import filodb.memory.format.{PrimitiveVectorReader, UnsafeUtils}
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.memory.format.vectors.{CustomBuckets, LongHistogram}
 import filodb.query.QueryResult
-import filodb.query.exec.{InProcessPlanDispatcher, MultiSchemaPartitionsExec}
+import filodb.query.exec.{InProcessPlanDispatcher, InternalRangeFunction, MultiSchemaPartitionsExec, PeriodicSamplesMapper}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -692,6 +692,37 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     }
 
   }
+
+  it("should bring up DownsampledTimeSeriesShard and be able to read data PeriodicSeriesMapper") {
+
+    val downsampleTSStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore,
+      settings.filodbConfig)
+
+    downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
+      0, rawDataStoreConfig, settings.rawDatasetIngestionConfig.downsampleConfig)
+
+    downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
+
+    val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
+
+    val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(counterName))
+    val qc = QueryContext(plannerParams = PlannerParams(sampleLimit = 1000))
+    val exec = MultiSchemaPartitionsExec(qc,
+      InProcessPlanDispatcher, batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
+    exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(150000),
+      Some(InternalRangeFunction.Rate), qc))
+
+    val querySession = QuerySession(QueryContext(), queryConfig)
+    val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName", 3)
+    val res = exec.execute(downsampleTSStore, querySession)(queryScheduler)
+      .runAsync(queryScheduler).futureValue.asInstanceOf[QueryResult]
+    queryScheduler.shutdown()
+
+    res.result.size shouldEqual 1
+    res.result.foreach(_.rows.nonEmpty shouldEqual true)
+
+  }
+
 
   it("should bring up DownsampledTimeSeriesShard and NOT be able to read untyped data using SelectRawPartitionsExec") {
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Downsample shard does not provide an impl for ChunkInfoIterator's `nextInfo` method since data is offheap.
Earlier, we used FilteredChunkInfoIterator to add the counting which invokes `nextInfo` in its logic and causes this error.

```
Caused by: scala.NotImplementedError: an implementation is missing
	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:230)
	at filodb.core.memstore.PagedReadablePartition$$anon$1.nextInfo(PagedReadablePartition.scala:75)
	at filodb.core.memstore.PagedReadablePartition$$anon$1.nextInfo(PagedReadablePartition.scala:71)
	at filodb.core.store.FilteredChunkInfoIterator.hasNext(ChunkSetInfo.scala:341)
	at filodb.core.store.WindowedChunkIterator.nextWindow(ChunkSetInfo.scala:421)
	at filodb.query.exec.ChunkedWindowIterator.doNext(PeriodicSamplesMapper.scala:227)
	at filodb.query.exec.ChunkedWindowIterator.doNext(PeriodicSamplesMapper.scala:184)```

This PR fixes code to use a separate CountingChunkInfoIterator instead.
Added unit test to catch such errors in future.