### PR TITLE
feat(query): don't error histogram aggregation with heterogenous bucket scheme

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -216,8 +216,10 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
 
   /**
    * Adds the values from another Histogram.
-   * If the other histogram has the same bucket scheme, then the values are just added per bucket and true is returned.
-   * If the scheme is different, it assigns NaN to values and false is returned.
+   * If the other histogram has the same bucket scheme, then the values are just added per bucket.
+   * If the scheme is different, it assigns NaN to values.
+   * @param other Histogram to be added
+   * @return true when input histogram has same schema and false when schema is different
    */
   final def addNoCorrection(other: HistogramWithBuckets): Boolean = {
     // Allow addition when type of bucket is different
@@ -251,7 +253,8 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
    * Adds the values from another Histogram, making a monotonic correction to ensure correctness
    */
   final def add(other: HistogramWithBuckets): Unit = {
-    // Call makeMonotonic only when buckets have same schema
+    // Call makeMonotonic only when buckets have same schema as result is NaN otherwise and monotonic correction
+    // isn't needed
     if (addNoCorrection(other)) makeMonotonic()
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -229,6 +229,9 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
       }
       true
     } else {
+      cforRange { 0 until numBuckets } { b =>
+        values(b) = Double.NaN
+      }
       false
       // TODO: In the future, support adding buckets of different scheme.  Below is an example
       // NOTE: there are two issues here: below add picks the existing bucket scheme (not commutative)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Exception is thrown for the entire query when histogram schema is not same even for a single instant 

**New behavior :**
Return NaN for timestamps where schema does not match and return aggregation result for other timestamps
