### PR TITLE
feat(core): Block and error queries until recovery is complete

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -388,7 +388,7 @@ object CliMain extends FilodbClusterNode {
       case Some(intervalSecs) =>
         val fut = Observable.intervalAtFixedRate(intervalSecs.seconds).foreach { n =>
           client.logicalPlan2Query(ref, plan, qOpts) match {
-            case QueryResult(_, schema, result) => result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
+            case QueryResult(_, _, result, _, _) => result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
             case err: QueryError                => throw new ClientException(err)
           }
         }.recover {
@@ -399,7 +399,7 @@ object CliMain extends FilodbClusterNode {
       case None =>
         try {
           client.logicalPlan2Query(ref, plan, qOpts) match {
-            case QueryResult(_, schema, result) => println(s"Output schema: $schema")
+            case QueryResult(_, schema, result, _, _) => println(s"Output schema: $schema")
                                                    println(s"Number of Range Vectors: ${result.size}")
                                                    result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
             case QueryError(_,ex)               => println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -133,7 +133,7 @@ final class QueryActor(memStore: MemStore,
             querySession.close()
             replyTo ! res
             res match {
-              case QueryResult(_, _, vectors) => resultVectors.record(vectors.length)
+              case QueryResult(_, _, vectors, _, _) => resultVectors.record(vectors.length)
               case e: QueryError =>
                 queryErrors.increment()
                 queryExecuteSpan.fail(e.t.getMessage)

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -152,7 +152,7 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
                  100L, 1000L, 100L, window = 1000L, function = RangeFunctionId.CountOverTime), qOpt)
     coordinatorActor ! q2
     expectMsgPF(10.seconds.dilated) {
-      case QueryResult(_, schema, vectors) =>
+      case QueryResult(_, schema, vectors, _, _) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn),
                                        ColumnInfo("value", ColumnType.DoubleColumn))
         // query is counting each partition....

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -157,7 +157,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       probe.send(coordinatorActor, q1)
       val info1 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, srvs) =>
+        case QueryResult(_, schema, srvs, _, _) =>
           schema.columns shouldEqual timeMinSchema.columns
           srvs should have length (1)
           srvs(0).rows.toSeq should have length (2)   // 2 samples per series
@@ -168,7 +168,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
         Seq("min"), Some(300000), None), qOpt)
       probe.send(coordinatorActor, q2)
       val info2 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, Nil) =>
+        case QueryResult(_, schema, Nil, _, _) =>
           schema.columns shouldEqual Nil
       }
     }
@@ -205,7 +205,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       memStore.refreshIndexForTesting(dataset1.ref)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors) =>
+        case QueryResult(_, schema, vectors, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
@@ -218,7 +218,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                      RawSeries(AllChunksSelector, multiFilter, Seq("count"), Some(300000), None), 120000L, 10000L, 130000L)), qOpt)
       probe.send(coordinatorActor, q3)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors) =>
+        case QueryResult(_, schema, vectors, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(98.0, 108.0)
@@ -232,7 +232,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                      10000L, 130000L)),  qOpt)
       probe.send(coordinatorActor, q4)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors) =>
+        case QueryResult(_, schema, vectors, _, _) =>
           schema.columns shouldEqual Nil
           vectors should have length (0)
       }
@@ -257,7 +257,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       (0 until numQueries).foreach { _ =>
         probe.expectMsgPF() {
-          case QueryResult(_, schema, vectors) =>
+          case QueryResult(_, schema, vectors, _, _) =>
             schema.columns shouldEqual valueSchema.columns
             vectors should have length (1)
             vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
@@ -287,7 +287,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                       queryOpt)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors) =>
+        case QueryResult(_, schema, vectors, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0, 14.0)
@@ -311,7 +311,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
         queryOpt)
       probe.send(coordinatorActor, q2)
       val info1 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, srvs) =>
+        case QueryResult(_, schema, srvs, _, _) =>
           schema.columns shouldEqual timeMinSchema.columns
           srvs should have length (6)
           val groupedByKey = srvs.groupBy(_.key.labelValues)
@@ -383,7 +383,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                    RawSeries(AllChunksSelector, Nil, Seq("AvgTone")), 0, 10, 99)), qOpt)
     probe.send(coordinatorActor, q2)
     probe.expectMsgPF() {
-      case QueryResult(_, schema, vectors) =>
+      case QueryResult(_, schema, vectors, _, _) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", LongColumn),
                                        ColumnInfo("value", DoubleColumn))
         vectors should have length (1)

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -52,6 +52,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                                  downsampleConfig: DownsampleConfig)
                                 (implicit val ioPool: ExecutionContext) extends StrictLogging {
 
+  @volatile var isReadyForQuery = false
   private val downsampleTtls = downsampleConfig.ttls
   private val downsampledDatasetRefs = downsampleConfig.downsampleDatasetRefs(rawDatasetRef.dataset)
 
@@ -120,6 +121,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
         indexUpdatedHour.set(hour() - indexJobIntervalInHours - 1)
         startHousekeepingTask()
         startStatsUpdateTask()
+        logger.info(s"Shard now ready for query dataset=$indexDataset shard=$shardNum")
+        isReadyForQuery = true
       }.runAsync(housekeepingSched)
   }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -32,6 +32,12 @@ extends MemStore with StrictLogging {
 
   override def isDownsampleStore: Boolean = true
 
+  def checkReadyForQuery(ref: DatasetRef, shard: Int): Unit = {
+    if (!getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
+      throw new IllegalStateException(s"TSDB is not ready for query yet since shard=$shard is still bootstrapping.")
+    }
+  }
+
   override def metastore: MetaStore = ??? // Not needed
 
   // TODO: Change the API to return Unit Or ShardAlreadySetup, instead of throwing.  Make idempotent.

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -32,10 +32,8 @@ extends MemStore with StrictLogging {
 
   override def isDownsampleStore: Boolean = true
 
-  def checkReadyForQuery(ref: DatasetRef, shard: Int): Unit = {
-    if (!getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
-      throw new IllegalStateException(s"TSDB is not ready for query yet since shard=$shard is still bootstrapping.")
-    }
+  def isReadyForQuery(ref: DatasetRef, shard: Int): Boolean = {
+    getShardE(ref: DatasetRef, shard: Int).isReadyForQuery
   }
 
   override def metastore: MetaStore = ??? // Not needed

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -43,10 +43,8 @@ extends MemStore with StrictLogging {
 
   def isDownsampleStore: Boolean = false
 
-  override def checkReadyForQuery(ref: DatasetRef, shard: Int): Unit = {
-    if (!getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
-      throw new IllegalStateException(s"TSDB is not ready for query yet since shard=$shard is still bootstrapping.")
-    }
+  override def isReadyForQuery(ref: DatasetRef, shard: Int): Boolean = {
+    getShardE(ref: DatasetRef, shard: Int).isReadyForQuery
   }
 
   // TODO: Change the API to return Unit Or ShardAlreadySetup, instead of throwing.  Make idempotent.

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -246,6 +246,8 @@ class TimeSeriesShard(val ref: DatasetRef,
   import FiloSchedulers._
   import TimeSeriesShard._
 
+  @volatile var isReadyForQuery = false
+
   val shardStats = new TimeSeriesShardStats(ref, shardNum)
   val shardKeyLevelIngestionMetricsEnabled = filodbConfig.getBoolean("shard-key-level-ingestion-metrics-enabled")
   val shardKeyLevelQueryMetricsEnabled = filodbConfig.getBoolean("shard-key-level-query-metrics-enabled")

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -31,7 +31,8 @@ case class PlannerParams(applicationId: String = "filodb",
                         splitSizeMs: Long = 1.day.toMillis,
                         skipAggregatePresent: Boolean = false,
                         processFailure: Boolean = true,
-                        processMultiPartition: Boolean = false)
+                        processMultiPartition: Boolean = false,
+                        partialResultsOk: Boolean = false)
 object PlannerParams {
   def apply(constSpread: Option[SpreadProvider], sampleLimit: Int): PlannerParams =
     PlannerParams(spreadOverride = constSpread, sampleLimit = sampleLimit)
@@ -83,7 +84,9 @@ object QueryContext {
   */
 case class QuerySession(qContext: QueryContext,
                         queryConfig: QueryConfig,
-                        var lock: Option[Lock] = None) {
+                        var lock: Option[Lock] = None,
+                        var resultCouldBePartial: Boolean = false,
+                        var partialResultsReason: Option[String] = None) {
   def close(): Unit = {
     lock.foreach(_.unlock())
     lock = None

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -71,7 +71,7 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
     */
   def isDownsampleStore: Boolean
 
-  def checkReadyForQuery(datasetRef: DatasetRef, shard: Int): Unit
+  def isReadyForQuery(datasetRef: DatasetRef, shard: Int): Boolean
 
   /**
    * Scans and returns data in partitions according to the method.  The partitions are ready to be queried.

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -71,6 +71,8 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
     */
   def isDownsampleStore: Boolean
 
+  def checkReadyForQuery(datasetRef: DatasetRef, shard: Int): Unit
+
   /**
    * Scans and returns data in partitions according to the method.  The partitions are ready to be queried.
    * FiloPartitions contains chunks in offheap memory.

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -25,6 +25,8 @@ final case class QueryError(id: String, t: Throwable) extends QueryResponse with
   */
 class BadQueryException(message: String) extends RuntimeException(message)
 
+class ServiceUnavailableException(message: String) extends RuntimeException(message)
+
 case class RemoteQueryFailureException(statusCode: Int, requestStatus: String, errorType: String, errorMessage: String )
   extends RuntimeException {
   override def getMessage: String = {
@@ -49,7 +51,9 @@ object QueryResultType extends Enum[QueryResultType] {
 
 final case class QueryResult(id: String,
                              resultSchema: ResultSchema,
-                             result: Seq[RangeVector]) extends QueryResponse {
+                             result: Seq[RangeVector],
+                             isPartialResult: Boolean = false,
+                             partialResultReason: Option[String] = None) extends QueryResponse {
   def resultType: QueryResultType = {
     result match {
       case Nil => QueryResultType.RangeVectors

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -27,7 +27,7 @@ trait ReduceAggregateExec extends NonLeafExecPlan {
                         firstSchema: Task[ResultSchema],
                         querySession: QuerySession): Observable[RangeVector] = {
     val results = childResponses.flatMap {
-        case (QueryResult(_, _, result), _) => Observable.fromIterable(result)
+        case (QueryResult(_, _, result, _, _), _) => Observable.fromIterable(result)
         case (QueryError(_, ex), _)         => throw ex
     }
     val task = for { schema <- firstSchema }

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -68,11 +68,11 @@ final case class BinaryJoinExec(queryContext: QueryContext,
                               querySession: QuerySession): Observable[RangeVector] = {
     val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, _, result), _)
+      case (QueryResult(_, _, result, _, _), _)
         if (result.size  > queryContext.plannerParams.joinQueryCardLimit && cardinality == Cardinality.OneToOne) =>
         throw new BadQueryException(s"This query results in more than ${queryContext.plannerParams.joinQueryCardLimit}"
           + s" join cardinality. Try applying more filters.")
-      case (QueryResult(_, _, result), i) => (result, i)
+      case (QueryResult(_, _, result, _, _), i) => (result, i)
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map { resp =>
       span.mark("binary-join-child-results-available")
@@ -199,9 +199,9 @@ final case class BinaryJoinExec(queryContext: QueryContext,
     */
   override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
     resp match {
-      case QueryResult(_, schema, _) if rs == ResultSchema.empty =>
+      case QueryResult(_, schema, _, _, _) if rs == ResultSchema.empty =>
         schema     /// First schema, take as is
-      case QueryResult(_, schema, _) =>
+      case QueryResult(_, schema, _, _, _) =>
         if (!rs.hasSameColumnsAs(schema)) throw SchemaMismatch(rs.toString, schema.toString)
         else rs
     }

--- a/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
@@ -18,7 +18,7 @@ trait DistConcatExec extends NonLeafExecPlan {
                         firstSchema: Task[ResultSchema],
                         querySession: QuerySession): Observable[RangeVector] = {
     childResponses.flatMap {
-      case (QueryResult(_, _, result), _) => Observable.fromIterable(result)
+      case (QueryResult(_, _, result, _, _), _) => Observable.fromIterable(result)
       case (QueryError(_, ex), _)         => throw ex
     }
   }

--- a/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
+++ b/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
@@ -19,7 +19,7 @@ case class EmptyResultExec(queryContext: QueryContext,
     Task(QueryResult(queryContext.queryId,
       new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                            ColumnInfo("value", ColumnType.DoubleColumn)), 1),
-      Seq.empty))
+      Seq.empty, false, None))
   }
 
   override def doExecute(source: ChunkSource,

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -7,6 +7,7 @@ import spire.syntax.cfor._
 import filodb.core.query._
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String}
 import filodb.memory.format.vectors.Histogram
+import filodb.query.BadQueryException
 
 object HistogramQuantileMapper {
   import ZeroCopyUTF8String._
@@ -63,7 +64,7 @@ final case class HistogramQuantileMapper(funcParams: Seq[FuncArgs]) extends Rang
         val sortedBucketRvs = histBuckets._2.toArray.map { bucket =>
           val labelValues = bucket.key.labelValues
           if (!labelValues.contains(le))
-            throw new IllegalArgumentException("Cannot calculate histogram quantile" +
+            throw new BadQueryException("Cannot calculate histogram quantile" +
               s"because 'le' tag is absent in the time series ${bucket.key.labelValues}")
           val leStr = labelValues(le).toString
           val leDouble = if (leStr == "+Inf") Double.PositiveInfinity else leStr.toDouble

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -73,6 +73,8 @@ case class UnsupportedChunkSource() extends ChunkSource {
 
   override def isDownsampleStore: Boolean = false
 
+  override def checkReadyForQuery(ref: DatasetRef, shard: Int): Unit = {}
+
   override def topKCardinality(ref: DatasetRef,
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -73,7 +73,7 @@ case class UnsupportedChunkSource() extends ChunkSource {
 
   override def isDownsampleStore: Boolean = false
 
-  override def checkReadyForQuery(ref: DatasetRef, shard: Int): Unit = {}
+  override def isReadyForQuery(ref: DatasetRef, shard: Int): Boolean = true
 
   override def topKCardinality(ref: DatasetRef,
                                shards: Seq[Int],

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -112,6 +112,7 @@ final case class LabelValuesExec(queryContext: QueryContext,
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = {
+    source.checkReadyForQuery(dataset, shard)
     val parentSpan = Kamon.currentSpan()
     val rvs = if (source.isInstanceOf[MemStore]) {
       val memStore = source.asInstanceOf[MemStore]

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -47,6 +47,6 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema,
                         queryWithPlanName(queryContext)))
 
-    QueryResult(id, resultSchema, srvSeq)
+    QueryResult(id, resultSchema, srvSeq, false, None) // TODO need to actually get isPartialResponse from http response
   }
 }

--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -86,9 +86,10 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = {
+    source.checkReadyForQuery(dataset, shard)
     finalPlan = finalizePlan(source, querySession)
     finalPlan.doExecute(source, querySession)(sched)
-   }
+  }
 
   protected def args: String = s"dataset=$dataset, shard=$shard, " +
                                s"chunkMethod=$chunkMethod, filters=$filters, colName=$colName, schema=$schema"

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -76,14 +76,16 @@ case class PromQlRemoteExec(queryEndpoint: String,
   def toQueryResponse(data: Data, id: String, parentSpan: kamon.trace.Span): QueryResponse = {
     val queryResponse = if (data.result.isEmpty) {
       logger.debug("PromQlRemoteExec generating empty QueryResult as result is empty")
-      QueryResult(id, ResultSchema.empty, Seq.empty)
+      // TODO need to actually get isPartialResponse from http response
+      QueryResult(id, ResultSchema.empty, Seq.empty, false, None)
     } else {
       if (data.result.head.aggregateResponse.isDefined) genAggregateResult(data, id)
       else {
         val samples = data.result.head.values.getOrElse(Seq(data.result.head.value.get))
         if (samples.isEmpty) {
           logger.debug("PromQlRemoteExec generating empty QueryResult as samples is empty")
-          QueryResult(id, ResultSchema.empty, Seq.empty)
+          // TODO need to actually get isPartialResponse from http response
+          QueryResult(id, ResultSchema.empty, Seq.empty, false, None)
         } else {
           samples.head match {
             // Passing histogramMap = true so DataSampl will be HistSampl for histograms
@@ -99,8 +101,10 @@ case class PromQlRemoteExec(queryEndpoint: String,
   def genAggregateResult(data: Data, id: String): QueryResult = {
 
     val aggregateResponse = data.result.head.aggregateResponse.get
-    if (aggregateResponse.aggregateSampl.isEmpty) QueryResult(id, ResultSchema.empty, Seq.empty)
-    else {
+    if (aggregateResponse.aggregateSampl.isEmpty) {
+      // TODO need to actually get isPartialResponse from http response
+      QueryResult(id, ResultSchema.empty, Seq.empty, false, None)
+    } else {
       aggregateResponse.aggregateSampl.head match {
         case AvgSampl(timestamp, value, count)           => genAvgQueryResult(data, id)
         case StdValSampl(timestamp, stddev, mean, count) => genStdValQueryResult(data, id)
@@ -132,7 +136,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
         queryWithPlanName(queryContext))
       // TODO: Handle stitching with verbose flag
     }
-    QueryResult(id, resultSchema.get("default").get, rangeVectors)
+    // TODO need to actually get isPartialResponse from http response
+    QueryResult(id, resultSchema.get("default").get, rangeVectors, false, None)
   }
 
   def genHistQueryResult(data: Data, id: String): QueryResult = {
@@ -166,7 +171,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
       SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, queryContext.origQueryParams.toString)
       // TODO: Handle stitching with verbose flag
     }
-    QueryResult(id, resultSchema.get("histogram").get, rangeVectors)
+    // TODO need to actually get isPartialResponse from http response
+    QueryResult(id, resultSchema.get("histogram").get, rangeVectors, false, None)
   }
 
   def genAvgQueryResult(data: Data, id: String): QueryResult = {
@@ -192,7 +198,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
     }
 
     // TODO: Handle stitching with verbose flag
-    QueryResult(id, resultSchema.get(Avg.entryName).get, rangeVectors)
+    // TODO need to actually get isPartialResponse from http response
+    QueryResult(id, resultSchema.get(Avg.entryName).get, rangeVectors, false, None)
   }
 
   def genStdValQueryResult(data: Data, id: String): QueryResult = {
@@ -219,6 +226,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
     }
 
     // TODO: Handle stitching with verbose flag
-    QueryResult(id, resultSchema.get("stdval").get, rangeVectors)
+    // TODO need to actually get isPartialResponse from http response
+    QueryResult(id, resultSchema.get("stdval").get, rangeVectors, false, None)
   }
 }

--- a/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
@@ -58,7 +58,8 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
                       (implicit sched: Scheduler): Task[QueryResponse] = {
     val rangeVectors : Seq[RangeVector] = Seq(ScalarFixedDouble(params, evaluate))
     Task {
-      QueryResult(queryContext.queryId, resultSchema, rangeVectors)
+      QueryResult(queryContext.queryId, resultSchema, rangeVectors, querySession.resultCouldBePartial,
+        querySession.partialResultsReason)
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -55,7 +55,7 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       Task {
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
-          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult)
+          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult(querySession))
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -59,7 +59,8 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          QueryResult(queryContext.queryId, resultSchema, _)
+          QueryResult(queryContext.queryId, resultSchema, _, querySession.resultCouldBePartial,
+            querySession.partialResultsReason)
         })
       }.flatten
     }

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -42,6 +42,7 @@ final case class SelectChunkInfosExec(queryContext: QueryContext,
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = {
+    source.checkReadyForQuery(dataset, shard)
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     val lookupRes = source.lookupPartitions(dataset, partMethod, chunkMethod, querySession)
 

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -55,7 +55,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
                               querySession: QuerySession): Observable[RangeVector] = {
     val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, schema, result), i) => (schema, result, i)
+      case (QueryResult(_, schema, result, _, _), i) => (schema, result, i)
       case (QueryError(_, ex), _)              => throw ex
     }.toListL.map { resp =>
       span.mark("binary-join-child-results-available")
@@ -269,9 +269,9 @@ final case class SetOperatorExec(queryContext: QueryContext,
     */
   override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
     resp match {
-      case QueryResult(_, schema, _) if rs == ResultSchema.empty =>
+      case QueryResult(_, schema, _, _, _) if rs == ResultSchema.empty =>
         schema     /// First schema, take as is
-      case QueryResult(_, schema, _) =>
+      case QueryResult(_, schema, _, _, _) =>
         if (!rs.hasSameColumnsAs(schema)) throw SchemaMismatch(rs.toString, schema.toString)
         else rs
     }

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -76,7 +76,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
                         querySession: QuerySession): Observable[RangeVector] = {
     qLogger.debug(s"StitchRvsExec: Stitching results:")
     val stitched = childResponses.map {
-      case (QueryResult(_, _, result), _) => result
+      case (QueryResult(_, _, result, _, _), _) => result
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map(_.flatten).map { srvs =>
       val groups = srvs.groupBy(_.key.labelValues)

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -68,7 +68,8 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          QueryResult(queryContext.queryId, resultSchema, _)
+          QueryResult(queryContext.queryId, resultSchema, _, querySession.resultCouldBePartial,
+            querySession.partialResultsReason)
         })
       }.flatten
     }

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -64,7 +64,7 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
     Kamon.runWithSpan(span, false) {
       Task {
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
-          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult)
+          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult(querySession))
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -91,7 +91,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp match {
-      case QueryResult(id, _, response) => {
+      case QueryResult(id, _, response, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
@@ -111,7 +111,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     resp match {
-      case QueryResult(_, _, results) => results.size shouldEqual 1
+      case QueryResult(_, _, results, _, _) => results.size shouldEqual 1
         results(0).rows.size shouldEqual 0
     }
   }
@@ -125,7 +125,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp match {
-      case QueryResult(id, _, response) =>
+      case QueryResult(id, _, response, _, _) =>
         response.size shouldEqual 1
         response(0).rows.map { row =>
           val r = row.asInstanceOf[BinaryRecordRowReader]
@@ -146,7 +146,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp match {
-      case QueryResult(id, _, response) => {
+      case QueryResult(id, _, response, _, _) => {
         response.size shouldEqual 1
         response(0).rows.map { row =>
           val r = row.asInstanceOf[BinaryRecordRowReader]
@@ -165,7 +165,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp match {
-      case QueryResult(id, _, response) => {
+      case QueryResult(id, _, response, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]

--- a/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
@@ -134,7 +134,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp match {
-      case QueryResult(id, _, response) => {
+      case QueryResult(id, _, response, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[TimeScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList
@@ -149,7 +149,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp match {
-      case QueryResult(id, _, response) => {
+      case QueryResult(id, _, response, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[HourScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList
@@ -165,7 +165,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp match {
-      case QueryResult(id, _, response) => {
+      case QueryResult(id, _, response, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[DayOfWeekScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -191,7 +191,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",_ws_=\"demo\",_ns_=\"App-2\"})"
     val logicalPlan = Parser.queryRangeToLogicalPlan(chunkMetaQuery, TimeStepParams(0, 60, Int.MaxValue))
     client.logicalPlan2Query(dataset, logicalPlan) match {
-      case QueryResult2(_, schema, result) => result.foreach(rv => println(rv.prettyPrint()))
+      case QueryResult2(_, _, result, _, _) => result.foreach(rv => println(rv.prettyPrint()))
       case e: QueryError => fail(e.t)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Answering queries before shard recovers fully can lead to incomplete results. Hence blocking queries
until shard recovers fully. Downsample shard should recover index and raw shard should have completed kafka recovery.

Validated using existing unit tests.
