### PR TITLE
bug(query):  absent/absent_over_time return empty result for nonexistent metric

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerMaterializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerMaterializer.scala
@@ -183,7 +183,8 @@ trait  PlannerMaterializer {
     val aggregate = Aggregate(AggregationOperator.Sum, lp, Nil, Seq("job"))
     // Add sum to aggregate all child responses
     // If all children have NaN value, sum will yield NaN and AbsentFunctionMapper will yield 1
-    val aggregatePlanResult = PlanResult(Seq(addAggregator(aggregate, qContext, vectors, Seq.empty)))
+    val aggregatePlanResult = PlanResult(Seq(addAggregator(aggregate, qContext.copy(plannerParams =
+      qContext.plannerParams.copy(skipAggregatePresent = true)), vectors, Seq.empty))) // No need for present for sum
     addAbsentFunctionMapper(aggregatePlanResult, lp.columnFilters,
       RangeParams(lp.startMs / 1000, lp.stepMs / 1000, lp.endMs / 1000), qContext)
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -288,7 +288,8 @@ class SingleClusterPlanner(dsRef: DatasetRef,
       val aggregate = Aggregate(AggregationOperator.Sum, lp, Nil, Seq("job"))
       // Add sum to aggregate all child responses
       // If all children have NaN value, sum will yield NaN and AbsentFunctionMapper will yield 1
-      val aggregatePlanResult = PlanResult(Seq(addAggregator(aggregate, qContext, series, Seq.empty)))
+      val aggregatePlanResult = PlanResult(Seq(addAggregator(aggregate, qContext.copy(plannerParams =
+        qContext.plannerParams.copy(skipAggregatePresent = true)), series, Seq.empty)))
       addAbsentFunctionMapper(aggregatePlanResult, lp.columnFilters,
         RangeParams(lp.startMs / 1000, lp.stepMs / 1000, lp.endMs / 1000), qContext)
     } else series

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -520,8 +520,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
-    execPlan.rangeVectorTransformers.head.isInstanceOf[AggregatePresenter] shouldEqual true
-    execPlan.rangeVectorTransformers.tail.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
+    execPlan.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
     execPlan.children(0).isInstanceOf[MultiSchemaPartitionsExec] shouldEqual(true)
     val multiSchemaExec = execPlan.children(0).asInstanceOf[MultiSchemaPartitionsExec]
 
@@ -537,9 +536,9 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
-    execPlan.rangeVectorTransformers.head.isInstanceOf[AggregatePresenter] shouldEqual true
+
     execPlan.children.head.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual(true)
-    execPlan.children.head.rangeVectorTransformers.tail.head.isInstanceOf[AbsentFunctionMapper] shouldEqual(true)
+    execPlan.children.head.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
 
     val multiSchemaExec = execPlan.children.head.children.head
     multiSchemaExec.rangeVectorTransformers.head.isInstanceOf[PeriodicSamplesMapper] shouldEqual(true)
@@ -554,8 +553,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
-    execPlan.rangeVectorTransformers.head.isInstanceOf[AggregatePresenter] shouldEqual true
-    execPlan.rangeVectorTransformers.tail.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
+    execPlan.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
     execPlan.children(0).isInstanceOf[MultiSchemaPartitionsExec] shouldEqual(true)
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
AbsentFunctionMapper does not get executed for metrics that are not present 

**New behavior :**
- Remove AgggregatePresent from sum aggregator which is added for absent and absent_over_time. AbsentFunctionMapper is not executed if the schema is empty and the ExecPlan has rangeVectorTransformers that can't handle empty schema
- Return empty result in ReduceAggregateExec when input schema is empty