### PR TITLE
bug(query): add escape characters in column filters when converting logical plan to query

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -1,5 +1,7 @@
 package filodb.coordinator.queryplanner
 
+import org.apache.commons.text.StringEscapeUtils
+
 import filodb.prometheus.ast.Vectors.PromMetricLabel
 import filodb.query._
 import filodb.query.AggregationOperator.CountValues
@@ -23,7 +25,7 @@ object LogicalPlanParser {
   import QueryConstants._
 
   private def getFiltersFromRawSeries(lp: RawSeries)= lp.filters.map(f => (f.column, f.filter.operatorString,
-    Quotes + f.filter.valuesStrings.head.toString + Quotes))
+    Quotes + StringEscapeUtils.escapeJava(f.filter.valuesStrings.head.toString) + Quotes))
 
   private def filtersToQuery(filters: Seq[(String, String, String)], columns: Seq[String]): String = {
     val columnString = if (columns.isEmpty) "" else s"::${columns.head}"

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -69,4 +69,11 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     // Converted query has time in seconds
     res shouldEqual("http_requests_total{job=\"app\"} offset 300s")
   }
+
+  it("should generate query from LogicalPlan having escape characters") {
+    val query = """sum(rate(my_counter{_ws_="demo",_ns_=~".+",app_identity=~".+\\.test\\.identity",status=~"5.."}[60s]))"""
+    val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
+    val res = LogicalPlanParser.convertToQuery(lp)
+    res shouldEqual query
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -111,7 +111,8 @@ object Dependencies {
     "com.opencsv"            % "opencsv"                      % "3.3",
     "org.sisioh"             %% "akka-cluster-custom-downing" % "0.0.21",
     "com.typesafe.akka"      %% "akka-testkit"                % akkaVersion % Test,
-    "com.typesafe.akka"      %% "akka-multi-node-testkit"     % akkaVersion % Test
+    "com.typesafe.akka"      %% "akka-multi-node-testkit"     % akkaVersion % Test,
+    "org.apache.commons" % "commons-text" % "1.9"
   )
 
   lazy val cliDeps = Seq(


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Logical plan column filters do not have escape characters. While converting to query column filter value is used directly

**New behavior :**
Add escape character to column filter value
