### PR TITLE
bug(sparkJobs): Cardinality buster scale bugs

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/FiloCassandraConnector.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/FiloCassandraConnector.scala
@@ -42,6 +42,11 @@ trait FiloCassandraConnector extends StrictLogging {
 
   import Util._
 
+  def execCqlNoAsync(cql: Statement, notAppliedResponse: Response = NotApplied): Response = {
+    val res = session.execute(cql)
+    if (res.wasApplied()) Success else notAppliedResponse
+  }
+
   def execCql(cql: String, notAppliedResponse: Response = NotApplied): Future[Response] =
     session.executeAsync(cql).toScalaFuture.toResponse(notAppliedResponse)
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -460,13 +460,22 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     ret
   }
 
-  def deletePartKeys(ref: DatasetRef,
-                     shard: Int,
-                     pks: Observable[Array[Byte]]): Future[Long] = {
+  def scanPartKeysByStartEndTimeRangeNoAsync(ref: DatasetRef,
+                                             shard: Int,
+                                             split: (String, String),
+                                             startTimeGTE: Long,
+                                             startTimeLTE: Long,
+                                             endTimeGTE: Long,
+                                             endTimeLTE: Long): Iterator[Array[Byte]] = {
     val pkTable = getOrCreatePartitionKeysTable(ref, shard)
-    pks.mapAsync(writeParallelism) { pk =>
-      Task.fromFuture(pkTable.deletePartKey(pk))
-    }.countL.runAsync
+    pkTable.scanPksByStartEndTimeRangeNoAsync(split, startTimeGTE, startTimeLTE, endTimeGTE, endTimeLTE)
+  }
+
+  def deletePartKeyNoAsync(ref: DatasetRef,
+                           shard: Int,
+                           pk: Array[Byte]): Response = {
+    val pkTable = getOrCreatePartitionKeysTable(ref, shard)
+    pkTable.deletePartKeyNoAsync(pk)
   }
 
   def getPartKeysByUpdateHour(ref: DatasetRef,

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -81,9 +81,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
     val readData2 = colStore.scanPartKeys(dataset, 0).toListL.runAsync.futureValue.toSet
     readData2.map(pk => new String(pk.partKey, StandardCharsets.UTF_8).toInt) shouldEqual expectedKeys
 
-    val numDeleted = colStore.deletePartKeys(dataset, 0,
-      Observable.fromIterable(readData2.map(_.partKey))).futureValue
-    numDeleted shouldEqual readData2.size
+    readData2.map(_.partKey).foreach(pk => colStore.deletePartKeyNoAsync(dataset, 0, pk))
 
     val readData3 = colStore.scanPartKeys(dataset, 0).toListL.runAsync.futureValue
     readData3.isEmpty shouldEqual true

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -3,8 +3,6 @@ package filodb.cardbuster
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
-import scala.concurrent.Await
-
 import kamon.Kamon
 import monix.execution.Scheduler
 import net.ceedubs.ficus.Ficus._
@@ -20,13 +18,12 @@ import filodb.memory.format.UnsafeUtils
 class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
                                 inDownsampleTables: Boolean) extends Serializable {
 
-  @transient lazy private val numPartKeysDeleting = Kamon.counter("num-partkeys-deleting").withoutTags()
   @transient lazy protected val readSched = Scheduler.io("cass-read-sched")
   @transient lazy protected val writeSched = Scheduler.io("cass-write-sched")
   @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(dsSettings.cassandraConfig)
   @transient lazy private val schemas = Schemas.fromConfig(dsSettings.filodbConfig).get
 
-  @transient lazy private val colStore =
+  @transient lazy private[cardbuster] val colStore =
                 new CassandraColumnStore(dsSettings.filodbConfig, readSched, session, inDownsampleTables)(writeSched)
 
   @transient lazy private val downsampleRefsByRes = dsSettings.downsampleResolutions
@@ -36,10 +33,10 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
                                   dsSettings.rawDatasetIngestionConfig.downsampleConfig.resolutions.last
   @transient lazy private val dsDatasetRef = downsampleRefsByRes(highestDSResolution)
 
-  @transient lazy private val dataset = if (inDownsampleTables) dsDatasetRef else rawDatasetRef
+  @transient lazy private[cardbuster] val dataset = if (inDownsampleTables) dsDatasetRef else rawDatasetRef
 
   @transient lazy val deleteFilter = dsSettings.filodbConfig
-    .as[Seq[Map[String, String]]]("cardbuster.delete-pk-filters").map(_.mapValues(_.r).toSeq)
+    .as[Seq[Map[String, String]]]("cardbuster.delete-pk-filters").map(_.mapValues(_.r.pattern).toSeq)
 
   @transient lazy val startTimeGTE = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dsSettings.filodbConfig
     .as[String]("cardbuster.delete-startTimeGTE"))).toEpochMilli
@@ -53,45 +50,55 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
   @transient lazy val endTimeLTE = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dsSettings.filodbConfig
     .as[String]("cardbuster.delete-endTimeLTE"))).toEpochMilli
 
-  def bustIndexRecords(shard: Int): Unit = {
+  def bustIndexRecords(shard: Int, split: (String, String)): Unit = {
+    val numPartKeysDeleted = Kamon.counter("num-partkeys-deleted").withTag("dataset", dataset.toString)
+        .withTag("shard", shard)
+    val numPartKeysCouldNotDelete = Kamon.counter("num-partkeys-could-not-delete").withTag("dataset", dataset.toString)
+      .withTag("shard", shard)
     require(deleteFilter.nonEmpty, "cardbuster.delete-pk-filters should be non-empty")
-    BusterContext.log.info(s"Busting cardinality in shard=$shard with " +
+    BusterContext.log.info(s"Starting to bust cardinality in shard=$shard with " +
       s"filter=$deleteFilter " +
       s"inDownsampleTables=$inDownsampleTables " +
       s"startTimeGTE=$startTimeGTE " +
       s"startTimeLTE=$startTimeLTE " +
       s"endTimeGTE=$endTimeGTE " +
-      s"endTimeLTE=$endTimeLTE "
+      s"endTimeLTE=$endTimeLTE " +
+      s"split=$split"
     )
-    val toDelete = colStore.scanPartKeys(dataset, shard)
-      .filter { pkr =>
-        val timeOk = pkr.startTime >= startTimeGTE &&
-                     pkr.startTime <= startTimeLTE &&
-                     pkr.endTime >= endTimeGTE &&
-                     pkr.endTime <= endTimeLTE
+    val candidateKeys = colStore.scanPartKeysByStartEndTimeRangeNoAsync(dataset, shard,
+      split, startTimeGTE, startTimeLTE,
+      endTimeGTE, endTimeLTE)
 
-        if (timeOk) {
-          val pk = pkr.partKey
-          val rawSchemaId = RecordSchema.schemaID(pk, UnsafeUtils.arayOffset)
-          val schema = schemas(rawSchemaId)
-          val pkPairs = schema.partKeySchema.toStringPairs(pk, UnsafeUtils.arayOffset)
-          val willDelete = deleteFilter.exists(filter => filter.forall { case (filterKey, filterValRegex) =>
-            pkPairs.exists { case (pkKey, pkVal) =>
-              pkKey == filterKey && filterValRegex.findAllMatchIn(pkVal).nonEmpty
-            }
-          })
-          if (willDelete) {
-            BusterContext.log.debug(s"Deleting part key $pkPairs with startTime=${pkr.startTime} and " +
-              s"endTime=${pkr.endTime} from shard=$shard")
-            numPartKeysDeleting.increment()
+    var numDeleted = 0
+    var numCouldNotDelete = 0
+    candidateKeys.filter { pk =>
+      val rawSchemaId = RecordSchema.schemaID(pk, UnsafeUtils.arayOffset)
+      val schema = schemas(rawSchemaId)
+      val pkPairs = schema.partKeySchema.toStringPairs(pk, UnsafeUtils.arayOffset)
+      val willDelete = deleteFilter.exists { filter => // at least one filter should match
+        filter.forall { case (filterKey, filterValRegex) => // should match all tags in this filter
+          pkPairs.exists { case (pkKey, pkVal) =>
+            pkKey == filterKey && filterValRegex.matcher(pkVal).matches
           }
-          willDelete
-        } else {
-          false
         }
-      }.map(_.partKey)
-    val fut = colStore.deletePartKeys(dataset, shard, toDelete)
-    val numKeysDeleted = Await.result(fut, dsSettings.cassWriteTimeout)
-    BusterContext.log.info(s"Deleted keys from shard shard=$shard numKeysDeleted=$numKeysDeleted")
+      }
+      if (willDelete) {
+        BusterContext.log.debug(s"Deleting part key $pkPairs from shard=$shard")
+      }
+      willDelete
+    }.foreach { pk =>
+      try {
+        colStore.deletePartKeyNoAsync(dataset, shard, pk)
+        numPartKeysDeleted.increment()
+        numDeleted += 1
+      } catch { case e: Exception =>
+        BusterContext.log.error(s"Could not delete a part key: ${e.getMessage}")
+        numPartKeysCouldNotDelete.increment()
+        numCouldNotDelete += 1
+      }
+      Unit
+    }
+    BusterContext.log.info(s"Finished deleting keys from shard shard=$shard " +
+      s"numDeleted=$numDeleted numCouldNotDelete=$numCouldNotDelete")
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We are running async Cassandra calls in spark jobs causing indeterministic wait times

**New behavior :**

Change cass calls to synchronous calls along with more parallelism at spark level.
