### PR TITLE
bug(query): empty outputrange in fastreduce

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -268,6 +268,7 @@ object RangeVectorAggregator extends StrictLogging {
       source.foldLeftF(accs) { case (_, rv) =>
         count += 1
         val rowIter = rv.rows
+        if (period.isEmpty) period = rv.outputRange
         try {
           cforRange { 0 until outputLen } { i =>
             val mapped = rowAgg.map(rv.key, rowIter.next, mapIntos(i))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Fast reduce is called with skipMapPhase as false in map-reduce phase. When skipMapPhase is false empty period gets assigned to outputrange in IteratorBackRangeVector which is input to the reduce phase. So final outputrange is empty

**New behavior :**
Assign outputrange from input range vector
