### PR TITLE
perf(core): Improve performance of index bootstrap by refreshing regularly

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -397,6 +397,7 @@ private[filodb] final class IngestionActor(ref: DatasetRef,
     memStore match {
       case ro: DownsampledTimeSeriesStore => ro.getShard(ref, shardNum)
                                             .foreach { shard =>
+                                              shard.shutdown()
                                               ro.removeShard(ref, shardNum, shard)
                                             }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -114,7 +114,12 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   private def hour(millis: Long = System.currentTimeMillis()) = millis / 1000 / 60 / 60
 
+  def startFlushingIndex(): Unit =
+    partKeyIndex.startFlushThread(downsampleStoreConfig.partIndexFlushMinDelaySeconds,
+                                  downsampleStoreConfig.partIndexFlushMaxDelaySeconds)
+
   def recoverIndex(): Future[Unit] = {
+    startFlushingIndex()
     indexBootstrapper
       .bootstrapIndexDownsample(partKeyIndex, shardNum, indexDataset, indexTtlMs){ _ => createPartitionID() }
       .map { count =>
@@ -148,7 +153,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       purgeExpiredIndexEntries()
       indexRefresh()
     }.map { _ =>
-      partKeyIndex.refreshReadersBlocking()
+//      partKeyIndex.refreshReadersBlocking()
     }.onErrorRestartUnlimited.completedL.runAsync(housekeepingSched)
   }
 
@@ -217,7 +222,9 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     next
   }
 
-  def refreshPartKeyIndexBlocking(): Unit = {}
+  def refreshPartKeyIndexBlocking(): Unit = {
+    partKeyIndex.refreshReadersBlocking()
+  }
 
   def lookupPartitions(partMethod: PartitionScanMethod,
                        chunkMethod: ChunkScanMethod,
@@ -244,6 +251,16 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
         } else {
           throw new UnsupportedOperationException("Cannot have empty filters")
         }
+    }
+  }
+
+  def shutdown(): Unit = {
+    try {
+      partKeyIndex.closeIndex();
+      houseKeepingFuture.cancel();
+      gaugeUpdateFuture.cancel();
+    } catch { case e: Exception =>
+      logger.error("Exception when shutting down downsample shard", e)
     }
   }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -152,8 +152,6 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                                                            rawStoreConfig.flushInterval).mapAsync { _ =>
       purgeExpiredIndexEntries()
       indexRefresh()
-    }.map { _ =>
-//      partKeyIndex.refreshReadersBlocking()
     }.onErrorRestartUnlimited.completedL.runAsync(housekeepingSched)
   }
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -140,6 +140,9 @@ extends MemStore with StrictLogging {
   }
 
   def shutdown(): Unit = {
+    datasets.valuesIterator.foreach { d =>
+      d.values().asScala.foreach(_.shutdown())
+    }
     reset()
   }
 

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -41,7 +41,6 @@ class IndexBootstrapper(colStore: ColumnStore) {
       }
       .countL
       .map { count =>
-        index.refreshReadersBlocking()
         recoverIndexLatency.update(System.currentTimeMillis() - start)
         count
       }
@@ -73,7 +72,6 @@ class IndexBootstrapper(colStore: ColumnStore) {
       }
       .countL
       .map { count =>
-        index.refreshReadersBlocking()
         recoverIndexLatency.update(System.currentTimeMillis() - start)
         count
       }
@@ -115,7 +113,6 @@ class IndexBootstrapper(colStore: ColumnStore) {
      }
      .countL
      .map { count =>
-       index.refreshReadersBlocking()
        recoverIndexLatency.update(System.currentTimeMillis() - start)
        count
      }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -602,11 +602,11 @@ class TimeSeriesShard(val ref: DatasetRef,
   def ingest(data: SomeData): Long = ingest(data.records, data.offset)
 
   def recoverIndex(): Future[Unit] = {
+    startFlushingIndex()
     val indexBootstrapper = new IndexBootstrapper(colStore)
     indexBootstrapper.bootstrapIndexRaw(partKeyIndex, shardNum, ref)(bootstrapPartKey)
                      .executeOn(ingestSched) // to make sure bootstrapIndex task is run on ingestion thread
                      .map { count =>
-                        startFlushingIndex()
                        logger.info(s"Bootstrapped index for dataset=$ref shard=$shardNum with $count records")
                      }.runAsync(ingestSched)
   }
@@ -1716,23 +1716,27 @@ class TimeSeriesShard(val ref: DatasetRef,
   }
 
   def shutdown(): Unit = {
-    if (storeConfig.meteringEnabled) {
-      cardTracker.close()
-    }
-    evictedPartKeys.synchronized {
-      if (!evictedPartKeysDisposed) {
-        evictedPartKeysDisposed = true
-        evictedPartKeys.dispose()
+    try {
+      logger.info(s"Shutting down dataset=$ref shard=$shardNum")
+      if (storeConfig.meteringEnabled) {
+        cardTracker.close()
       }
+      evictedPartKeys.synchronized {
+        if (!evictedPartKeysDisposed) {
+          evictedPartKeysDisposed = true
+          evictedPartKeys.dispose()
+        }
+      }
+      reset() // Not really needed, but clear everything just to be consistent
+      partKeyIndex.closeIndex()
+      /* Don't explicitly free the memory just yet. These classes instead rely on a finalize
+         method to ensure that no threads are accessing the memory before it's freed.
+      blockStore.releaseBlocks()
+      */
+      headroomTask.cancel()
+      ingestSched.shutdown()
+    } catch { case e: Exception =>
+      logger.error("Exception when shutting down shard", e)
     }
-    reset()   // Not really needed, but clear everything just to be consistent
-    partKeyIndex.closeIndex()
-    logger.info(s"Shutting down dataset=$ref shard=$shardNum")
-    /* Don't explcitly free the memory just yet. These classes instead rely on a finalize
-       method to ensure that no threads are accessing the memory before it's freed.
-    blockStore.releaseBlocks()
-    */
-    headroomTask.cancel()
-    ingestSched.shutdown()
   }
 }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -328,6 +328,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
     val tsShard = memStore.asInstanceOf[TimeSeriesMemStore].getShard(dataset1.ref, 0).get
     tsShard.recoverIndex().futureValue
+    tsShard.refreshPartKeyIndexBlocking()
 
     tsShard.partitions.size shouldEqual 1 // only ingesting partitions should be loaded into heap
     tsShard.partKeyIndex.indexNumEntries shouldEqual 2 // all partitions should be added to index
@@ -342,6 +343,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     tsShard.partKeyIndex.endTimeFromPartId(1) shouldEqual Long.MaxValue
     tsShard.partKeyIndex.partKeyFromPartId(0).get shouldEqual new BytesRef(pks(0))
     tsShard.partKeyIndex.partKeyFromPartId(1).get shouldEqual new BytesRef(pks(1))
+    tsShard.shutdown()
 
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

We bootstrap the index and flush at one go. This consumes too much resources since too much data is accumulated without compression.


**New behavior :**

Start the flush thread before starting to bootstrap the index.

