### PR TITLE
perf(core): Reduce index parallel scans to 2 by default

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -264,7 +264,7 @@ filodb {
 
     # Parallel scans per shard. Use this property and num-token-range-splits-for-scans to
     # issue parallel queries to cassandra during index load to index reduce recovery times
-    index-scan-parallelism-per-shard = 10
+    index-scan-parallelism-per-shard = 2
 
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Change default parallel index scans to 2