### PR TITLE
bug(query): incorrect time in copyWithUpdatedTimeRange function

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -117,10 +117,10 @@ object LogicalPlanUtils extends StrictLogging {
                                             }
       case lp: VectorPlan                  => lp.copy(scalars = copyWithUpdatedTimeRange(lp.scalars, timeRange).
                                             asInstanceOf[ScalarPlan])
-      case lp: ScalarTimeBasedPlan         => lp.copy(rangeParams = RangeParams(timeRange.startMs * 1000,
-                                              lp.rangeParams.stepSecs, timeRange.endMs * 1000))
-      case lp: ScalarFixedDoublePlan       => lp.copy(timeStepParams = RangeParams(timeRange.startMs * 1000,
-                                              lp.timeStepParams.stepSecs, timeRange.endMs * 1000))
+      case lp: ScalarTimeBasedPlan         => lp.copy(rangeParams = RangeParams(timeRange.startMs / 1000,
+                                              lp.rangeParams.stepSecs, timeRange.endMs / 1000))
+      case lp: ScalarFixedDoublePlan       => lp.copy(timeStepParams = RangeParams(timeRange.startMs / 1000,
+                                              lp.timeStepParams.stepSecs, timeRange.endMs / 1000))
       case lp: ScalarBinaryOperation       =>  val updatedLhs = if (lp.lhs.isRight) Right(copyWithUpdatedTimeRange
                                               (lp.lhs.right.get, timeRange).asInstanceOf[ScalarBinaryOperation]) else
                                               Left(lp.lhs.left.get)
@@ -128,8 +128,8 @@ object LogicalPlanUtils extends StrictLogging {
                                                 lp.rhs.right.get, timeRange).asInstanceOf[ScalarBinaryOperation])
                                               else Left(lp.rhs.left.get)
                                               lp.copy(lhs = updatedLhs, rhs = updatedRhs, rangeParams =
-                                                RangeParams(timeRange.startMs * 1000, lp.rangeParams.stepSecs,
-                                                  timeRange.endMs * 1000))
+                                                RangeParams(timeRange.startMs / 1000, lp.rangeParams.stepSecs,
+                                                  timeRange.endMs / 1000))
     }
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -259,7 +259,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers {
       TimeStepParams(start, step, end))
       .asInstanceOf[PeriodicSeriesPlan]
 
-    val rawPlanner gs= new SingleClusterPlanner(dsRef, schemas, mapperRef, earliestRetainedTimestampFn = earliestRawTime, queryConfig)
+    val rawPlanner = new SingleClusterPlanner(dsRef, schemas, mapperRef, earliestRetainedTimestampFn = earliestRawTime, queryConfig)
     val downsamplePlanner = new SingleClusterPlanner(dsRef, schemas, mapperRef, earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig)
     val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
       earliestRawTime, latestDownsampleTime, disp)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -1,11 +1,15 @@
 package filodb.coordinator.queryplanner
 
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import filodb.coordinator.ShardMapper
+
 import scala.concurrent.duration._
-
 import monix.execution.Scheduler
-
-import filodb.core.DatasetRef
-import filodb.core.query.{QueryContext, QuerySession}
+import filodb.core.{DatasetRef, MetricsTestData}
+import filodb.core.metadata.Schemas
+import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.ChunkSource
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
@@ -47,6 +51,20 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers {
   private def disp = InProcessPlanDispatcher
   val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
                                                  earliestRawTime, latestDownsampleTime, disp)
+  implicit val system = ActorSystem()
+  val node = TestProbe().ref
+
+  val mapper = new ShardMapper(32)
+  val promQlQueryParams = PromQlQueryParams("sum(heap_usage)", 100, 1, 1000)
+  for { i <- 0 until 32 } mapper.registerNode(Seq(i), node)
+  def mapperRef = mapper
+
+  val dataset = MetricsTestData.timeseriesDataset
+  val dsRef = dataset.ref
+  val schemas = Schemas(dataset.schema)
+
+  val config = ConfigFactory.load("application_test.conf")
+  val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
 
   it("should direct raw-cluster-only queries to raw planner") {
     val logicalPlan = Parser.queryRangeToLogicalPlan("rate(foo[2m])",
@@ -221,5 +239,35 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers {
 
     rawEp.lp.isInstanceOf[BinaryJoin] shouldEqual(true)
     downsampleEp.lp.isInstanceOf[BinaryJoin] shouldEqual(true)
+  }
+
+  it("should direct overlapping binary join offset queries with vector(0) to both raw & downsample planner and stitch") {
+
+    val start = now/1000 - 5.minutes.toSeconds
+    val step = 1.minute.toSeconds
+    val end = now/1000 - 2.minutes.toSeconds
+
+    val rawRetention = 10090.minutes
+    val downsampleRetention= 183.days
+
+    val earliestRawTime = now - rawRetention.toMillis
+    val earliestDownSampleTime = now - downsampleRetention.toMillis
+    val latestDownsampleTime = now - 12.hours.toMillis
+
+    val query ="""sum(rate(foo{job = "app"}[5m]) or vector(0)) - sum(rate(foo{job = "app"}[5m] offset 8d)) * 0.5"""
+    val logicalPlan = Parser.queryRangeToLogicalPlan(query,
+      TimeStepParams(start, step, end))
+      .asInstanceOf[PeriodicSeriesPlan]
+
+    val rawPlanner gs= new SingleClusterPlanner(dsRef, schemas, mapperRef, earliestRetainedTimestampFn = earliestRawTime, queryConfig)
+    val downsamplePlanner = new SingleClusterPlanner(dsRef, schemas, mapperRef, earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig)
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+      earliestRawTime, latestDownsampleTime, disp)
+
+    val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
+    val stitchExec = ep.asInstanceOf[StitchRvsExec]
+    stitchExec.children.size shouldEqual 2
+    stitchExec.children(0).isInstanceOf[BinaryJoinExec] shouldEqual(true)
+    stitchExec.children(1).isInstanceOf[BinaryJoinExec] shouldEqual(true)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Time is not converted to seconds while updating time for ScalarTimeBasedPlan, ScalarFixedDoublePlan and ScalarBinaryOperation

**New behavior :**
Convert time to seconds