### PR TITLE
bug(query): NaN causes failure in counter correction and negative rate

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -444,7 +444,8 @@ class BufferableCounterCorrectionIterator(iter: Iterator[RowReader]) extends Ite
   override def hasNext: Boolean = iter.hasNext
   override def next(): TransientRow = {
     val next = iter.next()
-    val nextVal = next.getDouble(1)
+    var nextVal = next.getDouble(1)
+    if (nextVal.isNaN) nextVal = 0 // explicit counter reset due to end of time series marker
     if (nextVal < prevVal) {
       correction += prevVal
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

NaN in counter value is compared, and counter correction fails to detect drop

**New behavior :**

1. Read NaN counter value as 0
2. Mark counter drop correctly in chunks

Open Issue: Existing chunks with missed drop detection may not work when faster-rate is enabled.

Acknowledgement @TanviBhavsar for jointly working on this PR and reproducing the issue in dev environment.