### PR TITLE
bug(core): Handle possible dupes in evictable partIds list

### DIFF
--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -514,13 +514,13 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     parts.size shouldEqual 1
     parts.head.partID shouldEqual 0 // same partId as before for ODPed partitions
     session.close() // release lock
-    shard.evictableOdpPartIds.size() shouldEqual 1
+    shard.evictableOdpPartIds.size shouldEqual 1
 
     // mark some parts as evictable
     markPartitionsForEviction(21 until 25)
     shard.evictForHeadroom() shouldEqual true
     // odp partitions should be evicted first before regular partitions
-    shard.evictableOdpPartIds.size() shouldEqual 0
+    shard.evictableOdpPartIds.size shouldEqual 0
 
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Evictable Part Ids can have duplicates for intermittent time series and it can possibly get out of hand.
Hence using a LinkedHashSet to maintain the evictable Part Ids list.


TODO:
We need to reduce memory usage and use unboxed data structures. As an observation, LinkedHashSet is using roughly 70MB for 1mil Ints. For 8 shards, one can expect 560mb or so. Compare this with simple array of 8 * 1mil ints: 32MB.

