### PR TITLE
bug(query): handle multiple rangevector transformers with absent function

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -130,16 +130,18 @@ trait ExecPlan extends QueryCommand {
         .record(Math.max(0, System.currentTimeMillis - startExecute))
       span.mark(s"execute-step2-start-${getClass.getSimpleName}")
       FiloSchedulers.assertThreadName(QuerySchedName)
+      val transformerEmptySchema = allTransformers.filter(_.canHandleEmptySchemas)
       val dontRunTransformers = if (allTransformers.isEmpty) true else !allTransformers.forall(_.canHandleEmptySchemas)
       // It is possible a null schema is returned (due to no time series). In that case just return empty results
-      val resultTask = if (resSchema == ResultSchema.empty && dontRunTransformers) {
+      val resultTask = if (resSchema == ResultSchema.empty && transformerEmptySchema.isEmpty) {
         qLogger.debug(s"queryId: ${queryContext.queryId} Empty plan $this, returning empty results")
         span.mark("empty-plan")
         span.mark(s"execute-step2-end-${getClass.getSimpleName}")
         Task.eval(QueryResult(queryContext.queryId, resSchema, Nil, querySession.resultCouldBePartial,
           querySession.partialResultsReason))
       } else {
-        val finalRes = allTransformers.foldLeft((res.rvs, resSchema)) { (acc, transf) =>
+        val transformersToRun = if (resSchema == ResultSchema.empty) transformerEmptySchema else allTransformers
+        val finalRes = transformersToRun.foldLeft((res.rvs, resSchema)) { (acc, transf) =>
           val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult(querySession))
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Absent function mapper is not executed when there are multiple rangeVectorTransformers on the same ExecPlan 

**New behavior :**
Run rangeVectorTransformers which can handle empty schema when schema is empty