### PR TITLE
bug(core): Exclusive lock timeout should be more than query timeout

### DIFF
--- a/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
@@ -49,7 +49,7 @@ object ChunkMap extends StrictLogging {
     classOf[ChunkMap].getDeclaredField("lockState"))
 
   private val InitialExclusiveRetryTimeoutNanos = 1.millisecond.toNanos
-  private val MaxExclusiveRetryTimeoutNanos = 1.minute.toNanos
+  private val MaxExclusiveRetryTimeoutNanos = 10.minute.toNanos
 
   private val exclusiveLockWait = Kamon.counter("memory-exclusive-lock-waits").withoutTags
   private val sharedLockLingering = Kamon.counter("memory-shared-lock-lingering").withoutTags


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Query timeout should kick in first. We dont want exclusive lock shutdowns to kick in before query timeout.