### PR TITLE
bug(core): Also purge index-only partitions not in heap

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -202,9 +202,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   def removePartKeys(partIds: debox.Buffer[Int]): Unit = {
     if (!partIds.isEmpty) {
       val terms = new util.ArrayList[BytesRef]()
-      cforRange {
-        0 until partIds.length
-      } { i =>
+      cforRange { 0 until partIds.length } { i =>
         terms.add(new BytesRef(partIds(i).toString.getBytes(StandardCharsets.UTF_8)))
       }
       indexWriter.deleteDocuments(new TermInSetQuery(PART_ID, terms))

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -200,11 +200,15 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     * Delete partitions with given partIds
     */
   def removePartKeys(partIds: debox.Buffer[Int]): Unit = {
-    val terms = new util.ArrayList[BytesRef]()
-    cforRange { 0 until partIds.length } { i =>
-      terms.add(new BytesRef(partIds(i).toString.getBytes(StandardCharsets.UTF_8)))
+    if (!partIds.isEmpty) {
+      val terms = new util.ArrayList[BytesRef]()
+      cforRange {
+        0 until partIds.length
+      } { i =>
+        terms.add(new BytesRef(partIds(i).toString.getBytes(StandardCharsets.UTF_8)))
+      }
+      indexWriter.deleteDocuments(new TermInSetQuery(PART_ID, terms))
     }
-    indexWriter.deleteDocuments(new TermInSetQuery(PART_ID, terms))
   }
 
   def indexRamBytes: Long = indexWriter.ramBytesUsed()

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -811,8 +811,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   private def purgeExpiredPartitions(): Unit = ingestSched.executeTrampolined { () =>
     assertThreadName(IngestSchedName)
     val start = System.currentTimeMillis()
-    val partsToPurge = partKeyIndex.partIdsEndedBefore(
-      System.currentTimeMillis() - storeConfig.demandPagedRetentionPeriod.toMillis)
+    val partsToPurge = partKeyIndex.partIdsEndedBefore(start - storeConfig.demandPagedRetentionPeriod.toMillis)
     var numDeleted = 0
     val removedParts = debox.Buffer.empty[Int]
     val partIter = InMemPartitionIterator2(partsToPurge)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -88,6 +88,9 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val partitionsPagedFromColStore = Kamon.counter("memstore-partitions-paged-in").withTags(TagSet.from(tags))
   val partitionsQueried = Kamon.counter("memstore-partitions-queried").withTags(TagSet.from(tags))
   val purgedPartitions = Kamon.counter("memstore-partitions-purged").withTags(TagSet.from(tags))
+  val purgedPartitionsFromIndex = Kamon.counter("memstore-partitions-purged-index").withTags(TagSet.from(tags))
+  val purgePartitionTimeMs = Kamon.counter("memstore-partitions-purge-time-ms", MeasurementUnit.time.milliseconds)
+                                              .withTags(TagSet.from(tags))
   val partitionsRestored = Kamon.counter("memstore-partitions-paged-restored").withTags(TagSet.from(tags))
   val chunkIdsEvicted = Kamon.counter("memstore-chunkids-evicted").withTags(TagSet.from(tags))
   val partitionsEvicted = Kamon.counter("memstore-partitions-evicted").withTags(TagSet.from(tags))
@@ -807,11 +810,13 @@ class TimeSeriesShard(val ref: DatasetRef,
 
   private def purgeExpiredPartitions(): Unit = ingestSched.executeTrampolined { () =>
     assertThreadName(IngestSchedName)
+    val start = System.currentTimeMillis()
     val partsToPurge = partKeyIndex.partIdsEndedBefore(
       System.currentTimeMillis() - storeConfig.demandPagedRetentionPeriod.toMillis)
     var numDeleted = 0
     val removedParts = debox.Buffer.empty[Int]
-    InMemPartitionIterator2(partsToPurge).foreach { p =>
+    val partIter = InMemPartitionIterator2(partsToPurge)
+    partIter.foreach { p =>
       if (!p.ingesting) {
         logger.debug(s"Purging partition with partId=${p.partID}  ${p.stringPartition} from " +
           s"memory in dataset=$ref shard=$shardNum")
@@ -826,10 +831,13 @@ class TimeSeriesShard(val ref: DatasetRef,
         numDeleted += 1
       }
     }
-    if (!removedParts.isEmpty) partKeyIndex.removePartKeys(removedParts)
-    if (numDeleted > 0) logger.info(s"Purged $numDeleted partitions from memory and " +
-                        s"index from dataset=$ref shard=$shardNum")
+    partKeyIndex.removePartKeys(partIter.skippedPartIDs)
+    partKeyIndex.removePartKeys(removedParts)
+    if (numDeleted > 0) logger.info(s"Purged $numDeleted partitions from memory/index " +
+      s"and ${partIter.skippedPartIDs.len} from index only from dataset=$ref shard=$shardNum")
     shardStats.purgedPartitions.increment(numDeleted)
+    shardStats.purgedPartitionsFromIndex.increment(removedParts.len + partIter.skippedPartIDs.len)
+    shardStats.purgePartitionTimeMs.increment(System.currentTimeMillis() - start)
   }
 
   /**


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently there is a bug where we do not remove/purge partitions in index that do not have a TSP on heap.
This PR fixes the bug.