### PR TITLE
bug(query): logical plan to query function does mot preserve brackets

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -95,14 +95,14 @@ object LogicalPlanParser {
   private def scalarBinaryOperationToQuery(lp: ScalarBinaryOperation): String = {
     val rhs = if (lp.rhs.isLeft) lp.rhs.left.get.toString else convertToQuery(lp.rhs.right.get)
     val lhs = if (lp.lhs.isLeft) lp.lhs.left.get.toString else convertToQuery(lp.lhs.right.get)
-    s"$lhs$Space${lp.operator.operatorString}$Space$rhs"
+    s"($lhs$Space${lp.operator.operatorString}$Space$rhs)"
   }
 
   private def scalarVectorBinaryOperationToQuery(lp: ScalarVectorBinaryOperation): String = {
     val periodicSeriesQuery = convertToQuery(lp.vector)
-    if (lp.scalarIsLhs) s"${functionArgsToQuery(lp.scalarArg)}$Space${lp.operator.operatorString}$Space" +
-      s"$periodicSeriesQuery"
-    else s"$periodicSeriesQuery ${lp.operator.operatorString} ${functionArgsToQuery(lp.scalarArg)}"
+    if (lp.scalarIsLhs) s"(${functionArgsToQuery(lp.scalarArg)}$Space${lp.operator.operatorString}$Space" +
+      s"$periodicSeriesQuery)"
+    else s"($periodicSeriesQuery ${lp.operator.operatorString} ${functionArgsToQuery(lp.scalarArg)})"
   }
 
   private def periodicSeriesWithWindowingToQuery(lp: PeriodicSeriesWithWindowing): String = {
@@ -140,7 +140,7 @@ object LogicalPlanParser {
     }
     val grouping = if (lp.include.isEmpty) groupingType else s"$groupingType$OpeningRoundBracket" +
       s"${lp.include.mkString(Comma)}$ClosingRoundBracket"
-    s"$lhs$Space${lp.operator.operatorString}$on$ignoring$grouping$Space$rhs"
+    s"($lhs$Space${lp.operator.operatorString}$on$ignoring$grouping$Space$rhs)"
   }
 
   def miscellaneousFnToQuery(lp: ApplyMiscellaneousFunction): String = {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -7,62 +7,60 @@ import filodb.prometheus.parse.Parser
 
 class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
 
-  private def parseAndAssertResult(query: String, expectedResult: String) = {
+  private def parseAndAssertResult(query: String)(expectedResult: String = query) = {
     val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
     val res = LogicalPlanParser.convertToQuery(lp)
     res shouldEqual expectedResult
   }
 
   it("should generate query from LogicalPlan") {
-    parseAndAssertResult("""http_requests_total{job="app"}""", """http_requests_total{job="app"}""")
-    parseAndAssertResult("""sum(http_requests_total{job="app"})""", """sum(http_requests_total{job="app"})""")
-    parseAndAssertResult("""sum(count(http_requests_total{job="app"}))""", """sum(count(http_requests_total{job="app"}))""")
-    parseAndAssertResult("""sum(http_requests_total{job="app",instance="inst-1"}) by (instance)""", """sum(http_requests_total{job="app",instance="inst-1"}) by (instance)""")
-    parseAndAssertResult("""count(http_requests_total{job="app",instance="inst-1"}) without (instance)""", """count(http_requests_total{job="app",instance="inst-1"}) without (instance)""")
-    parseAndAssertResult("""absent(http_requests_total{job="app"})""", """absent(http_requests_total{job="app"})""")
-    parseAndAssertResult("""exp(http_requests_total{job="app"})""", """exp(http_requests_total{job="app"})""")
-    parseAndAssertResult("""clamp_min(http_requests_total{job="app"},1000.0)""", """clamp_min(http_requests_total{job="app"},1000.0)""")
-    parseAndAssertResult("""histogram_quantile(0.2,sum(http_requests_total{job="app"}))""", """histogram_quantile(0.2,sum(http_requests_total{job="app"}))""")
-    parseAndAssertResult("""5.1 > bool 2.2""", """(5.1 > bool 2.2)""")
-    parseAndAssertResult("""http_requests_total1{job="app"} + 2.1 + 3.1""", """((http_requests_total1{job="app"} + 2.1) + 3.1)""")
-    parseAndAssertResult("""sum_over_time(http_requests_total{job="app"}[5s])""", """sum_over_time(http_requests_total{job="app"}[5s])""")
-    parseAndAssertResult("""rate(http_requests_total{job="app"}[5s] offset 200s)""", """rate(http_requests_total{job="app"}[5s] offset 200s)""")
-    parseAndAssertResult("""holt_winters(http_requests_total{job="app"}[5s],0.1,0.6)""", """holt_winters(http_requests_total{job="app"}[5s],0.1,0.6)""")
-    parseAndAssertResult("""predict_linear(http_requests_total{job="app"}[5s],7200.0)""", """predict_linear(http_requests_total{job="app"}[5s],7200.0)""")
-    parseAndAssertResult("""rate(http_req_latency{app="foobar",_bucket_="0.5"}[5s])""", """rate(http_req_latency{app="foobar",_bucket_="0.5"}[5s])""")
-    parseAndAssertResult("""sort(http_requests_total{job="app"})""", """sort(http_requests_total{job="app"})""")
-    parseAndAssertResult("""sort_desc(http_requests_total{job="app"})""", """sort_desc(http_requests_total{job="app"})""")
-    parseAndAssertResult("""http_requests_total1{job="app"} + http_requests_total2{job="app"}""", """(http_requests_total1{job="app"} + http_requests_total2{job="app"})""")
+    parseAndAssertResult("""http_requests_total{job="app"}""") ()
+    parseAndAssertResult("""sum(http_requests_total{job="app"})""") ()
+    parseAndAssertResult("""sum(count(http_requests_total{job="app"}))""")()
+    parseAndAssertResult("""sum(http_requests_total{job="app",instance="inst-1"}) by (instance)""")()
+    parseAndAssertResult("""count(http_requests_total{job="app",instance="inst-1"}) without (instance)""")()
+    parseAndAssertResult("""absent(http_requests_total{job="app"})""")()
+    parseAndAssertResult("""exp(http_requests_total{job="app"})""")()
+    parseAndAssertResult("""clamp_min(http_requests_total{job="app"},1000.0)""")()
+    parseAndAssertResult("""histogram_quantile(0.2,sum(http_requests_total{job="app"}))""")()
+    parseAndAssertResult("""5.1 > bool 2.2""")("""(5.1 > bool 2.2)""")
+    parseAndAssertResult("""http_requests_total1{job="app"} + 2.1 + 3.1""") ("""((http_requests_total1{job="app"} + 2.1) + 3.1)""")
+    parseAndAssertResult("""sum_over_time(http_requests_total{job="app"}[5s])""") ()
+    parseAndAssertResult("""rate(http_requests_total{job="app"}[5s] offset 200s)""") ()
+    parseAndAssertResult("""holt_winters(http_requests_total{job="app"}[5s],0.1,0.6)""") ()
+    parseAndAssertResult("""predict_linear(http_requests_total{job="app"}[5s],7200.0)""") ()
+    parseAndAssertResult("""rate(http_req_latency{app="foobar",_bucket_="0.5"}[5s])""") ()
+    parseAndAssertResult("""sort(http_requests_total{job="app"})""") ()
+    parseAndAssertResult("""sort_desc(http_requests_total{job="app"})""") ()
+    parseAndAssertResult("""http_requests_total1{job="app"} + http_requests_total2{job="app"}""") ("""(http_requests_total1{job="app"} + http_requests_total2{job="app"})""")
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / ignoring(instance) """ +
-        """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / ignoring(instance) http_requests_total2{job="app",instance="inst-1"})""")
+        """http_requests_total2{job="app",instance="inst-1"}""") ("""(http_requests_total1{job="app",instance="inst-1"} / ignoring(instance) http_requests_total2{job="app",instance="inst-1"})""")
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / on(instance) """ +
-      """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / on(instance) http_requests_total2{job="app",instance="inst-1"})""".stripMargin)
+      """http_requests_total2{job="app",instance="inst-1"}""") ("""(http_requests_total1{job="app",instance="inst-1"} / on(instance) http_requests_total2{job="app",instance="inst-1"})""".stripMargin)
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left """ +
-      """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left """ +
+      """http_requests_total2{job="app",instance="inst-1"}""") ("""(http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left """ +
       """http_requests_total2{job="app",instance="inst-1"})""")
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left(job) """
-      + """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left(job) """
+      + """http_requests_total2{job="app",instance="inst-1"}""") ("""(http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left(job) """
       + """http_requests_total2{job="app",instance="inst-1"})""")
-    parseAndAssertResult("""hist_to_prom_vectors(http_request_latency)""", """hist_to_prom_vectors(http_request_latency)""")
+    parseAndAssertResult("""hist_to_prom_vectors(http_request_latency)""") ("""hist_to_prom_vectors(http_request_latency)""")
     parseAndAssertResult("""label_join(http_requests_total1{job="app",instance="inst-1"},"dst","-"""" +
-      ""","instance","job")""", """label_join(http_requests_total1{job="app",instance="inst-1"},"dst","-"""" +
-      ""","instance","job")""")
+      ""","instance","job")""") ()
     parseAndAssertResult("""label_replace(http_requests_total{job="app",instance="inst-1"},"$1-new-label-$2","""
-      + s""""instance","(.*)-(.*)")""", """label_replace(http_requests_total{job="app",instance="inst-1"},"$1-new-label-$2","""
-      + s""""instance","(.*)-(.*)")""")
-    parseAndAssertResult("""scalar(http_requests_total{job="app",instance="inst-1"})""", """scalar(http_requests_total{job="app",instance="inst-1"})""")
-    parseAndAssertResult("""vector(1.5)""", """vector(1.5)""")
-    parseAndAssertResult("""time()""", """time()""")
-    parseAndAssertResult("""http_requests_total::count{job="app"}""", """http_requests_total::count{job="app"}""")
-    parseAndAssertResult("""http_requests_total::sum{job="app"}""", """http_requests_total::sum{job="app"}""")
-    parseAndAssertResult("""topk(2.0,http_requests_total{job="app"})""", """topk(2.0,http_requests_total{job="app"})""")
-    parseAndAssertResult("""quantile(0.2,http_requests_total{job="app"})""", """quantile(0.2,http_requests_total{job="app"})""")
-    parseAndAssertResult("""count_values("freq",http_requests_total{job="app"})""", """count_values("freq",http_requests_total{job="app"})""")
-    parseAndAssertResult("""timestamp(http_requests_total{job="app"})""", """timestamp(http_requests_total{job="app"})""")
-    parseAndAssertResult("""absent(http_requests_total{job="app"})""", """absent(http_requests_total{job="app"})""")
-    parseAndAssertResult("""absent(sum(http_requests_total{job="app"}))""", """absent(sum(http_requests_total{job="app"}))""")
-    parseAndAssertResult("""absent(sum_over_time(http_requests_total{job="app"}[5s]))""", """absent(sum_over_time(http_requests_total{job="app"}[5s]))""")
-    parseAndAssertResult("""absent(rate(http_requests_total{job="app"}[5s] offset 200s))""", """absent(rate(http_requests_total{job="app"}[5s] offset 200s))""")
+      + s""""instance","(.*)-(.*)")""")()
+    parseAndAssertResult("""scalar(http_requests_total{job="app",instance="inst-1"})""")()
+    parseAndAssertResult("""vector(1.5)""")()
+    parseAndAssertResult("""time()""")()
+    parseAndAssertResult("""http_requests_total::count{job="app"}""")()
+    parseAndAssertResult("""http_requests_total::sum{job="app"}""")()
+    parseAndAssertResult("""topk(2.0,http_requests_total{job="app"})""")()
+    parseAndAssertResult("""quantile(0.2,http_requests_total{job="app"})""")()
+    parseAndAssertResult("""count_values("freq",http_requests_total{job="app"})""")()
+    parseAndAssertResult("""timestamp(http_requests_total{job="app"})""")()
+    parseAndAssertResult("""absent(http_requests_total{job="app"})""")()
+    parseAndAssertResult("""absent(sum(http_requests_total{job="app"}))""")()
+    parseAndAssertResult("""absent(sum_over_time(http_requests_total{job="app"}[5s]))""")()
+    parseAndAssertResult("""absent(rate(http_requests_total{job="app"}[5s] offset 200s))""")()
   }
 
   it("should generate query from LogicalPlan having offset") {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -76,4 +76,25 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     val res = LogicalPlanParser.convertToQuery(lp)
     res shouldEqual query
   }
+
+  it("should preserve brackets in Binary join query") {
+    val query = """foo / (bar + baz)"""
+    val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
+    val res = LogicalPlanParser.convertToQuery(lp)
+    res shouldEqual "(foo / (bar + baz))"
+  }
+
+  it("should preserve brackets in scalar binary operation query") {
+    val query = """1 / (2 + 3)"""
+    val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
+    val res = LogicalPlanParser.convertToQuery(lp)
+    res shouldEqual "(1.0 / (2.0 + 3.0))"
+  }
+
+  it("should preserve brackets in scalar vector operation query") {
+    val query = """1 / (2 + foo)"""
+    val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
+    val res = LogicalPlanParser.convertToQuery(lp)
+    res shouldEqual "(1.0 / (2.0 + foo))"
+  }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -7,59 +7,62 @@ import filodb.prometheus.parse.Parser
 
 class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
 
-  private def parseAndAssertResult(query: String) = {
+  private def parseAndAssertResult(query: String, expectedResult: String) = {
     val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
     val res = LogicalPlanParser.convertToQuery(lp)
-    res shouldEqual(query)
+    res shouldEqual expectedResult
   }
 
   it("should generate query from LogicalPlan") {
-    parseAndAssertResult("""http_requests_total{job="app"}""")
-    parseAndAssertResult("""sum(http_requests_total{job="app"})""")
-    parseAndAssertResult("""sum(count(http_requests_total{job="app"}))""")
-    parseAndAssertResult("""sum(http_requests_total{job="app",instance="inst-1"}) by (instance)""")
-    parseAndAssertResult("""count(http_requests_total{job="app",instance="inst-1"}) without (instance)""")
-    parseAndAssertResult("""absent(http_requests_total{job="app"})""")
-    parseAndAssertResult("""exp(http_requests_total{job="app"})""")
-    parseAndAssertResult("""clamp_min(http_requests_total{job="app"},1000.0)""")
-    parseAndAssertResult("""histogram_quantile(0.2,sum(http_requests_total{job="app"}))""")
-    parseAndAssertResult("""http_requests_total{job="app"} + 2.1""")
-    parseAndAssertResult("""5.1 > bool 2.2""")
-    parseAndAssertResult("""http_requests_total1{job="app"} + 2.1 + 3.1""")
-    parseAndAssertResult("""sum_over_time(http_requests_total{job="app"}[5s])""")
-    parseAndAssertResult("""rate(http_requests_total{job="app"}[5s] offset 200s)""")
-    parseAndAssertResult("""holt_winters(http_requests_total{job="app"}[5s],0.1,0.6)""")
-    parseAndAssertResult("""predict_linear(http_requests_total{job="app"}[5s],7200.0)""")
-    parseAndAssertResult("""rate(http_req_latency{app="foobar",_bucket_="0.5"}[5s])""")
-    parseAndAssertResult("""sort(http_requests_total{job="app"})""")
-    parseAndAssertResult("""sort_desc(http_requests_total{job="app"})""")
-    parseAndAssertResult("""http_requests_total1{job="app"} + http_requests_total2{job="app"}""")
+    parseAndAssertResult("""http_requests_total{job="app"}""", """http_requests_total{job="app"}""")
+    parseAndAssertResult("""sum(http_requests_total{job="app"})""", """sum(http_requests_total{job="app"})""")
+    parseAndAssertResult("""sum(count(http_requests_total{job="app"}))""", """sum(count(http_requests_total{job="app"}))""")
+    parseAndAssertResult("""sum(http_requests_total{job="app",instance="inst-1"}) by (instance)""", """sum(http_requests_total{job="app",instance="inst-1"}) by (instance)""")
+    parseAndAssertResult("""count(http_requests_total{job="app",instance="inst-1"}) without (instance)""", """count(http_requests_total{job="app",instance="inst-1"}) without (instance)""")
+    parseAndAssertResult("""absent(http_requests_total{job="app"})""", """absent(http_requests_total{job="app"})""")
+    parseAndAssertResult("""exp(http_requests_total{job="app"})""", """exp(http_requests_total{job="app"})""")
+    parseAndAssertResult("""clamp_min(http_requests_total{job="app"},1000.0)""", """clamp_min(http_requests_total{job="app"},1000.0)""")
+    parseAndAssertResult("""histogram_quantile(0.2,sum(http_requests_total{job="app"}))""", """histogram_quantile(0.2,sum(http_requests_total{job="app"}))""")
+    parseAndAssertResult("""5.1 > bool 2.2""", """(5.1 > bool 2.2)""")
+    parseAndAssertResult("""http_requests_total1{job="app"} + 2.1 + 3.1""", """((http_requests_total1{job="app"} + 2.1) + 3.1)""")
+    parseAndAssertResult("""sum_over_time(http_requests_total{job="app"}[5s])""", """sum_over_time(http_requests_total{job="app"}[5s])""")
+    parseAndAssertResult("""rate(http_requests_total{job="app"}[5s] offset 200s)""", """rate(http_requests_total{job="app"}[5s] offset 200s)""")
+    parseAndAssertResult("""holt_winters(http_requests_total{job="app"}[5s],0.1,0.6)""", """holt_winters(http_requests_total{job="app"}[5s],0.1,0.6)""")
+    parseAndAssertResult("""predict_linear(http_requests_total{job="app"}[5s],7200.0)""", """predict_linear(http_requests_total{job="app"}[5s],7200.0)""")
+    parseAndAssertResult("""rate(http_req_latency{app="foobar",_bucket_="0.5"}[5s])""", """rate(http_req_latency{app="foobar",_bucket_="0.5"}[5s])""")
+    parseAndAssertResult("""sort(http_requests_total{job="app"})""", """sort(http_requests_total{job="app"})""")
+    parseAndAssertResult("""sort_desc(http_requests_total{job="app"})""", """sort_desc(http_requests_total{job="app"})""")
+    parseAndAssertResult("""http_requests_total1{job="app"} + http_requests_total2{job="app"}""", """(http_requests_total1{job="app"} + http_requests_total2{job="app"})""")
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / ignoring(instance) """ +
-        """http_requests_total2{job="app",instance="inst-1"}""")
+        """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / ignoring(instance) http_requests_total2{job="app",instance="inst-1"})""")
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / on(instance) """ +
-      """http_requests_total2{job="app",instance="inst-1"}""")
+      """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / on(instance) http_requests_total2{job="app",instance="inst-1"})""".stripMargin)
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left """ +
-      """http_requests_total2{job="app",instance="inst-1"}""")
+      """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left """ +
+      """http_requests_total2{job="app",instance="inst-1"})""")
     parseAndAssertResult("""http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left(job) """
-      + """http_requests_total2{job="app",instance="inst-1"}""")
-    parseAndAssertResult("""hist_to_prom_vectors(http_request_latency)""")
+      + """http_requests_total2{job="app",instance="inst-1"}""", """(http_requests_total1{job="app",instance="inst-1"} / on(instance) group_left(job) """
+      + """http_requests_total2{job="app",instance="inst-1"})""")
+    parseAndAssertResult("""hist_to_prom_vectors(http_request_latency)""", """hist_to_prom_vectors(http_request_latency)""")
     parseAndAssertResult("""label_join(http_requests_total1{job="app",instance="inst-1"},"dst","-"""" +
+      ""","instance","job")""", """label_join(http_requests_total1{job="app",instance="inst-1"},"dst","-"""" +
       ""","instance","job")""")
     parseAndAssertResult("""label_replace(http_requests_total{job="app",instance="inst-1"},"$1-new-label-$2","""
+      + s""""instance","(.*)-(.*)")""", """label_replace(http_requests_total{job="app",instance="inst-1"},"$1-new-label-$2","""
       + s""""instance","(.*)-(.*)")""")
-    parseAndAssertResult("""scalar(http_requests_total{job="app",instance="inst-1"})""")
-    parseAndAssertResult("""vector(1.5)""")
-    parseAndAssertResult("""time()""")
-    parseAndAssertResult("""http_requests_total::count{job="app"}""")
-    parseAndAssertResult("""http_requests_total::sum{job="app"}""")
-    parseAndAssertResult("""topk(2.0,http_requests_total{job="app"})""")
-    parseAndAssertResult("""quantile(0.2,http_requests_total{job="app"})""")
-    parseAndAssertResult("""count_values("freq",http_requests_total{job="app"})""")
-    parseAndAssertResult("""timestamp(http_requests_total{job="app"})""")
-    parseAndAssertResult("""absent(http_requests_total{job="app"})""")
-    parseAndAssertResult("""absent(sum(http_requests_total{job="app"}))""")
-    parseAndAssertResult("""absent(sum_over_time(http_requests_total{job="app"}[5s]))""")
-    parseAndAssertResult("""absent(rate(http_requests_total{job="app"}[5s] offset 200s))""")
+    parseAndAssertResult("""scalar(http_requests_total{job="app",instance="inst-1"})""", """scalar(http_requests_total{job="app",instance="inst-1"})""")
+    parseAndAssertResult("""vector(1.5)""", """vector(1.5)""")
+    parseAndAssertResult("""time()""", """time()""")
+    parseAndAssertResult("""http_requests_total::count{job="app"}""", """http_requests_total::count{job="app"}""")
+    parseAndAssertResult("""http_requests_total::sum{job="app"}""", """http_requests_total::sum{job="app"}""")
+    parseAndAssertResult("""topk(2.0,http_requests_total{job="app"})""", """topk(2.0,http_requests_total{job="app"})""")
+    parseAndAssertResult("""quantile(0.2,http_requests_total{job="app"})""", """quantile(0.2,http_requests_total{job="app"})""")
+    parseAndAssertResult("""count_values("freq",http_requests_total{job="app"})""", """count_values("freq",http_requests_total{job="app"})""")
+    parseAndAssertResult("""timestamp(http_requests_total{job="app"})""", """timestamp(http_requests_total{job="app"})""")
+    parseAndAssertResult("""absent(http_requests_total{job="app"})""", """absent(http_requests_total{job="app"})""")
+    parseAndAssertResult("""absent(sum(http_requests_total{job="app"}))""", """absent(sum(http_requests_total{job="app"}))""")
+    parseAndAssertResult("""absent(sum_over_time(http_requests_total{job="app"}[5s]))""", """absent(sum_over_time(http_requests_total{job="app"}[5s]))""")
+    parseAndAssertResult("""absent(rate(http_requests_total{job="app"}[5s] offset 200s))""", """absent(rate(http_requests_total{job="app"}[5s] offset 200s))""")
   }
 
   it("should generate query from LogicalPlan having offset") {
@@ -96,5 +99,12 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
     val res = LogicalPlanParser.convertToQuery(lp)
     res shouldEqual "(1.0 / (2.0 + foo))"
+  }
+
+  it("should convert scalar vector operation query") {
+    val query = """http_requests_total{job="app"} + 2.1"""
+    val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
+    val res = LogicalPlanParser.convertToQuery(lp)
+    res shouldEqual "(http_requests_total{job=\"app\"} + 2.1)"
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -354,9 +354,9 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     execPlan.queryContext.plannerParams.skipAggregatePresent shouldEqual (false)
   }
 
-  it("should generate Exec plan for Binary join with single regex match") {
-    val lp = Parser.queryToLogicalPlan("test1{_ws_ = \"demo\", _ns_ =~ \"App\"} + " +
-      "test2{_ws_ = \"demo\", _ns_ =~ \"App\"}", 1000, 1000)
+  it("should preserve brackets in Binary join with regex query") {
+    val lp = Parser.queryToLogicalPlan("sum(test1{_ws_ = \"demo\", _ns_ =~ \"App\"}) / " +
+      "(sum(test2{_ws_ = \"demo\", _ns_ =~ \"App\"})+sum(test3{_ws_ = \"demo\", _ns_ =~ \"App\"}))", 1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
       Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
         ColumnFilter("_ns_", Equals("App"))))
@@ -365,6 +365,6 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
     execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
-      ("""test1{_ws_="demo",_ns_="App"} + test2{_ws_="demo",_ns_="App"}""")
+      ("""(sum(test1{_ws_="demo",_ns_="App"}) / (sum(test2{_ws_="demo",_ns_="App"}) + sum(test3{_ws_="demo",_ns_="App"})))""")
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -354,6 +354,20 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     execPlan.queryContext.plannerParams.skipAggregatePresent shouldEqual (false)
   }
 
+  it("should generate Exec plan for Binary join with single regex match") {
+    val lp = Parser.queryToLogicalPlan("test1{_ws_ = \"demo\", _ns_ =~ \"App\"} + " +
+      "test2{_ws_ = \"demo\", _ns_ =~ \"App\"}", 1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App"))))
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
+    execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      ("""(test1{_ws_="demo",_ns_="App"} + test2{_ws_="demo",_ns_="App"})""")
+  }
+
   it("should preserve brackets in Binary join with regex query") {
     val lp = Parser.queryToLogicalPlan("sum(test1{_ws_ = \"demo\", _ns_ =~ \"App\"}) / " +
       "(sum(test2{_ws_ = \"demo\", _ns_ =~ \"App\"})+sum(test3{_ws_ = \"demo\", _ns_ =~ \"App\"}))", 1000, 1000)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Logical plan to query function converts queries with brackets like `foo / (bar + baz)` to '`foo / bar + baz` as the function/logical plan does not know that  original query had brackets 

**New behavior :**
Enclose all binary join queries in brackets
