### PR TITLE
Downsample repair

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -262,7 +262,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
       Await.result(
         target.writePartKeys(datasetRef,
-          shard, Observable.fromIterable(partKeys), diskTimeToLiveSeconds, updateHour),
+          shard, Observable.fromIterable(partKeys), diskTimeToLiveSeconds, updateHour, !downsampledData),
         5.minutes
       )
     }

--- a/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
@@ -69,16 +69,16 @@ class ChunkCopier(conf: SparkConf) {
   // Examples: 2019-10-20T12:34:56Z  or  2019-10-20T12:34:56-08:00
   private def parseDateTime(str: String) = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str))
 
-  val ingestionTimeStart = parseDateTime(conf.get("spark.filodb.chunks.copier.repairStartTime"))
-  val ingestionTimeEnd = parseDateTime(conf.get("spark.filodb.chunks.copier.repairEndTime"))
+  val copyStartTime = parseDateTime(conf.get("spark.filodb.chunks.copier.start.time"))
+  val copyEndTime = parseDateTime(conf.get("spark.filodb.chunks.copier.end.time"))
 
   // Destructively deletes everything in the target before updating anthing. Is used when chunks aren't aligned.
-  val deleteFirst = conf.getBoolean("spark.filodb.chunks.copier.deleteFirst", false)
+  val deleteFirst = conf.getBoolean("spark.filodb.chunks.copier.delete.first", false)
 
   // Disable the copy phase either for fully deleting with no replacement, or for no-op testing.
   val noCopy = conf.getBoolean("spark.filodb.chunks.copier.noCopy", false)
 
-  val isDownsampleRepair = conf.getBoolean("spark.filodb.chunks.copier.isDownsampleCopy", false)
+  val isDownsampleRepair = conf.getBoolean("spark.filodb.chunks.copier.is.downsample.copy", false)
   val diskTimeToLiveSeconds = if (isDownsampleRepair) {
     val dsSettings = new DownsamplerSettings(rawSourceConfig)
     val highestDSResolution = dsSettings.rawDatasetIngestionConfig.downsampleConfig.resolutions.last
@@ -110,8 +110,8 @@ class ChunkCopier(conf: SparkConf) {
     sourceCassandraColStore.copyOrDeleteChunksByIngestionTimeRange(
       datasetRef,
       splitIter,
-      ingestionTimeStart.toEpochMilli(),
-      ingestionTimeEnd.toEpochMilli(),
+      copyStartTime.toEpochMilli(),
+      copyEndTime.toEpochMilli(),
       batchSize,
       targetCassandraColStore,
       diskTimeToLiveSeconds)
@@ -121,8 +121,8 @@ class ChunkCopier(conf: SparkConf) {
     targetCassandraColStore.copyOrDeleteChunksByIngestionTimeRange(
       datasetRef,
       splitIter,
-      ingestionTimeStart.toEpochMilli(),
-      ingestionTimeEnd.toEpochMilli(),
+      copyStartTime.toEpochMilli(),
+      copyEndTime.toEpochMilli(),
       batchSize,
       targetCassandraColStore,
       0) // ttl 0 is interpreted as delete

--- a/spark-jobs/src/main/scala/filodb/repair/ChunkCopierValidator.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/ChunkCopierValidator.scala
@@ -13,6 +13,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters.asScalaIteratorConverter
 
 import filodb.cassandra.FiloSessionProvider
@@ -20,6 +21,7 @@ import filodb.cassandra.columnstore.{CassandraColumnStore, CassandraTokenRangeSp
 import filodb.core.{DatasetRef, GlobalConfig}
 import filodb.core.metadata.Schemas
 import filodb.core.store.{ChunkSetInfoOnHeap, ScanSplit}
+
 
 case class ChunkRecord(partition: String,
                        chunkId: Long,
@@ -64,9 +66,17 @@ class ChunkCopierValidator(sparkConf: SparkConf) extends StrictLogging {
   val targetConfig = rawTargetConfig.getConfig("filodb")
   val sourceCassConfig = sourceConfig.getConfig("cassandra")
   val targetCassConfig = targetConfig.getConfig("cassandra")
+
+  val isDownsampleCopy = sparkConf.getBoolean("spark.filodb.chunks.copier.validator.is.downsample.copy", false)
   val datasetName = sparkConf.get("spark.filodb.chunks.copier.validator.dataset")
-  val datasetRef = DatasetRef.fromDotString(datasetName)
   val targetDatasetConfig = datasetConfig(targetConfig, datasetName)
+  val datasetRef = if (isDownsampleCopy) {
+    val downsampleResolution = Duration(
+      sparkConf.get("spark.filodb.chunks.copier.validator.dataset.downsample.resolution"))
+    DatasetRef(s"${datasetName}_ds_${downsampleResolution.toMinutes}")
+  } else {
+    DatasetRef.fromDotString(datasetName)
+  }
 
   // Examples: 2019-10-20T12:34:56Z  or  2019-10-20T12:34:56-08:00
   private def parseDateTime(str: String) = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str))
@@ -82,9 +92,9 @@ class ChunkCopierValidator(sparkConf: SparkConf) extends StrictLogging {
   val targetSession = FiloSessionProvider.openSession(targetCassConfig)
 
   val sourceCassandraColStore = new CassandraColumnStore(
-  sourceConfig, readSched, sourceSession, false)(writeSched)
+  sourceConfig, readSched, sourceSession, isDownsampleCopy)(writeSched)
   val targetCassandraColStore = new CassandraColumnStore(
-  targetConfig, readSched, targetSession, false)(writeSched)
+  targetConfig, readSched, targetSession, isDownsampleCopy)(writeSched)
 
   private[filodb] def getSourceScanSplits = sourceCassandraColStore.getScanSplits(datasetRef, numSplitsForScans)
 

--- a/spark-jobs/src/test/scala/filodb/repair/ChunkCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/ChunkCopierSpec.scala
@@ -63,8 +63,8 @@ class ChunkCopierSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll wi
       sparkConf.set("spark.filodb.chunks.copier.source.config.file", sourceConfigPath)
       sparkConf.set("spark.filodb.chunks.copier.target.config.file", targetConfigPath)
       sparkConf.set("spark.filodb.chunks.copier.dataset", "prometheus")
-      sparkConf.set("spark.filodb.chunks.copier.repairStartTime", "2020-10-13T00:00:00Z")
-      sparkConf.set("spark.filodb.chunks.copier.repairEndTime", "2020-10-13T05:00:00Z")
+      sparkConf.set("spark.filodb.chunks.copier.start.time", "2020-10-13T00:00:00Z")
+      sparkConf.set("spark.filodb.chunks.copier.end.time", "2020-10-13T05:00:00Z")
       ChunkCopierMain.run(sparkConf).close()
 
       verifyTestData(sourceColStore, targetColStore,
@@ -88,10 +88,10 @@ class ChunkCopierSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll wi
       sparkConf.setMaster("local[2]")
       sparkConf.set("spark.filodb.chunks.copier.source.config.value", parseFileConfig(sourceConfigPath))
       sparkConf.set("spark.filodb.chunks.copier.target.config.value", parseFileConfig(targetConfigPath))
-      sparkConf.set("spark.filodb.chunks.copier.isDownsampleCopy", "true")
+      sparkConf.set("spark.filodb.chunks.copier.is.downsample.copy", "true")
       sparkConf.set("spark.filodb.chunks.copier.dataset", "prometheus")
-      sparkConf.set("spark.filodb.chunks.copier.repairStartTime", "2020-10-13T00:00:00Z")
-      sparkConf.set("spark.filodb.chunks.copier.repairEndTime", "2020-10-13T05:00:00Z")
+      sparkConf.set("spark.filodb.chunks.copier.start.time", "2020-10-13T00:00:00Z")
+      sparkConf.set("spark.filodb.chunks.copier.end.time", "2020-10-13T05:00:00Z")
       ChunkCopierMain.run(sparkConf).close()
 
       verifyTestData(sourceColStore, targetColStore,

--- a/spark-jobs/src/test/scala/filodb/repair/ChunkCopierValidatorSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/ChunkCopierValidatorSpec.scala
@@ -24,6 +24,8 @@ class ChunkCopierValidatorSpec extends AnyFunSpec with Matchers with BeforeAndAf
       conf.set("spark.filodb.chunks.copier.validator.target.config.value", parseFileConfig(targetConfigPath))
 
       conf.set("spark.filodb.chunks.copier.validator.dataset", "prometheus")
+      conf.set("spark.filodb.chunks.copier.validator.is.downsample.copy", "false")
+      conf.set("spark.filodb.chunks.copier.validator.dataset.downsample.resolution", "")
 
       conf.set("spark.filodb.chunks.copier.validator.start.time", "2020-10-13T00:00:00Z")
       conf.set("spark.filodb.chunks.copier.validator.end.time", "2020-10-13T05:00:00Z")

--- a/spark-jobs/src/test/scala/filodb/repair/ChunkCopierValidatorSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/ChunkCopierValidatorSpec.scala
@@ -25,8 +25,8 @@ class ChunkCopierValidatorSpec extends AnyFunSpec with Matchers with BeforeAndAf
 
       conf.set("spark.filodb.chunks.copier.validator.dataset", "prometheus")
 
-      conf.set("spark.filodb.chunks.copier.validator.repairStartTime", "2020-10-13T00:00:00Z")
-      conf.set("spark.filodb.chunks.copier.validator.repairEndTime", "2020-10-13T05:00:00Z")
+      conf.set("spark.filodb.chunks.copier.validator.start.time", "2020-10-13T00:00:00Z")
+      conf.set("spark.filodb.chunks.copier.validator.end.time", "2020-10-13T05:00:00Z")
       conf
     }
 

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -55,8 +55,6 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
     Map.empty, 100, rawDataStoreConfig)
 
   val datasetName = "prometheus"
-  val dataset = Dataset(datasetName, Schemas.gauge)
-  val shardStats = new TimeSeriesShardStats(dataset.ref, -1)
 
   val sparkConf = {
     val conf = new SparkConf(loadDefaults = true)
@@ -90,15 +88,16 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
   describe("raw data repair") {
     it("should copy data for repair window") {
+      val dataset = Dataset(datasetName, Schemas.gauge)
       val sourceColStore = new CassandraColumnStore(sourceConfig, s, sourceSession)
       val targetColStore = new CassandraColumnStore(targetConfig, s, targetSession)
-      truncateColStore(sourceColStore)
-      truncateColStore(targetColStore)
-      prepareTestData(sourceColStore)
+      truncateColStore(sourceColStore, dataset)
+      truncateColStore(targetColStore, dataset)
+      prepareTestData(sourceColStore, dataset)
 
       PartitionKeysCopierMain.run(sparkConf).close()
 
-      validateRepairData(targetColStore)
+      validateRepairData(targetColStore, dataset)
     }
   }
 
@@ -112,22 +111,23 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
       sparkConf.set("spark.filodb.partitionkeys.copier.source.config.value", parseFileConfig(sourceConfigPath))
       sparkConf.set("spark.filodb.partitionkeys.copier.target.config.value", parseFileConfig(targetConfigPath))
 
+      val dataset = Dataset(s"${datasetName}_ds_5", Schemas.gauge)
       val sourceColStore = new CassandraColumnStore(sourceConfig, s, sourceSession, true)
       val targetColStore = new CassandraColumnStore(targetConfig, s, targetSession, true)
-      truncateColStore(sourceColStore)
-      truncateColStore(targetColStore)
-      prepareTestData(sourceColStore)
+      truncateColStore(sourceColStore, dataset)
+      truncateColStore(targetColStore, dataset)
+      prepareTestData(sourceColStore, dataset)
 
       PartitionKeysCopierMain.run(sparkConf).close()
 
-      validateRepairData(targetColStore)
+      validateRepairData(targetColStore, dataset, true)
 
       sparkConf.set("spark.filodb.partitionkeys.copier.source.config.file", sourceConfigPath)
       sparkConf.set("spark.filodb.partitionkeys.copier.target.config.file", targetConfigPath)
     }
   }
 
-  def truncateColStore(colStore: CassandraColumnStore): Unit = {
+  def truncateColStore(colStore: CassandraColumnStore, dataset: Dataset): Unit = {
     colStore.initialize(dataset.ref, numOfShards).futureValue
     colStore.truncate(dataset.ref, numOfShards).futureValue
   }
@@ -136,7 +136,9 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
     offheapMem.free()
   }
 
-  def prepareTestData(colStore: CassandraColumnStore): Unit = {
+  def prepareTestData(colStore: CassandraColumnStore, dataset: Dataset): Unit = {
+    val shardStats = new TimeSeriesShardStats(dataset.ref, -1)
+
     def writePartKeys(pk: PartKeyRecord, shard: Int): Unit = {
       colStore.writePartKeys(dataset.ref, shard, Observable.now(pk), 259200, 0L, false).futureValue
     }
@@ -189,7 +191,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
     }
   }
 
-  def validateRepairData(colStore: CassandraColumnStore): Unit = {
+  def validateRepairData(colStore: CassandraColumnStore, dataset: Dataset, isDownsampleRepair: Boolean = false): Unit = {
     def getWorkspace(map: Map[String, String]): String = {
       val ws: String = map.get("_ws_").get
       ws
@@ -229,22 +231,24 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
       }
     }
 
-    // verify data in pk_by_update_time table
-    val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
-    for (shard <- 0 until numOfShards) {
-      val partKeyRecords = Await.result(colStore.getPartKeysByUpdateHour(dataset.ref, shard, updateHour).toListL.runAsync, Duration(1, "minutes"))
-      // because there will be 3 records that meets the copier time period.
-      partKeyRecords.size shouldEqual 3
-      for (pkr <- partKeyRecords) {
-        // verify all the records fall in the copier time period.
-        // either pkr.startTime or pkr.endTime should fall in the startTime:endTime window
-        var metric = getPartKeyMap(pkr).get("_metric_").get
-        val startTimeFallsInWindow = pkr.startTime >= startTime && pkr.startTime <= endTime
-        val endTimeFallsInWindow = pkr.endTime >= startTime && pkr.endTime <= endTime
-        if (startTimeFallsInWindow || endTimeFallsInWindow) {
-          assert(true)
-        } else {
-          assert(false, "Either startTime or endTime doesn't fall in the migration window.")
+    if (!isDownsampleRepair) {
+      // verify data in pk_by_update_time table
+      val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
+      for (shard <- 0 until numOfShards) {
+        val partKeyRecords = Await.result(colStore.getPartKeysByUpdateHour(dataset.ref, shard, updateHour).toListL.runAsync, Duration(1, "minutes"))
+        // because there will be 3 records that meets the copier time period.
+        partKeyRecords.size shouldEqual 3
+        for (pkr <- partKeyRecords) {
+          // verify all the records fall in the copier time period.
+          // either pkr.startTime or pkr.endTime should fall in the startTime:endTime window
+          var metric = getPartKeyMap(pkr).get("_metric_").get
+          val startTimeFallsInWindow = pkr.startTime >= startTime && pkr.startTime <= endTime
+          val endTimeFallsInWindow = pkr.endTime >= startTime && pkr.endTime <= endTime
+          if (startTimeFallsInWindow || endTimeFallsInWindow) {
+            assert(true)
+          } else {
+            assert(false, "Either startTime or endTime doesn't fall in the migration window.")
+          }
         }
       }
     }

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -67,8 +67,8 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
     conf.set("spark.filodb.partitionkeys.copier.dataset", datasetName)
 
-    conf.set("spark.filodb.partitionkeys.copier.repairStartTime", "2020-10-13T00:00:00Z")
-    conf.set("spark.filodb.partitionkeys.copier.repairEndTime", "2020-10-13T05:00:00Z")
+    conf.set("spark.filodb.partitionkeys.copier.start.time", "2020-10-13T00:00:00Z")
+    conf.set("spark.filodb.partitionkeys.copier.end.time", "2020-10-13T05:00:00Z")
     conf
   }
 
@@ -104,7 +104,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
 
   describe("downsample data repair") {
     it("should copy data for repair window") {
-      sparkConf.set("spark.filodb.partitionkeys.copier.isDownsampleCopy", "true")
+      sparkConf.set("spark.filodb.partitionkeys.copier.is.downsample.copy", "true")
 
       // Test this with value based configs
       sparkConf.remove("spark.filodb.partitionkeys.copier.source.config.file")
@@ -207,8 +207,8 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
       map
     }
 
-    val startTime = parseDateTime(sparkConf.get("spark.filodb.partitionkeys.copier.repairStartTime")).toEpochMilli()
-    val endTime = parseDateTime(sparkConf.get("spark.filodb.partitionkeys.copier.repairEndTime")).toEpochMilli()
+    val startTime = parseDateTime(sparkConf.get("spark.filodb.partitionkeys.copier.start.time")).toEpochMilli()
+    val endTime = parseDateTime(sparkConf.get("spark.filodb.partitionkeys.copier.end.time")).toEpochMilli()
 
     // verify data in index table.
     for (shard <- 0 until numOfShards) {

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierValidatorSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierValidatorSpec.scala
@@ -26,8 +26,8 @@ class PartitionKeysCopierValidatorSpec extends AnyFunSpec with Matchers with Bef
 
       conf.set("spark.filodb.partitionkeys.validator.dataset", "prometheus")
 
-      conf.set("spark.filodb.partitionkeys.validator.repairStartTime", "2020-10-13T00:00:00Z")
-      conf.set("spark.filodb.partitionkeys.validator.repairEndTime", "2020-10-13T05:00:00Z")
+      conf.set("spark.filodb.partitionkeys.validator.start.time", "2020-10-13T00:00:00Z")
+      conf.set("spark.filodb.partitionkeys.validator.end.time", "2020-10-13T05:00:00Z")
       conf
     }
 

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierValidatorSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierValidatorSpec.scala
@@ -25,6 +25,7 @@ class PartitionKeysCopierValidatorSpec extends AnyFunSpec with Matchers with Bef
       conf.set("spark.filodb.partitionkeys.validator.target.config.value", parseFileConfig(targetConfigPath))
 
       conf.set("spark.filodb.partitionkeys.validator.dataset", "prometheus")
+      conf.set("spark.filodb.partitionkeys.validator.is.downsample.copy", "false")
 
       conf.set("spark.filodb.partitionkeys.validator.start.time", "2020-10-13T00:00:00Z")
       conf.set("spark.filodb.partitionkeys.validator.end.time", "2020-10-13T05:00:00Z")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
1. Given dataset `x` passed in repair config, downsample index repair tries to repair dataset `x`.
2. Index downsample repair tries to write to `part_key_by_update_time` table which doesn't exist.

**New behavior :** 
1. Given dataset `x` passed in repair config, downsample index repair will repair dataset `x_ds_${highestDSResolution.toMinutes}`
2. Index downsample will not write to `part_key_by_update_time` table.
