### PR TITLE
bug(query): topk next on empty iterator

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -276,7 +276,8 @@ object LogicalPlanUtils extends StrictLogging {
       case lp: SeriesKeysByFilters         => None
       case lp: ApplyInstantFunctionRaw     => getPeriodicSeriesPlan(lp.vectors)
       case lp: ScalarBinaryOperation       =>  if (lp.lhs.isRight) getPeriodicSeriesPlan(lp.lhs.right.get)
-      else if (lp.rhs.isRight) getPeriodicSeriesPlan(lp.rhs.right.get) else None
+                                               else if (lp.rhs.isRight) getPeriodicSeriesPlan(lp.rhs.right.get)
+                                               else None
       case lp: ScalarFixedDoublePlan       => None
       case lp: RawChunkMeta                => None
     }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -87,8 +87,8 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
       l1.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
       l1.rangeVectorTransformers.size shouldEqual 2
       l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].start shouldEqual (100)
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].end shouldEqual (10000)
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual (100)
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual (10000)
       l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
   }
@@ -159,8 +159,8 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
         2000000
       l1.rangeVectorTransformers.size shouldEqual 2
       l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].start shouldEqual (1060000)
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].end shouldEqual (2000000)
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual (1060000)
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual (2000000)
       l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
     val queryParams = child2.queryContext.origQueryParams.
@@ -293,8 +293,8 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
         2000000
       l1.rangeVectorTransformers.size shouldEqual 2
       l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].start shouldEqual 1080000
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].end shouldEqual 2000000
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual 1080000
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual 2000000
       l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
 
@@ -373,8 +373,8 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
       l1.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
       l1.rangeVectorTransformers.size shouldEqual 2
       l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].start shouldEqual from *1000
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].end shouldEqual  to * 1000
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual from *1000
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual  to * 1000
       l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
   }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -267,7 +267,8 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers {
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
     val stitchExec = ep.asInstanceOf[StitchRvsExec]
     stitchExec.children.size shouldEqual 2
-    stitchExec.children(0).isInstanceOf[BinaryJoinExec] shouldEqual(true)
+    // Raw cluster does not have data for offset 8 days
+    stitchExec.children(0).isInstanceOf[EmptyResultExec] shouldEqual(true)
     stitchExec.children(1).isInstanceOf[BinaryJoinExec] shouldEqual(true)
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
@@ -480,7 +480,7 @@ class ScalarQueriesSpec extends AnyFunSpec with Matchers {
       """T~ScalarOperationMapper(operator=SUB, scalarOnLhs=false)
         |-FA1~
         |-E~ScalarBinaryOperationExec(params = RangeParams(1000,1000,1000), operator = DIV, lhs = Left(10.0), rhs = Left(2.0)) on InProcessPlanDispatcher
-        |-T~AggregatePresenter(aggrOp=Sum, aggrParams=List())
+        |-T~AggregatePresenter(aggrOp=Sum, aggrParams=List(), rangeParams=RangeParams(1000,1000,1000))
         |--E~LocalPartitionReduceAggregateExec(aggrOp=Sum, aggrParams=List()) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-669137818])
         |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
         |----T~PeriodicSamplesMapper(start=1000000, step=1000000, end=1000000, window=None, functionId=None, rawSource=true, offsetMs=None)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
@@ -238,9 +238,9 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
       val rangeFrom = from + (splitSizeMs * i) + (stepMs * i)
       val rangeTo = min(rangeFrom + splitSizeMs, to)
       exec.children.head.children.head.rangeVectorTransformers
-        .head.asInstanceOf[PeriodicSamplesMapper].start shouldEqual rangeFrom
+        .head.asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual rangeFrom
       exec.children.head.children.head.rangeVectorTransformers
-        .head.asInstanceOf[PeriodicSamplesMapper].end shouldEqual rangeTo
+        .head.asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual rangeTo
     }
 
     // assert that all child plans are not altered
@@ -396,76 +396,66 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
 
     val splitEp1 = planner.materialize(logicalPlan1, QueryContext(plannerParams = plannerParams2))
                           .asInstanceOf[SplitLocalPartitionDistConcatExec]
-    splitEp1.children should have length(4)
+    splitEp1.children should have length(3)
 
-    splitEp1.children.head.isInstanceOf[EmptyResultExec] shouldEqual true // outside retention period
-
-    val ep11 = splitEp1.children(1)
+    val ep11 = splitEp1.children(0)
     val psm11 = ep11.children.head.asInstanceOf[MultiSchemaPartitionsExec]
                 .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    psm11.start shouldEqual (nowSeconds * 1000
+    psm11.startMs shouldEqual (nowSeconds * 1000
                             - 3.days.toMillis // retention
                             + 1.minute.toMillis // step
                             + WindowConstants.staleDataLookbackMillis) // default window
-    psm11.end shouldEqual psm11.start - WindowConstants.staleDataLookbackMillis + 1.day.toMillis
+   psm11.endMs shouldEqual psm11.startMs + 1.day.toMillis
 
-    val ep12 = splitEp1.children(2)
+    val ep12 = splitEp1.children(1)
     val psm12 = ep12.children.head.asInstanceOf[MultiSchemaPartitionsExec]
                 .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    psm12.start shouldEqual psm11.end + 1.minute.toMillis // step
-    psm12.end shouldEqual psm12.start + 1.day.toMillis
+    psm12.startMs shouldEqual psm11.endMs + 1.minute.toMillis // step
+    psm12.endMs shouldEqual psm12.startMs + 1.day.toMillis
 
-    val ep13 = splitEp1.children(3)
+    val ep13 = splitEp1.children(2)
     val psm13 = ep13.children.head.asInstanceOf[MultiSchemaPartitionsExec]
       .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    psm13.start shouldEqual psm12.end + 1.minute.toMillis // step
-    psm13.end shouldEqual min(psm13.start + 1.day.toMillis, nowSeconds*1000)
+    psm13.startMs shouldEqual psm12.endMs + 1.minute.toMillis // step
+    psm13.endMs shouldEqual min(psm13.startMs + 1.day.toMillis, nowSeconds*1000)
 
     // Case 2: no offset, some window
     val logicalPlan2 = Parser.queryRangeToLogicalPlan("""rate(foo{job="bar"}[20m])""",
       TimeStepParams(nowSeconds - 4.days.toSeconds, 1.minute.toSeconds, nowSeconds))
     val splitEp2 = planner.materialize(logicalPlan2, QueryContext(plannerParams = plannerParams2)).asInstanceOf[SplitLocalPartitionDistConcatExec]
-    splitEp2.children should have length(4)
+    splitEp2.children should have length(3)
 
-    splitEp2.children.head.isInstanceOf[EmptyResultExec] shouldEqual true
-    val ep21 = splitEp2.children(1)
+    val ep21 = splitEp2.children(0)
     val psm21 = ep21.children.head.asInstanceOf[MultiSchemaPartitionsExec]
       .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    psm21.start shouldEqual (nowSeconds * 1000
+    psm21.startMs shouldEqual (nowSeconds * 1000
       - 3.days.toMillis // retention
       + 1.minute.toMillis // step
       + 20.minutes.toMillis) // window
-    psm21.end shouldEqual psm21.start - 20.minutes.toMillis + 1.day.toMillis
+    psm21.endMs shouldEqual psm21.startMs + 1.day.toMillis
 
     // Case 3: offset and some window
     val logicalPlan3 = Parser.queryRangeToLogicalPlan("""rate(foo{job="bar"}[20m] offset 15m)""",
       TimeStepParams(nowSeconds - 4.days.toSeconds, 1.minute.toSeconds, nowSeconds))
 
     val splitEp3 = planner.materialize(logicalPlan3, QueryContext(plannerParams = plannerParams2)).asInstanceOf[SplitLocalPartitionDistConcatExec]
-    splitEp3.children should have length(4)
+    splitEp3.children should have length(3)
 
-    splitEp3.children.head.isInstanceOf[EmptyResultExec] shouldEqual true
-    val ep31 = splitEp3.children(1)
+    val ep31 = splitEp3.children(0)
     val psm31 = ep31.children.head.asInstanceOf[MultiSchemaPartitionsExec]
       .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    psm31.start shouldEqual (nowSeconds * 1000
+    psm31.startMs shouldEqual (nowSeconds * 1000
       - 3.days.toMillis // retention
       + 1.minute.toMillis // step
       + 20.minutes.toMillis  // window
       + 15.minutes.toMillis) // offset
-    psm31.end shouldEqual psm31.start - 20.minutes.toMillis - 15.minutes.toMillis + 1.day.toMillis
+    psm31.endMs shouldEqual psm31.startMs + 1.day.toMillis
 
     // Case 4: outside retention
     val logicalPlan4 = Parser.queryRangeToLogicalPlan("""foo{job="bar"}""",
       TimeStepParams(nowSeconds - 10.days.toSeconds, 1.minute.toSeconds, nowSeconds - 5.days.toSeconds))
     val ep4 = planner.materialize(logicalPlan4, QueryContext(plannerParams = plannerParams2))
-    ep4.children should have length (5)
-    ep4.children.foreach { childPlan =>
-      childPlan.isInstanceOf[EmptyResultExec] shouldEqual true
-      import filodb.core.GlobalScheduler._
-      val res = childPlan.dispatcher.dispatch(childPlan).runAsync.futureValue.asInstanceOf[QueryResult]
-      res.result.isEmpty shouldEqual true
-    }
+    ep4.isInstanceOf[EmptyResultExec] shouldEqual true
   }
 
   it("should generate SplitExec wrapper with appropriate splits " +
@@ -483,8 +473,8 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
     ("""sum(rate(foo{job="bar"}[3d]))""",1000, 100, 1000), plannerParams = plannerParams2)).asInstanceOf[LocalPartitionReduceAggregateExec]
     val psm = ep.children.head.asInstanceOf[MultiSchemaPartitionsExec]
       .rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    psm.start shouldEqual (nowSeconds * 1000)
-    psm.end shouldEqual (nowSeconds * 1000)
+    psm.startMs shouldEqual (nowSeconds * 1000)
+    psm.endMs shouldEqual (nowSeconds * 1000)
   }
 
   it("should generate SplitExec wrapper with appropriate splits and should generate child execPlans with offset") {
@@ -519,9 +509,9 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
       rvt.offsetMs.get shouldEqual 300000
       rvt.startWithOffset shouldEqual(expRvtStartOffset) // (700 - 300) * 1000
       rvt.endWithOffset shouldEqual (expRvtEndOffset) // (10000 - 300) * 1000
-      rvt.start shouldEqual expRvtStart // start and end should be same as query TimeStepParams
-      rvt.end shouldEqual expRvtEnd
-      rvt.step shouldEqual 1000000
+      rvt.startMs shouldEqual expRvtStart // start and end should be same as query TimeStepParams
+      rvt.endMs shouldEqual expRvtEnd
+      rvt.stepMs shouldEqual 1000000
     }
 
   }
@@ -559,9 +549,9 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
       rvt.offsetMs.get shouldEqual 300000
       rvt.startWithOffset shouldEqual(expRvtStartOffset) // (700 - 300) * 1000
       rvt.endWithOffset shouldEqual (expRvtEndOffset) // (10000 - 300) * 1000
-      rvt.start shouldEqual expRvtStart // start and end should be same as query TimeStepParams
-      rvt.end shouldEqual expRvtEnd
-      rvt.step shouldEqual 1000000
+      rvt.startMs shouldEqual expRvtStart // start and end should be same as query TimeStepParams
+      rvt.endMs shouldEqual expRvtEnd
+      rvt.stepMs shouldEqual 1000000
     }
   }
 
@@ -685,9 +675,9 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
       rvt1.offsetMs.get shouldEqual(300000)
       rvt1.startWithOffset shouldEqual(expRvtStartOffset) // (700 - 300) * 1000
       rvt1.endWithOffset shouldEqual (expRvtEndOffset) // (10000 - 300) * 1000
-      rvt1.start shouldEqual expRvtStart
-      rvt1.end shouldEqual expRvtEnd
-      rvt1.step shouldEqual 1000000
+      rvt1.startMs shouldEqual expRvtStart
+      rvt1.endMs shouldEqual expRvtEnd
+      rvt1.stepMs shouldEqual 1000000
 
       binaryJoin.rhs(0).isInstanceOf[MultiSchemaPartitionsExec] shouldEqual(true)
       val multiSchemaExec2 = binaryJoin.rhs(0).asInstanceOf[MultiSchemaPartitionsExec]
@@ -700,9 +690,9 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
       rvt2.offsetMs.isEmpty shouldEqual true
       rvt2.startWithOffset shouldEqual(expRvtStart)
       rvt2.endWithOffset shouldEqual (expRvtEnd)
-      rvt2.start shouldEqual expRvtStart
-      rvt2.end shouldEqual expRvtEnd
-      rvt2.step shouldEqual 1000000
+      rvt2.startMs shouldEqual expRvtStart
+      rvt2.endMs shouldEqual expRvtEnd
+      rvt2.stepMs shouldEqual 1000000
     }
 
   }

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -12,6 +12,7 @@ trait TsdbQueryParams
 /**
   * This class provides PromQl query parameters
   * Config has routing parameters
+ *  startSecs, stepSecs, endSecs should not be used for query execution as it can be changed by query planner
   */
 case class PromQlQueryParams(promQl: String, startSecs: Long, stepSecs: Long, endSecs: Long , remoteQueryPath:
                             Option[String] = None, verbose: Boolean = false) extends TsdbQueryParams

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -122,7 +122,7 @@ final case class AggregatePresenter(aggrOp: AggregationOperator,
                                     rangeParams: RangeParams,
                                     funcParams: Seq[FuncArgs] = Nil) extends RangeVectorTransformer {
 
-  protected[exec] def args: String = s"aggrOp=$aggrOp, aggrParams=$aggrParams"
+  protected[exec] def args: String = s"aggrOp=$aggrOp, aggrParams=$aggrParams, rangeParams=$rangeParams"
 
   def apply(source: Observable[RangeVector],
             querySession: QuerySession,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
`topk` throws next on empty iterator when query start time is less than raw retention time. It happens because time of PeriodicSamplesMapper is changed according to raw retention time. However, AggregatePresenter uses query start time

**New behavior :**

- Retrieve PeriodicSeries/PeriodicSeriesWithWindowing plan from Logical plan. 
- Calculate new start time according to the raw retention time
- Update time for all plans in LogicalPlan 

