### PR TITLE
misc(downsample): filter PartKeys with endDate older than ttl during bootstrap

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -115,7 +115,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
   private def hour(millis: Long = System.currentTimeMillis()) = millis / 1000 / 60 / 60
 
   def recoverIndex(): Future[Unit] = {
-    indexBootstrapper.bootstrapIndexDownsample(partKeyIndex, shardNum, indexDataset){ _ => createPartitionID() }
+    indexBootstrapper
+      .bootstrapIndexDownsample(partKeyIndex, shardNum, indexDataset, indexTtlMs){ _ => createPartitionID() }
       .map { count =>
         logger.info(s"Bootstrapped index for dataset=$indexDataset shard=$shardNum with $count records")
       }.map { _ =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

During bootstrap, all partkeys fetched from persistent store will be added to lucene index. After this fix, the entries which have endDate older than longest retention will be filtered, so that those partkeys are not indexed anymore.