### PR TITLE
refactor(core): Refactor headroom task and prepare for locking during TSP eviction

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/OffHeapMemory.scala
+++ b/core/src/main/scala/filodb.core/downsample/OffHeapMemory.scala
@@ -18,12 +18,13 @@ class OffHeapMemory(schemas: Seq[Schema],
 
   logger.info(s"Allocating OffHeap memory $this with nativeMemManagerSize=$nativeMemSize " +
     s"and blockMemorySize=$blockMemSize")
+  val evictionLock = new EvictionLock
   val blockStore = new PageAlignedBlockManager(blockMemSize,
     stats = new MemoryStats(kamonTags),
     reclaimer = new ReclaimListener {
       override def onReclaim(metadata: Long, numBytes: Int): Unit = {}
     },
-    numPagesPerBlock = 50)
+    numPagesPerBlock = 50, evictionLock)
 
   val blockMemFactory = new BlockMemFactory(blockStore, maxMetaSize, kamonTags, false)
 

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -1,11 +1,11 @@
 package filodb.core.query
 
 import java.util.UUID
-import java.util.concurrent.locks.Lock
 
 import scala.concurrent.duration._
 
 import filodb.core.{SpreadChange, SpreadProvider}
+import filodb.memory.EvictionLock
 
 trait TsdbQueryParams
 
@@ -85,11 +85,11 @@ object QueryContext {
   */
 case class QuerySession(qContext: QueryContext,
                         queryConfig: QueryConfig,
-                        var lock: Option[Lock] = None,
+                        var lock: Option[EvictionLock] = None,
                         var resultCouldBePartial: Boolean = false,
                         var partialResultsReason: Option[String] = None) {
   def close(): Unit = {
-    lock.foreach(_.unlock())
+    lock.foreach(_.releaseSharedLock())
     lock = None
   }
 }

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -398,8 +398,8 @@ object MachineMetricsData {
 
   val histKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
   val histPartKey = histKeyBuilder.partKeyFromObjects(histDataset.schema, "request-latency", extraTags)
-
-  val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024, new MemoryStats(Map("test"-> "test")), null, 16)
+  val evictionLock = new EvictionLock
+  val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024, new MemoryStats(Map("test"-> "test")), null, 16, evictionLock)
   val histIngestBH = new BlockMemFactory(blockStore, histDataset.schema.data.blockMetaSize,
                                          dummyContext, true)
   val histMaxBH = new BlockMemFactory(blockStore, histMaxDS.schema.data.blockMetaSize,

--- a/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartitionSetSpec.scala
@@ -30,7 +30,7 @@ class PartitionSetSpec extends MemFactoryCleanupTest with ScalaFutures {
   }
 
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
-    new MemoryStats(Map("test"-> "test")), reclaimer, 1)
+    new MemoryStats(Map("test"-> "test")), reclaimer, 1, evictionLock)
   protected val bufferPool = new WriteBufferPool(memFactory, dataset2.schema.data, TestData.storeConf)
   private val ingestBlockHolder = new BlockMemFactory(blockStore, dataset2.schema.data.blockMetaSize,
                                     dummyContext, true)

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -74,7 +74,7 @@ class TimeSeriesPartitionSpec extends MemFactoryCleanupTest with ScalaFutures {
   }
 
   private val blockStore = new PageAlignedBlockManager(200 * 1024 * 1024,
-    new MemoryStats(Map("test"-> "test")), reclaimer, 1)
+    new MemoryStats(Map("test"-> "test")), reclaimer, 1, evictionLock)
   protected val ingestBlockHolder = new BlockMemFactory(blockStore, schema1.data.blockMetaSize,
                                       dummyContext, true)
 

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -182,7 +182,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     try {
       if (freeBlocks.size < num) {
         if (!odp) {
-          tryReclaimOnDemand(num)
+          tryReclaimWhenAllocating(num)
         } else {
             val msg = s"Unable to allocate ODP block(s) without forcing a reclamation: " +
                       s"num_blocks=$num num_bytes=$memorySize freeBlocks=${freeBlocks.size}"
@@ -219,7 +219,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     * This method must be called with the primary lock object held. To avoid deadlock, this
     * method releases and re-acquires the lock.
     */
-  private def tryReclaimOnDemand(num: Int): Unit = {
+  private def tryReclaimWhenAllocating(num: Int): Unit = {
     lock.unlock()
     var acquired: Boolean = false
     try {

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -257,10 +257,10 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
    * Calculate lock timeout based on headroom space available.
    * Lower the space available, longer the timeout.
    */
-  def getHeadroomLockTimeout(pct: Double, maxTimeoutMillis: Int): Int = {
+  def getHeadroomLockTimeout(ensurePercent: Double): Int = {
     // Ramp up the timeout as the current headroom shrinks. Max timeout per attempt is a little
     // over 2 seconds, and the total timeout can be double that, for a total of 4 seconds.
-    ((1.0 - (currentFreePercent / pct)) * maxTimeoutMillis).toInt
+    ((1.0 - (currentFreePercent / ensurePercent)) * EvictionLock.maxTimeoutMillis).toInt
   }
 
   /**
@@ -270,11 +270,10 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     *
     * Caller MUST acquire eviction lock in exclusive mode before invoking this method.
     * This ensures there are no queries running while eviction is going on.
-    * @param pct percentage: 0.0 to 100.0
+    * @param ensurePercent percentage: 0.0 to 100.0
     */
-  def ensureHeadroom(pct: Double): Int = {
-    var numFree: Int = 0
-      numFree = ensureFreePercent(pct)
+  def ensureHeadroom(ensurePercent: Double): Int = {
+    val numFree = ensureFreePercent(ensurePercent)
     val numBytes = numFree * blockSizeInBytes
     logger.debug(s"BlockManager.ensureHeadroom numFree: $numFree ($numBytes bytes)")
     numFree

--- a/memory/src/main/scala/filodb.memory/EvictionLock.scala
+++ b/memory/src/main/scala/filodb.memory/EvictionLock.scala
@@ -1,0 +1,49 @@
+package filodb.memory
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * This lock protects memory regions accessed by queries and prevents them from being evicted.
+ */
+class EvictionLock {
+
+  // Acquired when reclaiming on demand. Acquire shared lock to prevent block reclamation.
+  private final val reclaimLock = new Latch
+
+  def tryExclusiveReclaimLock(finalTimeoutMillis: Int): Boolean = {
+    // Attempting to acquire the exclusive lock must wait for concurrent queries to finish, but
+    // waiting will also stall new queries from starting. To protect against this, attempt with
+    // a timeout to let any stalled queries through. To prevent starvation of the exclusive
+    // lock attempt, increase the timeout each time, but eventually give up. The reason why
+    // waiting for an exclusive lock causes this problem is that the thread must enqueue itself
+    // into the lock as a waiter, and all new shared requests must wait their turn. The risk
+    // with timing out is that if there's a continuous stream of long running queries (more than
+    // one second), then the exclusive lock will never be acqiured, and then ensureFreeBlocks
+    // won't be able to do its job. The timeout settings might need to be adjusted in that case.
+    // Perhaps the timeout should increase automatically if ensureFreeBlocks failed the last time?
+    // This isn't safe to do until we gain higher confidence that the shared lock is always
+    // released by queries.
+
+    var timeout = 1;
+    while (true) {
+      val acquired = reclaimLock.tryAcquireExclusiveNanos(TimeUnit.MILLISECONDS.toNanos(timeout))
+      if (acquired) {
+        return true
+      }
+      if (timeout >= finalTimeoutMillis) {
+        return false
+      }
+      Thread.`yield`()
+      timeout = Math.min(finalTimeoutMillis, timeout << 1)
+    }
+    false // never reached, but scala compiler complains otherwise
+  }
+
+  def releaseExclusive(): Unit = reclaimLock.releaseExclusive()
+
+  def acquireSharedLock(): Unit = reclaimLock.lock()
+
+  def releaseSharedLock(): Unit = reclaimLock.unlock()
+
+  override def toString: String = reclaimLock.toString
+}

--- a/memory/src/test/scala/filodb.memory/BlockMemFactorySpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockMemFactorySpec.scala
@@ -12,9 +12,10 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
 
   val pageSize = PageManager.getInstance().pageSize()
 
+  val evictionLock = new EvictionLock
   it should "Mark all blocks of BlockMemFactory as reclaimable when used as done in ingestion pipeline" in {
     val stats = new MemoryStats(Map("test1" -> "test1"))
-    val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1)
+    val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1, evictionLock)
     val bmf = new BlockMemFactory(blockManager, 50, Map("test" -> "val"), false)
 
     // simulate encoding of multiple ts partitions in flush group
@@ -48,7 +49,7 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
 
   it should "Mark all blocks of BlockMemFactory as reclaimable when used in ODP by DemandPagedChunkStore" in {
     val stats = new MemoryStats(Map("test1" -> "test1"))
-    val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1)
+    val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1, evictionLock)
 
     // create block mem factories for different time buckets
     val bmf = new BlockMemFactory(blockManager, 50, Map("test" -> "val"), true)
@@ -89,7 +90,7 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
 
   it should "Reclaim Ingestion and ODP blocks in right order when used together" in {
     val stats = new MemoryStats(Map("test1" -> "test1"))
-    val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1)
+    val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1, evictionLock)
 
     val ingestionFactory = new BlockMemFactory(blockManager, 50, Map("test" -> "val"), false)
 

--- a/memory/src/test/scala/filodb.memory/BlockSpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockSpec.scala
@@ -9,8 +9,9 @@ import org.scalatest.matchers.should.Matchers
 class BlockSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   import PageAlignedBlockManagerSpec._
 
+  val evictionLock = new EvictionLock
   val stats = new MemoryStats(Map("test1" -> "test1"))
-  val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1)
+  val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1, evictionLock)
 
   before {
     testReclaimer.reclaimedBytes = 0

--- a/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerConcurrentSpec.scala
+++ b/memory/src/test/scala/filodb.memory/PageAlignedBlockManagerConcurrentSpec.scala
@@ -9,8 +9,9 @@ class PageAlignedBlockManagerConcurrentSpec extends FixtureAnyFunSuite
 with ConductorFixture with Matchers with BeforeAndAfterAll {
   import PageAlignedBlockManagerSpec._
 
+  val evictionLock = new EvictionLock
   val memoryStats = new MemoryStats(Map("test"-> "test"))
-  val blockManager = new PageAlignedBlockManager(2048 * 1024, memoryStats, testReclaimer, 1)
+  val blockManager = new PageAlignedBlockManager(2048 * 1024, memoryStats, testReclaimer, 1, evictionLock)
   val pageSize = blockManager.blockSizeInBytes
 
   override def afterAll(): Unit = {

--- a/memory/src/test/scala/filodb.memory/format/vectors/IntBinaryVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/IntBinaryVectorTest.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import debox.Buffer
 
-import filodb.memory.{BlockMemFactory, MemoryStats, PageAlignedBlockManager}
+import filodb.memory.{BlockMemFactory, EvictionLock, MemoryStats, PageAlignedBlockManager}
 import filodb.memory.format._
 
 class IntBinaryVectorTest extends NativeVectorTest {
@@ -115,8 +115,9 @@ class IntBinaryVectorTest extends NativeVectorTest {
 
     it("should append correctly when memory has previous values / was not zeroed") {
       import collection.JavaConverters._
+      val evictionLock = new EvictionLock
       val blockStore = new PageAlignedBlockManager(10 * 1024 * 1024,
-        new MemoryStats(Map("test"-> "test")), null, 16) {
+        new MemoryStats(Map("test"-> "test")), null, 16, evictionLock) {
         freeBlocks.asScala.foreach(_.set(0x55))   // initialize blocks to nonzero value
       }
       val blockFactory = new BlockMemFactory(blockStore, 24, Map("foo" -> "bar"), true)

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -69,8 +69,9 @@ final case class BinaryJoinExec(queryContext: QueryContext,
     val taskOfResults = childResponses.map {
       case (QueryResult(_, _, result, _, _), _)
         if (result.size  > queryContext.plannerParams.joinQueryCardLimit && cardinality == Cardinality.OneToOne) =>
-        throw new BadQueryException(s"This query results in more than ${queryContext.plannerParams.joinQueryCardLimit}"
-          + s" join cardinality. Try applying more filters.")
+        throw new BadQueryException(s"The join in this query has input cardinality of ${result.size} which" +
+          s" is more than limit of ${queryContext.plannerParams.joinQueryCardLimit}." +
+          s" Try applying more filters or reduce time range.")
       case (QueryResult(_, _, result, _, _), i) => (result, i)
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map { resp =>
@@ -129,8 +130,8 @@ final case class BinaryJoinExec(queryContext: QueryContext,
 
           // OneToOne cardinality case is already handled. this condition handles OneToMany case
           if (results.size >= queryContext.plannerParams.joinQueryCardLimit)
-            throw new BadQueryException(s"This query results in more than ${queryContext.plannerParams.
-              joinQueryCardLimit} " + s"join cardinality. Try applying more filters.")
+            throw new BadQueryException(s"The result of this join query has cardinality ${results.size} and " +
+              s"is more than limit of ${queryContext.plannerParams.joinQueryCardLimit}. Try applying more filters.")
 
           val res = if (lhsIsOneSide) binOp(rvOne.rows, rvOtherCorrect.rows) else binOp(rvOtherCorrect.rows, rvOne.rows)
           results.put(resKey, ResultVal(IteratorBackedRangeVector(resKey, res, period), rvOtherCorrect))

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -131,7 +131,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
           // OneToOne cardinality case is already handled. this condition handles OneToMany case
           if (results.size >= queryContext.plannerParams.joinQueryCardLimit)
             throw new BadQueryException(s"The result of this join query has cardinality ${results.size} and " +
-              s"is more than limit of ${queryContext.plannerParams.joinQueryCardLimit}. Try applying more filters.")
+              s"has reached the limit of ${queryContext.plannerParams.joinQueryCardLimit}. Try applying more filters.")
 
           val res = if (lhsIsOneSide) binOp(rvOne.rows, rvOtherCorrect.rows) else binOp(rvOtherCorrect.rows, rvOne.rows)
           results.put(resKey, ResultVal(IteratorBackedRangeVector(resKey, res, period), rvOtherCorrect))

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -524,8 +524,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         .toListL.runAsync.futureValue
     }
     thrown.getCause.getClass shouldEqual classOf[BadQueryException]
-    thrown.getCause.getMessage shouldEqual "This query results in more than 1 join cardinality." +
-      " Try applying more filters."
+    thrown.getCause.getMessage shouldEqual "The join in this query has input cardinality of 2 which is more than " +
+      "limit of 1. Try applying more filters or reduce time range."
   }
 
   it("should throw BadQueryException - one-to-one with on - cardinality limit 1") {
@@ -548,8 +548,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         .toListL.runAsync.futureValue
     }
     thrown.getCause.getClass shouldEqual classOf[BadQueryException]
-    thrown.getCause.getMessage shouldEqual "This query results in more than 1 join cardinality." +
-      " Try applying more filters."
+    thrown.getCause.getMessage shouldEqual "The join in this query has input cardinality of 2 which is more than " +
+      "limit of 1. Try applying more filters or reduce time range."
   }
 
   it ("should stitch same RVs from multiple shards on LHS and RHS before joining by ignoring NaN") {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -422,8 +422,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     }
 
     thrown.getCause.getClass shouldEqual classOf[BadQueryException]
-    thrown.getCause.getMessage shouldEqual "This query results in more than 1 join cardinality." +
-      " Try applying more filters."
+    thrown.getCause.getMessage shouldEqual "The result of this join query has cardinality 1 and has reached the " +
+      "limit of 1. Try applying more filters."
   }
 
   it("should throw BadQueryException - many-to-one with ignoring - cardinality limit 1") {
@@ -449,8 +449,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     }
 
     thrown.getCause.getClass shouldEqual classOf[BadQueryException]
-    thrown.getCause.getMessage shouldEqual "This query results in more than 1 join cardinality." +
-      " Try applying more filters."
+    thrown.getCause.getMessage shouldEqual "The result of this join query has cardinality 1 and " +
+      "has reached the limit of 1. Try applying more filters."
   }
 
   it("should throw BadQueryException - many-to-one with by and grouping without arguments - cardinality limit 1") {
@@ -481,7 +481,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     }
 
     thrown.getCause.getClass shouldEqual classOf[BadQueryException]
-    thrown.getCause.getMessage shouldEqual "This query results in more than 3 join cardinality." +
-      " Try applying more filters."
+    thrown.getCause.getMessage shouldEqual "The result of this join query has cardinality 3 and " +
+      "has reached the limit of 3. Try applying more filters."
   }
 }

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -26,8 +26,9 @@ import org.scalatest.matchers.should.Matchers
 trait RawDataWindowingSpec extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   import MetricsTestData._
 
+  val evictionLock = new EvictionLock
   private val blockStore = new PageAlignedBlockManager(100 * 1024 * 1024,
-    new MemoryStats(Map("test"-> "test")), null, 16)
+    new MemoryStats(Map("test"-> "test")), null, 16, evictionLock)
   val storeConf = TestData.storeConf.copy(maxChunksSize = 200)
   protected val ingestBlockHolder = new BlockMemFactory(blockStore, timeseriesSchema.data.blockMetaSize,
                                       MMD.dummyContext, true)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Simple refactor. No logic changes.
Move reclaimLock acquisition into TimeSeriesShard so that TimeSeriesPartition eviction can also be 
done regularly in the headroom task while the shard eviction lock is being held.