### PR TITLE
fix(query): Syntactic fix of a scaladoc comment

### DIFF
--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -156,46 +156,46 @@ case class PeriodicSeries(rawSeries: RawSeriesLikePlan,
 }
 
 /**
- *  Subquery represents a series of N points conceptually generated
- *  by running N homogeneous queries where
- *  SW = subquery window
- *  SS = subquery step
- *  N = SW / SS + 1
- *  For example, foo[5m:1m], would generate a series of 6 points 1 minute apart.
- *
- *  query_range API is an equivalent of subquery though the concept of subquery
- *  is wider. query_range can be called with start/end/step parameters only on the
- *  top most expression in the query while subqueries can be:
- *  (1) top level expression (complete equivalent to query_range)
- *  (2) arguments to time range functions, potentially nested several levels deep
- *
- *  So, there are two major cases for a subquery expression:
- *  A) any_instant_expression[W:S] as a top level expression. In this case, subquery
- *     would issue "any_instant_expression" with its own start, end, and step
- *     parameters. If such an expression is called with query_range API, where start != end
- *     and step is not zero, an exception is thrown. No special subquery
- *     node in logical plan is generated as all of the PeriodicSeries logical plans can
- *     handle range_query API's start, step, and end parameters.
- *  B) RangeFunction(any_instant_expression[W:S]) at any node/level of abstract syntax tree.
- *     In this case, we ALWAYS have a range function involved and SubqueryWithWindowing
- *     logical plan node is generated. The plan is almost identical in the functionality to
- *     PeriodicSeriesWithWindowing. The difference between the two is that currently
- *     PeriodicSeriesWithWindowing expects a RawSeriesLikePlan while subquery is NOT
- *     necessarily an instant selector. PeriodicSeriesWithWindowing needs to be refactored,
- *     so, it could handle any PeriodicSeries; however, at this point we are going to
- *     replicate the functionality in the specialized SubqueryWithWindowing logical plan.
- *     We do so, that we can integrage subquery code without affecting existing existing
- *     code paths, stabilize the codebase, and later merge the two.
- *  Below is an example of B) case:
- *  sum_over_time(<someExpression>[5m:1m]) called with query_range API parameters:
- *  start=S, end=E, step=ST
- *  Here query range API start,end, and step correspond to startMs, stepMs, and endMs,
- *  however, it's not necessarily the case for nested subqueries because start, step, and en
- *  will depend on the parent expression of the subquery
- *  subqueryStepMs is used exclusively for debugging/logging, as the actual subquery step is
- *  already baked into innerPeriodicSeries which is constructed with the subquery step before
- *  passing to the constructor of SubqueryWithWindowing
- */
+  *  Subquery represents a series of N points conceptually generated
+  *  by running N homogeneous queries where
+  *  SW = subquery window
+  *  SS = subquery step
+  *  N = SW / SS + 1
+  *  For example, foo[5m:1m], would generate a series of 6 points 1 minute apart.
+  *
+  *  query_range API is an equivalent of subquery though the concept of subquery
+  *  is wider. query_range can be called with start/end/step parameters only on the
+  *  top most expression in the query while subqueries can be:
+  *  (1) top level expression (complete equivalent to query_range)
+  *  (2) arguments to time range functions, potentially nested several levels deep
+  *
+  *  So, there are two major cases for a subquery expression:
+  *  A) any_instant_expression[W:S] as a top level expression. In this case, subquery
+  *     would issue "any_instant_expression" with its own start, end, and step
+  *     parameters. If such an expression is called with query_range API, where start != end
+  *     and step is not zero, an exception is thrown. No special subquery
+  *     node in logical plan is generated as all of the PeriodicSeries logical plans can
+  *     handle range_query API's start, step, and end parameters.
+  *  B) RangeFunction(any_instant_expression[W:S]) at any node/level of abstract syntax tree.
+  *     In this case, we ALWAYS have a range function involved and SubqueryWithWindowing
+  *     logical plan node is generated. The plan is almost identical in the functionality to
+  *     PeriodicSeriesWithWindowing. The difference between the two is that currently
+  *     PeriodicSeriesWithWindowing expects a RawSeriesLikePlan while subquery is NOT
+  *     necessarily an instant selector. PeriodicSeriesWithWindowing needs to be refactored,
+  *     so, it could handle any PeriodicSeries; however, at this point we are going to
+  *     replicate the functionality in the specialized SubqueryWithWindowing logical plan.
+  *     We do so, that we can integrage subquery code without affecting existing existing
+  *     code paths, stabilize the codebase, and later merge the two.
+  *  Below is an example of B) case:
+  *  sum_over_time(<someExpression>[5m:1m]) called with query_range API parameters:
+  *  start=S, end=E, step=ST
+  *  Here query range API start,end, and step correspond to startMs, stepMs, and endMs,
+  *  however, it's not necessarily the case for nested subqueries because start, step, and en
+  *  will depend on the parent expression of the subquery
+  *  subqueryStepMs is used exclusively for debugging/logging, as the actual subquery step is
+  *  already baked into innerPeriodicSeries which is constructed with the subquery step before
+  *  passing to the constructor of SubqueryWithWindowing
+  */
 case class SubqueryWithWindowing(
   innerPeriodicSeries: PeriodicSeriesPlan, // someExpression
   startMs: Long, // S
@@ -232,7 +232,7 @@ case class SubqueryWithWindowing(
  * several clusters.
  * original_start, original_end are the start and end parameters of TimeRangeParam passed to toSeriesPlan()
  * invoked to generate TopLevelSubquery
- * @param startMs = original_start  - subquery_lookback
+ * @param startMs (original_start  - subquery_lookback)
  * @param stepMs is the value of the subquery step, not used by the planners but for debugging/documentation
  * @param endMs should always be the same as original_start
  */


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: