### PR TITLE
perf(query): NaN Optimization in SerializedRangeVector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
   - openjdk11
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=3 -XX:MaxMetaspaceSize=512m -sbt-launch-repo https://repo1.maven.org/maven2 test
+  - sbt ++$TRAVIS_SCALA_VERSION -sbt-launch-repo https://repo1.maven.org/maven2 test
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ scala:
 jdk:
   - openjdk11
 
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=3 -XX:MaxMetaspaceSize=512m -sbt-launch-repo https://repo1.maven.org/maven2 test
+
 # These directories are cached to S3 at the end of the build
 cache:
   directories:

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -294,7 +294,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val key = CustomRangeVectorKey(keysMap)
     val cols = Seq(ColumnInfo("value", ColumnType.DoubleColumn))
     import filodb.core.query.NoCloseCursor._
-    val ser = SerializedRangeVector(IteratorBackedRangeVector(key, Iterator.empty), cols)
+    val ser = SerializedRangeVector(IteratorBackedRangeVector(key, Iterator.empty, None), cols)
 
     val schema = ResultSchema(MachineMetricsData.dataset1.schema.infosFromIDs(0 to 0), 1)
 
@@ -312,7 +312,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val cols = Seq(ColumnInfo("value", ColumnType.MapColumn))
     import filodb.core.query.NoCloseCursor._
     val ser = Seq(SerializedRangeVector(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-      new UTF8MapIteratorRowReader(input.toIterator)), cols))
+      new UTF8MapIteratorRowReader(input.toIterator), None), cols))
 
     val result = QueryResult2("someId", schema, ser)
     val roundTripResult = roundTrip(result).asInstanceOf[QueryResult2]

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -144,6 +144,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
           rowbuf.iterator
         }
         override val key: RangeVectorKey = rvKey
+        override def outputRange: Option[RvRange] = None
       }
       val srv = SerializedRangeVector(rv, cols)
       val observedTs = srv.rows.toSeq.map(_.getLong(0))

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -312,7 +312,6 @@ final class SerializedRangeVector(val key: RangeVectorKey,
   import NoCloseCursor._
   // Possible for records to spill across containers, so we read from all containers
   override def rows: RangeVectorCursor = {
-    // TODO if period.isDefined, then need to insert NaNs
     val it = containers.toIterator.flatMap(_.iterate(schema)).slice(startRecordNo, startRecordNo + numRowsInt)
     if (period.isDefined &&
         schema.isTimeSeries &&

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -127,7 +127,7 @@ trait RangeVector {
    * If Some, then it describes start/step/end of output data.
    * Present only for time series data that is periodic. If raw data is requested, then None.
    */
-  def outputRange: Option[RvRange] = None
+  def outputRange: Option[RvRange]
 
   // FIXME remove default in numRows since many impls simply default to None. Shouldn't scalars implement this
   def numRows: Option[Int] = None

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -171,7 +171,7 @@ final case class RangeParams(startSecs: Long, stepSecs: Long, endSecs: Long)
 
 trait ScalarSingleValue extends ScalarRangeVector {
   def rangeParams: RangeParams
-  override def outputRange: Option[RvRange] = Some(RvRange(rangeParams.stepSecs * 1000,
+  override def outputRange: Option[RvRange] = Some(RvRange(rangeParams.startSecs * 1000,
                                              rangeParams.stepSecs * 1000, rangeParams.endSecs * 1000))
   val numRowsSerialized : Int = 1
 

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -108,9 +108,8 @@ case class RvRange(startMs: Long, stepMs: Long, endMs: Long)
 
 object RvRange {
   def union(v1: Option[RvRange], v2: Option[RvRange]): Option[RvRange] = {
+    require(v1.map(_.stepMs) == v2.map(_.stepMs), s"Steps for Rvs being stitched were not equal: $v1 and $v2")
     if (v1.isDefined && v2.isDefined) {
-      require(v1.get.stepMs == v2.get.stepMs, s"Steps for Rvs being stitched were " +
-        s"not equal: ${v1.get.stepMs} and ${v2.get.stepMs}")
       Some(RvRange(Math.min(v1.get.startMs, v2.get.startMs), v1.get.stepMs, Math.max(v1.get.endMs, v2.get.endMs)))
     } else None
   }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -318,7 +318,7 @@ final class SerializedRangeVector(val key: RangeVectorKey,
         schema.isTimeSeries &&
         period.get.startMs != period.get.endMs &&
         schema.columns.size == 2 &&
-        schema.columns(1).colType == DoubleColumn || schema.columns(1).colType == HistogramColumn) {
+        (schema.columns(1).colType == DoubleColumn || schema.columns(1).colType == HistogramColumn)) {
 
       new Iterator[RowReader] {
         var curTime = period.get.startMs

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -327,7 +327,10 @@ final class SerializedRangeVector(val key: RangeVectorKey,
         val emptyHist = new TransientHistRow(0L, Histogram.empty)
         override def hasNext: Boolean = curTime <= period.get.endMs
         override def next(): RowReader = {
-          if (bufIt.head.getLong(0) == curTime) bufIt.next()
+          if (bufIt.hasNext && bufIt.head.getLong(0) == curTime) {
+            curTime += period.get.stepMs
+            bufIt.next()
+          }
           else {
             if (schema.columns(1).colType == DoubleColumn) {
               emptyDouble.timestamp = curTime

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -8,6 +8,7 @@ import org.joda.time.DateTime
 
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column
+import filodb.core.metadata.Column.ColumnType
 import filodb.core.store.ChunkScanMethod
 import filodb.memory.format.RowReader
 
@@ -68,6 +69,12 @@ final case class ResultSchema(columns: Seq[ColumnInfo], numRowKeyColumns: Int,
 
 object ResultSchema {
   val empty = ResultSchema(Nil, 1)
+
+  def valueColumnType(schema: ResultSchema): ColumnType = {
+    require(schema.isTimeSeries, s"Schema $schema is not time series based, cannot continue query")
+    require(schema.columns.size >= 2, s"Schema $schema has less than 2 columns, cannot continue query")
+    schema.columns(1).colType
+  }
 }
 
 /**

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -25,7 +25,7 @@ class RangeVectorSpec  extends AnyFunSpec with Matchers {
       def schemaNames: Seq[String] = Nil
     }
 
-    override def period: Option[RvRange] = None
+    override def outputRange: Option[RvRange] = None
   }
 
   val cols = Array(new ColumnInfo("timestamp", ColumnType.TimestampColumn),

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -24,6 +24,8 @@ class RangeVectorSpec  extends AnyFunSpec with Matchers {
       def partIds: Seq[Int] = Nil
       def schemaNames: Seq[String] = Nil
     }
+
+    override def period: Option[RvRange] = None
   }
 
   val cols = Array(new ColumnInfo("timestamp", ColumnType.TimestampColumn),

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -49,7 +49,8 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
                       (900, Double.NaN), (1000, Double.NaN)), key,
       RvRange(0, 100, 1000))
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
-    srv.numRows shouldEqual Some(4)
+    srv.numRows shouldEqual Some(11)
+    srv.numRowsSerialized shouldEqual 4
     val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
     res.length shouldEqual 11
     res.map(_._1) shouldEqual (0 to 1000 by 100)

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -1,0 +1,20 @@
+package filodb.core.query
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
+
+  it("should remove NaNs at encoding and add NaNs on decoding") {
+    // TODO
+  }
+
+  it("should remove Hist.empty at encoding and add Hist.empty on decoding") {
+    // TODO
+  }
+
+  it("should not bother removing when start == end even if there is NaN. This may contain Raw data") {
+    // TODO
+  }
+
+}

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -73,6 +73,7 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
       RvRange(1000, 100, 1000))
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
     srv.numRows shouldEqual Some(11)
+    srv.numRowsSerialized shouldEqual 11
     val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
     res.length shouldEqual 11
     res.map(_._1) shouldEqual (0 to 1000 by 100)
@@ -96,7 +97,8 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
                       RvRange(0, 100, 1000))
 
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
-
+    srv.numRows shouldEqual Some(11)
+    srv.numRowsSerialized shouldEqual 4
     val res = srv.rows.map(r => (r.getLong(0), r.getHistogram(1))).toList
     res.length shouldEqual 11
     res.map(_._1) shouldEqual (0 to 1000 by 100)

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -3,18 +3,103 @@ package filodb.core.query
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import filodb.core.binaryrecord2.RecordSchema
+import filodb.core.metadata.Column.ColumnType
+import filodb.memory.format.{ZeroCopyUTF8String => UTF8Str}
+import filodb.memory.format.vectors.{CustomBuckets, Histogram, HistogramWithBuckets, LongHistogram}
+
 class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
 
+  private def toRv(samples: Seq[(Long, Double)],
+                   rangeVectorKey: RangeVectorKey,
+                   rvPeriod: RvRange): RangeVector = {
+    new RangeVector {
+      import NoCloseCursor._
+      override def key: RangeVectorKey = rangeVectorKey
+      override def rows(): RangeVectorCursor = samples.map(r => new TransientRow(r._1, r._2)).iterator
+
+      override def period: Option[RvRange] = Some(rvPeriod)
+    }
+  }
+
+  private def toHistRv(samples: Seq[(Long, HistogramWithBuckets)],
+                       rangeVectorKey: RangeVectorKey,
+                       rvPeriod: RvRange): RangeVector = {
+    new RangeVector {
+      import NoCloseCursor._
+      override def key: RangeVectorKey = rangeVectorKey
+      override def rows(): RangeVectorCursor = samples.map(r => new TransientHistRow(r._1, r._2)).iterator
+
+      override def period: Option[RvRange] = Some(rvPeriod)
+    }
+  }
+
   it("should remove NaNs at encoding and add NaNs on decoding") {
-    // TODO
+    val builder = SerializedRangeVector.newBuilder()
+    val recSchema = new RecordSchema(Seq(ColumnInfo("time", ColumnType.TimestampColumn),
+      ColumnInfo("value", ColumnType.DoubleColumn)))
+    val keysMap = Map(UTF8Str("key1") -> UTF8Str("val1"),
+                      UTF8Str("key2") -> UTF8Str("val2"))
+    val key = CustomRangeVectorKey(keysMap)
+
+    val rv = toRv(Seq((0, Double.NaN), (100, 1.0), (200, Double.NaN),
+                      (300, 3.0), (400, Double.NaN),
+                      (500, 5.0), (600, 6.0),
+                      (700, Double.NaN), (800, Double.NaN),
+                      (900, Double.NaN), (1000, Double.NaN)), key,
+      RvRange(0, 100, 1000))
+    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
+    srv.numRows shouldEqual Some(4)
+    val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
+    res.length shouldEqual 11
+    res.map(_._1) shouldEqual (0 to 1000 by 100)
+    res.map(_._2).filterNot(_.isNaN) shouldEqual Seq(1.0, 3.0, 5.0, 6.0)
+  }
+
+  it("should NOT remove NaNs at encoding and add NaNs on decoding for instant queries where start == end") {
+    val builder = SerializedRangeVector.newBuilder()
+    val recSchema = new RecordSchema(Seq(ColumnInfo("time", ColumnType.TimestampColumn),
+      ColumnInfo("value", ColumnType.DoubleColumn)))
+    val keysMap = Map(UTF8Str("key1") -> UTF8Str("val1"),
+      UTF8Str("key2") -> UTF8Str("val2"))
+    val key = CustomRangeVectorKey(keysMap)
+
+    val rv = toRv(Seq((0, Double.NaN), (100, 1.0), (200, Double.NaN),
+      (300, 3.0), (400, Double.NaN),
+      (500, 5.0), (600, 6.0),
+      (700, Double.NaN), (800, Double.NaN),
+      (900, Double.NaN), (1000, Double.NaN)), key,
+      RvRange(1000, 100, 1000))
+    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
+    srv.numRows shouldEqual Some(11)
+    val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
+    res.length shouldEqual 11
+    res.map(_._1) shouldEqual (0 to 1000 by 100)
+    res.map(_._2).filterNot(_.isNaN) shouldEqual Seq(1.0, 3.0, 5.0, 6.0)
   }
 
   it("should remove Hist.empty at encoding and add Hist.empty on decoding") {
-    // TODO
-  }
+    val builder = SerializedRangeVector.newBuilder()
+    val recSchema = new RecordSchema(Seq(ColumnInfo("time", ColumnType.TimestampColumn),
+      ColumnInfo("value", ColumnType.HistogramColumn)))
+    val keysMap = Map(UTF8Str("key1") -> UTF8Str("val1"),
+      UTF8Str("key2") -> UTF8Str("val2"))
+    val key = CustomRangeVectorKey(keysMap)
 
-  it("should not bother removing when start == end even if there is NaN. This may contain Raw data") {
-    // TODO
+    val h1 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), ( 0L to 10L by 5).toArray)
+
+    val rv = toHistRv(Seq((0, Histogram.empty), (100, h1), (200, Histogram.empty),
+                          (300, h1), (400, Histogram.empty), (500, h1),
+                          (600, h1), (700, Histogram.empty), (800, Histogram.empty),
+                          (900, Histogram.empty), (1000, Histogram.empty)), key,
+                      RvRange(0, 100, 1000))
+
+    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
+
+    val res = srv.rows.map(r => (r.getLong(0), r.getHistogram(1))).toList
+    res.length shouldEqual 11
+    res.map(_._1) shouldEqual (0 to 1000 by 100)
+    res.map(_._2).filterNot(_.isEmpty) shouldEqual Seq(h1, h1, h1, h1)
   }
 
 }

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -18,7 +18,7 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
       override def key: RangeVectorKey = rangeVectorKey
       override def rows(): RangeVectorCursor = samples.map(r => new TransientRow(r._1, r._2)).iterator
 
-      override def period: Option[RvRange] = Some(rvPeriod)
+      override def outputRange: Option[RvRange] = Some(rvPeriod)
     }
   }
 
@@ -30,7 +30,7 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
       override def key: RangeVectorKey = rangeVectorKey
       override def rows(): RangeVectorCursor = samples.map(r => new TransientHistRow(r._1, r._2)).iterator
 
-      override def period: Option[RvRange] = Some(rvPeriod)
+      override def outputRange: Option[RvRange] = Some(rvPeriod)
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -169,7 +169,7 @@ object RangeVectorAggregator extends StrictLogging {
                 cardinalityLimit: Int = Int.MaxValue): Observable[RangeVector] = {
     // reduce the range vectors using the foldLeft construct. This results in one aggregate per group.
     val task = source.toListL.map { rvs =>
-      val period = rvs.headOption.flatMap(_.period)
+      val period = rvs.headOption.flatMap(_.outputRange)
       // now reduce each group and create one result range vector per group
       val groupedResult = mapReduceInternal(rvs, rowAgg, skipMapPhase, grouping)
 
@@ -251,7 +251,7 @@ object RangeVectorAggregator extends StrictLogging {
       source.foldLeftF(accs) { case (_, rv) =>
         count += 1
         val rowIter = rv.rows
-        if (period.isEmpty) period = rv.period
+        if (period.isEmpty) period = rv.outputRange
         try {
           cforRange { 0 until outputLen } { i =>
             accs(i) = rowAgg.reduceAggregate(accs(i), rowIter.next)

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -169,6 +169,7 @@ object RangeVectorAggregator extends StrictLogging {
                 cardinalityLimit: Int = Int.MaxValue): Observable[RangeVector] = {
     // reduce the range vectors using the foldLeft construct. This results in one aggregate per group.
     val task = source.toListL.map { rvs =>
+      val period = rvs.headOption.flatMap(_.period)
       // now reduce each group and create one result range vector per group
       val groupedResult = mapReduceInternal(rvs, rowAgg, skipMapPhase, grouping)
 
@@ -178,7 +179,7 @@ object RangeVectorAggregator extends StrictLogging {
           s"Try applying more filters")
       groupedResult.map { case (rvk, aggHolder) =>
         val rowIterator = new CustomCloseCursor(aggHolder.map(_.toRowReader))(aggHolder.close())
-        IteratorBackedRangeVector(rvk, rowIterator)
+        IteratorBackedRangeVector(rvk, rowIterator, period)
       }
     }
     Observable.fromTask(task).flatMap(rvs => Observable.fromIterable(rvs))
@@ -234,6 +235,7 @@ object RangeVectorAggregator extends StrictLogging {
    * Time wise first iteration also uses less memory for high-cardinality use cases and reduces the
    * time window of holding chunk map locks to each time series, instead of the entire query.
    */
+  // scalastyle:off method.length
   def fastReduce(rowAgg: RowAggregator,
                  skipMapPhase: Boolean,
                  source: Observable[RangeVector],
@@ -241,6 +243,7 @@ object RangeVectorAggregator extends StrictLogging {
     // Can't use an Array here because rowAgg.AggHolderType does not have a ClassTag
     val accs = collection.mutable.ArrayBuffer.fill(outputLen)(rowAgg.zero)
     var count = 0
+    var period: Option[RvRange] = None
 
     // FoldLeft means we create the source PeriodicMapper etc and process immediately.  We can release locks right away
     // NOTE: ChunkedWindowIterator automatically releases locks after last window.  So it should all just work.  :)
@@ -248,6 +251,7 @@ object RangeVectorAggregator extends StrictLogging {
       source.foldLeftF(accs) { case (_, rv) =>
         count += 1
         val rowIter = rv.rows
+        if (period.isEmpty) period = rv.period
         try {
           cforRange { 0 until outputLen } { i =>
             accs(i) = rowAgg.reduceAggregate(accs(i), rowIter.next)
@@ -279,7 +283,7 @@ object RangeVectorAggregator extends StrictLogging {
       if (count > 0) {
         import NoCloseCursor._ // The base range vectors are already closed, so no close propagation needed
         Observable.now(IteratorBackedRangeVector(CustomRangeVectorKey.empty,
-          NoCloseCursor(accs.toIterator.map(_.toRowReader))))
+          NoCloseCursor(accs.toIterator.map(_.toRowReader)), period))
       } else {
         Observable.empty
       }

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -88,6 +88,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
       val (oneSide, otherSide, lhsIsOneSide) =
         if (cardinality == Cardinality.OneToMany) (lhsRvs, rhsRvs, true)
         else (rhsRvs, lhsRvs, false)
+      val period = oneSide.headOption.flatMap(_.period)
       // load "one" side keys in a hashmap
       val oneSideMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
       oneSide.foreach { rv =>
@@ -132,7 +133,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
               joinQueryCardLimit} " + s"join cardinality. Try applying more filters.")
 
           val res = if (lhsIsOneSide) binOp(rvOne.rows, rvOtherCorrect.rows) else binOp(rvOtherCorrect.rows, rvOne.rows)
-          results.put(resKey, ResultVal(IteratorBackedRangeVector(resKey, res), rvOtherCorrect))
+          results.put(resKey, ResultVal(IteratorBackedRangeVector(resKey, res, period), rvOtherCorrect))
         }
       }
       Observable.fromIterable(results.values.map(_.resultRv))

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -88,7 +88,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
       val (oneSide, otherSide, lhsIsOneSide) =
         if (cardinality == Cardinality.OneToMany) (lhsRvs, rhsRvs, true)
         else (rhsRvs, lhsRvs, false)
-      val period = oneSide.headOption.flatMap(_.period)
+      val period = oneSide.headOption.flatMap(_.outputRange)
       // load "one" side keys in a hashmap
       val oneSideMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
       oneSide.foreach { rv =>

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -155,7 +155,7 @@ trait ExecPlan extends QueryCommand {
           .doOnStart(_ => span.mark("before-first-materialized-result-rv"))
           .map {
             case srv: SerializableRangeVector =>
-              numResultSamples += srv.numRowsInt
+              numResultSamples += srv.numRowsSerialized
               // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
               if (enforceLimit && numResultSamples > queryContext.plannerParams.sampleLimit)
                 throw new BadQueryException(s"This query results in more than ${queryContext.plannerParams.
@@ -164,7 +164,7 @@ trait ExecPlan extends QueryCommand {
             case rv: RangeVector =>
               // materialize, and limit rows per RV
               val srv = SerializedRangeVector(rv, builder, recSchema, queryWithPlanName(queryContext))
-              numResultSamples += srv.numRowsInt
+              numResultSamples += srv.numRowsSerialized
               // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
               if (enforceLimit && numResultSamples > queryContext.plannerParams.sampleLimit)
                 throw new BadQueryException(s"This query results in more than ${queryContext.plannerParams.

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -91,7 +91,7 @@ final case class HistogramQuantileMapper(funcParams: Seq[FuncArgs]) extends Rang
           }
           override def close(): Unit = rvs.foreach(_.rows().close())
         }
-        IteratorBackedRangeVector(histBuckets._1, quantileResult)
+        IteratorBackedRangeVector(histBuckets._1, quantileResult, sortedBucketRvs.headOption.flatMap(_._2.period))
       }
       Observable.fromIterable(quantileResults)
     }

--- a/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/HistogramQuantileMapper.scala
@@ -91,7 +91,7 @@ final case class HistogramQuantileMapper(funcParams: Seq[FuncArgs]) extends Rang
           }
           override def close(): Unit = rvs.foreach(_.rows().close())
         }
-        IteratorBackedRangeVector(histBuckets._1, quantileResult, sortedBucketRvs.headOption.flatMap(_._2.period))
+        IteratorBackedRangeVector(histBuckets._1, quantileResult, sortedBucketRvs.headOption.flatMap(_._2.outputRange))
       }
       Observable.fromIterable(quantileResults)
     }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -52,7 +52,7 @@ trait MetadataDistConcatExec extends NonLeafExecPlan {
       }
       import NoCloseCursor._
       IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-        new UTF8MapIteratorRowReader(metadataResult.toIterator))
+        new UTF8MapIteratorRowReader(metadataResult.toIterator), None)
     }
     Observable.fromTask(taskOfResults)
   }
@@ -86,7 +86,7 @@ final case class PartKeysExec(queryContext: QueryContext,
           fetchFirstLastSampleTimes, end, start, queryContext.plannerParams.sampleLimit)
         import NoCloseCursor._
         Observable.now(IteratorBackedRangeVector(
-          new CustomRangeVectorKey(Map.empty), UTF8MapIteratorRowReader(response)))
+          new CustomRangeVectorKey(Map.empty), UTF8MapIteratorRowReader(response), None))
       case other =>
         Observable.empty
     }
@@ -131,7 +131,7 @@ final case class LabelValuesExec(queryContext: QueryContext,
       }
       import NoCloseCursor._
       Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-        new UTF8MapIteratorRowReader(response)))
+        new UTF8MapIteratorRowReader(response), None))
     } else {
       Observable.empty
     }

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -42,7 +42,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
 
     import NoCloseCursor._
     val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-      UTF8MapIteratorRowReader(iteratorMap.toIterator))
+      UTF8MapIteratorRowReader(iteratorMap.toIterator), None)
 
     val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema,
                         queryWithPlanName(queryContext)))

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -40,6 +40,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
 
   val startWithOffset = startMs - offsetMs.getOrElse(0L)
   val endWithOffset = endMs - offsetMs.getOrElse(0L)
+  val outputRvRange = Some(RvRange(startMs, stepMs, endMs))
 
   val isLastFn = functionId.isEmpty || functionId.contains(InternalRangeFunction.LastSampleHistMax) ||
     functionId.contains(InternalRangeFunction.Timestamp)
@@ -60,7 +61,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
     // enforcement of minimum step is good since we have a high limit on number of samples
     if (startMs < endMs && stepMs < querySession.queryConfig.minStepMs) // range query with small step
       throw new BadQueryException(s"step should be at least ${querySession.queryConfig.minStepMs/1000}s")
-    val valColType = RangeVectorTransformer.valueColumnType(sourceSchema)
+    val valColType = ResultSchema.valueColumnType(sourceSchema)
     // If a max column is present, the ExecPlan's job is to put it into column 2
     val hasMaxCol = valColType == ColumnType.HistogramColumn && sourceSchema.colIDs.length > 2 &&
                       sourceSchema.columns(2).name == "max"
@@ -82,7 +83,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
           val windowPlusPubInt = extendLookback(rv, windowLength)
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorH(rdrv, startWithOffset, adjustedStep, endWithOffset,
-                    windowPlusPubInt, rangeFuncGen().asChunkedH, querySession, histRow))
+                    windowPlusPubInt, rangeFuncGen().asChunkedH, querySession, histRow), outputRvRange)
         }
       case c: ChunkedRangeFunction[_] =>
         source.map { rv =>
@@ -92,7 +93,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
           val windowPlusPubInt = extendLookback(rv, windowLength)
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorD(rdrv, startWithOffset, adjustedStep, endWithOffset,
-                    windowPlusPubInt, rangeFuncGen().asChunkedD, querySession))
+                    windowPlusPubInt, rangeFuncGen().asChunkedD, querySession), outputRvRange)
         }
       // Iterator-based: Wrap long columns to yield a double value
       case f: RangeFunction if valColType == ColumnType.LongColumn =>
@@ -100,7 +101,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
           val windowPlusPubInt = extendLookback(rv, windowLength)
           IteratorBackedRangeVector(rv.key,
             new SlidingWindowIterator(new LongToDoubleIterator(rv.rows), startWithOffset, adjustedStep, endWithOffset,
-              windowPlusPubInt, rangeFuncGen().asSliding, querySession.queryConfig))
+              windowPlusPubInt, rangeFuncGen().asSliding, querySession.queryConfig), outputRvRange)
         }
       // Otherwise just feed in the double column
       case f: RangeFunction =>
@@ -108,7 +109,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
           val windowPlusPubInt = extendLookback(rv, windowLength)
           IteratorBackedRangeVector(rv.key,
             new SlidingWindowIterator(rv.rows, startWithOffset, adjustedStep, endWithOffset, windowPlusPubInt,
-              rangeFuncGen().asSliding, querySession.queryConfig))
+              rangeFuncGen().asSliding, querySession.queryConfig), outputRvRange)
         }
     }
 
@@ -117,14 +118,13 @@ final case class PeriodicSamplesMapper(startMs: Long,
     offsetMs.map(o => rvs.map { rv =>
       new RangeVector {
         val row = new TransientRow()
-
         override def key: RangeVectorKey = rv.key
-
         override def rows(): RangeVectorCursor = rv.rows.mapRow { r =>
           row.setLong(0, r.getLong(0) + o)
           row.setDouble(1, r.getDouble(1))
           row
         }
+        override def period: Option[RvRange] = outputRvRange
       }
     }).getOrElse(rvs)
   }

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -124,7 +124,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
           row.setDouble(1, r.getDouble(1))
           row
         }
-        override def period: Option[RvRange] = outputRvRange
+        override def outputRange: Option[RvRange] = outputRvRange
       }
     }).getOrElse(rvs)
   }

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -131,7 +131,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         }
         override def numRows: Option[Int] = Option(samples.size)
 
-        override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+        override def outputRange: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
                                                             promQlQueryParams.stepSecs * 1000,
                                                             promQlQueryParams.endSecs * 1000))
       }
@@ -170,7 +170,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
         override def numRows: Option[Int] = Option(samples.size)
 
-        override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+        override def outputRange: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
           promQlQueryParams.stepSecs * 1000,
           promQlQueryParams.endSecs * 1000))
 
@@ -200,7 +200,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
           }
           override def numRows: Option[Int] = Option(d.aggregateResponse.get.aggregateSampl.size)
 
-          override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+          override def outputRange: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
             promQlQueryParams.stepSecs * 1000,
             promQlQueryParams.endSecs * 1000))
       }
@@ -232,7 +232,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         }
         override def numRows: Option[Int] = Option(d.aggregateResponse.get.aggregateSampl.size)
 
-        override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+        override def outputRange: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
           promQlQueryParams.stepSecs * 1000,
           promQlQueryParams.endSecs * 1000))
       }

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -131,6 +131,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
         }
         override def numRows: Option[Int] = Option(samples.size)
 
+        override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+                                                            promQlQueryParams.stepSecs * 1000,
+                                                            promQlQueryParams.endSecs * 1000))
       }
       SerializedRangeVector(rv, builder, recordSchema.get("default").get,
         queryWithPlanName(queryContext))
@@ -167,6 +170,10 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
         override def numRows: Option[Int] = Option(samples.size)
 
+        override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+          promQlQueryParams.stepSecs * 1000,
+          promQlQueryParams.endSecs * 1000))
+
       }
       SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, queryContext.origQueryParams.toString)
       // TODO: Handle stitching with verbose flag
@@ -192,7 +199,11 @@ case class PromQlRemoteExec(queryEndpoint: String,
             }
           }
           override def numRows: Option[Int] = Option(d.aggregateResponse.get.aggregateSampl.size)
-        }
+
+          override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+            promQlQueryParams.stepSecs * 1000,
+            promQlQueryParams.endSecs * 1000))
+      }
       SerializedRangeVector(rv, builder, recordSchema.get(Avg.entryName).get,
         queryWithPlanName(queryContext))
     }
@@ -220,6 +231,10 @@ case class PromQlRemoteExec(queryEndpoint: String,
           }
         }
         override def numRows: Option[Int] = Option(d.aggregateResponse.get.aggregateSampl.size)
+
+        override def period: Option[RvRange] = Some(RvRange(promQlQueryParams.startSecs * 1000,
+          promQlQueryParams.stepSecs * 1000,
+          promQlQueryParams.endSecs * 1000))
       }
       SerializedRangeVector(rv, builder, recordSchema.get(QueryFunctionConstants.stdVal).get,
         queryWithPlanName(queryContext))

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -110,7 +110,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
     val result = new mutable.HashMap[Map[Utf8Str, Utf8Str], ArrayBuffer[RangeVector]]()
     val rhsMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
 
-    val period = lhsRvs.headOption.flatMap(_.period)
+    val period = lhsRvs.headOption.flatMap(_.outputRange)
 
     rhsRvs.foreach { rv =>
       val jk = joinKeys(rv.key)

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -110,6 +110,8 @@ final case class SetOperatorExec(queryContext: QueryContext,
     val result = new mutable.HashMap[Map[Utf8Str, Utf8Str], ArrayBuffer[RangeVector]]()
     val rhsMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
 
+    val period = lhsRvs.headOption.flatMap(_.period)
+
     rhsRvs.foreach { rv =>
       val jk = joinKeys(rv.key)
       // Don't add range vector if it is empty
@@ -162,7 +164,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
           }
         }
         val arrayBuffer = result.getOrElse(jk, ArrayBuffer())
-        val resRv = IteratorBackedRangeVector(lhs.key, rows)
+        val resRv = IteratorBackedRangeVector(lhs.key, rows, period)
         if (index >= 0) arrayBuffer.update(index, resRv) else arrayBuffer.append(resRv)
         result.put(jk, arrayBuffer)
       } else if (jk.isEmpty) {

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -14,7 +14,7 @@ object StitchRvsExec {
 
   def stitch(v1: RangeVector, v2: RangeVector): RangeVector = {
     val rows = StitchRvsExec.merge(Seq(v1.rows(), v2.rows()))
-    IteratorBackedRangeVector(v1.key, rows)
+    IteratorBackedRangeVector(v1.key, rows, RvRange.union(v1.period, v2.period))
   }
 
   def merge(vectors: Iterable[RangeVectorCursor]): RangeVectorCursor = {
@@ -83,7 +83,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
       groups.mapValues { toMerge =>
         val rows = StitchRvsExec.merge(toMerge.map(_.rows))
         val key = toMerge.head.key
-        IteratorBackedRangeVector(key, rows)
+        IteratorBackedRangeVector(key, rows, toMerge.headOption.flatMap(_.period))
       }.values
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten
@@ -109,7 +109,7 @@ final case class StitchRvsMapper() extends RangeVectorTransformer {
       groups.mapValues { toMerge =>
         val rows = StitchRvsExec.merge(toMerge.map(_.rows))
         val key = toMerge.head.key
-        IteratorBackedRangeVector(key, rows)
+        IteratorBackedRangeVector(key, rows, toMerge.headOption.flatMap(_.period))
       }.values
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -14,7 +14,7 @@ object StitchRvsExec {
 
   def stitch(v1: RangeVector, v2: RangeVector): RangeVector = {
     val rows = StitchRvsExec.merge(Seq(v1.rows(), v2.rows()))
-    IteratorBackedRangeVector(v1.key, rows, RvRange.union(v1.period, v2.period))
+    IteratorBackedRangeVector(v1.key, rows, RvRange.union(v1.outputRange, v2.outputRange))
   }
 
   def merge(vectors: Iterable[RangeVectorCursor]): RangeVectorCursor = {
@@ -83,7 +83,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
       groups.mapValues { toMerge =>
         val rows = StitchRvsExec.merge(toMerge.map(_.rows))
         val key = toMerge.head.key
-        IteratorBackedRangeVector(key, rows, toMerge.headOption.flatMap(_.period))
+        IteratorBackedRangeVector(key, rows, toMerge.headOption.flatMap(_.outputRange))
       }.values
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten
@@ -109,7 +109,7 @@ final case class StitchRvsMapper() extends RangeVectorTransformer {
       groups.mapValues { toMerge =>
         val rows = StitchRvsExec.merge(toMerge.map(_.rows))
         val key = toMerge.head.key
-        IteratorBackedRangeVector(key, rows, toMerge.headOption.flatMap(_.period))
+        IteratorBackedRangeVector(key, rows, toMerge.headOption.flatMap(_.outputRange))
       }.values
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
@@ -110,7 +110,7 @@ class CountValuesRowAggregator(label: String, limit: Int = 1000) extends RowAggr
     }
     resRvs.map { case (key, builder) =>
       val numRows = builder.allContainers.map(_.countRecords()).sum
-      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0)
+      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0, None)
     }.toSeq
   }
 

--- a/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
@@ -70,7 +70,7 @@ class QuantileRowAggregator(q: Double) extends RowAggregator {
       mutRow.setValues(r.getLong(0), qVal)
       mutRow
     }
-    Seq(IteratorBackedRangeVector(aggRangeVector.key, result))
+    Seq(IteratorBackedRangeVector(aggRangeVector.key, result, aggRangeVector.period))
   }
 
   def reductionSchema(source: ResultSchema): ResultSchema = {

--- a/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
@@ -70,7 +70,7 @@ class QuantileRowAggregator(q: Double) extends RowAggregator {
       mutRow.setValues(r.getLong(0), qVal)
       mutRow
     }
-    Seq(IteratorBackedRangeVector(aggRangeVector.key, result, aggRangeVector.period))
+    Seq(IteratorBackedRangeVector(aggRangeVector.key, result, aggRangeVector.outputRange))
   }
 
   def reductionSchema(source: ResultSchema): ResultSchema = {

--- a/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
@@ -5,7 +5,6 @@ import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVecto
 import filodb.memory.format.RowReader
 import filodb.query.AggregationOperator
 import filodb.query.AggregationOperator._
-import filodb.query.exec._
 
 trait AggregateHolder {
   /**
@@ -119,7 +118,7 @@ object RowAggregator {
     * Factory for RowAggregator
     */
   def apply(aggrOp: AggregationOperator, params: Seq[Any], schema: ResultSchema): RowAggregator = {
-    val valColType = RangeVectorTransformer.valueColumnType(schema)
+    val valColType = ResultSchema.valueColumnType(schema)
     aggrOp match {
       case Min      => MinRowAggregator
       case Max      => MaxRowAggregator

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -153,7 +153,10 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
     resRvs.map { case (key, builder) =>
       val numRows = builder.allContainers.map(_.countRecords()).sum
       logger.debug(s"TopkPresent before creating SRV key = ${key.labelValues.mkString(",")}")
-      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0, None)
+      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0,
+                                                    Some(RvRange(rangeParams.startSecs * 1000,
+                                                      rangeParams.stepSecs * 1000,
+                                                      rangeParams.endSecs * 1000)))
     }.toSeq
   }
 

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -153,8 +153,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
     resRvs.map { case (key, builder) =>
       val numRows = builder.allContainers.map(_.countRecords()).sum
       logger.debug(s"TopkPresent before creating SRV key = ${key.labelValues.mkString(",")}")
-      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0,
-        Some(RvRange(rangeParams.startSecs * 1000, rangeParams.stepSecs * 1000, rangeParams.endSecs * 1000)))
+      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0, None)
     }.toSeq
   }
 

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -140,7 +140,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
           i += 2
         }
         resRvs.keySet.foreach { rvs =>
-          if (!rvkSeen.contains(rvs)) addRecordToBuilder(resRvs.get(rvs).get, timestamp * 1000, Double.NaN)
+          if (!rvkSeen.contains(rvs)) addRecordToBuilder(resRvs(rvs), timestamp * 1000, Double.NaN)
         }
       }
       // address step == 0 case
@@ -151,9 +151,10 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
     }
 
     resRvs.map { case (key, builder) =>
-      val numRows = builder.allContainers.map(_.countRecords).sum
+      val numRows = builder.allContainers.map(_.countRecords()).sum
       logger.debug(s"TopkPresent before creating SRV key = ${key.labelValues.mkString(",")}")
-      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0)
+      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0,
+        Some(RvRange(rangeParams.startSecs * 1000, rangeParams.stepSecs * 1000, rangeParams.endSecs * 1000)))
     }.toSeq
   }
 

--- a/query/src/main/scala/filodb/query/exec/rangefn/MiscellaneousFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/MiscellaneousFunction.scala
@@ -37,7 +37,7 @@ final case class LabelReplaceFunction(funcParams: Seq[String]) extends Miscellan
   override def execute(source: Observable[RangeVector]): Observable[RangeVector] = {
     source.map { rv =>
       val newLabel = labelReplaceImpl(rv.key, funcParams)
-      IteratorBackedRangeVector(newLabel, rv.rows, rv.period)
+      IteratorBackedRangeVector(newLabel, rv.rows, rv.outputRange)
     }
   }
 
@@ -97,7 +97,7 @@ final case class LabelJoinFunction(funcParams: Seq[String]) extends Miscellaneou
   override def execute(source: Observable[RangeVector]): Observable[RangeVector] = {
     source.map { rv =>
       val newLabel = labelJoinImpl(rv.key)
-      IteratorBackedRangeVector(newLabel, rv.rows, rv.period)
+      IteratorBackedRangeVector(newLabel, rv.rows, rv.outputRange)
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/rangefn/MiscellaneousFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/MiscellaneousFunction.scala
@@ -37,7 +37,7 @@ final case class LabelReplaceFunction(funcParams: Seq[String]) extends Miscellan
   override def execute(source: Observable[RangeVector]): Observable[RangeVector] = {
     source.map { rv =>
       val newLabel = labelReplaceImpl(rv.key, funcParams)
-      IteratorBackedRangeVector(newLabel, rv.rows)
+      IteratorBackedRangeVector(newLabel, rv.rows, rv.period)
     }
   }
 
@@ -97,7 +97,7 @@ final case class LabelJoinFunction(funcParams: Seq[String]) extends Miscellaneou
   override def execute(source: Observable[RangeVector]): Observable[RangeVector] = {
     source.map { rv =>
       val newLabel = labelJoinImpl(rv.key)
-      IteratorBackedRangeVector(newLabel, rv.rows)
+      IteratorBackedRangeVector(newLabel, rv.rows, rv.period)
     }
   }
 

--- a/query/src/test/scala/filodb/query/ResultTypesSpec.scala
+++ b/query/src/test/scala/filodb/query/ResultTypesSpec.scala
@@ -29,6 +29,7 @@ class ResultTypesSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
       override def numRows: Option[Int] = Option(rows.size)
 
+      override def outputRange: Option[RvRange] = None
     }
     val queryResult = QueryResult("id:1", resultSchema, Seq(rv))
     queryResult.resultType.toString shouldEqual ("RangeVectors")
@@ -45,6 +46,8 @@ class ResultTypesSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(1L, 3.3d)).toIterator
       override def numRows: Option[Int] = Option(rows.size)
 
+      override def outputRange: Option[RvRange] = None
+
     }
 
     val rv2 = new RangeVector {
@@ -56,6 +59,7 @@ class ResultTypesSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 9.4d)).toIterator
       override def numRows: Option[Int] = Option(rows.size)
+      override def outputRange: Option[RvRange] = None
 
     }
     val queryResult = QueryResult("id:1", resultSchema, Seq(rv1, rv2))
@@ -73,6 +77,7 @@ class ResultTypesSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3.3d)).toIterator
       override def numRows: Option[Int] = Option(rows.size)
+      override def outputRange: Option[RvRange] = None
 
     }
 

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -39,6 +39,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
       }.take(20)
       override def key: RangeVectorKey = ignoreKey
       override def rows(): RangeVectorCursor = data.iterator
+      override def outputRange: Option[RvRange] = None
     })
 
     val rangeParams = RangeParams(0, 1, 0)
@@ -307,6 +308,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
       import NoCloseCursor._
       override def key: RangeVectorKey = rangeVectorKey
       override def rows(): RangeVectorCursor = samples.map(r => new TransientRow(r._1, r._2)).iterator
+      override def outputRange: Option[RvRange] = None
     }
   }
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -47,6 +47,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> s"tag2-$i".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(i).iterator
+      override def outputRange: Option[RvRange] = None
+
     }
   }
 
@@ -58,6 +60,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> samplesLhs(i).key.labelValues("tag2".utf8)))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(i).iterator
+      override def outputRange: Option[RvRange] = None
+
     }
   }
 
@@ -70,6 +74,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "job".utf8 -> s"somejob".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(i).iterator
+      override def outputRange: Option[RvRange] = None
     }
   }
 
@@ -81,6 +86,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "job".utf8 -> s"somejob".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(i).iterator
+      override def outputRange: Option[RvRange] = None
+
     }
   }
 
@@ -149,6 +156,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         Map("__name__".utf8 -> s"someMetricLhs".utf8, "_pi_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs2: RangeVector = new RangeVector {
@@ -156,6 +164,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         Map("__name__".utf8 -> s"someMetricLhs".utf8, "_step_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs1: RangeVector = new RangeVector {
@@ -163,6 +172,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         Map("__name__".utf8 -> s"someMetricRhs".utf8,"_pi_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs2: RangeVector = new RangeVector {
@@ -170,6 +180,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         Map("__name__".utf8 -> s"someMetricRhs".utf8, "_step_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
@@ -199,6 +210,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         Map("__name__".utf8 -> s"someMetricLhs".utf8, "_pi_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs2: RangeVector = new RangeVector {
@@ -206,6 +218,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         Map("__name__".utf8 -> s"someMetricLhs".utf8, "_step_".utf8 -> "0".utf8, "tag2".utf8 -> "tag2Val".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs1: RangeVector = new RangeVector {
@@ -214,6 +227,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> "tag2Val".utf8, "tag1".utf8 -> "tag1Val1".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs2: RangeVector = new RangeVector {
@@ -222,6 +236,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> "tag2Val".utf8, "tag1".utf8 -> "tag1Val1".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs3: RangeVector = new RangeVector {
@@ -230,6 +245,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> "tag2Val".utf8, "tag1".utf8 -> "tag1Val2".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs4: RangeVector = new RangeVector {
@@ -238,6 +254,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> "tag2Val".utf8, "tag1".utf8 -> "tag1Val2".utf8))
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
@@ -271,6 +288,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> samplesLhs(2).key.labelValues("tag2".utf8))) // duplicate value
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val samplesRhs2 = scala.util.Random.shuffle(duplicate +: samplesRhs.toList) // they may come out of order
@@ -302,6 +320,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
           "tag2".utf8 -> samplesLhs(2).key.labelValues("tag2".utf8))) // duplicate value
       import NoCloseCursor._
       val rows: RangeVectorCursor = data(2).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val samplesLhs2 = scala.util.Random.shuffle(duplicate +: samplesLhs.toList) // they may come out of order
@@ -398,6 +417,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
             "tag2".utf8 -> s"tag2-$i".utf8))
         import NoCloseCursor._
         val rows: RangeVectorCursor = data(i).iterator
+        override def outputRange: Option[RvRange] = None
       }
     }
 
@@ -409,6 +429,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
             "tag2".utf8 -> samplesLhs(i).key.labelValues("tag2".utf8)))
         import NoCloseCursor._
         val rows: RangeVectorCursor = data(i).iterator
+        override def outputRange: Option[RvRange] = None
       }
     }
 
@@ -442,6 +463,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
             "tag2".utf8 -> s"tag2-$i".utf8))
         import NoCloseCursor._
         val rows: RangeVectorCursor = data(i).iterator
+        override def outputRange: Option[RvRange] = None
       }
     }
 
@@ -453,6 +475,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
             "tag2".utf8 -> samplesLhs(i).key.labelValues("tag2".utf8)))
         import NoCloseCursor._
         val rows: RangeVectorCursor = data(i).iterator
+        override def outputRange: Option[RvRange] = None
       }
     }
 
@@ -551,6 +574,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(5900, Double.NaN ),
         new TransientRow(6000, Double.NaN )
       ).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs2 = new RangeVector {
@@ -573,6 +597,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(5900,2.0 ),
         new TransientRow(6000,2.0 )
       ).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs1 = new RangeVector {
@@ -597,6 +622,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(5900, Double.NaN ),
         new TransientRow(6000, Double.NaN )
       ).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhs2 = new RangeVector {
@@ -621,6 +647,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(5900,2.0 ),
         new TransientRow(6000,2.0 )
       ).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     // scalastyle:off

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -52,6 +52,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -64,6 +65,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 1)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -76,6 +78,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 8)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -88,6 +91,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 2)).iterator
+      override def outputRange: Option[RvRange] = None
     }
   )
   val sampleNodeRole: Array[RangeVector] = Array(
@@ -102,6 +106,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 1)).iterator
+      override def outputRange: Option[RvRange] = None
     }
   )
 
@@ -116,6 +121,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 2)).iterator
+      override def outputRange: Option[RvRange] = None
     }
   )
 
@@ -330,6 +336,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
         import NoCloseCursor._
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 3)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         val key: RangeVectorKey = CustomRangeVectorKey(
@@ -342,6 +349,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
         import NoCloseCursor._
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 1)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
    val sampleRhs: Array[RangeVector] = Array(
@@ -356,6 +364,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
         import NoCloseCursor._
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 1)).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -54,6 +54,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 100)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -66,6 +67,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 200)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -78,6 +80,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 300)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -90,6 +93,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 400)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -102,6 +106,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 500)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -114,6 +119,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 600)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -126,6 +132,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 700)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -138,6 +145,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 800)).iterator
+      override def outputRange: Option[RvRange] = None
     }
   )
   val sampleNoKey: Array[RangeVector] = Array(
@@ -147,6 +155,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 1)).iterator
+      override def outputRange: Option[RvRange] = None
     }
   )
 
@@ -160,6 +169,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 100)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -170,6 +180,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 200)).iterator
+      override def outputRange: Option[RvRange] = None
     }
   )
 
@@ -186,6 +197,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 100),
         new TransientRow(2L, Double.NaN)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -198,6 +210,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, Double.NaN)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val sampleAllNaN : Array[RangeVector] = Array(
@@ -212,6 +225,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       import NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, Double.NaN)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val sampleMultipleRows: Array[RangeVector] = Array(
@@ -227,6 +241,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 100),
         new TransientRow(2L, 300)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(
@@ -240,6 +255,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 200),
         new TransientRow(2L, 400)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val sampleCanary = sampleHttpRequests.filter(_.key.labelValues.get(ZeroCopyUTF8String("group")).get.
@@ -1009,21 +1025,25 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val lhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRvDupe = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRvDupe2 = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value2".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
@@ -1054,20 +1074,24 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val rhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhsRvDupe = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
     val rhsRvDupe2 = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema)))
@@ -1098,21 +1122,25 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val lhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRvDupe = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRvDupe2 = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
@@ -1141,20 +1169,24 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val rhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhsRvDupe = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
     val rhsRvDupe2 = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema)))
@@ -1183,20 +1215,24 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val rhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhsRvDupe = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
     val rhsRvDupe2 = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema)))
@@ -1225,21 +1261,25 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val lhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRvDupe = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(30).drop(20).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhsRvDupe2 = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value1".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).drop(30).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val rhsRv = new RangeVector {
       val key: RangeVectorKey = CustomRangeVectorKey(Map("tag".utf8 -> s"value2".utf8))
       val rows: RangeVectorCursor = dataRows.take(40).iterator
+      override def outputRange: Option[RvRange] = None
     }
 
     val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
@@ -1268,6 +1308,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
           new TransientRow(1L, 100),
           new TransientRow(2L, 200),
           new TransientRow(3L, Double.NaN)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
     val lhs1: Array[RangeVector] = Array(
@@ -1282,6 +1323,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
         import NoCloseCursor._
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(3L, 300)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
     val lhs2: Array[RangeVector] = Array(
@@ -1297,6 +1339,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 100),
           new TransientRow(2L, 200)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
     val queryContext = QueryContext(plannerParams = PlannerParams(joinQueryCardLimit = 10)) // set join card limit to 1

--- a/query/src/test/scala/filodb/query/exec/HistToPromSeriesMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistToPromSeriesMapperSpec.scala
@@ -30,7 +30,7 @@ class HistToPromSeriesMapperSpec extends AnyFunSpec with Matchers with ScalaFutu
 
   it("should convert single schema histogram to appropriate Prom bucket time series") {
     import NoCloseCursor._
-    val rv = IteratorBackedRangeVector(rvKey, rows.toIterator)
+    val rv = IteratorBackedRangeVector(rvKey, rows.toIterator, None)
 
     val mapper = HistToPromSeriesMapper(MMD.histDataset.schema.partition)
     val sourceObs = Observable.now(rv)
@@ -66,7 +66,7 @@ class HistToPromSeriesMapperSpec extends AnyFunSpec with Matchers with ScalaFutu
 
   it("should convert multiple schema histograms to Prom bucket time series") {
     import filodb.core.query.NoCloseCursor._
-    val rv = IteratorBackedRangeVector(rvKey, (rows ++ tenRows).toIterator)
+    val rv = IteratorBackedRangeVector(rvKey, (rows ++ tenRows).toIterator, None)
 
     val mapper = HistToPromSeriesMapper(MMD.histDataset.schema.partition)
     val sourceObs = Observable.now(rv)

--- a/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
@@ -73,7 +73,7 @@ class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFut
   it ("should calculate histogram_quantile correctly") {
     val histRvs = bucketValues.zipWithIndex.map { case (rv, i) =>
       import NoCloseCursor._
-      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator)
+      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator, None)
     }
 
     val expectedResult = Seq(histKey1 -> quantile50Result)
@@ -83,9 +83,9 @@ class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFut
   it ("should calculate histogram_quantile correctly for multiple histograms") {
     import NoCloseCursor._
     val histRvs = bucketValues.zipWithIndex.map { case (rv, i) =>
-      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator)
+      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator, None)
     } ++ bucketValues.zipWithIndex.map { case (rv, i) =>
-      IteratorBackedRangeVector(histBuckets2(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator)
+      IteratorBackedRangeVector(histBuckets2(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator, None)
     }
 
     val expectedResult = Seq(histKey2 -> quantile50Result, histKey1 -> quantile50Result)
@@ -95,7 +95,7 @@ class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFut
   it ("should sort the buckets to calculate histogram_quantile correctly ") {
     import NoCloseCursor._
     val histRvs = bucketValues.zipWithIndex.map { case (rv, i) =>
-      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator)
+      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator, None)
     }
 
     val shuffledHistRvs = Random.shuffle(histRvs.toSeq).toArray
@@ -116,7 +116,7 @@ class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFut
       Array[(Int, Double)]( (10, 35), (20, 45), (30, 46), (40, 89) )
     ).zipWithIndex.map { case (rv, i) =>
       import NoCloseCursor._
-      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2)).toIterator)
+      IteratorBackedRangeVector(histBuckets1(i), rv.map(s => new TransientRow(s._1, s._2)).toIterator, None)
     }
 
     val expectedResult = Seq(histKey1 -> Seq((10, 4.666666666666667), (20, 3.3), (30, 3.4), (40, 1.9)))

--- a/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
@@ -45,6 +45,7 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1000L, 1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -52,6 +53,7 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1000L, 5d)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val testSampleNan: Array[RangeVector] = Array(
@@ -63,6 +65,7 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
         new TransientRow(1000L, Double.NaN),
         new TransientRow(2000L, 1d),
         new TransientRow(3000L, Double.NaN)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -72,6 +75,7 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
         new TransientRow(1000L, 5d),
         new TransientRow(2000L, Double.NaN),
         new TransientRow(3000L, Double.NaN)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   it("should generate range vector for empty Sample") {

--- a/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
@@ -28,6 +28,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3.3d),
         new TransientRow(2L, 5.1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = ignoreKey
@@ -35,6 +36,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(3L, 3239.3423d),
         new TransientRow(4L, 94935.1523d)).iterator
+      override def outputRange: Option[RvRange] = None
     })
   val queryConfig = new QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
@@ -56,6 +58,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = data.iterator
+      override def outputRange: Option[RvRange] = None
     })
     fireBinaryOperatorTests(samples, scalar)
     fireComparatorOperatorTests(samples, scalar)
@@ -73,6 +76,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, Double.NaN),
           new TransientRow(2L, 5.6d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -80,6 +84,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 4.6d),
           new TransientRow(2L, 4.4d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -87,6 +92,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 0d),
           new TransientRow(2L, 5.4d)).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     fireBinaryOperatorTests(samples, Double.NaN)
@@ -111,6 +117,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
           new TransientRow(2L, 5.9d),
           new TransientRow(2L, Double.NaN),
           new TransientRow(2L, 3.3d)).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     fireBinaryOperatorTests(samples, scalar)
@@ -266,6 +273,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 1),
           new TransientRow(2L, 2)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -273,6 +281,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 1),
           new TransientRow(2L, 2)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -280,6 +289,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 1),
           new TransientRow(2L, 2)).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     val expectedVal = samples.map(_.rows.map(v => v.getDouble(1) * 2))
@@ -305,6 +315,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 15.004124836249305),
           new TransientRow(2L, 2)).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     val expectedVal = samples.map(_.rows.map(v => scala.math.floor(v.getDouble(1))))

--- a/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
@@ -26,6 +26,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3.3d),
         new TransientRow(2L, 5.1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = ignoreKey
@@ -33,6 +34,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(3L, 3239.3423d),
         new TransientRow(4L, 94935.1523d)).iterator
+      override def outputRange: Option[RvRange] = None
     })
   val rand = new Random()
   val error = 0.00000001d
@@ -51,6 +53,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
 
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = data.iterator
+      override def outputRange: Option[RvRange] = None
     })
     fireInstantFunctionTests(samples)
   }
@@ -66,6 +69,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, Double.NaN),
           new TransientRow(2L, 5.6d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -73,6 +77,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 4.6d),
           new TransientRow(2L, 4.4d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -80,6 +85,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 0d),
           new TransientRow(2L, 5.4d)).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     fireInstantFunctionTests(samples)
@@ -102,6 +108,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
           new TransientRow(2L, 5.9d),
           new TransientRow(2L, Double.NaN),
           new TransientRow(2L, 3.3d)).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     fireInstantFunctionTests(samples)
@@ -290,6 +297,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
           new TransientRow(4L, 1230767999), // 2008-12-31 23:59:59 just before leap second.
           new TransientRow(5L, 1569179748)  // 2019-09-22 19:15:48 Sunday
         ).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     applyFunctionAndAssertResult(samples, Array(List(2.0, 3.0, 1.0, 12.0, 9.0).toIterator), InstantFunctionId.Month)
@@ -310,6 +318,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
           new TransientRow(1L, Double.NaN),
           new TransientRow(2L, Double.NaN)
         ).iterator
+        override def outputRange: Option[RvRange] = None
       }
     )
     applyFunctionAndAssertResult(samples, Array(List(Double.NaN, Double.NaN).toIterator), InstantFunctionId.Month)

--- a/query/src/test/scala/filodb/query/exec/rangefn/LabelReplaceSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/LabelReplaceSpec.scala
@@ -35,6 +35,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3.3d),
         new TransientRow(2L, 5.1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -43,6 +44,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(3L, 100d),
         new TransientRow(4L, 200d)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val queryConfig = new QueryConfig(config.getConfig("query"))
@@ -63,6 +65,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 3.3d),
           new TransientRow(2L, 5.1d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = sampleKey2
@@ -71,6 +74,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(3L, 100d),
           new TransientRow(4L, 200d)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
     val expectedLabels = List(Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("demo.io new Label Value 90"),
@@ -109,6 +113,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 3.3d),
           new TransientRow(2L, 5.1d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -117,6 +122,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(3L, 100d),
           new TransientRow(4L, 200d)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
     val expectedLabels = List(Map(ZeroCopyUTF8String("instance") -> ZeroCopyUTF8String("Instance-100"),
@@ -156,6 +162,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 3.3d),
           new TransientRow(2L, 5.1d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = ignoreKey
@@ -164,6 +171,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(3L, 100d),
           new TransientRow(4L, 200d)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
     val expectedLabels = sampleWithKey.toList.map(_.key.labelValues)

--- a/query/src/test/scala/filodb/query/exec/rangefn/LableJoinSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/LableJoinSpec.scala
@@ -60,6 +60,7 @@ class LableJoinSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3.3d),
         new TransientRow(2L, 5.1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -68,6 +69,7 @@ class LableJoinSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(3L, 100d),
         new TransientRow(4L, 200d)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val sampleWithoutDst: Array[RangeVector] = Array(
@@ -78,6 +80,7 @@ class LableJoinSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3.3d),
         new TransientRow(2L, 5.1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey4
@@ -86,6 +89,7 @@ class LableJoinSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(3L, 100d),
         new TransientRow(4L, 200d)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val queryConfig = new QueryConfig(config.getConfig("query"))

--- a/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
@@ -51,6 +51,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -58,6 +59,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 5d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey1
@@ -67,6 +69,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(1L, 3d),
         new TransientRow(2L, 3d),
         new TransientRow(3L, 3d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey1
@@ -74,6 +77,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 2d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -81,6 +85,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 4d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -88,6 +93,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 6d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey1
@@ -95,6 +101,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 0d)).iterator
+      override def outputRange: Option[RvRange] = None
     })
 
   val oneSample: Array[RangeVector] = Array(
@@ -107,6 +114,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(2L, 10d),
         new TransientRow(3L, 30d)
       ).iterator
+      override def outputRange: Option[RvRange] = None
     })
   
   it("should generate scalar") {

--- a/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
@@ -40,6 +40,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 1d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -47,6 +48,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 5d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey1
@@ -54,6 +56,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 3d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey1
@@ -61,6 +64,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 2d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -68,6 +72,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 4d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey2
@@ -75,6 +80,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 6d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey1
@@ -82,12 +88,14 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq(
         new TransientRow(1L, 0d)).iterator
+      override def outputRange: Option[RvRange] = None
     },
     new RangeVector {
       override def key: RangeVectorKey = testKey1
 
       import filodb.core.query.NoCloseCursor._
       override def rows(): RangeVectorCursor = Seq.empty[RowReader].iterator
+      override def outputRange: Option[RvRange] = None
     }
     )
 
@@ -125,6 +133,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
         import filodb.core.query.NoCloseCursor._
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 1d)).iterator
+        override def outputRange: Option[RvRange] = None
       },
       new RangeVector {
         override def key: RangeVectorKey = testKey2
@@ -132,6 +141,7 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
         import filodb.core.query.NoCloseCursor._
         override def rows(): RangeVectorCursor = Seq(
           new TransientRow(1L, 5d)).iterator
+        override def outputRange: Option[RvRange] = None
       })
 
     val byLabels = List("src")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

When doing binary joins on high churn time series over longer time ranges, we send a lot of time series over the wire. Since these time series are ephemeral, we end up writing too many NaNs over the wire on the SerializedRangeVector. This increases network usage as well as heap usage on both ends.

**New behavior :**

We compress the SerializedRangeVector by including start/step/end in the range vector and omitting the NaNs entirely. While reading the values out at the receiver, we uncompress by inserting NaNs at appropriate steps where there is no value.

Work in Progress:
* Unit tests
* Local E2E tests