### PR TITLE
bug(core): Acquire write lock when mutating write buffers

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -133,6 +133,7 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
    * @param flushIntervalMillis flush-interval in milliseconds
    * @param acceptDuplicateSamples accept duplicate samples
    */
+  // scalastyle:off method.length
   def ingest(ingestionTime: Long, row: RowReader, overflowBlockHolder: BlockMemFactory,
              createChunkAtFlushBoundary: Boolean, flushIntervalMillis: Option[Long],
              acceptDuplicateSamples: Boolean,
@@ -156,7 +157,9 @@ extends ChunkMap(memFactory, initMapSize) with ReadablePartition {
           createChunkAtFlushBoundary, flushIntervalMillis, acceptDuplicateSamples, maxChunkTime)
       } else {
         cforRange { 0 until schema.numDataColumns } { col =>
-          currentChunks(col).addFromReaderNoNA(row, col) match {
+          chunkmapWithExclusive { // acquire write lock to ensure readers don't read partial data
+            currentChunks(col).addFromReaderNoNA(row, col)
+          } match {
             case r: VectorTooSmall =>
               switchBuffersAndIngest(ingestionTime, ts, row, overflowBlockHolder,
                 createChunkAtFlushBoundary, flushIntervalMillis, acceptDuplicateSamples, maxChunkTime)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Since we don't stop readers when write buffers are mutated, readers can sometimes read partial data leading to intermittent query errors. This PR adds acquisition of write lock during ingestion and mutation of write buffers. 

