### PR TITLE
bug(query): Dont serialize finalPlan field in MultiSchemaPartitionsExec

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -36,10 +36,11 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
 
   override def allTransformers: Seq[RangeVectorTransformer] = finalPlan.rangeVectorTransformers
 
-  var finalPlan: ExecPlan = _
+  @transient // dont serialize the SelectRawPartitionsExec plan created for plan execution
+  var finalPlan: SelectRawPartitionsExec = _
 
   private def finalizePlan(source: ChunkSource,
-                           querySession: QuerySession): ExecPlan = {
+                           querySession: QuerySession): SelectRawPartitionsExec = {
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     Kamon.currentSpan().mark("filtered-partition-scan")
     val lookupRes = source.lookupPartitions(dataset, partMethod, chunkMethod, querySession)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

When MultiSchemaPartitionsExec is serialized due to nested ExecPlanFuncArgs plan dispatch, finalPlan field should not be sent
over the wire