### PR TITLE
feat(repair): Use inline dataset config for repair jobs

### DIFF
--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -1,3 +1,5 @@
+dataset-prometheus = { include required("timeseries-dev-source.conf") }
+
 filodb {
   store-factory = "filodb.cassandra.CassandraTSStoreFactory"
 
@@ -8,9 +10,7 @@ filodb {
     create-tables-enabled = true
   }
 
-  dataset-configs = [
-    "conf/timeseries-dev-source.conf"
-  ]
+  inline-dataset-configs = [ ${dataset-prometheus} ]
 
   memstore {
     # Number of bytes of offheap mem to allocate to write buffers for all shards.  Ex. 1000MB, 1G, 2GB

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1,5 +1,6 @@
 filodb {
   # list of paths to dataset + ingestion config files
+  # deprecated in favor of inline-dataset-configs
   dataset-configs = [ ]
 
   # As an alternative to dataset-configs, one can inline list each dataset/stream ingestion config

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -43,7 +43,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
-  val conf = ConfigFactory.parseFile(new File("conf/timeseries-filodb-server.conf"))
+  val conf = ConfigFactory.parseFile(new File("conf/timeseries-filodb-server.conf")).resolve()
 
   val settings = new DownsamplerSettings(conf)
   val queryConfig = new QueryConfig(settings.filodbConfig.getConfig("query"))


### PR DESCRIPTION
**Current behavior :** Repair jobs rely on `dataset-config` which needs to be parsed separately.

**New behavior :** Repair jobs will rely on `inline-dataset-config` which is part of source config. No separate file need to be parsed.


**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
