### PR TITLE
bug(core): Reduce possibility of double purge

### DIFF
--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -90,7 +90,8 @@ object StoreConfig {
                                            |num-block-pages = 100
                                            |failure-retries = 3
                                            |retry-delay = 15 seconds
-                                           |part-index-flush-max-delay = 60 seconds
+                                           |// less than 1 min to reduce possibility of double purge of time series
+                                           |part-index-flush-max-delay = 55 seconds
                                            |part-index-flush-min-delay = 30 seconds
                                            |multi-partition-odp = false
                                            |demand-paging-parallelism = 10

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -85,7 +85,7 @@ object PrometheusModel {
                   else
                     qr.result.map(toPromResult(_, verbose, qr.resultType))
     SuccessResponse(Data(toPromResultType(qr.resultType), results.filter(r => r.values.nonEmpty || r.value.isDefined)),
-                    if (qr.mayBePartial) "partial" else "success")
+                    "success", Some(qr.mayBePartial), qr.partialResultReason)
   }
 
   def toPromExplainPlanResponse(ex: ExecPlan): ExplainPlanResponse = {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Maximum time to consistency is 1m for lucene changes. So two `purgePartitions` calls from flush pipeline that are spaced 1m or less can cause double delete of partitions, and double decrement of time series count.

1. Reducing lucene consistency to 55 seconds.
2. Catching exceptions in Card Tracker.

