### PR TITLE
bug(core): IngestionTimeIndex Table write was using wrong TTL

### DIFF
--- a/conf/histogram-dev-source.conf
+++ b/conf/histogram-dev-source.conf
@@ -39,10 +39,6 @@
         # TTL for on-disk / C* data.  Data older than this may be purged.
         disk-time-to-live = 24 hours
 
-        # amount of time paged chunks should be retained in memory.
-        # We need to have a minimum of x hours free blocks or else init won't work.
-        demand-paged-chunk-retention-period = 12 hours
-
         max-chunks-size = 400
 
         # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,

--- a/conf/timeseries-128shards-source.conf
+++ b/conf/timeseries-128shards-source.conf
@@ -13,7 +13,7 @@
 
       store {
         flush-interval = 10 minutes
-        demand-paged-chunk-retention-period = 12 hours
+        disk-time-to-live = 12 hours
         max-chunks-size = 360
         max-num-partitions = 10000
         # Very few blocks, so just flush one time

--- a/conf/timeseries-dev-buddy.conf
+++ b/conf/timeseries-dev-buddy.conf
@@ -32,10 +32,6 @@ sourceconfig {
     # TTL for on-disk / C* data.  Data older than this may be purged.
     disk-time-to-live = 24 hours
 
-    # amount of time paged chunks should be retained in memory.
-    # We need to have a minimum of x hours free blocks or else init won't work.
-    demand-paged-chunk-retention-period = 12 hours
-
     # maximum userTime range allowed in a single chunk. This needs to be longer than flush interval
     # to ensure that normal flushes result in only one chunk.
     # If not specified, max-chunk-time = 1.1 * flush-interval

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -32,10 +32,6 @@
         # TTL for on-disk / C* data.  Data older than this may be purged.
         disk-time-to-live = 24 hours
 
-        # amount of time paged chunks should be retained in memory.
-        # We need to have a minimum of x hours free blocks or else init won't work.
-        demand-paged-chunk-retention-period = 12 hours
-
         # maximum userTime range allowed in a single chunk. This needs to be longer than flush interval
         # to ensure that normal flushes result in only one chunk.
         # If not specified, max-chunk-time = 1.1 * flush-interval

--- a/conf/timeseries-standalonetest-source.conf
+++ b/conf/timeseries-standalonetest-source.conf
@@ -14,9 +14,8 @@
       store {
         # Standalone tests need a short flush interval to ensure it finishes running
         flush-interval = 2 minutes
-        disk-time-to-live = 2 hours
+        disk-time-to-live = 12 hours
 
-        demand-paged-chunk-retention-period = 12 hours
         max-chunks-size = 400
 
         shard-mem-size = 512MB

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -249,9 +249,9 @@ filodb {
     #      = 5MB per cass partition. Goal is to keep it under 10MB.
     pk-by-updated-time-table-num-splits = 200
 
-    # TTL for rows in partitionkeys_by_update_time table. Ensure it is long enough to ensure that
+    # TTL for rows in ingestion time index tables. Ensure it is long enough to ensure that
     # downsampler or repair migration will complete in that time
-    pk-by-updated-time-table-ttl = 3 days
+    write-time-index-ttl = 7 days
 
     # Creation of tables is enabled. Do not set to true in production to avoid
     # multiple nodes trying to create table at once

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -251,7 +251,7 @@ filodb {
 
     # TTL for rows in ingestion time index tables. Ensure it is long enough to ensure that
     # downsampler or repair migration will complete in that time
-    write-time-index-ttl = 7 days
+    write-time-index-ttl = 3 days
 
     # Creation of tables is enabled. Do not set to true in production to avoid
     # multiple nodes trying to create table at once

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -56,7 +56,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
   private val downsampledDatasetRefs = downsampleConfig.downsampleDatasetRefs(rawDatasetRef.dataset)
 
   private val indexDataset = downsampledDatasetRefs.last
-  private val indexTtl = downsampleTtls.last
+  private val indexTtlMs = downsampleTtls.last.toMillis
 
   private val downsampleStoreConfig = StoreConfig(filodbConfig.getConfig("downsampler.downsample-store-config"))
 
@@ -64,7 +64,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   private val stats = new DownsampledTimeSeriesShardStats(rawDatasetRef, shardNum)
 
-  private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, shardNum, indexTtl)
+  private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, shardNum, indexTtlMs)
 
   private val indexUpdatedHour = new AtomicLong(0)
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -7,7 +7,6 @@ import java.util.PriorityQueue
 import scala.collection.JavaConverters._
 import scala.collection.immutable.HashSet
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration.FiniteDuration
 
 import com.googlecode.javaewah.{EWAHCompressedBitmap, IntIterator}
 import com.typesafe.scalalogging.StrictLogging
@@ -72,7 +71,7 @@ final case class PartKeyLuceneIndexRecord(partKey: Array[Byte], startTime: Long,
 class PartKeyLuceneIndex(ref: DatasetRef,
                          schema: PartitionSchema,
                          shardNum: Int,
-                         retention: FiniteDuration, // only used to calculate fallback startTime
+                         retentionMillis: Long, // only used to calculate fallback startTime
                          diskLocation: Option[File] = None
                          ) extends StrictLogging {
 
@@ -433,7 +432,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
                                (partKeyNumBytes: Int = partKeyOnHeapBytes.length): Unit = {
     var startTime = startTimeFromPartId(partId) // look up index for old start time
     if (startTime == NOT_FOUND) {
-      startTime = System.currentTimeMillis() - retention.toMillis
+      startTime = System.currentTimeMillis() - retentionMillis
       logger.warn(s"Could not find in Lucene startTime for partId=$partId in dataset=$ref. Using " +
         s"$startTime instead.", new IllegalStateException()) // assume this time series started retention period ago
     }

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -86,7 +86,6 @@ object StoreConfig {
 
   val defaults = ConfigFactory.parseString("""
                                            |disk-time-to-live = 3 days
-                                           |ingestion-time-index-retention = 7 days
                                            |max-chunks-size = 400
                                            |max-data-per-shard-query = 300 MB
                                            |max-blob-buffer-size = 15000

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -12,7 +12,6 @@ import filodb.core.downsample.DownsampleConfig
 final case class StoreConfig(flushInterval: FiniteDuration,
                              timeAlignedChunksEnabled: Boolean,
                              diskTTLSeconds: Int,
-                             demandPagedRetentionPeriod: FiniteDuration,
                              maxChunksSize: Int,
                              // Max write buffer size for Histograms, UTF8Strings, other blobs
                              maxBlobBufferSize: Int,
@@ -49,7 +48,6 @@ final case class StoreConfig(flushInterval: FiniteDuration,
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
                                "time-aligned-chunks-enabled" -> timeAlignedChunksEnabled,
                                "disk-time-to-live" -> (diskTTLSeconds + "s"),
-                               "demand-paged-chunk-retention-period" -> (demandPagedRetentionPeriod.toSeconds + "s"),
                                "max-chunks-size" -> maxChunksSize,
                                "max-blob-buffer-size" -> maxBlobBufferSize,
                                "shard-mem-size" -> shardMemSize,
@@ -88,7 +86,7 @@ object StoreConfig {
 
   val defaults = ConfigFactory.parseString("""
                                            |disk-time-to-live = 3 days
-                                           |demand-paged-chunk-retention-period = 72 hours
+                                           |ingestion-time-index-retention = 7 days
                                            |max-chunks-size = 400
                                            |max-data-per-shard-query = 300 MB
                                            |max-blob-buffer-size = 15000
@@ -131,7 +129,6 @@ object StoreConfig {
     StoreConfig(flushInterval,
                 timeAlignedChunksEnabled,
                 config.as[FiniteDuration]("disk-time-to-live").toSeconds.toInt,
-                config.as[FiniteDuration]("demand-paged-chunk-retention-period"),
                 config.getInt("max-chunks-size"),
                 config.getInt("max-blob-buffer-size"),
                 config.getMemorySize("shard-mem-size").toBytes,

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -15,7 +15,7 @@ filodb {
     retry-interval-max-jitter = 10s
     ingestion-consistency-level = "ONE"
     pk-by-updated-time-table-num-splits = 200
-    pk-by-updated-time-table-ttl = 1 day
+    write-time-index-ttl = 1 day
     create-tables-enabled = true
     num-token-range-splits-for-scans = 2
     index-scan-parallelism-per-shard = 2

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -41,7 +41,7 @@ object TestData {
   val sourceConfStr = """
     store {
       max-chunks-size = 100
-      demand-paged-chunk-retention-period = 10 hours
+      disk-time-to-live = 10 hours
       shard-mem-size = 100MB
       groups-per-shard = 4
       ingestion-buffer-mem-size = 80MB

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -21,7 +21,7 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   import Filter._
   import GdeltTestData._
 
-  val keyIndex = new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, 0, 1.hour)
+  val keyIndex = new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, 0, 1.hour.toMillis)
   val partBuilder = new RecordBuilder(TestData.nativeMem)
 
   def partKeyOnHeap(dataset: Dataset,
@@ -269,7 +269,7 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   }
 
   it("should ignore unsupported columns and return empty filter") {
-    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, 0, 1.hour)
+    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, 0, 1.hour.toMillis)
     partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
       index2.addPartKey(partKeyOnHeap(dataset6, ZeroPointer, addr), i, System.currentTimeMillis())()
     }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -237,7 +237,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
   it("should flush dirty part keys during start-ingestion, end-ingestion and re-ingestion") {
     memStore.setup(dataset1.ref, schemas1, 0, TestData.storeConf.copy(groupsPerShard = 2,
-                                                        demandPagedRetentionPeriod = 1.hour,
+                                                        diskTTLSeconds = 1.hour.toSeconds.toInt,
                                                         flushInterval = 10.minutes))
     Thread sleep 1000
     val numPartKeysWritten = partKeysWritten
@@ -315,7 +315,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
     val memStore = new TimeSeriesMemStore(config, colStore, new InMemoryMetaStore(), Some(policy))
     memStore.setup(dataset1.ref, schemas1, 0, TestData.storeConf.copy(groupsPerShard = 2,
-      demandPagedRetentionPeriod = 1.hour,
+      diskTTLSeconds = 1.hour.toSeconds.toInt,
       flushInterval = 10.minutes))
     Thread sleep 1000
 

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -67,9 +67,6 @@ sourceconfig {
     # TTL for on-disk / C* data.  Data older than this may be purged.
     disk-time-to-live = 3 days
 
-    # amount of time paged chunks should be retained in memory
-    demand-paged-chunk-retention-period = 72 hours
-
     max-chunks-size = 500
 
     # Number of bytes of offheap mem to allocate to chunk storage in each shard.  Ex. 1000MB, 1G, 2GB

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -22,7 +22,7 @@ class PartKeyIndexBenchmark {
   org.slf4j.LoggerFactory.getLogger("filodb").asInstanceOf[Logger].setLevel(Level.ERROR)
 
   val ref = DatasetRef("prometheus")
-  val partKeyIndex = new PartKeyLuceneIndex(ref, untyped.partition, 0, 1.hour)
+  val partKeyIndex = new PartKeyLuceneIndex(ref, untyped.partition, 0, 1.hour.toMillis)
   val numSeries = 1000000
   val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory)
   val untypedData = TestTimeseriesProducer.timeSeriesData(0, numSeries) take numSeries


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Consolidate ` demand-paged-chunk-retention-period` and `disk-time-to-live` configs in IngestionConfig
* Rename `pk-by-updated-time-table-ttl` to `write-time-index-ttl`. Change its default to 7 days.
* Fixed IngestionTimeIndex table writes to use `write-time-index-ttl` instead of `disk-time-to-live`
