### PR TITLE
bug(core): Make shutdown on eviction lock timeout less aggressive

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -90,7 +90,7 @@ case class QuerySession(qContext: QueryContext,
                         var resultCouldBePartial: Boolean = false,
                         var partialResultsReason: Option[String] = None) {
   def close(): Unit = {
-    lock.foreach(_.releaseSharedLock())
+    lock.foreach(_.releaseSharedLock(qContext.queryId))
     lock = None
   }
 }

--- a/memory/src/main/scala/filodb.memory/BlockManager.scala
+++ b/memory/src/main/scala/filodb.memory/BlockManager.scala
@@ -224,7 +224,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     var acquired: Boolean = false
     try {
       val start = System.nanoTime()
-      acquired = reclaimLock.tryExclusiveReclaimLock(EvictionLock.direCircumstanceTimeoutMillis)
+      acquired = reclaimLock.tryExclusiveReclaimLock(EvictionLock.direCircumstanceMaxTimeoutMillis)
 
       if (!acquired) {
         // Don't stall ingestion forever. Some queries might return invalid results because

--- a/memory/src/main/scala/filodb.memory/EvictionLock.scala
+++ b/memory/src/main/scala/filodb.memory/EvictionLock.scala
@@ -46,7 +46,6 @@ class EvictionLock(debugInfo: String = "none") extends StrictLogging {
       if (reclaimLock.tryAcquireExclusiveNanos(TimeUnit.MILLISECONDS.toNanos(timeout))) {
         return true
       }
-      // if we did not get lock, count failures and judge if the node is in bad state
       if (timeout >= finalTimeoutMillis) {
         logger.error(s"Could not acquire exclusive access to eviction lock $debugInfo " +
           s"with finalTimeoutMillis=$finalTimeoutMillis LockState: $this runningQueries: $runningQueries")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently we shutdown too prematurely even if memory is slightly lower than threshold, and we didn't get the lock 5 eviction iterations. This is too aggressive, considering that timeout calculated (due to just below threshold) will be very small.

New algorithm:
1. Don't shutdown if not able to reclaim for multiple attempts as done today. Rely on ingestion failure to trigger forced shutdown.
2. If really close to threshold, increase timeout much more steeply than being done today. Given that query timeout is 60s, the maximum timeout should be at least that.
3. Also track queries that are holding the shared eviction locks for debugging purposes. This involves some small cost in memory and latency. 
