### PR TITLE
bug(query): Stitch must accept NaN on only one RV and not return NaN for that

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -847,9 +847,9 @@ class TimeSeriesShard(val ref: DatasetRef,
     partKeyIndex.removePartKeys(partIter.skippedPartIDs)
     partKeyIndex.removePartKeys(removedParts)
     if (numDeleted > 0) logger.info(s"Purged $numDeleted partitions from memory/index " +
-      s"and ${partIter.skippedPartIDs.len} from index only from dataset=$ref shard=$shardNum")
+      s"and ${partIter.skippedPartIDs.length} from index only from dataset=$ref shard=$shardNum")
     shardStats.purgedPartitions.increment(numDeleted)
-    shardStats.purgedPartitionsFromIndex.increment(removedParts.len + partIter.skippedPartIDs.len)
+    shardStats.purgedPartitionsFromIndex.increment(removedParts.length + partIter.skippedPartIDs.length)
     shardStats.purgePartitionTimeMs.increment(System.currentTimeMillis() - start)
   }
 

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -47,6 +47,45 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers {
     mergeAndValidate(rvs, expected)
   }
 
+  it ("should merge with two overlapping RVs with NaNs correctly") {
+    val rvs = Seq (
+      Seq(  (10L, 3d),
+        (20L, 3d),
+        (30L, 3d),
+        (40L, 3d),
+        (50L, 3d),
+        (60L, Double.NaN),
+        (70L, Double.NaN),
+        (80L, Double.NaN),
+        (90L, Double.NaN),
+        (100L, Double.NaN)
+      ),
+      Seq(  (10L, Double.NaN),
+        (20L, Double.NaN),
+        (30L, 4d),
+        (50L, 4d),
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      )
+    )
+    val expected =
+      Seq(  (10L, 3d),
+        (20L, 3d),
+        (30L, Double.NaN),
+        (40L, 3d),
+        (50L, Double.NaN),
+        (60L, 3d),
+        (70L, 3d),
+        (80L, 3d),
+        (90L, 3d),
+        (100L, 3d)
+      )
+    mergeAndValidate(rvs, expected)
+  }
+
   it ("should merge one RV correctly") {
     val input =       Seq(  (10L, 3d),
       (20L, 3d),


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, stitching returns NaN if both RVs have a sample for same instant, irrespective of whether
only one RV has NaN for that instant.
This PR fixes it to pick the non-NaN value for those instants.

This fixes Binary Join stitching issues seen when querying across spread change boundaries.