### PR TITLE
bug(core): Fix Partition Eviction Issues

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -413,7 +413,8 @@ filodb {
     # This is also memory for write-buffers, off-heap partKey and chunkMap. Falling below this
     # number means data will be evicted from memory and possibly lost new data if not enough eviction happens.
     # It should be large enough to accommodate a spike of newly time series ingested.
-    ensure-memory-headroom-percent = 5
+    ensure-block-memory-headroom-percent = 5
+    ensure-tsp-headroom-percent = 5
 
     # Maximum number of partitions to target on heap per shard. If numPartitions exceed this value
     # eviction will trigger on the shard. Set this by considering java heap setting, and total size

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -415,6 +415,11 @@ filodb {
     # It should be large enough to accommodate a new partition key, a new OffheapLFSortedIDMap structure
     # (a couple hundred bytes) plus 1000 write buffers.
     min-write-buffers-free-percentage = 10
+
+    # Maximum number of partitions to target on heap per shard. If numPartitions exceed this value
+    # eviction will trigger on the shard. Set this by considering java heap setting, and total size
+    # of partition keys and chunk-map on off-heap. Decreasing this will free off-heap memory more quickly.
+    max-partitions-on-heap-per-shard = 1000000
   }
 
   # for standalone worker cluster configuration, see akka-bootstrapper

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -409,12 +409,12 @@ filodb {
     # Parallelism of persistance flush tasks. Should never be greater than groups-per-shard
     flush-task-parallelism = 2
 
-    # Minimum amount of memory (as a memory string, eg 2MB, 1GB) to maintain in the write buffers.
+    # Minimum amount of memory as percentage of capacity to maintain in the write buffers.
     # This is also memory for other time series data structures.  Falling below this number means data will be
     # evicted from memory and possibly lost new data if not enough eviction happens.
     # It should be large enough to accommodate a new partition key, a new OffheapLFSortedIDMap structure
     # (a couple hundred bytes) plus 1000 write buffers.
-    min-write-buffers-free = 5MB
+    min-write-buffers-free-percentage = 10
   }
 
   # for standalone worker cluster configuration, see akka-bootstrapper

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -409,12 +409,11 @@ filodb {
     # Parallelism of persistance flush tasks. Should never be greater than groups-per-shard
     flush-task-parallelism = 2
 
-    # Minimum amount of memory as percentage of capacity to maintain in the write buffers.
-    # This is also memory for other time series data structures.  Falling below this number means data will be
-    # evicted from memory and possibly lost new data if not enough eviction happens.
-    # It should be large enough to accommodate a new partition key, a new OffheapLFSortedIDMap structure
-    # (a couple hundred bytes) plus 1000 write buffers.
-    min-write-buffers-free-percentage = 5
+    # Minimum amount of memory as percentage of capacity to maintain in the native memory manager.
+    # This is also memory for write-buffers, off-heap partKey and chunkMap. Falling below this
+    # number means data will be evicted from memory and possibly lost new data if not enough eviction happens.
+    # It should be large enough to accommodate a spike of newly time series ingested.
+    ensure-memory-headroom-percent = 5
 
     # Maximum number of partitions to target on heap per shard. If numPartitions exceed this value
     # eviction will trigger on the shard. Set this by considering java heap setting, and total size

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -414,11 +414,12 @@ filodb {
     # evicted from memory and possibly lost new data if not enough eviction happens.
     # It should be large enough to accommodate a new partition key, a new OffheapLFSortedIDMap structure
     # (a couple hundred bytes) plus 1000 write buffers.
-    min-write-buffers-free-percentage = 10
+    min-write-buffers-free-percentage = 5
 
     # Maximum number of partitions to target on heap per shard. If numPartitions exceed this value
     # eviction will trigger on the shard. Set this by considering java heap setting, and total size
     # of partition keys and chunk-map on off-heap. Decreasing this will free off-heap memory more quickly.
+    # Default to a high number - tune if needed
     max-partitions-on-heap-per-shard = 1000000
   }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -409,11 +409,16 @@ filodb {
     # Parallelism of persistance flush tasks. Should never be greater than groups-per-shard
     flush-task-parallelism = 2
 
+    # Minimum amount of memory as percentage of capacity to maintain in the block manager.
+    # Increase if very large volume of ODP queries are expected within headroom task interval since
+    # eviction will not happen during queries.
+    ensure-block-memory-headroom-percent = 5
+
     # Minimum amount of memory as percentage of capacity to maintain in the native memory manager.
     # This is also memory for write-buffers, off-heap partKey and chunkMap. Falling below this
     # number means data will be evicted from memory and possibly lost new data if not enough eviction happens.
-    # It should be large enough to accommodate a spike of newly time series ingested.
-    ensure-block-memory-headroom-percent = 5
+    # Increase if very high cardinality ODP queries are expected within headroom task interval since
+    # eviction will not happen during queries.
     ensure-tsp-headroom-percent = 5
 
     # Maximum number of partitions to target on heap per shard. If numPartitions exceed this value

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -85,15 +85,19 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
     // 1. Fetch partitions from memstore
     val partIdsNotInMemory = partLookupRes.partIdsNotInMemory
 
-    // ensure there is room for full-odp partitions. Need to do this all at one time
-    // because doing it one by one can evict another ODPed partition
-    // TODO need to double check eviction and query races. Failing queries in these situations may be simpler
-    // FIXME partSet read is not protected with lock
-    val numPartitionsToEvict = evictionPolicy.numPartitionsToEvict(partSet.size, bufferMemoryManager)
-    if (numPartitionsToEvict > 0 && // need to evict since we are running out of space
-      evictablePartIds.size() < partIdsNotInMemory.length) { // no room left
-      throw new ServiceUnavailableException("Too many ingesting time series. Not able to evict enough to " +
-        "make room for ODPed TSPs. Try query after sometime")
+    if (partIdsNotInMemory.nonEmpty) { // query needs to ODP partitions
+      // ensure there is room for full-odp partitions. Need to do this all at one time
+      // because doing it one by one can evict another ODPed partition
+      // TODO need to double check eviction and query races. Failing queries in these situations may be simpler
+      // partSet.size read is not protected with lock, but reading a slightly stale value should be ok,
+      // and the possibility of corrupt read is not possible because it is a 32 bit value and there is no
+      // word tearing
+      val numPartitionsToEvict = evictionPolicy.numPartitionsToEvict(partSet.size, bufferMemoryManager)
+      if (numPartitionsToEvict > 0 && // need to evict since we are running out of space
+        evictablePartIds.size() < partIdsNotInMemory.length) { // no room left
+        throw new ServiceUnavailableException("Too many ingesting time series. Not able to evict enough to " +
+          "make room for ODPed TSPs. Try query after sometime")
+      }
     }
 
     // 2. Now determine list of partitions to ODP and the time ranges to ODP

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -204,6 +204,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
             val stamp = partSetLock.writeLock()
             try {
               part.ingesting = false
+              evictablePartIds.add(part.partID)
               partSet.add(part)
             } finally {
               partSetLock.unlockWrite(stamp)

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -202,18 +202,18 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
                 sch   = schemas(RecordSchema.schemaID(partKeyBytesRef.bytes, unsafeKeyOffset))
                 part <- Option(createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, id, sch, 4))
                           if sch != Schemas.UnknownSchema } yield {
-            val stamp = partSetLock.writeLock()
-            try {
-              markPartAsNotIngesting(part, odp = true)
-              partSet.add(part)
-            } finally {
-              partSetLock.unlockWrite(stamp)
+              val stamp = partSetLock.writeLock()
+              try {
+                markPartAsNotIngesting(part, odp = true)
+                partSet.add(part)
+              } finally {
+                partSetLock.unlockWrite(stamp)
+              }
+              val pkBytes = util.Arrays.copyOfRange(partKeyBytesRef.bytes, partKeyBytesRef.offset,
+                partKeyBytesRef.offset + partKeyBytesRef.length)
+              callback(part.partID, pkBytes)
+              part
             }
-            val pkBytes = util.Arrays.copyOfRange(partKeyBytesRef.bytes, partKeyBytesRef.offset,
-                            partKeyBytesRef.offset + partKeyBytesRef.length)
-            callback(part.partID, pkBytes)
-            part
-          }
           // create the partition and update data structures (but no need to add to Lucene!)
           // NOTE: if no memory, then no partition!
         case p: TimeSeriesPartition =>

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -203,8 +203,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
                           if sch != Schemas.UnknownSchema } yield {
             val stamp = partSetLock.writeLock()
             try {
-              part.ingesting = false
-              evictablePartIds.add(part.partID)
+              markPartAsNotIngesting(part)
               partSet.add(part)
             } finally {
               partSetLock.unlockWrite(stamp)

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -201,7 +201,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
                 group = partKeyGroup(schemas.part.binSchema, partKeyBytesRef.bytes, unsafeKeyOffset, numGroups)
                 sch  <- Option(schemas(RecordSchema.schemaID(partKeyBytesRef.bytes, unsafeKeyOffset)))
                           } yield {
-            val part = createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, id, sch, 4)
+            val part = createNewPartition(partKeyBytesRef.bytes, unsafeKeyOffset, group, id, sch, true, 4)
             if (part == OutOfMemPartition) throw new ServiceUnavailableException("The server has too many ingesting " +
               "time series and does not have resources to serve this long time range query. Please try " +
               "after sometime.")

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -16,7 +16,7 @@ import filodb.core.{DatasetRef, Types}
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore.ratelimit.QuotaSource
 import filodb.core.metadata.Schemas
-import filodb.core.query.QuerySession
+import filodb.core.query.{QuerySession, ServiceUnavailableException}
 import filodb.core.store._
 import filodb.memory.NativeMemoryManager
 
@@ -84,6 +84,18 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
 
     // 1. Fetch partitions from memstore
     val partIdsNotInMemory = partLookupRes.partIdsNotInMemory
+
+    // ensure there is room for full-odp partitions. Need to do this all at one time
+    // because doing it one by one can evict another ODPed partition
+    // TODO need to double check eviction and query races. Failing queries in these situations may be simpler
+    // FIXME partSet read is not protected with lock
+    val numPartitionsToEvict = evictionPolicy.numPartitionsToEvict(partSet.size, bufferMemoryManager)
+    if (numPartitionsToEvict > 0 && // need to evict since we are running out of space
+      evictablePartIds.size() < partIdsNotInMemory.length) { // no room left
+      throw new ServiceUnavailableException("Too many ingesting time series. Not able to evict enough to " +
+        "make room for ODPed TSPs. Try query after sometime")
+    }
+
     // 2. Now determine list of partitions to ODP and the time ranges to ODP
     val partKeyBytesToPage = new ArrayBuffer[Array[Byte]]()
     val pagingMethods = new ArrayBuffer[ChunkScanMethod]

--- a/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
@@ -2,7 +2,7 @@ package filodb.core.memstore
 
 import com.typesafe.scalalogging.StrictLogging
 
-import filodb.memory.{MemFactory, NativeMemoryManager}
+import filodb.memory.NativeMemoryManager
 
 /**
  * This is a policy that determines when partitions should be evicted out of memory
@@ -41,6 +41,12 @@ class WriteBufferFreeEvictionPolicy(minBufferMemPercentage: Double) extends Part
 /**
  * A policy, used for testing, which evicts any partitions if the # of partitions is above a max.
  */
-class FixedMaxPartitionsEvictionPolicy(maxPartitions: Int) extends PartitionEvictionPolicy with StrictLogging {
+class FixedMaxPartitionsEvictionPolicy(maxPartitions: Int) extends PartitionEvictionPolicy {
   def shouldEvict(numPartitions: Int, memManager: NativeMemoryManager): Boolean = numPartitions > maxPartitions
+}
+
+class CompositeEvictionPolicy(p: Seq[PartitionEvictionPolicy]) extends PartitionEvictionPolicy {
+  def shouldEvict(numPartitions: Int, memManager: NativeMemoryManager): Boolean = {
+    p.exists(_.shouldEvict(numPartitions, memManager))
+  }
 }

--- a/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
@@ -44,8 +44,8 @@ class WriteBufferFreeEvictionPolicy(headroomPercent: Double) extends PartitionEv
  */
 class FixedMaxPartitionsEvictionPolicy(headroomPercent: Double) extends PartitionEvictionPolicy {
   def numPartitionsToEvictForHeadroom(numPartitions: Int, maxPartitions: Int, memManager: NativeMemoryManager): Int = {
-    val headroomCount = (maxPartitions * headroomPercent / 100).toInt
-    Math.max(numPartitions - headroomCount + 1, 0)
+    val headroom = (maxPartitions * headroomPercent / 100).toInt
+    Math.max(numPartitions - (maxPartitions - headroom), 0)
   }
 }
 

--- a/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
@@ -49,8 +49,9 @@ class FixedMaxPartitionsEvictionPolicy(headroomPercent: Double) extends Partitio
   }
 }
 
-class CompositeEvictionPolicy(maxPartPolicy: FixedMaxPartitionsEvictionPolicy,
-                              freeBufferPolicy: WriteBufferFreeEvictionPolicy) extends PartitionEvictionPolicy {
+class CompositeEvictionPolicy(headroomPercent: Double) extends PartitionEvictionPolicy {
+  val maxPartPolicy = new FixedMaxPartitionsEvictionPolicy(headroomPercent)
+  val freeBufferPolicy = new WriteBufferFreeEvictionPolicy(headroomPercent)
   def numPartitionsToEvictForHeadroom(numPartitions: Int, maxPartitions: Int, memManager: NativeMemoryManager): Int = {
     Math.max(maxPartPolicy.numPartitionsToEvictForHeadroom(numPartitions, maxPartitions, memManager),
              freeBufferPolicy.numPartitionsToEvictForHeadroom(numPartitions, maxPartitions, memManager))

--- a/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
@@ -43,7 +43,7 @@ class WriteBufferFreeEvictionPolicy(minBufferMemPercentage: Double) extends Part
  */
 class FixedMaxPartitionsEvictionPolicy(maxPartitions: Int) extends PartitionEvictionPolicy {
   def numPartitionsToEvict(numPartitions: Int, memManager: NativeMemoryManager): Int =
-    Math.max(numPartitions - maxPartitions, 0)
+    Math.max(numPartitions - maxPartitions + 1, 0)
 }
 
 class CompositeEvictionPolicy(maxPartPolicy: FixedMaxPartitionsEvictionPolicy,

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -39,10 +39,8 @@ extends MemStore with StrictLogging {
 
   private val partEvictionPolicy = evictionPolicy.getOrElse {
     new CompositeEvictionPolicy(
-      Seq(
-        new WriteBufferFreeEvictionPolicy(filodbConfig.getDouble("min-write-buffers-free-percentage")),
-        new FixedMaxPartitionsEvictionPolicy(filodbConfig.getInt("max-partitions-on-heap-per-shard"))
-      )
+        new FixedMaxPartitionsEvictionPolicy(filodbConfig.getInt("max-partitions-on-heap-per-shard")),
+        new WriteBufferFreeEvictionPolicy(filodbConfig.getDouble("min-write-buffers-free-percentage"))
     )
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -38,7 +38,7 @@ extends MemStore with StrictLogging {
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
 
   private val partEvictionPolicy = evictionPolicy.getOrElse {
-    new WriteBufferFreeEvictionPolicy(filodbConfig.getMemorySize("memstore.min-write-buffers-free").toBytes)
+    new WriteBufferFreeEvictionPolicy(filodbConfig.getDouble("min-write-buffers-free-percentage"))
   }
 
   def isDownsampleStore: Boolean = false

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -36,11 +36,12 @@ extends MemStore with StrictLogging {
   val stats = new ChunkSourceStats
 
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
+  private val ensureHeadroomPercent = filodbConfig.getDouble("memstore.ensure-memory-headroom-percent")
 
   private val partEvictionPolicy = evictionPolicy.getOrElse {
     new CompositeEvictionPolicy(
-        new FixedMaxPartitionsEvictionPolicy(filodbConfig.getInt("max-partitions-on-heap-per-shard")),
-        new WriteBufferFreeEvictionPolicy(filodbConfig.getDouble("min-write-buffers-free-percentage"))
+        new FixedMaxPartitionsEvictionPolicy(ensureHeadroomPercent),
+        new WriteBufferFreeEvictionPolicy(ensureHeadroomPercent)
     )
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -38,7 +38,12 @@ extends MemStore with StrictLogging {
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
 
   private val partEvictionPolicy = evictionPolicy.getOrElse {
-    new WriteBufferFreeEvictionPolicy(filodbConfig.getDouble("min-write-buffers-free-percentage"))
+    new CompositeEvictionPolicy(
+      Seq(
+        new WriteBufferFreeEvictionPolicy(filodbConfig.getDouble("min-write-buffers-free-percentage")),
+        new FixedMaxPartitionsEvictionPolicy(filodbConfig.getInt("max-partitions-on-heap-per-shard"))
+      )
+    )
   }
 
   def isDownsampleStore: Boolean = false

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -36,14 +36,9 @@ extends MemStore with StrictLogging {
   val stats = new ChunkSourceStats
 
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
-  private val ensureHeadroomPercent = filodbConfig.getDouble("memstore.ensure-memory-headroom-percent")
+  private val ensureTspHeadroomPercent = filodbConfig.getDouble("memstore.ensure-tsp-headroom-percent")
 
-  private val partEvictionPolicy = evictionPolicy.getOrElse {
-    new CompositeEvictionPolicy(
-        new FixedMaxPartitionsEvictionPolicy(ensureHeadroomPercent),
-        new WriteBufferFreeEvictionPolicy(ensureHeadroomPercent)
-    )
-  }
+  private val partEvictionPolicy = evictionPolicy.getOrElse(new CompositeEvictionPolicy(ensureTspHeadroomPercent))
 
   def isDownsampleStore: Boolean = false
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1456,7 +1456,8 @@ class TimeSeriesShard(val ref: DatasetRef,
   private def partitionsToEvict(): EWAHCompressedBitmap = {
     // Iterate and add eligible partitions to delete to our list
     // Need to filter out partitions with no endTime. Any endTime calculated would not be set within one flush interval.
-    partKeyIndex.partIdsOrderedByEndTime(storeConfig.numToEvict, evictionWatermark, Long.MaxValue - 1)
+    val numPartsToEvict = partitions.size() * storeConfig.percentTSPsToEvict / 100
+    partKeyIndex.partIdsOrderedByEndTime(numPartsToEvict, evictionWatermark, Long.MaxValue - 1)
   }
 
   private[core] def getPartition(partKey: Array[Byte]): Option[TimeSeriesPartition] = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1627,7 +1627,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         if (!acquired) logger.error(s"Since addPartitionsDisabled is true, proceeding with reclaim " +
           s"even though eviction lock couldn't be acquired with final timeout of $timeoutMs ms. Trading " +
           s"off possibly wrong query results (due to old inactive partitions that would be evicted " +
-          s"and skipped) in order to unblock ingestion and stop data loss.")
+          s"and skipped) in order to unblock ingestion and stop data loss. LockState: $evictionLock")
         try {
           if (blockEvictionLockTimeoutMs > 0) {
             blockStore.ensureHeadroom(ensureBlockHeadroomPercent)

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -95,5 +95,5 @@ case class QuerySession(qContext: QueryContext,
 }
 
 object QuerySession {
-  def forTestingOnly: QuerySession = QuerySession(QueryContext(), EmptyQueryConfig)
+  def makeForTestingOnly(): QuerySession = QuerySession(QueryContext(), EmptyQueryConfig)
 }

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -150,3 +150,5 @@ object ResultMaker extends StrictLogging {
     def fromResult(res: Result): Unit = {}
   }
 }
+
+class ServiceUnavailableException(message: String) extends RuntimeException(message)

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -20,7 +20,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              // Number of bytes to allocate to ingestion write buffers per shard
                              ingestionBufferMemSize: Long,
                              maxBufferPoolSize: Int,
-                             numToEvict: Int,
+                             percentTSPsToEvict: Int,
                              groupsPerShard: Int,
                              numPagesPerBlock: Int,
                              failureRetries: Int,
@@ -53,7 +53,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "shard-mem-size" -> shardMemSize,
                                "ingestion-buffer-mem-size" -> ingestionBufferMemSize,
                                "max-buffer-pool-size" -> maxBufferPoolSize,
-                               "num-partitions-to-evict" -> numToEvict,
+                               "percent-partitions-to-evict" -> percentTSPsToEvict,
                                "groups-per-shard" -> groupsPerShard,
                                "max-chunk-time" -> (maxChunkTime.toSeconds + "s"),
                                "num-block-pages" -> numPagesPerBlock,
@@ -91,7 +91,7 @@ object StoreConfig {
                                            |max-blob-buffer-size = 15000
                                            |ingestion-buffer-mem-size = 10M
                                            |max-buffer-pool-size = 10000
-                                           |num-partitions-to-evict = 1000
+                                           |percent-partitions-to-evict = 10
                                            |groups-per-shard = 60
                                            |num-block-pages = 100
                                            |failure-retries = 3

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -20,8 +20,6 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              // Number of bytes to allocate to ingestion write buffers per shard
                              ingestionBufferMemSize: Long,
                              maxBufferPoolSize: Int,
-
-                             percentTSPsToEvict: Int,
                              groupsPerShard: Int,
                              numPagesPerBlock: Int,
                              failureRetries: Int,
@@ -54,7 +52,6 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "shard-mem-size" -> shardMemSize,
                                "ingestion-buffer-mem-size" -> ingestionBufferMemSize,
                                "max-buffer-pool-size" -> maxBufferPoolSize,
-                               "percent-partitions-to-evict" -> percentTSPsToEvict,
                                "groups-per-shard" -> groupsPerShard,
                                "max-chunk-time" -> (maxChunkTime.toSeconds + "s"),
                                "num-block-pages" -> numPagesPerBlock,
@@ -92,7 +89,6 @@ object StoreConfig {
                                            |max-blob-buffer-size = 15000
                                            |ingestion-buffer-mem-size = 10M
                                            |max-buffer-pool-size = 10000
-                                           |percent-partitions-to-evict = 10
                                            |groups-per-shard = 60
                                            |num-block-pages = 100
                                            |failure-retries = 3
@@ -134,7 +130,6 @@ object StoreConfig {
                 config.getMemorySize("shard-mem-size").toBytes,
                 config.getMemorySize("ingestion-buffer-mem-size").toBytes,
                 config.getInt("max-buffer-pool-size"),
-                config.getInt("num-partitions-to-evict"),
                 config.getInt("groups-per-shard"),
                 config.getInt("num-block-pages"),
                 config.getInt("failure-retries"),

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -20,6 +20,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              // Number of bytes to allocate to ingestion write buffers per shard
                              ingestionBufferMemSize: Long,
                              maxBufferPoolSize: Int,
+
                              percentTSPsToEvict: Int,
                              groupsPerShard: Int,
                              numPagesPerBlock: Int,

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -32,8 +32,6 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              demandPagingParallelism: Int,
                              demandPagingEnabled: Boolean,
                              evictedPkBfCapacity: Int,
-                             // Amount of free blocks to periodically reclaim, as a percent of total number of blocks
-                             ensureHeadroomPercent: Double,
                              // filters on ingested records to log in detail
                              traceFilters: Map[String, String],
                              maxDataPerShardQuery: Long,
@@ -64,7 +62,6 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "demand-paging-enabled" -> demandPagingEnabled,
                                "max-data-per-shard-query" -> maxDataPerShardQuery,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
-                               "ensure-headroom-percent" -> ensureHeadroomPercent,
                                "metering-enabled" -> meteringEnabled,
                                "accept-duplicate-samples" -> acceptDuplicateSamples,
                                "ingest-resolution-millis" -> estimatedIngestResolutionMillis).asJava)
@@ -99,7 +96,6 @@ object StoreConfig {
                                            |demand-paging-parallelism = 10
                                            |demand-paging-enabled = true
                                            |evicted-pk-bloom-filter-capacity = 5000000
-                                           |ensure-headroom-percent = 5.0
                                            |trace-filters = {}
                                            |metering-enabled = true
                                            |accept-duplicate-samples = false
@@ -141,7 +137,6 @@ object StoreConfig {
                 config.getInt("demand-paging-parallelism"),
                 config.getBoolean("demand-paging-enabled"),
                 config.getInt("evicted-pk-bloom-filter-capacity"),
-                config.getDouble("ensure-headroom-percent"),
                 config.as[Map[String, String]]("trace-filters"),
                 config.getMemorySize("max-data-per-shard-query").toBytes,
                 config.getBoolean("metering-enabled"),

--- a/core/src/main/scala/filodb.core/store/package.scala
+++ b/core/src/main/scala/filodb.core/store/package.scala
@@ -149,7 +149,7 @@ package object store {
                  columnIDs: Seq[ColumnId],
                  partMethod: PartitionScanMethod,
                  chunkMethod: ChunkScanMethod = AllChunkScan,
-                 querySession: QuerySession = QuerySession.forTestingOnly): Iterator[RowReader] =
+                 querySession: QuerySession = QuerySession.makeForTestingOnly): Iterator[RowReader] =
       source.scanPartitions(dataset.ref, columnIDs, partMethod, chunkMethod, querySession)
             .toIterator()
             .flatMap(_.timeRangeRows(chunkMethod, columnIDs.toArray))

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -50,7 +50,7 @@ filodb {
 
   memstore {
     flush-task-parallelism = 1
-    min-write-buffers-free-percentage = 5
+    ensure-memory-headroom-percent = 5
     max-partitions-on-heap-per-shard = 10000
   }
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -50,7 +50,8 @@ filodb {
 
   memstore {
     flush-task-parallelism = 1
-    min-write-buffers-free = 1MB
+    min-write-buffers-free-percentage = 5
+    max-partitions-on-heap-per-shard = 10000
   }
 
   tasks {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -50,7 +50,8 @@ filodb {
 
   memstore {
     flush-task-parallelism = 1
-    ensure-memory-headroom-percent = 5
+    ensure-block-memory-headroom-percent = 5
+    ensure-tsp-headroom-percent = 5
     max-partitions-on-heap-per-shard = 10000
   }
 

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -464,7 +464,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     shard.addPartitionsDisabled() shouldEqual true
 
     markPartitionsForEviction(10 until 20)
-    shard.evictForHeadroom() // this should evict only 10 partitions, but cannot reach headroom
+    shard.evictForHeadroom() shouldEqual true // this should evict only 10 partitions, but cannot reach headroom
     // but add of new partitions is enabled since we were able to evict some
     shard.addPartitionsDisabled() shouldEqual false
     shard.partitions.size() shouldEqual 1090
@@ -503,7 +503,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     ex2.getCause.isInstanceOf[ServiceUnavailableException] shouldEqual true
 
     // after next headroom task run....
-    shard.evictForHeadroom()
+    shard.evictForHeadroom() shouldEqual true
 
     // now query should succeed
     val parts = memStore.scanPartitions(dataset1.ref, Seq(0, 1), FilteredPartitionScan(split, Seq(filter)),
@@ -516,7 +516,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
     // mark some parts as evictable
     markPartitionsForEviction(21 until 25)
-    shard.evictForHeadroom()
+    shard.evictForHeadroom() shouldEqual true
     // odp partitions should be evicted first before regular partitions
     shard.evictableOdpPartIds.size() shouldEqual 0
 

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -425,7 +425,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val shard = memStore.getShardE(dataset1.ref, 0)
     for { n <- partIDs } {
       val part = shard.partitions.get(n)
-      shard.markPartAsNotIngesting(part)
+      shard.markPartAsNotIngesting(part, false)
     }
   }
 
@@ -497,7 +497,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     parts3.map(_.partID).toSet shouldEqual Set()
 
     markPartitionsForEviction(4 to 10)
-    memStore.getShardE(dataset1.ref, 0).checkEnableAddPartitions()
+    memStore.getShardE(dataset1.ref, 0).runHeadroomTask()
 
     val data4 = records(dataset1, linearMultiSeries(numSeries = 30).drop(22).take(6))
     memStore.ingest(dataset1.ref, 0, data4)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -457,7 +457,6 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     Thread sleep 1000    // see if this will make things pass sooner
 
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 20
-    memStore.getShardE(dataset1.ref, 0).evictionWatermark shouldEqual endTime + 1
     memStore.getShardE(dataset1.ref, 0).addPartitionsDisabled() shouldEqual false
     import collection.JavaConverters._
 
@@ -579,7 +578,6 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
     memStore.getShardE(dataset1.ref, 0).addPartitionsDisabled() shouldEqual true
     memStore.numPartitions(dataset1.ref, 0) shouldEqual 21   // due to the way the eviction policy works
-    memStore.getShardE(dataset1.ref, 0).evictionWatermark shouldEqual 0
 
     memStore.refreshIndexForTesting(dataset1.ref)
     // Check partitions are now 0 to 20, 21/22 did not get added

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -154,10 +154,10 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
     val filter = ColumnFilter("MonthYear", Filter.Equals(197902))
     val method = FilteredPartitionScan(paramSet.head, Seq(filter))
     val lookupRes = memStore.lookupPartitions(dataset2.ref, method, AllChunkScan,
-      querySession = QuerySession.forTestingOnly)
+      querySession = QuerySession.makeForTestingOnly)
     val rangeVectorObs = memStore.rangeVectors(dataset2.ref, lookupRes, schema2.colIDs("NumArticles").get,
                                                schema2, false,
-                                               QuerySession.forTestingOnly)
+                                               QuerySession.makeForTestingOnly)
     val rangeVectors = rangeVectorObs.toListL.runAsync.futureValue
 
     rangeVectors should have length (1)

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -254,16 +254,6 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
   }
 
   /**
-   * Calculate lock timeout based on headroom space available.
-   * Lower the space available, longer the timeout.
-   */
-  def getHeadroomLockTimeout(ensurePercent: Double): Int = {
-    // Ramp up the timeout as the current headroom shrinks. Max timeout per attempt is a little
-    // over 2 seconds, and the total timeout can be double that, for a total of 4 seconds.
-    ((1.0 - (currentFreePercent / ensurePercent)) * EvictionLock.maxTimeoutMillis).toInt
-  }
-
-  /**
     * Expected to be called via a background task, to periodically ensure that enough blocks
     * are free for new allocations. This helps prevent ODP activity from reclaiming immediately
     * from itself.

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -1,6 +1,7 @@
 package filodb.memory
 
 import java.util.concurrent.locks.ReentrantLock
+import javax.naming.ServiceUnavailableException
 
 import com.kenai.jffi.{MemoryIO, PageManager}
 import com.typesafe.scalalogging.StrictLogging
@@ -184,9 +185,10 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
         if (!odp) {
           tryReclaimWhenAllocating(num)
         } else {
-            val msg = s"Unable to allocate ODP block(s) without forcing a reclamation: " +
-                      s"num_blocks=$num num_bytes=$memorySize freeBlocks=${freeBlocks.size}"
-            throw new MemoryRequestException(msg)
+            logger.error(s"Unable to allocate ODP block(s) without forcing a reclamation: " +
+                      s"num_blocks=$num num_bytes=$memorySize freeBlocks=${freeBlocks.size}")
+            throw new ServiceUnavailableException(s"This query requires paging of chunks for which " +
+              s"memory is currently not available. Please try again after sometime")
         }
       }
 
@@ -231,9 +233,9 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
         // Don't stall ingestion forever. Some queries might return invalid results because
         // the lock isn't held. If the lock state is broken, then ingestion is really stuck
         // and the node must be restarted. Queries should always release the lock.
-        logger.error(s"Lock for BlockManager.tryReclaimOnDemand timed out: ${reclaimLock}")
+        logger.error(s"Lock for BlockManager.tryReclaimWhenAllocating timed out: ${reclaimLock}")
       } else {
-        logger.debug("Lock for BlockManager.tryReclaimOnDemand aquired")
+        logger.debug("Lock for BlockManager.tryReclaimWhenAllocating acquired")
       }
 
       val stall = System.nanoTime() - start

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -227,7 +227,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     try {
       val start = System.nanoTime()
       // Give up after waiting (in total) a little over 16 seconds.
-      acquired = reclaimLock.tryExclusiveReclaimLock(8192)
+      acquired = reclaimLock.tryExclusiveReclaimLock(EvictionLock.direCircumstanceTimeoutMillis)
 
       if (!acquired) {
         // Don't stall ingestion forever. Some queries might return invalid results because

--- a/memory/src/main/scala/filodb.memory/EvictionLock.scala
+++ b/memory/src/main/scala/filodb.memory/EvictionLock.scala
@@ -8,6 +8,7 @@ import filodb.memory.data.Shutdown
 
 object EvictionLock {
   val maxTimeoutMillis = 2048
+  val direCircumstanceTimeoutMillis = 32768
 }
 /**
  * This lock protects memory regions accessed by queries and prevents them from

--- a/memory/src/main/scala/filodb.memory/EvictionLock.scala
+++ b/memory/src/main/scala/filodb.memory/EvictionLock.scala
@@ -54,13 +54,13 @@ class EvictionLock(debugInfo: String = "none") extends StrictLogging {
           // The lock state is logged in case it's stuck due to a runaway query somewhere.
           logger.warn(s"Lock for ensureHeadroom timed out: ${this}")
         }
+      }
+      if (timeout >= finalTimeoutMillis) {
         numFailures += 1
         if (numFailures >= 5) {
           Shutdown.haltAndCatchFire(new RuntimeException(s"Headroom task was unable to acquire exclusive lock " +
             s"for $numFailures consecutive attempts. Shutting down process. $debugInfo"))
         }
-      }
-      if (timeout >= finalTimeoutMillis) {
         return false
       }
       Thread.`yield`()

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -3,6 +3,7 @@ package filodb.memory
 import scala.language.reflectiveCalls
 
 import com.kenai.jffi.PageManager
+import javax.naming.ServiceUnavailableException
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -192,11 +193,9 @@ class PageAlignedBlockManagerSpec extends AnyFlatSpec with Matchers with BeforeA
     blockManager.usedOdpBlocks.size() shouldEqual 4
 
     // reclaim should fail now because none of the blocks are reclaimable
-    try {
+    intercept[ServiceUnavailableException] {
       blockManager.requestBlock(true)
       fail
-    } catch {
-      case e: MemoryRequestException => // expected
     }
 
     blockManager.releaseBlocks()

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -25,8 +25,6 @@ final case class QueryError(id: String, t: Throwable) extends QueryResponse with
   */
 class BadQueryException(message: String) extends RuntimeException(message)
 
-class ServiceUnavailableException(message: String) extends RuntimeException(message)
-
 case class RemoteQueryFailureException(statusCode: Int, requestStatus: String, errorType: String, errorMessage: String )
   extends RuntimeException {
   override def getMessage: String = {

--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -5,10 +5,9 @@ import monix.execution.Scheduler
 
 import filodb.core.{DatasetRef, QueryTimeoutException}
 import filodb.core.metadata.Schemas
-import filodb.core.query.{ColumnFilter, QueryContext, QuerySession}
+import filodb.core.query.{ColumnFilter, QueryContext, QuerySession, ServiceUnavailableException}
 import filodb.core.store._
 import filodb.query.Query.qLogger
-import filodb.query.ServiceUnavailableException
 
 final case class UnknownSchemaQueryErr(id: Int) extends
   Exception(s"Unknown schema ID $id during query.  This likely means a schema config change happened and " +

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -6,9 +6,8 @@ import monix.execution.Scheduler
 import filodb.core.DatasetRef
 import filodb.core.memstore.TimeSeriesShard
 import filodb.core.metadata.Column
-import filodb.core.query._
+import filodb.core.query.{ServiceUnavailableException, _}
 import filodb.core.store._
-import filodb.query.ServiceUnavailableException
 
 object SelectChunkInfosExec {
   import Column.ColumnType._


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, we use lucene index to identify partIds eligible for eviction. This is not proving to be reliable. Getting top-k partitions with oldest endTime from lucene is complex and is complex possibly has bugs. Even if fixed, it yields to complex eviction logic. There are cases when ODP may cause the partition to never be evicted at all because of existing watermark logic.

Hence:
* Explicitly maintain a queue of partIds eligible for eviction. When partition stops ingesting or is ODPed, the partId is added to this list
* Eviction happens very quickly from this queue. Lucene queries will not be an issue. ODPed partitions get evicted first to be consistent with block eviction.

Another issue is we still have ODP cannibalism where ODP queries can silently evict other TSPs required by the same ODP query. This is prevented by disallowing inline eviction for ODP queries. Instead, we evict regularly in the headroom task to create room for ODPed partitions.

