### PR TITLE
misc(query): add trace-info to RemoteExec plans

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -44,7 +44,8 @@ object PlannerParams {
 final case class QueryContext(origQueryParams: TsdbQueryParams = UnavailablePromQlQueryParams,
                               queryId: String = UUID.randomUUID().toString,
                               submitTime: Long = System.currentTimeMillis(),
-                              plannerParams: PlannerParams = PlannerParams())
+                              plannerParams: PlannerParams = PlannerParams(),
+                              traceInfo: Map[String, Any] = Map.empty[String, Any])
 
 object QueryContext {
   def apply(constSpread: Option[SpreadProvider], sampleLimit: Int): QueryContext =

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -45,7 +45,7 @@ final case class QueryContext(origQueryParams: TsdbQueryParams = UnavailableProm
                               queryId: String = UUID.randomUUID().toString,
                               submitTime: Long = System.currentTimeMillis(),
                               plannerParams: PlannerParams = PlannerParams(),
-                              traceInfo: Map[String, Any] = Map.empty[String, Any])
+                              traceInfo: Map[String, String] = Map.empty[String, String])
 
 object QueryContext {
   def apply(constSpread: Option[SpreadProvider], sampleLimit: Int): QueryContext =

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -28,7 +28,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
                               (implicit sched: Scheduler): Future[QueryResponse] = {
     remoteExecHttpClient.httpMetadataGet(queryContext.plannerParams.applicationId, queryEndpoint,
-      httpTimeoutMs, queryContext.submitTime, getUrlParams())
+      httpTimeoutMs, queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
       .map { response =>
         response.unsafeBody match {
           case Left(error) => QueryError(queryContext.queryId, error.error)

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -49,7 +49,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
     import PromCirceSupport._
     import io.circe.parser
     remoteExecHttpClient.httpGet(queryContext.plannerParams.applicationId, queryEndpoint,
-      requestTimeoutMs, queryContext.submitTime, getUrlParams())
+      requestTimeoutMs, queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
       .map { response =>
         // Error response from remote partition is a nested json present in response.body
         // as response status code is not 2xx

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -134,7 +134,8 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
   }
 
   def httpMetadataGet(applicationId: String, httpEndpoint: String,
-                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any], traceInfo: Map[String, String])
+                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any],
+                      traceInfo: Map[String, String])
                      (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], MetadataSuccessResponse]]] = {
     val queryTimeElapsed = System.currentTimeMillis() - submitTime

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -91,13 +91,14 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
  */
 trait RemoteExecHttpClient extends StrictLogging {
 
+  val traceInfoHeader = "trace-info"
   def httpGet(applicationId: String, httpEndpoint: String,
-              httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+              httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any], traceInfo: Map[String, Any])
              (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], SuccessResponse]]]
 
   def httpMetadataGet(applicationId: String, httpEndpoint: String,
-                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any], traceInfo: Map[String, Any])
                      (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], MetadataSuccessResponse]]]
 
@@ -116,15 +117,17 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
   ShutdownHookThread(shutdown())
 
   def httpGet(applicationId: String, httpEndpoint: String,
-              httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+              httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any], traceInfo: Map[String, Any])
              (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], SuccessResponse]]] = {
     val queryTimeElapsed = System.currentTimeMillis() - submitTime
     val readTimeout = FiniteDuration(httpTimeoutMs - queryTimeElapsed, TimeUnit.MILLISECONDS)
     val url = uri"$httpEndpoint?$urlParams"
+    val traceInfoStr = traceInfo.map{case (k, v) => k + "=" + v}.mkString(",")
     logger.debug("promQlExec url={}", url)
     sttp
       .header(HeaderNames.UserAgent, applicationId)
+      .header(traceInfoHeader, traceInfoStr)
       .get(url)
       .readTimeout(readTimeout)
       .response(asJson[SuccessResponse])
@@ -132,15 +135,17 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
   }
 
   def httpMetadataGet(applicationId: String, httpEndpoint: String,
-                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any])
+                      httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any], traceInfo: Map[String, Any])
                      (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], MetadataSuccessResponse]]] = {
     val queryTimeElapsed = System.currentTimeMillis() - submitTime
     val readTimeout = FiniteDuration(httpTimeoutMs - queryTimeElapsed, TimeUnit.MILLISECONDS)
     val url = uri"$httpEndpoint?$urlParams"
-    logger.debug("promMetadataExec url={}", url)
+    val traceInfoStr = traceInfo.map{case (k, v) => k + "=" + v}.mkString(",")
+    logger.debug("promMetadataExec url={} traceInfo={}", url, traceInfoStr)
     sttp
       .header(HeaderNames.UserAgent, applicationId)
+      .header(traceInfoHeader, traceInfoStr)
       .get(url)
       .readTimeout(readTimeout)
       .response(asJson[MetadataSuccessResponse])


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

trace-info is added to querycontext. When a query execution is proxied to remote server, trace-info is added to the http headers.