### PR TITLE
bug(cass): Backward compatibility with older versions of Guava

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/Util.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/Util.scala
@@ -1,7 +1,6 @@
 package filodb.cassandra
 
 import java.nio.ByteBuffer
-import java.util.concurrent.Executor
 
 import scala.concurrent.{Future, Promise}
 import scala.util.Random
@@ -50,15 +49,17 @@ object Util {
     }
   }
 
-  import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
+  import com.google.common.util.concurrent.{FutureCallback, ListenableFuture}
 
   implicit class CassandraFutureOps[A](lf: ListenableFuture[A]) {
-    def toScalaFuture(implicit executor: Executor): Future[A] = {
+    def toScalaFuture: Future[A] = {
       val promise = Promise[A]()
-      Futures.addCallback(lf, new FutureCallback[A] {
+      // GuavaCompatibility.INSTANCE is used in case the older version of guava Futures
+      // class is loaded
+      GuavaCompatibility.INSTANCE.addCallback(lf, new FutureCallback[A] {
         def onFailure(t: Throwable): Unit = promise failure t
         def onSuccess(result: A): Unit = promise success result
-      }, executor)
+      })
 
       promise.future
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Working around these errors when older version of guava is loaded into classpath/fatJar by using GuavaCompatibility class in cassandra driver:

```
Caused by: java.lang.IncompatibleClassChangeError: null
	at filodb.com.google.common.util.concurrent.Futures.addCallback(Futures.java:1014)
	at filodb.cassandra.Util$CassandraFutureOps.toScalaFuture(Util.scala:61)
	at filodb.cassandra.Util$ResultSetFutureOps.toIterator(Util.scala:70)
```