### PR TITLE
bug(query):  add config to InProcessPlanDispatcher

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
@@ -14,7 +14,7 @@ import filodb.core.downsample.OffHeapMemory
 import filodb.core.memstore._
 import filodb.core.memstore.FiloSchedulers.QuerySchedName
 import filodb.core.metadata.{Dataset, Schemas}
-import filodb.core.query.{ColumnFilter, PlannerParams, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query.{ColumnFilter, EmptyQueryConfig, PlannerParams, QueryConfig, QueryContext, QuerySession}
 import filodb.core.query.Filter.Equals
 import filodb.core.store.{InMemoryMetaStore, PartKeyRecord, StoreConfig, TimeRangeChunkScan}
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -186,7 +186,7 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(gaugeName))
     val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams = PlannerParams(sampleLimit = numSamples * 2)),
-      InProcessPlanDispatcher, dataset.ref, 0, queryFilters, TimeRangeChunkScan(firstSampleTime, firstSampleTime + 2 *
+      InProcessPlanDispatcher(EmptyQueryConfig), dataset.ref, 0, queryFilters, TimeRangeChunkScan(firstSampleTime, firstSampleTime + 2 *
         numSamples))
     val queryConfig = new QueryConfig(config.getConfig("query"))
     val querySession = QuerySession(QueryContext(), queryConfig)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -45,6 +45,7 @@ class SingleClusterPlanner(dsRef: DatasetRef,
                            splitSizeMs: => Long = 1.day.toMillis)
                            extends QueryPlanner with StrictLogging with PlannerMaterializer {
 
+  val inproc = InProcessPlanDispatcher(queryConfig)
   override val schemas = schema
   val shardColumns = dsOptions.shardKeyColumns.sorted
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -44,8 +44,6 @@ class SingleClusterPlanner(dsRef: DatasetRef,
                            minTimeRangeForSplitMs: => Long = 1.day.toMillis,
                            splitSizeMs: => Long = 1.day.toMillis)
                            extends QueryPlanner with StrictLogging with PlannerMaterializer {
-
-  val inproc = InProcessPlanDispatcher(queryConfig)
   override val schemas = schema
   val shardColumns = dsOptions.shardKeyColumns.sorted
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import monix.execution.Scheduler
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
-import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query.{EmptyQueryConfig, PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.ChunkSource
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
@@ -48,7 +48,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers {
   val earliestRawTime = now - rawRetention.toMillis
   val latestDownsampleTime = now - 4.minutes.toMillis // say it takes 4 minutes to downsample
 
-  private def disp = InProcessPlanDispatcher
+  private def disp = InProcessPlanDispatcher(EmptyQueryConfig)
   val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
                                                  earliestRawTime, latestDownsampleTime, disp)
   implicit val system = ActorSystem()

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
@@ -49,8 +49,10 @@ class ScalarQueriesSpec extends AnyFunSpec with Matchers {
   val windowed1 = PeriodicSeriesWithWindowing(raw1, from, 1000, to, 5000, RangeFunctionId.Rate)
   val summed1 = Aggregate(AggregationOperator.Sum, windowed1, Nil, Seq("job"))
 
-  def maskDispatcher(input: String) = {
-    input.replaceAll("Actor\\[.*\\]", "Actor\\[\\]").replaceAll("\\s+", "")
+  private def maskDispatcher(input: String) = {
+   input.replaceAll("Actor\\[.*\\]", "Actor\\[\\]").
+     replaceAll("InProcessPlanDispatcher\\(.*\\)", "InProcessPlanDispatcher").
+     replaceAll("\\s+", "")
   }
 
   it("should generate Scalar exec plan") {
@@ -273,7 +275,7 @@ class ScalarQueriesSpec extends AnyFunSpec with Matchers {
     val expected =
       """T~InstantVectorFunctionMapper(function=Minute)
         |-T~VectorFunctionMapper(funcParams=List())
-        |--E~ScalarFixedDoubleExec(params=RangeParams(1000,1000,1000), value=1.136239445E9) on InProcessPlanDispatcher
+        |--E~ScalarFixedDoubleExec(params=RangeParams(1000,1000,1000), value=1.136239445E9) on InProcessPlanDispatcher(filodb.core.query.EmptyQueryConfig$@1d4fb213)
         |""".stripMargin
     maskDispatcher(execPlan.printTree()) shouldEqual (maskDispatcher(expected))
   }
@@ -488,6 +490,6 @@ class ScalarQueriesSpec extends AnyFunSpec with Matchers {
         |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
         |----T~PeriodicSamplesMapper(start=1000000, step=1000000, end=1000000, window=None, functionId=None, rawSource=true, offsetMs=None)
         |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=21, chunkMethod=TimeRangeChunkScan(700000,1000000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(http_requests_total))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-669137818])""".stripMargin
-    maskDispatcher(execPlan.printTree()) shouldEqual (maskDispatcher(expected))
+    maskDispatcher(execPlan.printTree()).shouldEqual(maskDispatcher(expected))
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -122,7 +122,8 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
     val lp = Parser.queryToLogicalPlan("test{job = \"app\"} + rr1{job = \"app\"}", 1000, 1000)
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
-    execPlan.dispatcher shouldEqual (InProcessPlanDispatcher) //rr1 and test belong to different clusters
+    // rr1 and test belong to different clusters
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual true
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
     execPlan.asInstanceOf[BinaryJoinExec].rhs.head.asInstanceOf[MockExecPlan].name shouldEqual ("rules1")
     execPlan.asInstanceOf[BinaryJoinExec].lhs.head.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
@@ -132,7 +133,8 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
     val lp = Parser.queryToLogicalPlan("rr1{job = \"app\"} + rr2{job = \"app\"}", 1000, 1000)
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
-    execPlan.dispatcher shouldEqual (InProcessPlanDispatcher) //rr1 and rr2 belong to different clusters
+    // rr1 and rr2 belong to different clusters
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual true
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
     execPlan.asInstanceOf[BinaryJoinExec].lhs.head.asInstanceOf[MockExecPlan].name shouldEqual ("rules1")
     execPlan.asInstanceOf[BinaryJoinExec].rhs.head.asInstanceOf[MockExecPlan].name shouldEqual ("rules2")

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -59,7 +59,7 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
     override def children: Seq[ExecPlan] = Nil
     override def submitTime: Long = 1000
     override def dataset: DatasetRef = ???
-    override def dispatcher: PlanDispatcher = InProcessPlanDispatcher
+    override def dispatcher: PlanDispatcher = InProcessPlanDispatcher(queryConfig)
     override def doExecute(source: ChunkSource, querySession: QuerySession)
                           (implicit sched: Scheduler): ExecResult = ???
     override protected def args: String = "mock-args"

--- a/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
+++ b/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
@@ -2,6 +2,7 @@ package filodb.query.exec
 
 import monix.eval.Task
 import monix.execution.Scheduler
+
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query.{ColumnInfo, EmptyQueryConfig, QueryContext, QuerySession, ResultSchema}

--- a/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
+++ b/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
@@ -2,16 +2,15 @@ package filodb.query.exec
 
 import monix.eval.Task
 import monix.execution.Scheduler
-
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{ColumnInfo, QueryContext, QuerySession, ResultSchema}
+import filodb.core.query.{ColumnInfo, EmptyQueryConfig, QueryContext, QuerySession, ResultSchema}
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, QueryResult}
 
 case class EmptyResultExec(queryContext: QueryContext,
                            dataset: DatasetRef) extends LeafExecPlan {
-  override def dispatcher: PlanDispatcher = InProcessPlanDispatcher
+  override def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 
   override def execute(source: ChunkSource,
                        querySession: QuerySession)

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -20,10 +20,7 @@ import filodb.query.QueryResponse
   */
 
   case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
-
-  // Empty query config, since its does not apply in case of non-leaf plans
-  //val queryConfig: QueryConfig = EmptyQueryConfig
-
+  
   override def dispatch(plan: ExecPlan)(implicit sched: Scheduler): Task[QueryResponse] = {
     // unsupported source since its does not apply in case of non-leaf plans
     val source = UnsupportedChunkSource()

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -19,8 +19,7 @@ import filodb.query.QueryResponse
   * calls only for children.
   */
 
-//case class InProcessPlanDispatcher1 (queryConfig: QueryConfig)
-case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
+  case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
 
   // Empty query config, since its does not apply in case of non-leaf plans
   //val queryConfig: QueryConfig = EmptyQueryConfig

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -20,7 +20,7 @@ import filodb.query.QueryResponse
   */
 
   case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
-  
+
   override def dispatch(plan: ExecPlan)(implicit sched: Scheduler): Task[QueryResponse] = {
     // unsupported source since its does not apply in case of non-leaf plans
     val source = UnsupportedChunkSource()

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -9,7 +9,7 @@ import filodb.core.{DatasetRef, Types}
 import filodb.core.memstore.PartLookupResult
 import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
-import filodb.core.query.{EmptyQueryConfig, QueryConfig, QuerySession}
+import filodb.core.query.{QueryConfig, QuerySession}
 import filodb.core.store._
 import filodb.query.QueryResponse
 
@@ -18,10 +18,12 @@ import filodb.query.QueryResponse
   * Goal is that Non-Leaf plans can be executed locally in JVM and make network
   * calls only for children.
   */
-case object InProcessPlanDispatcher extends PlanDispatcher {
+
+//case class InProcessPlanDispatcher1 (queryConfig: QueryConfig)
+case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
 
   // Empty query config, since its does not apply in case of non-leaf plans
-  val queryConfig: QueryConfig = EmptyQueryConfig
+  //val queryConfig: QueryConfig = EmptyQueryConfig
 
   override def dispatch(plan: ExecPlan)(implicit sched: Scheduler): Task[QueryResponse] = {
     // unsupported source since its does not apply in case of non-leaf plans

--- a/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
@@ -68,5 +68,5 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
     * to the node where it will be executed. The Query Engine
     * will supply this parameter
     */
-  override final def dispatcher: PlanDispatcher = InProcessPlanDispatcher
+  override final def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 }

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -71,6 +71,6 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
     * to the node where it will be executed. The Query Engine
     * will supply this parameter
     */
-  override def dispatcher: PlanDispatcher = InProcessPlanDispatcher
+  override def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 
 }

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -80,5 +80,5 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
     * to the node where it will be executed. The Query Engine
     * will supply this parameter
     */
-  override final def dispatcher: PlanDispatcher = InProcessPlanDispatcher
+  override final def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 }

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -1,24 +1,21 @@
 package filodb.query.exec
 
 import java.util.concurrent.{Executors, TimeUnit}
-
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
-
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-
 import filodb.core.MetricsTestData.{builder, timeseriesDataset, timeseriesSchema}
 import filodb.core.TestData
 import filodb.core.binaryrecord2.{RecordBuilder, RecordContainer}
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.{Column, Dataset, Schemas}
-import filodb.core.query.{ColumnFilter, Filter, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query.{ColumnFilter, EmptyQueryConfig, Filter, QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.{AllChunkScan, InMemoryMetaStore, NullColumnStore}
 import filodb.memory.MemFactory
 import filodb.memory.data.ChunkMap
@@ -100,7 +97,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
-    val dispatcher: PlanDispatcher = InProcessPlanDispatcher
+    val dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 
     val dummyDispatcher = DummyDispatcher(memStore, querySession)
 
@@ -128,7 +125,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     val emptyFilters = Seq (ColumnFilter("__name__", Filter.Equals("nonsense".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
-    val dispatcher: PlanDispatcher = InProcessPlanDispatcher
+    val dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 
     val dummyDispatcher = DummyDispatcher(memStore, querySession)
 

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -1,9 +1,8 @@
 package filodb.query.exec
 
 import scala.annotation.tailrec
-
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
-import filodb.core.query.{ColumnInfo, CustomRangeVectorKey, QueryContext, RangeVector, RangeVectorCursor, RangeVectorKey, ResultSchema, RvRange, TransientRow}
+import filodb.core.query.{ColumnInfo, CustomRangeVectorKey, EmptyQueryConfig, QueryContext, RangeVector, RangeVectorCursor, RangeVectorKey, ResultSchema, RvRange, TransientRow}
 import filodb.core.query.NoCloseCursor.NoCloseCursor
 import filodb.memory.format.UnsafeUtils
 import filodb.query.QueryResult
@@ -138,7 +137,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers {
   it ("should reduce result schemas with different fixedVecLengths without error") {
 
     // null needed below since there is a require in code that prevents empty children
-    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher, Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
+    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig), Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
 
     val rs1 = ResultSchema(List(ColumnInfo("timestamp",
       TimestampColumn), ColumnInfo("value", DoubleColumn)), 1, Map(), Some(430), List(0, 1))

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -679,7 +679,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     Seq(gaugeName, gaugeLowFreqName, counterName, histName).foreach { metricName =>
       val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(metricName))
       val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams = PlannerParams(sampleLimit = 1000)),
-        InProcessPlanDispatcher, batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
+        InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
 
       val querySession = QuerySession(QueryContext(), queryConfig)
       val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName", 3)
@@ -708,7 +708,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(counterName))
     val qc = QueryContext(plannerParams = PlannerParams(sampleLimit = 1000))
     val exec = MultiSchemaPartitionsExec(qc,
-      InProcessPlanDispatcher, batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
+      InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
     exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(150000),
       Some(InternalRangeFunction.Rate), qc))
 
@@ -738,7 +738,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
       val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(untypedName))
       val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams
-        = PlannerParams(sampleLimit = 1000)), InProcessPlanDispatcher, batchDownsampler.rawDatasetRef, 0,
+        = PlannerParams(sampleLimit = 1000)), InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0,
         queryFilters, AllChunkScan)
 
       val querySession = QuerySession(QueryContext(), queryConfig)
@@ -761,7 +761,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(gaugeName))
     val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams = PlannerParams(sampleLimit = 1000)),
-      InProcessPlanDispatcher, batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan, colName = Option("sum"))
+      InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan,
+      colName = Option("sum"))
     val querySession = QuerySession(QueryContext(), queryConfig)
     val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName", 3)
     val res = exec.execute(downsampleTSStore, querySession)(queryScheduler)
@@ -885,6 +886,4 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     // readKeys should not contain bulk PK records
     readKeys2 shouldEqual metricNames.toSet
   }
-
-
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
InprocessPlanDispatcher currently uses empty config.  Some queries need queryConfig.fastReduceMaxWindows in AggregateMapReduce and they are failing when InprocessPlanDispatcher is used

**New behavior :**
Assign query planner config to InprocessPlanDispatcher
