### PR TITLE
fix(core): change disk-ttl configuration type to Long

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -140,7 +140,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   // Future optimization: group by token range and batch?
   def write(ref: DatasetRef,
             chunksets: Observable[ChunkSet],
-            diskTimeToLiveSeconds: Int = 259200): Future[Response] = {
+            diskTimeToLiveSeconds: Long = 259200): Future[Response] = {
     chunksets.mapAsync(writeParallelism) { chunkset =>
       val start = System.currentTimeMillis()
       val partBytes = BinaryRegionLarge.asNewByteArray(chunkset.partition)
@@ -165,7 +165,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   private def writeChunks(ref: DatasetRef,
                           partition: Array[Byte],
                           chunkset: ChunkSet,
-                          diskTimeToLiveSeconds: Int): Future[Response] = {
+                          diskTimeToLiveSeconds: Long): Future[Response] = {
     val chunkTable = getOrCreateChunkTable(ref)
     chunkTable.writeChunks(partition, chunkset.info, chunkset.chunks, sinkStats, diskTimeToLiveSeconds)
       .collect {
@@ -433,7 +433,7 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   def writePartKeys(ref: DatasetRef,
                     shard: Int,
                     partKeys: Observable[PartKeyRecord],
-                    diskTTLSeconds: Int, updateHour: Long,
+                    diskTTLSeconds: Long, updateHour: Long,
                     writeToPkUTTable: Boolean = true): Future[Response] = {
     val pkTable = getOrCreatePartitionKeysTable(ref, shard)
     val pkByUTTable = getOrCreatePartitionKeysByUpdateTimeTable(ref)

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
@@ -76,13 +76,13 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
     s"WHERE partKey = ?"
   )
 
-  def writePartKey(pk: PartKeyRecord, diskTimeToLiveSeconds: Int): Future[Response] = {
+  def writePartKey(pk: PartKeyRecord, diskTimeToLiveSeconds: Long): Future[Response] = {
     if (diskTimeToLiveSeconds <= 0) {
       connector.execStmtWithRetries(writePartitionCqlNoTtl.bind(
         toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong))
     } else {
       connector.execStmtWithRetries(writePartitionCql.bind(
-        toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong, diskTimeToLiveSeconds: JInt))
+        toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong, diskTimeToLiveSeconds.toInt: JInt))
     }
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -79,7 +79,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
                   chunkInfo: ChunkSetInfo,
                   chunks: Seq[ByteBuffer],
                   stats: ChunkSinkStats,
-                  diskTimeToLive: Int): Future[Response] = {
+                  diskTimeToLive: Long): Future[Response] = {
     var chunkBytes = 0L
     val chunkList = chunks.map { bytes =>
                       val finalBytes = compressChunk(bytes)
@@ -90,7 +90,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
                                       .setLong(1, chunkInfo.id)
                                       .setBytes(2, toBuffer(ChunkSetInfo.toBytes(chunkInfo)))
                                       .setList(3, chunkList, classOf[ByteBuffer])
-                                      .setInt(4, diskTimeToLive)
+                                      .setInt(4, diskTimeToLive.toInt)
     stats.addChunkWriteStats(chunks.length, chunkBytes, chunkInfo.numRows)
     connector.execStmtWithRetries(insert.setConsistencyLevel(writeConsistencyLevel))
   }
@@ -102,7 +102,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
   def writeChunks(partKeyBytes: ByteBuffer,
                   row: Row,
                   stats: ChunkSinkStats,
-                  diskTimeToLiveSeconds: Int): Future[Response] = {
+                  diskTimeToLiveSeconds: Long): Future[Response] = {
 
     val info = row.getBytes(1)
     val chunks = row.getList(2, classOf[ByteBuffer])
@@ -116,7 +116,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
       row.getLong(0): java.lang.Long,      // chunkid
       info,
       chunks,
-      diskTimeToLiveSeconds: java.lang.Integer)
+      diskTimeToLiveSeconds.toInt: java.lang.Integer)
     )
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -856,7 +856,11 @@ class TimeSeriesShard(val ref: DatasetRef,
         val shardKey = schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset, schema.options.shardKeyColumns)
         captureTimeseriesCount(schema, shardKey, -1)
         if (storeConfig.meteringEnabled) {
-          cardTracker.decrementCount(shardKey)
+          try {
+            cardTracker.decrementCount(shardKey)
+          } catch { case e: Exception =>
+            logger.error("Got exception when reducing cardinality in tracker", e)
+          }
         }
         removePartition(p)
         removedParts += p.partID
@@ -869,7 +873,11 @@ class TimeSeriesShard(val ref: DatasetRef,
         val shardKey = schema.partKeySchema.colValues(pk.bytes, unsafePkOffset,
           schemas.part.options.shardKeyColumns)
         if (storeConfig.meteringEnabled) {
-          cardTracker.decrementCount(shardKey)
+          try {
+            cardTracker.decrementCount(shardKey)
+          } catch { case e: Exception =>
+            logger.error("Got exception when reducing cardinality in tracker", e)
+          }
         }
         captureTimeseriesCount(schema, shardKey, -1)
       }

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -29,7 +29,7 @@ trait ChunkSink {
    * @return Success when the chunksets stream ends and is completely written.
    *         Future.failure(exception) if an exception occurs.
    */
-  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Int = 259200): Future[Response]
+  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Long = 259200): Future[Response]
 
   /**
     * Used to bootstrap lucene index with partition keys for a shard
@@ -47,7 +47,7 @@ trait ChunkSink {
                               updateHour: Long): Observable[PartKeyRecord]
 
   def writePartKeys(ref: DatasetRef, shard: Int,
-                    partKeys: Observable[PartKeyRecord], diskTTLSeconds: Int,
+                    partKeys: Observable[PartKeyRecord], diskTTLSeconds: Long,
                     updateHour: Long, writeToPkUTTable: Boolean = true): Future[Response]
   /**
    * Initializes the ChunkSink for a given dataset.  Must be called once before writing.
@@ -120,7 +120,7 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
   // in-memory store of partition keys
   val partitionKeys = new ConcurrentHashMap[DatasetRef, scala.collection.mutable.Set[Types.PartitionKey]]().asScala
 
-  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Int): Future[Response] = {
+  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Long): Future[Response] = {
     chunksets.foreach { chunkset =>
       val totalBytes = chunkset.chunks.map(_.limit()).sum
       sinkStats.addChunkWriteStats(chunkset.chunks.length, totalBytes, chunkset.info.numRows)
@@ -156,7 +156,7 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
   override def scanPartKeys(ref: DatasetRef, shard: Int): Observable[PartKeyRecord] = Observable.empty
 
   override def writePartKeys(ref: DatasetRef, shard: Int,
-                             partKeys: Observable[PartKeyRecord], diskTTLSeconds: Int,
+                             partKeys: Observable[PartKeyRecord], diskTTLSeconds: Long,
                              updateHour: Long, writeToPkUTTable: Boolean = true): Future[Response] = {
     partKeys.countL.map(c => sinkStats.partKeysWrite(c.toInt)).runAsync.map(_ => Success)
   }

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -11,7 +11,7 @@ import filodb.core.downsample.DownsampleConfig
 
 final case class StoreConfig(flushInterval: FiniteDuration,
                              timeAlignedChunksEnabled: Boolean,
-                             diskTTLSeconds: Int,
+                             diskTTLSeconds: Long,
                              maxChunksSize: Int,
                              // Max write buffer size for Histograms, UTF8Strings, other blobs
                              maxBlobBufferSize: Int,
@@ -117,7 +117,7 @@ object StoreConfig {
     val maxChunkTime = config.as[Option[FiniteDuration]]("max-chunk-time").getOrElse(fallbackMaxChunkTime)
     StoreConfig(flushInterval,
                 timeAlignedChunksEnabled,
-                config.as[FiniteDuration]("disk-time-to-live").toSeconds.toInt,
+                config.as[FiniteDuration]("disk-time-to-live").toSeconds,
                 config.getInt("max-chunks-size"),
                 config.getInt("max-blob-buffer-size"),
                 config.getMemorySize("shard-mem-size").toBytes,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

- Longer disk-ttl is causing integer overflows. This is causing inadvertent purging of partitionKeys.