### PR TITLE
misc(core): add drop marker whenever NaN is encountered during ingestion

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -371,6 +371,7 @@ object CliMain extends FilodbClusterNode {
     val str = vecReader.debugString(memReader, 0)
     println(s"Dropped: ${PrimitiveVectorReader.dropped(memReader, 0)}")
     println(s"VectorType: ${vecReader.getClass.getSimpleName}")
+    println(s"NumRows: ${vecReader.length(memReader, 0)}")
     println(str)
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -137,7 +137,7 @@ trait DoubleVectorDataReader extends CounterVectorReader {
   def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
     val it = iterate(acc, vector)
     val size = length(acc, vector)
-    (0 to size).map(_ => it.next).mkString(sep)
+    (0 until size).map(_ => it.next).mkString(sep)
   }
 
   /**
@@ -443,7 +443,7 @@ class DoubleCounterAppender(addr: BinaryRegion.NativePointer, maxBytes: Int, dis
 extends DoubleAppendingVector(addr, maxBytes, dispose) {
   private var last = Double.MinValue
   override final def addData(data: Double): AddResponse = {
-    if (!data.isNaN && data < last)
+    if (data.isNaN || data < last)
       PrimitiveVectorReader.markDrop(MemoryAccessor.nativePtrAccessor, addr)
     if (!data.isNaN)
       last = data

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -520,7 +520,7 @@ class RowHistogramReader(val acc: MemoryReader, histVect: Ptr.U8) extends Histog
   def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = System.lineSeparator): String = {
     val it = iterate(acc, vector)
     val size = length(acc, vector)
-    (0 to size).map(_ => it.asHistIt).mkString(sep)
+    (0 until size).map(_ => it.asHistIt.mkString(sep)).mkString(sep)
   }
 
   def length(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr): Int = length

--- a/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/IntBinaryVector.scala
@@ -283,7 +283,7 @@ trait IntVectorDataReader extends VectorDataReader {
   def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
     val it = iterate(acc, vector)
     val size = length(acc, vector)
-    (0 to size).map(_ => it.next).mkString(sep)
+    (0 until size).map(_ => it.next).mkString(sep)
   }
 
   /**

--- a/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/LongBinaryVector.scala
@@ -129,7 +129,7 @@ trait LongVectorDataReader extends VectorDataReader {
   def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = ","): String = {
     val it = iterate(acc, vector)
     val size = length(acc, vector)
-    (0 to size).map(_ => it.next).mkString(sep)
+    (0 until size).map(_ => it.next).mkString(sep)
   }
 
   /**

--- a/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/UTF8Vector.scala
@@ -119,7 +119,7 @@ trait UTF8VectorDataReader extends VectorDataReader {
   def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = "\n"): String = {
     val it = iterate(acc, vector)
     val size = length(acc, vector)
-    (0 to size).map(_ => it.next).mkString(sep)
+    (0 until size).map(_ => it.next).mkString(sep)
   }
 
   /**

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1,20 +1,6 @@
 package filodb.downsampler
 
-import java.io.File
-import java.time.Instant
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import com.typesafe.config.{ConfigException, ConfigFactory}
-import kamon.Kamon
-import monix.execution.Scheduler
-import monix.reactive.Observable
-import org.apache.spark.{SparkConf, SparkException}
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-
 import filodb.cardbuster.CardinalityBuster
 import filodb.core.GlobalScheduler._
 import filodb.core.MachineMetricsData
@@ -30,11 +16,23 @@ import filodb.downsampler.chunk.{BatchDownsampler, Downsampler, DownsamplerSetti
 import filodb.downsampler.index.{DSIndexJobSettings, IndexJobDriver}
 import filodb.memory.format.{PrimitiveVectorReader, UnsafeUtils}
 import filodb.memory.format.ZeroCopyUTF8String._
-import filodb.memory.format.vectors.{CustomBuckets, LongHistogram}
+import filodb.memory.format.vectors.{CustomBuckets, DoubleVector, LongHistogram}
 import filodb.query.QueryResult
 import filodb.query.exec.{InProcessPlanDispatcher, InternalRangeFunction, MultiSchemaPartitionsExec, PeriodicSamplesMapper}
+import kamon.Kamon
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import org.apache.spark.{SparkConf, SparkException}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import java.io.File
+import java.time.Instant
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 /**
   * Spec tests downsampling round trip.
@@ -52,6 +50,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   val batchDownsampler = new BatchDownsampler(settings)
 
   val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8, "_ns_".utf8 -> "my_ns".utf8)
+  val seriesTagsNaN = Map("_ws_".utf8 -> "my_ws".utf8, "_ns_".utf8 -> "my_ns".utf8, "nan_support".utf8 -> "yes".utf8)
   val bulkSeriesTags = Map("_ws_".utf8 -> "bulk_ws".utf8, "_ns_".utf8 -> "bulk_ns".utf8)
 
   val rawColStore = batchDownsampler.rawCassandraColStore
@@ -76,7 +75,9 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   var counterPartKeyBytes: Array[Byte] = _
 
   val histName = "my_histogram"
+  val histNameNaN = "my_histogram_NaN"
   var histPartKeyBytes: Array[Byte] = _
+  var histNaNPartKeyBytes: Array[Byte] = _
 
   val gaugeLowFreqName = "my_gauge_low_freq"
   var gaugeLowFreqPartKeyBytes: Array[Byte] = _
@@ -84,7 +85,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   val lastSampleTime = 74373042000L
   val pkUpdateHour = hour(lastSampleTime)
 
-  val metricNames = Seq(gaugeName, gaugeLowFreqName, counterName, histName, untypedName)
+  val metricNames = Seq(gaugeName, gaugeLowFreqName, counterName, histName, histNameNaN, untypedName)
 
   def hour(millis: Long = System.currentTimeMillis()): Long = millis / 1000 / 60 / 60
 
@@ -323,6 +324,57 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
+  it ("should write prom histogram data with NaNs to cassandra") {
+
+    val rawDataset = Dataset("prometheus", Schemas.promHistogram)
+
+    val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
+    val partKey = partBuilder.partKeyFromObjects(Schemas.promHistogram, histNameNaN, seriesTagsNaN)
+
+    val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey,
+      0, offheapMem.bufferPools(Schemas.promHistogram.schemaHash), batchDownsampler.shardStats,
+      offheapMem.nativeMemoryManager, 1)
+
+    histNaNPartKeyBytes = part.partKeyBytes
+
+    val bucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
+    val rawSamples = Stream( // time, sum, count, hist, name, tags
+      Seq(74372801000L, 0d, 1d, LongHistogram(bucketScheme, Array(0L, 0, 1)), histNameNaN, seriesTagsNaN),
+      Seq(74372801500L, 2d, 3d, LongHistogram(bucketScheme, Array(0L, 2, 3)), histNameNaN, seriesTagsNaN),
+      Seq(74372802000L, 5d, 6d, LongHistogram(bucketScheme, Array(2L, 5, 6)), histNameNaN, seriesTagsNaN),
+      Seq(74372802500L, Double.NaN, Double.NaN, LongHistogram(bucketScheme, Array(0L, 0, 0)), histNameNaN, seriesTagsNaN),
+
+      Seq(74372861000L, 9d, 9d, LongHistogram(bucketScheme, Array(2L, 5, 9)), histNameNaN, seriesTagsNaN),
+      Seq(74372861500L, 10d, 10d, LongHistogram(bucketScheme, Array(2L, 5, 10)), histNameNaN, seriesTagsNaN),
+      Seq(74372862000L, Double.NaN, Double.NaN, LongHistogram(bucketScheme, Array(0L, 0, 0)), histNameNaN, seriesTagsNaN),
+      Seq(74372862500L, 11d, 14d, LongHistogram(bucketScheme, Array(2L, 8, 14)), histNameNaN, seriesTagsNaN),
+
+      Seq(74372921000L, 2d, 2d, LongHistogram(bucketScheme, Array(0L, 0, 2)), histNameNaN, seriesTagsNaN),
+      Seq(74372921500L, 7d, 9d, LongHistogram(bucketScheme, Array(1L, 7, 9)), histNameNaN, seriesTagsNaN),
+      Seq(74372922000L, Double.NaN, Double.NaN, LongHistogram(bucketScheme, Array(0L, 0, 0)), histNameNaN, seriesTagsNaN),
+      Seq(74372922500L, 4d, 1d, LongHistogram(bucketScheme, Array(0L, 1, 1)), histNameNaN, seriesTagsNaN),
+
+      Seq(74372981000L, 17d, 21d, LongHistogram(bucketScheme, Array(2L, 16, 21)), histNameNaN, seriesTagsNaN),
+      Seq(74372981500L, 1d, 1d, LongHistogram(bucketScheme, Array(0L, 1, 1)), histNameNaN, seriesTagsNaN),
+      Seq(74372982000L, 15d, 15d, LongHistogram(bucketScheme, Array(0L, 15, 15)), histNameNaN, seriesTagsNaN),
+
+      Seq(74373041000L, 18d, 19d, LongHistogram(bucketScheme, Array(1L, 16, 19)), histNameNaN, seriesTagsNaN),
+      Seq(74373042000L, 20d, 25d, LongHistogram(bucketScheme, Array(4L, 20, 25)), histNameNaN, seriesTagsNaN)
+    )
+
+    MachineMetricsData.records(rawDataset, rawSamples).records.foreach { case (base, offset) =>
+      val rr = new BinaryRecordRowReader(Schemas.promHistogram.ingestionSchema, base, offset)
+      part.ingest( lastSampleTime, rr, offheapMem.blockMemFactory, createChunkAtFlushBoundary = false,
+        flushIntervalMillis = Option.empty, acceptDuplicateSamples = false)
+    }
+    part.switchBuffers(offheapMem.blockMemFactory, true)
+    val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
+
+    rawColStore.write(rawDataset.ref, Observable.fromIterator(chunks)).futureValue
+    val pk = PartKeyRecord(histNaNPartKeyBytes, 74372801000L, 74373042000L, Some(199))
+    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+  }
+
   val numShards = dsIndexJobSettings.numShards
   val bulkPkUpdateHours = {
     val start = pkUpdateHour / 6 * 6 // 6 is number of hours per downsample chunk
@@ -381,7 +433,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val metrics = Set((counterName, Schemas.promCounter.name),
       (gaugeName, Schemas.dsGauge.name),
       (gaugeLowFreqName, Schemas.dsGauge.name),
-      (histName, Schemas.promHistogram.name))
+      (histName, Schemas.promHistogram.name),
+      (histNameNaN, Schemas.promHistogram.name))
     val partKeys = downsampleColStore.scanPartKeys(batchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")), 0)
     val tsSchemaMetric = Await.result(partKeys.map(pkMetricSchemaReader).toListL.runAsync, 1 minutes)
     tsSchemaMetric.filter(k => metricNames.contains(k._1)).toSet shouldEqual metrics
@@ -557,6 +610,62 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     )
   }
 
+  it("should read and verify prom histogram data with NaNs in cassandra using " +
+    "PagedReadablePartition for 1-min downsampled data") {
+
+    val downsampledPartData1 = downsampleColStore.readRawPartitions(
+      batchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
+      0,
+      SinglePartitionScan(histNaNPartKeyBytes))
+      .toListL.runAsync.futureValue.head
+
+    val downsampledPart1 = new PagedReadablePartition(Schemas.promHistogram.downsample.get, 0, 0,
+      downsampledPartData1, Some(5.minutes.toMillis))
+
+    downsampledPart1.partKeyBytes shouldEqual histNaNPartKeyBytes
+
+    val ctrChunkInfo = downsampledPart1.infos(AllChunkScan).nextInfoReader
+    val acc = ctrChunkInfo.vectorAccessor(2)
+    val add = ctrChunkInfo.vectorAddress(2)
+    DoubleVector(acc, add).dropPositions(acc, add).toList shouldEqual Seq(2, 4, 6, 8, 11)
+    PrimitiveVectorReader.dropped(acc, add) shouldEqual true
+
+    val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3),
+      Kamon.counter("dummy").withoutTags())
+
+    val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
+    val downsampledData1 = rv1.rows.map { r =>
+      val h = r.getHistogram(3)
+      h.numBuckets shouldEqual 3
+      (0 until h.numBuckets).map(i => h.bucketTop(i)) shouldEqual bucketScheme
+      (r.getLong(0), r.getDouble(1), r.getDouble(2), (0 until h.numBuckets).map(i => h.bucketValue(i)))
+    }.toList
+
+    val expected = Seq(
+      (74372801000L, 0d, 1d, Vector(0d, 0d, 1d)),
+      (74372802000L, 5d, 6d, Vector(2d, 5d, 6d)),
+      (74372802500L, Double.NaN, Double.NaN, Vector(0.0, 0.0, 0.0)), // drop(2)
+
+      (74372861500L, 10.0, 10.0, Vector(2.0, 5.0, 10.0)),
+      (74372862000L, Double.NaN, Double.NaN, Vector(0.0, 0.0, 0.0)), // drop(4)
+      (74372862500L, 11.0, 14.0, Vector(2.0, 8.0, 14.0)),
+
+      (74372921000L, 2d, 2d, Vector(0d, 0d, 2d)), // drop (6)
+      (74372921500L, 7.0, 9.0, Vector(1.0, 7.0, 9.0)),
+      (74372922000L, Double.NaN, Double.NaN, Vector(0.0, 0.0, 0.0)), // drop (8)
+      (74372922500L, 4.0, 1.0, Vector(0.0, 1.0, 1.0)),
+
+      (74372981000L, 17d, 21d, Vector(2d, 16d, 21d)),
+      (74372981500L, 1d, 1d, Vector(0d, 1d, 1d)), // drop (11)
+      (74372982000L, 15d, 15d, Vector(0d, 15d, 15d)),
+
+      (74373042000L, 20d, 25d, Vector(4d, 20d, 25d))
+    )
+    // time, sum, count, histogram
+    downsampledData1.filter(_._2.isNaN).map(_._1) shouldEqual expected.filter(_._2.isNaN).map(_._1) // timestamp of NaN records should match
+    downsampledData1.filter(!_._2.isNaN) shouldEqual expected.filter(!_._2.isNaN) // Non NaN records should match
+  }
+
   it("should read and verify gauge data in cassandra using PagedReadablePartition for 5-min downsampled data") {
     val dsGaugePartKeyBytes = RecordBuilder.buildDownsamplePartKey(gaugePartKeyBytes, batchDownsampler.schemas).get
     val downsampledPartData2 = downsampleColStore.readRawPartitions(
@@ -639,7 +748,10 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampledPart1.partKeyBytes shouldEqual histPartKeyBytes
 
     val ctrChunkInfo = downsampledPart1.infos(AllChunkScan).nextInfoReader
-    PrimitiveVectorReader.dropped(ctrChunkInfo.vectorAccessor(2), ctrChunkInfo.vectorAddress(2)) shouldEqual true
+    val acc = ctrChunkInfo.vectorAccessor(2)
+    val add = ctrChunkInfo.vectorAddress(2)
+    DoubleVector(acc, add).dropPositions(acc, add).toList shouldEqual Seq(2, 4)
+    PrimitiveVectorReader.dropped(acc, add) shouldEqual true
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3),
       Kamon.counter("dummy").withoutTags())
@@ -656,12 +768,64 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampledData1 shouldEqual Seq(
       (74372801000L, 0d, 1d, Seq(0d, 0d, 1d)),
       (74372862000L, 11d, 14d, Seq(2d, 8d, 14d)),
-      (74372921000L, 2d, 2d, Seq(0d, 0d, 2d)),
+      (74372921000L, 2d, 2d, Seq(0d, 0d, 2d)), // drop (2)
       (74372981000L, 17d, 21d, Seq(2d, 16d, 21d)),
-      (74372981500L, 1d, 1d, Seq(0d, 1d, 1d)),
+      (74372981500L, 1d, 1d, Seq(0d, 1d, 1d)), // drop (4)
       (74372982000L, 15.0d, 15.0d, Seq(0.0, 15.0, 15.0)),
       (74373042000L, 20.0d, 25.0d, Seq(4.0, 20.0, 25.0))
     )
+  }
+
+  it("should read and verify prom histogram data with NaN in cassandra using " +
+    "PagedReadablePartition for 5-min downsampled data") {
+
+    val downsampledPartData1 = downsampleColStore.readRawPartitions(
+      batchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
+      0,
+      SinglePartitionScan(histNaNPartKeyBytes))
+      .toListL.runAsync.futureValue.head
+
+    val downsampledPart1 = new PagedReadablePartition(Schemas.promHistogram.downsample.get, 0, 0,
+      downsampledPartData1, Some(5.minutes.toMillis))
+
+    downsampledPart1.partKeyBytes shouldEqual histNaNPartKeyBytes
+
+    val ctrChunkInfo = downsampledPart1.infos(AllChunkScan).nextInfoReader
+    PrimitiveVectorReader.dropped(ctrChunkInfo.vectorAccessor(2), ctrChunkInfo.vectorAddress(2)) shouldEqual true
+
+    val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3),
+      Kamon.counter("dummy").withoutTags())
+
+    val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
+    val downsampledData1 = rv1.rows.map { r =>
+      val h = r.getHistogram(3)
+      h.numBuckets shouldEqual 3
+      (0 until h.numBuckets).map(i => h.bucketTop(i)) shouldEqual bucketScheme
+      (r.getLong(0), r.getDouble(1), r.getDouble(2), (0 until h.numBuckets).map(i => h.bucketValue(i)))
+    }.toList
+
+    val expected = Seq(
+      (74372801000L, 0d, 1d, Vector(0d, 0d, 1d)),
+      (74372802000L, 5.0, 6.0, Vector(2.0, 5.0, 6.0)),
+      (74372802500L, Double.NaN, Double.NaN, Vector(0.0, 0.0, 0.0)),
+
+      (74372861500L, 10.0, 10.0, Vector(2.0, 5.0, 10.0)),
+      (74372862000L, Double.NaN, Double.NaN, Vector(0.0, 0.0, 0.0)),
+      (74372862500L, 11d, 14d, Vector(2d, 8d, 14d)),
+
+      (74372921000L, 2d, 2d, Vector(0d, 0d, 2d)),
+      (74372921500L, 7.0, 9.0, Vector(1.0, 7.0, 9.0)),
+      (74372922000L, Double.NaN, Double.NaN, Vector(0.0, 0.0, 0.0)),
+
+      (74372981000L, 17d, 21d, Vector(2d, 16d, 21d)),
+      (74372981500L, 1d, 1d, Vector(0d, 1d, 1d)),
+      (74372982000L, 15.0d, 15.0d, Vector(0.0, 15.0, 15.0)),
+
+      (74373042000L, 20.0d, 25.0d, Vector(4.0, 20.0, 25.0))
+    )
+    // time, sum, count, histogram
+    downsampledData1.filter(_._2.isNaN).map(_._1) shouldEqual expected.filter(_._2.isNaN).map(_._1) // timestamp of NaN records should match
+    downsampledData1.filter(!_._2.isNaN) shouldEqual expected.filter(!_._2.isNaN) // Non NaN records should match
   }
 
   it("should bring up DownsampledTimeSeriesShard and be able to read data using SelectRawPartitionsExec") {
@@ -675,9 +839,11 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
 
     val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
+    val colFiltersNaN = seriesTagsNaN.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
 
-    Seq(gaugeName, gaugeLowFreqName, counterName, histName).foreach { metricName =>
-      val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(metricName))
+    Seq(gaugeName, gaugeLowFreqName, counterName, histNameNaN, histName).foreach { metricName =>
+      val colFltrs = if (metricName == histNameNaN) colFiltersNaN else colFilters
+      val queryFilters = colFltrs :+ ColumnFilter("_metric_", Equals(metricName))
       val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams = PlannerParams(sampleLimit = 1000)),
         InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan)
 
@@ -824,7 +990,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     }.toSet
 
     // downsample set should not have a few bulk metrics
-    readKeys.size shouldEqual 9904
+    readKeys.size shouldEqual 9905
 
     val readKeys2 = (0 until 4).flatMap { shard =>
       val partKeys = rawColStore.scanPartKeys(batchDownsampler.rawDatasetRef, shard)
@@ -832,7 +998,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     }.toSet
 
     // raw set should remain same since inDownsampleTables=true in
-    readKeys2.size shouldEqual 10006
+    readKeys2.size shouldEqual 10007
   }
 
   it ("should be able to bust cardinality in both raw and downsample tables with spark job") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

- Current Behavior: Whenever `NaN` is encountered, counter drop is not marked. But counter drop is marked when the subsequent value is lower than the previous non NaN value. But this breaks if NaN occurs at the chunk boundary.

- Changes: As NaN represents end of time-series, A counter drop is marked Whenever an NaN is ingested. For value comparison purposes NaN is considered as `0`. This fixes chunk boundary case as well.

thanks @vishramachandran for contributing to the PR