### PR TITLE
bug(core): Free partition count was wrong during eviction

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -414,12 +414,18 @@ filodb {
     # eviction will not happen during queries.
     ensure-block-memory-headroom-percent = 5
 
-    # Minimum amount of memory as percentage of capacity to maintain in the native memory manager.
-    # This is also memory for write-buffers, off-heap partKey and chunkMap. Falling below this
-    # number means data will be evicted from memory and possibly lost new data if not enough eviction happens.
+    # Headroom to maintain on the count of TSPs on the heap as a percent of
+    # value in max-partitions-on-heap-per-shard config.
     # Increase if very high cardinality ODP queries are expected within headroom task interval since
     # eviction will not happen during queries.
-    ensure-tsp-headroom-percent = 5
+    ensure-tsp-count-headroom-percent = 5
+
+    # Minimum amount of memory as percentage of capacity to maintain in the native memory manager.
+    # This is memory used for write-buffers, off-heap partKey and chunkMap. Falling below the headroom
+    # threshold means data will be force-evicted from memory and new data is dropped if not enough eviction can happen.
+    # Increase if very high cardinality ODP queries are expected within headroom task interval since
+    # eviction will not happen during queries.
+    ensure-native-memory-headroom-percent = 5
 
     # Maximum number of partitions to target on heap per shard. If numPartitions exceed this value
     # eviction will trigger on the shard. Set this by considering java heap setting, and total size

--- a/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartitionEvictionPolicy.scala
@@ -49,9 +49,10 @@ class FixedMaxPartitionsEvictionPolicy(headroomPercent: Double) extends Partitio
   }
 }
 
-class CompositeEvictionPolicy(headroomPercent: Double) extends PartitionEvictionPolicy {
-  val maxPartPolicy = new FixedMaxPartitionsEvictionPolicy(headroomPercent)
-  val freeBufferPolicy = new WriteBufferFreeEvictionPolicy(headroomPercent)
+class CompositeEvictionPolicy(tspCountHeadroomPercent: Double,
+                              nativeMemHeadroomPercent: Double) extends PartitionEvictionPolicy {
+  val maxPartPolicy = new FixedMaxPartitionsEvictionPolicy(tspCountHeadroomPercent)
+  val freeBufferPolicy = new WriteBufferFreeEvictionPolicy(nativeMemHeadroomPercent)
   def numPartitionsToEvictForHeadroom(numPartitions: Int, maxPartitions: Int, memManager: NativeMemoryManager): Int = {
     Math.max(maxPartPolicy.numPartitionsToEvictForHeadroom(numPartitions, maxPartitions, memManager),
              freeBufferPolicy.numPartitionsToEvictForHeadroom(numPartitions, maxPartitions, memManager))

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -36,9 +36,11 @@ extends MemStore with StrictLogging {
   val stats = new ChunkSourceStats
 
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
-  private val ensureTspHeadroomPercent = filodbConfig.getDouble("memstore.ensure-tsp-headroom-percent")
+  private val ensureTspHeadroomPercent = filodbConfig.getDouble("memstore.ensure-tsp-count-headroom-percent")
+  private val ensureNmmHeadroomPercent = filodbConfig.getDouble("memstore.ensure-native-memory-headroom-percent")
 
-  private val partEvictionPolicy = evictionPolicy.getOrElse(new CompositeEvictionPolicy(ensureTspHeadroomPercent))
+  private val partEvictionPolicy = evictionPolicy.getOrElse(
+    new CompositeEvictionPolicy(ensureTspHeadroomPercent, ensureNmmHeadroomPercent))
 
   def isDownsampleStore: Boolean = false
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -307,7 +307,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   private val targetMaxPartitions = filodbConfig.getInt("memstore.max-partitions-on-heap-per-shard")
   private val ensureTspHeadroomPercent = filodbConfig.getDouble("memstore.ensure-tsp-count-headroom-percent")
   private val ensureBlockHeadroomPercent = filodbConfig.getDouble("memstore.ensure-block-memory-headroom-percent")
-  private val ensureNativeMemHeadroomPercent = filodbConfig.getDouble("ensure-native-memory-headroom-percent")
+  private val ensureNativeMemHeadroomPercent = filodbConfig.getDouble("memstore.ensure-native-memory-headroom-percent")
 
   /**
    * Queue of partIds that are eligible for eviction since they have stopped ingesting.

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -51,7 +51,8 @@ filodb {
   memstore {
     flush-task-parallelism = 1
     ensure-block-memory-headroom-percent = 5
-    ensure-tsp-headroom-percent = 5
+    ensure-tsp-count-headroom-percent = 5
+    ensure-native-memory-headroom-percent = 5
     max-partitions-on-heap-per-shard = 10000
   }
 

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -30,7 +30,8 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   val config = ConfigFactory.parseString("""
                                             |filodb.memstore.max-partitions-on-heap-per-shard = 1100
                                             |filodb.memstore.ensure-block-memory-headroom-percent = 10
-                                            |filodb.memstore.ensure-tsp-headroom-percent = 10
+                                            |filodb.memstore.ensure-tsp-count-headroom-percent = 10
+                                            |filodb.memstore.ensure-native-memory-headroom-percent = 10
                                             |  """.stripMargin)
                             .withFallback(ConfigFactory.load("application_test.conf"))
                             .getConfig("filodb")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

While deciding if eviction is needed, currentPartitionCount was used instead of availableRoom. Fixed that.
Also using freeNativeMemory to decide lock timeout. 