### PR TITLE
bug(query) : use updated col name to generate columnl ID's

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -101,7 +101,7 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
 
             // Get exact column IDs needed, including max column as needed for histogram calculations.
             // This code is responsible for putting exact IDs needed by any range functions.
-            val colIDs1 = getColumnIDs(sch, colName.toSeq, rangeVectorTransformers)
+            val colIDs1 = getColumnIDs(sch, newColName.toSeq, rangeVectorTransformers)
             val colIDs  = addIDsForHistMax(sch, colIDs1)
 
             // Modify transformers as needed for histogram w/ max, downsample, other schemas

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -525,6 +525,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]
+    result.result.head.key.labelValues.get(ZeroCopyUTF8String("metric")).get equals("request-latency")
     result.result.size shouldEqual 1
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
For Prometheus histogram sum & count queries like `histogram_sum` and `histogram_count` we need columns sum and count in Exec plan. Currently, original column list which is empty is getting used

**New behavior :**
Use newColName to generate ColID's