### PR TITLE
feat(query): Throw error if lookback smaller than data resolution for  counters

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -291,8 +291,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
   private def chooseDownsampleResolution(chunkScanMethod: ChunkScanMethod): (Int, DatasetRef) = {
     chunkScanMethod match {
       case AllChunkScan =>
-        // since it is the highest resolution/ttl
-        downsampleTtls.last.toMillis.toInt -> downsampledDatasetRefs.last
+        // pick last since it is the highest resolution
+        downsampleConfig.resolutions.last.toMillis.toInt -> downsampledDatasetRefs.last
       case TimeRangeChunkScan(startTime, _) =>
         var ttlIndex = downsampleTtls.indexWhere(t => startTime > System.currentTimeMillis() - t.toMillis)
         // -1 return value means query startTime is before the earliest retention. Just pick the highest resolution

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -251,10 +251,10 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                      querySession: QuerySession): Observable[ReadablePartition] = {
 
     // Step 1: Choose the downsample level depending on the range requested
-    val (resolution, downsampledDataset) = chooseDownsampleResolution(lookup.chunkMethod)
+    val (resolutionMs, downsampledDataset) = chooseDownsampleResolution(lookup.chunkMethod)
     logger.debug(s"Chose resolution $downsampledDataset for chunk method ${lookup.chunkMethod}")
 
-    capDataScannedPerShardCheck(lookup, resolution)
+    capDataScannedPerShardCheck(lookup, resolutionMs)
 
     // Step 2: Query Cassandra table for that downsample level using downsampleColStore
     // Create a ReadablePartition objects that contain the time series data. This can be either a
@@ -269,13 +269,13 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                                 SinglePartitionScan(partRec.partKey, shardNum),
                                 lookup.chunkMethod)
           .map { pd =>
-            val part = makePagedPartition(pd, lookup.firstSchemaId.get, Some(resolution), colIds)
+            val part = makePagedPartition(pd, lookup.firstSchemaId.get, resolutionMs, colIds)
             stats.partitionsQueried.increment()
             stats.singlePartCassFetchLatency.record(Math.max(0, System.currentTimeMillis - startExecute))
             part
           }
           .defaultIfEmpty(makePagedPartition(RawPartData(partRec.partKey, Seq.empty),
-            lookup.firstSchemaId.get, Some(resolution), colIds))
+            lookup.firstSchemaId.get, resolutionMs, colIds))
           .headL
       }
   }
@@ -288,29 +288,29 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     }
   }
 
-  private def chooseDownsampleResolution(chunkScanMethod: ChunkScanMethod): (Long, DatasetRef) = {
+  private def chooseDownsampleResolution(chunkScanMethod: ChunkScanMethod): (Int, DatasetRef) = {
     chunkScanMethod match {
       case AllChunkScan =>
         // since it is the highest resolution/ttl
-        downsampleTtls.last.toMillis -> downsampledDatasetRefs.last
+        downsampleTtls.last.toMillis.toInt -> downsampledDatasetRefs.last
       case TimeRangeChunkScan(startTime, _) =>
         var ttlIndex = downsampleTtls.indexWhere(t => startTime > System.currentTimeMillis() - t.toMillis)
         // -1 return value means query startTime is before the earliest retention. Just pick the highest resolution
         if (ttlIndex == -1) ttlIndex = downsampleTtls.size - 1
-        downsampleConfig.resolutions(ttlIndex).toMillis -> downsampledDatasetRefs(ttlIndex)
+        downsampleConfig.resolutions(ttlIndex).toMillis.toInt -> downsampledDatasetRefs(ttlIndex)
       case _ => ???
     }
   }
 
   private def makePagedPartition(part: RawPartData, firstSchemaId: Int,
-                                 resolution: Option[Long],
+                                 minResolutionMs: Int,
                                  colIds: Seq[Types.ColumnId]): ReadablePartition = {
     val schemaId = RecordSchema.schemaID(part.partitionKey, UnsafeUtils.arayOffset)
     if (schemaId != firstSchemaId) {
       throw SchemaMismatch(schemas.schemaName(firstSchemaId), schemas.schemaName(schemaId))
     }
     // FIXME It'd be nice to pass in the correct partId here instead of -1
-    new PagedReadablePartition(schemas(schemaId), shardNum, -1, part, resolution, colIds)
+    new PagedReadablePartition(schemas(schemaId), shardNum, -1, part, minResolutionMs, colIds)
   }
 
   /**

--- a/core/src/main/scala/filodb.core/memstore/PagedReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/PagedReadablePartition.scala
@@ -31,7 +31,7 @@ class PagedReadablePartition(override val schema: Schema,
                              override val shard: Int,
                              override val partID: Int,
                              partData: RawPartData,
-                             resolution: Option[Long],
+                             override val minResolutionMs: Int,
                              colIds: Seq[Types.ColumnId] = Seq.empty) extends ReadablePartition {
 
   import PagedReadablePartition._
@@ -82,6 +82,6 @@ class PagedReadablePartition(override val schema: Schema,
     }
   }
 
-  def publishInterval: Option[Long] = resolution
+  def publishInterval: Option[Long] = Some(minResolutionMs)
 
 }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -282,6 +282,8 @@ final case class RawDataRangeVector(key: RangeVectorKey,
   def publishInterval: Option[Long] = partition.publishInterval
 
   override def outputRange: Option[RvRange] = None
+
+  def minResolutionMs: Int = partition.minResolutionMs
 }
 
 /**

--- a/core/src/main/scala/filodb.core/store/ReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/store/ReadablePartition.scala
@@ -57,6 +57,8 @@ trait ReadablePartition extends FiloPartition {
 
   def shard: Int
 
+  def minResolutionMs: Int = 1
+
   /**
    * Obtains the native offheap pointer for the chunk id for data column columnID
    */

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -204,7 +204,7 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
     if (rawPartSchema == Schemas.UnknownSchema) throw UnknownSchemaQueryErr(rawSchemaId)
     rawPartSchema.downsample match {
       case Some(downsampleSchema) =>
-        val rawReadablePart = new PagedReadablePartition(rawPartSchema, 0, 0, rawPart, None)
+        val rawReadablePart = new PagedReadablePartition(rawPartSchema, 0, 0, rawPart, 1)
         DownsamplerContext.dsLogger.debug(s"Downsampling partition ${rawReadablePart.stringPartition}")
         val bufferPool = offHeapMem.bufferPools(rawPartSchema.downsample.get.schemaHash)
         val downsamplers = chunkDownsamplersByRawSchemaId(rawSchemaId)

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -466,7 +466,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.gauge.downsample.get, 0, 0,
-      downsampledPartData1, Some(1.minute.toMillis))
+      downsampledPartData1, 1.minute.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual dsGaugePartKeyBytes
 
@@ -503,7 +503,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.gauge.downsample.get, 0, 0,
-      downsampledPartData1, Some(1.minute.toMillis))
+      downsampledPartData1, 1.minute.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual dsGaugeLowFreqPartKeyBytes
 
@@ -531,7 +531,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.promCounter.downsample.get, 0, 0,
-      downsampledPartData1, Some(1.minute.toMillis))
+      downsampledPartData1, 1.minute.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual counterPartKeyBytes
 
@@ -574,7 +574,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.promHistogram.downsample.get, 0, 0,
-      downsampledPartData1, Some(5.minutes.toMillis))
+      downsampledPartData1, 5.minutes.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual histPartKeyBytes
 
@@ -620,7 +620,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.promHistogram.downsample.get, 0, 0,
-      downsampledPartData1, Some(5.minutes.toMillis))
+      downsampledPartData1, 5.minutes.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual histNaNPartKeyBytes
 
@@ -676,7 +676,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart2 = new PagedReadablePartition(Schemas.gauge.downsample.get, 0, 0,
-      downsampledPartData2, Some(5.minutes.toMillis))
+      downsampledPartData2, 5.minutes.toMillis.toInt)
 
     downsampledPart2.partKeyBytes shouldEqual dsGaugePartKeyBytes
 
@@ -703,7 +703,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.promCounter.downsample.get, 0, 0,
-      downsampledPartData1, Some(5.minutes.toMillis))
+      downsampledPartData1, 5.minutes.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual counterPartKeyBytes
 
@@ -744,7 +744,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.promHistogram.downsample.get, 0, 0,
-      downsampledPartData1, Some(5.minutes.toMillis))
+      downsampledPartData1, 5.minutes.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual histPartKeyBytes
 
@@ -787,7 +787,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .toListL.runAsync.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.promHistogram.downsample.get, 0, 0,
-      downsampledPartData1, Some(5.minutes.toMillis))
+      downsampledPartData1, 5.minutes.toMillis.toInt)
 
     downsampledPart1.partKeyBytes shouldEqual histNaNPartKeyBytes
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

If user provides a query with lookback < dataResolution, we silently return NaN for rate/increase queries when the window for rate contains only one sample. This happens often with downsample dataset and this is misleading for users.

This PR helps throw an error back to the user indicating to them that the lookback is small for the query range.
