### PR TITLE
bug(repair): Use resolution specific ttl for downsample dataset in chunks repair

### DIFF
--- a/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/ChunkCopier.scala
@@ -87,8 +87,9 @@ class ChunkCopier(conf: SparkConf) {
 
   val diskTimeToLiveSeconds = if (isDownsampleCopy) {
     val dsSettings = new DownsamplerSettings(rawSourceConfig)
-    val highestDSResolution = dsSettings.rawDatasetIngestionConfig.downsampleConfig.resolutions.last
-    dsSettings.ttlByResolution(highestDSResolution)
+    val downsampleResolution = Duration(conf.get("spark.filodb.chunks.copier.dataset.downsample.resolution"))
+      .asInstanceOf[FiniteDuration]
+    dsSettings.ttlByResolution(downsampleResolution)
   } else {
     targetDatasetConfig.getConfig("sourceconfig.store")
       .as[FiniteDuration]("disk-time-to-live").toSeconds.toInt


### PR DESCRIPTION
**Current behavior :** Chunk repair for downsample writes data with the highest resolution ttl.

**New behavior :** Chunk repair for downsample writes data with the resolution specific ttl.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

