### PR TITLE
bug(query): Handle isPartial message response in remoteExec

### DIFF
--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -9,18 +9,18 @@ final case class RemoteErrorResponse(status: String, errorType: String, error: S
 final case class ErrorResponse(errorType: String, error: String, status: String = "error") extends PromQueryResponse
 
 final case class SuccessResponse(data: Data, status: String = "success",
-                                 isPartial: Option[Boolean] = None,
+                                 partial: Option[Boolean] = None,
                                  message: Option[String] = None) extends PromQueryResponse
 
 final case class ExplainPlanResponse(debugInfo: Seq[String], status: String = "success",
-                                     isPartial: Option[Boolean]= None,
+                                     partial: Option[Boolean]= None,
                                      message: Option[String]= None) extends PromQueryResponse
 
 final case class Data(resultType: String, result: Seq[Result])
 
 final case class MetadataSuccessResponse(data: Seq[Map[String, String]],
                                          status: String = "success",
-                                         isPartial: Option[Boolean]= None,
+                                         partial: Option[Boolean]= None,
                                          message: Option[String]= None) extends PromQueryResponse
 
 final case class Result(metric: Map[String, String], values: Option[Seq[DataSampl]], value: Option[DataSampl] = None,

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -48,6 +48,6 @@ case class MetadataRemoteExec(queryEndpoint: String,
                         queryWithPlanName(queryContext)))
 
     QueryResult(id, resultSchema, srvSeq,
-      if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+      if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 }

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -77,7 +77,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
     val queryResponse = if (response.data.result.isEmpty) {
       logger.debug("PromQlRemoteExec generating empty QueryResult as result is empty")
       QueryResult(id, ResultSchema.empty, Seq.empty,
-        if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+        if (response.partial.isDefined) response.partial.get else false, response.message)
     } else {
       if (response.data.result.head.aggregateResponse.isDefined) genAggregateResult(response, id)
       else {
@@ -85,7 +85,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         if (samples.isEmpty) {
           logger.debug("PromQlRemoteExec generating empty QueryResult as samples is empty")
           QueryResult(id, ResultSchema.empty, Seq.empty,
-            if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+            if (response.partial.isDefined) response.partial.get else false, response.message)
         } else {
           samples.head match {
             // Passing histogramMap = true so DataSampl will be HistSampl for histograms
@@ -103,7 +103,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
     val aggregateResponse = response.data.result.head.aggregateResponse.get
     if (aggregateResponse.aggregateSampl.isEmpty) {
       QueryResult(id, ResultSchema.empty, Seq.empty,
-        if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+        if (response.partial.isDefined) response.partial.get else false, response.message)
     } else {
       aggregateResponse.aggregateSampl.head match {
         case AvgSampl(timestamp, value, count)           => genAvgQueryResult(response, id)
@@ -137,7 +137,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("default").get, rangeVectors,
-      if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+      if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
   def genHistQueryResult(response: SuccessResponse, id: String): QueryResult = {
@@ -172,7 +172,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("histogram").get, rangeVectors,
-      if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+      if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
   def genAvgQueryResult(response: SuccessResponse, id: String): QueryResult = {
@@ -199,7 +199,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
     // TODO: Handle stitching with verbose flag
     QueryResult(id, resultSchema.get(Avg.entryName).get, rangeVectors,
-      if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+      if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
   def genStdValQueryResult(response: SuccessResponse, id: String): QueryResult = {
@@ -227,6 +227,6 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
     // TODO: Handle stitching with verbose flag
     QueryResult(id, resultSchema.get("stdval").get, rangeVectors,
-      if (response.isPartial.isDefined) response.isPartial.get else false, response.message)
+      if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 }

--- a/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
+++ b/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
@@ -84,7 +84,7 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
             ex.timestamp shouldEqual(ex.timestamp)
           } else ex shouldEqual(res)
         }
-      case Left(ex) => println(ex)
+      case Left(ex) => throw ex
     }
   }
 
@@ -136,7 +136,7 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
             ex.timestamp shouldEqual(res.timestamp)
           } else ex shouldEqual(res)
         }
-      case Left(ex) => println(ex)
+      case Left(ex) => throw ex
     }
   }
 
@@ -191,7 +191,7 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
                   |                    "_step_": "10",
                   |                    "_type_": "prom-counter",
                   |                    "_ws_": "demo",
-                  |                    "instance": "c70cac88-928e-4905-9f37-c1c6ed27cf27",
+                  |                    "instance": "c70cac88-928e-4905-9f37-c1c6ed27cf27"
                   |                },
                   |                "value": [
                   |                    1619636156,
@@ -210,14 +210,15 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
     parser.decode[List[SuccessResponse]](input) match {
       case Right(successResponse) => {
         val response = successResponse.head
-        response.isPartial.get shouldEqual true
+        println(response)
+        response.partial.get shouldEqual true
         response.message.get shouldEqual "Result may be partial since some shards are still bootstrapping"
         response.status shouldEqual "partial"
         val result = response.data.result.head
         result.metric.size shouldEqual 8
         result.value.size shouldEqual 1
       }
-      case Left(ex) => println(ex)
+      case Left(ex) => throw ex
     }
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
