### PR TITLE
feat(query): Query statistics included in Query Result

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -419,7 +419,9 @@ object CliMain extends FilodbClusterNode {
       case Some(intervalSecs) =>
         val fut = Observable.intervalAtFixedRate(intervalSecs.seconds).foreach { n =>
           client.logicalPlan2Query(ref, plan, qOpts) match {
-            case QueryResult(_, _, result, _, _) => result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
+            case QueryResult(_, _, result, stats, _, _) =>
+              result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
+              println(s"QueryStats: $stats")
             case err: QueryError                => throw new ClientException(err)
           }
         }.recover {
@@ -430,9 +432,11 @@ object CliMain extends FilodbClusterNode {
       case None =>
         try {
           client.logicalPlan2Query(ref, plan, qOpts) match {
-            case QueryResult(_, schema, result, _, _) => println(s"Output schema: $schema")
+            case QueryResult(_, schema, result, stats, _, _) =>
+                                                   println(s"Output schema: $schema")
                                                    println(s"Number of Range Vectors: ${result.size}")
                                                    result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
+                                                   println(s"QueryStats: $stats")
             case QueryError(_,ex)               => println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")
           }
         } catch {

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -134,7 +134,7 @@ final class QueryActor(memStore: MemStore,
             querySession.close()
             replyTo ! res
             res match {
-              case QueryResult(_, _, vectors, _, _) => resultVectors.record(vectors.length)
+              case QueryResult(_, _, vectors, _, _, _) => resultVectors.record(vectors.length)
               case e: QueryError =>
                 queryErrors.increment()
                 queryExecuteSpan.fail(e.t.getMessage)

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -152,7 +152,7 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
                  100L, 1000L, 100L, window = 1000L, function = RangeFunctionId.CountOverTime), qOpt)
     coordinatorActor ! q2
     expectMsgPF(10.seconds.dilated) {
-      case QueryResult(_, schema, vectors, _, _) =>
+      case QueryResult(_, schema, vectors, _, _, _) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn),
                                        ColumnInfo("value", ColumnType.DoubleColumn))
         // query is counting each partition....

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -157,7 +157,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       probe.send(coordinatorActor, q1)
       val info1 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, srvs, _, _) =>
+        case QueryResult(_, schema, srvs, _, _, _) =>
           schema.columns shouldEqual timeMinSchema.columns
           srvs should have length (1)
           srvs(0).rows.toSeq should have length (2)   // 2 samples per series
@@ -168,7 +168,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
         Seq("min"), Some(300000), None), qOpt)
       probe.send(coordinatorActor, q2)
       val info2 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, Nil, _, _) =>
+        case QueryResult(_, schema, Nil, _, _, _) =>
           schema.columns shouldEqual Nil
       }
     }
@@ -205,7 +205,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       memStore.refreshIndexForTesting(dataset1.ref)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
@@ -218,7 +218,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                      RawSeries(AllChunksSelector, multiFilter, Seq("count"), Some(300000), None), 120000L, 10000L, 130000L)), qOpt)
       probe.send(coordinatorActor, q3)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(98.0, 108.0)
@@ -232,7 +232,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                      10000L, 130000L)),  qOpt)
       probe.send(coordinatorActor, q4)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _) =>
           schema.columns shouldEqual Nil
           vectors should have length (0)
       }
@@ -257,7 +257,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       (0 until numQueries).foreach { _ =>
         probe.expectMsgPF() {
-          case QueryResult(_, schema, vectors, _, _) =>
+          case QueryResult(_, schema, vectors, _, _, _) =>
             schema.columns shouldEqual valueSchema.columns
             vectors should have length (1)
             vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
@@ -287,7 +287,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                       queryOpt)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0, 14.0)
@@ -311,7 +311,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
         queryOpt)
       probe.send(coordinatorActor, q2)
       val info1 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, srvs, _, _) =>
+        case QueryResult(_, schema, srvs, _, _, _) =>
           schema.columns shouldEqual timeMinSchema.columns
           srvs should have length (6)
           val groupedByKey = srvs.groupBy(_.key.labelValues)
@@ -383,7 +383,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                    RawSeries(AllChunksSelector, Nil, Seq("AvgTone")), 0, 10, 99)), qOpt)
     probe.send(coordinatorActor, q2)
     probe.expectMsgPF() {
-      case QueryResult(_, schema, vectors, _, _) =>
+      case QueryResult(_, schema, vectors, _, _, _) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", LongColumn),
                                        ColumnInfo("value", DoubleColumn))
         vectors should have length (1)

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -161,7 +161,8 @@ filodb {
   spread-assignment = []
 
   shard-key-level-ingestion-metrics-enabled = true
-  shard-key-level-query-metrics-enabled = true
+  # info config used for metric breakdown
+  cluster-type = "raw" // possible values: downsample, raw, recRule, aggregates etc.
 
   query {
     translate-prom-to-filodb-histogram = true

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -20,7 +20,7 @@ import filodb.core.{DatasetRef, Types}
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore._
 import filodb.core.metadata.Schemas
-import filodb.core.query.{ColumnFilter, QuerySession}
+import filodb.core.query.{ColumnFilter, Filter, QuerySession}
 import filodb.core.store._
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -31,7 +31,6 @@ class DownsampledTimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val shardTotalRecoveryTime = Kamon.gauge("downsample-total-shard-recovery-time",
     MeasurementUnit.time.milliseconds).withTags(TagSet.from(tags))
   val partitionsQueried = Kamon.counter("downsample-partitions-queried").withTags(TagSet.from(tags))
-  val chunksQueried = Kamon.counter("downsample-chunks-queried").withTags(TagSet.from(tags))
   val queryTimeRangeMins = Kamon.histogram("query-time-range-minutes").withTags(TagSet.from(tags))
   val indexEntriesRefreshed = Kamon.counter("index-entries-refreshed").withTags(TagSet.from(tags))
   val indexEntriesPurged = Kamon.counter("index-entries-purged").withTags(TagSet.from(tags))
@@ -63,6 +62,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   private val indexDataset = downsampledDatasetRefs.last
   private val indexTtlMs = downsampleTtls.last.toMillis
+  private val clusterType = filodbConfig.getString("cluster-type")
 
   private val downsampleStoreConfig = StoreConfig(filodbConfig.getConfig("downsampler.downsample-store-config"))
 
@@ -244,8 +244,16 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
             RecordSchema.schemaID(pkRec.partKey, UnsafeUtils.arayOffset)
           }
           stats.queryTimeRangeMins.record((chunkMethod.endTime - chunkMethod.startTime) / 60000 )
+          val metricShardKeys = schemas.part.options.shardKeyColumns
+          val metricGroupBy = clusterType +: metricShardKeys.map { col =>
+            filters.collectFirst {
+              case ColumnFilter(c, Filter.Equals(filtVal: String)) if c == col => filtVal
+            }.getOrElse("unknown")
+          }.toList
+          val chunksReadCounter = querySession.queryStats.getChunksScannedCounter(metricGroupBy)
+
           PartLookupResult(shardNum, chunkMethod, debox.Buffer.empty,
-            _schema, debox.Map.empty, debox.Buffer.empty, recs, stats.chunksQueried)
+            _schema, debox.Map.empty, debox.Buffer.empty, recs, chunksReadCounter)
         } else {
           throw new UnsupportedOperationException("Cannot have empty filters")
         }

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -2,6 +2,7 @@ package filodb.core.query
 
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._
@@ -98,39 +99,40 @@ case class QuerySession(qContext: QueryContext,
   }
 }
 
-case class QueryStats() {
-
-  val partsScanned = TrieMap[Seq[String], AtomicInteger]()
-  val chunksScanned = TrieMap[Seq[String], AtomicInteger]()
-  val resultSize = TrieMap[Seq[String], AtomicInteger]()
-
-  override def toString: String = {
-    s"""
-    partsScanned:  $partsScanned
-    chunksScanned:  $chunksScanned
-    resultSize: $resultSize
-    """
+case class Stat() {
+  val partsScanned = new AtomicInteger
+  val chunksScanned = new AtomicInteger
+  val resultSize = new AtomicLong
+  override def toString: String = s"(partsScanned=$partsScanned, chunksScanned=$chunksScanned, resultSize=$resultSize)"
+  def add(s: Stat): Unit = {
+    partsScanned.addAndGet(s.partsScanned.get())
+    chunksScanned.addAndGet(s.chunksScanned.get())
+    resultSize.addAndGet(s.resultSize.get())
   }
+}
+
+case class QueryStats() {
+  val stat = TrieMap[Seq[String], Stat]()
+
+  override def toString: String = stat.toString()
 
   def add(s: QueryStats): Unit = {
-    s.partsScanned.foreach(c => partsScanned.getOrElseUpdate(c._1, new AtomicInteger(0)).addAndGet(c._2.get()))
-    s.chunksScanned.foreach(c => chunksScanned.getOrElseUpdate(c._1, new AtomicInteger(0)).addAndGet(c._2.get()))
-    s.resultSize.foreach(c => resultSize.getOrElseUpdate(c._1, new AtomicInteger(0)).addAndGet(c._2.get()))
+    s.stat.foreach(kv => stat.getOrElseUpdate(kv._1, Stat()).add(kv._2))
   }
 
   def getPartsScannedCounter(group: Seq[String] = Nil): AtomicInteger = {
-    val theNs = if (group.isEmpty && partsScanned.size == 1) partsScanned.head._1 else group
-    partsScanned.getOrElseUpdate(theNs, new AtomicInteger(0))
+    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    stat.getOrElseUpdate(theNs, Stat()).partsScanned
   }
 
   def getChunksScannedCounter(group: Seq[String] = Nil): AtomicInteger = {
-    val theNs = if (group.isEmpty && chunksScanned.size == 1) chunksScanned.head._1 else group
-    chunksScanned.getOrElseUpdate(theNs, new AtomicInteger(0))
+    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    stat.getOrElseUpdate(theNs, Stat()).chunksScanned
   }
 
-  def getResultSizeCounter(group: Seq[String] = Nil): AtomicInteger = {
-    val theNs = if (group.isEmpty && resultSize.size == 1) resultSize.head._1 else group
-    resultSize.getOrElseUpdate(theNs, new AtomicInteger(0))
+  def getResultSizeCounter(group: Seq[String] = Nil): AtomicLong = {
+    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    stat.getOrElseUpdate(theNs, Stat()).resultSize
   }
 
 }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -1,13 +1,13 @@
 package filodb.core.query
 
 import java.time.{LocalDateTime, YearMonth, ZoneOffset}
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.Iterator
 
 import com.typesafe.scalalogging.StrictLogging
 import debox.Buffer
 import kamon.Kamon
-import kamon.metric.Counter
 import org.joda.time.DateTime
 
 import filodb.core.binaryrecord2.{MapItemConsumer, RecordBuilder, RecordContainer, RecordSchema}
@@ -280,7 +280,7 @@ final case class RawDataRangeVector(key: RangeVectorKey,
                                     partition: ReadablePartition,
                                     chunkMethod: ChunkScanMethod,
                                     columnIDs: Array[Int],
-                                    chunksQueriedMetric: Counter) extends RangeVector {
+                                    chunksQueriedMetric: AtomicInteger) extends RangeVector {
   // Iterators are stateful, for correct reuse make this a def
   def rows(): RangeVectorCursor = partition.timeRangeRows(chunkMethod, columnIDs)
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -80,7 +80,7 @@ filodb {
   spread-default = 1
 
   shard-key-level-ingestion-metrics-enabled = true
-  shard-key-level-query-metrics-enabled = true
+  cluster-type = "raw"
 
   spread-assignment = [
     {

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -1,10 +1,11 @@
 package filodb.core
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.concurrent.duration._
 import scala.io.Source
 
 import com.typesafe.config.ConfigFactory
-import kamon.Kamon
 import monix.eval.Task
 import monix.reactive.Observable
 import org.joda.time.DateTime
@@ -14,7 +15,7 @@ import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{SomeData, TimeSeriesPartitionSpec, WriteBufferPool}
 import filodb.core.metadata.{Dataset, DatasetOptions, Schema, Schemas}
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{RangeVector, RangeVectorCursor, RangeVectorKey, RawDataRangeVector, RvRange, TransientRow}
+import filodb.core.query._
 import filodb.core.store._
 import filodb.memory._
 import filodb.memory.format.{vectors => bv, _}
@@ -416,7 +417,7 @@ object MachineMetricsData {
       false, Option.empty, false, 1.hour.toMillis) }
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(histIngestBH, encode = true)
-    (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 3), Kamon.counter("dummy").withoutTags()))  // select timestamp and histogram columns only
+    (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 3), new AtomicInteger()))  // select timestamp and histogram columns only
   }
 
   private val histMaxBP = new WriteBufferPool(TestData.nativeMem, histMaxDS.schema.data, TestData.storeConf)
@@ -432,7 +433,7 @@ object MachineMetricsData {
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(histMaxBH, encode = true)
     // Select timestamp, hist, max
-    (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 4, 3), Kamon.counter("dummy").withoutTags()))
+    (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 4, 3), new AtomicInteger()))
   }
 }
 

--- a/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
+++ b/core/src/test/scala/filodb.core/downsample/ShardDownsamplerSpec.scala
@@ -1,11 +1,13 @@
 package filodb.core.downsample
 
-import com.typesafe.config.ConfigFactory
-import kamon.Kamon
-import org.scalatest.BeforeAndAfterAll
+import java.util.concurrent.atomic.AtomicInteger
 
-import filodb.core.{MachineMetricsData => MMD}
-import filodb.core.TestData
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.{TestData, MachineMetricsData => MMD}
 import filodb.core.binaryrecord2.{RecordBuilder, RecordContainer, StringifyMapItemConsumer}
 import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesPartitionSpec, TimeSeriesShardStats, WriteBufferPool}
 import filodb.core.metadata._
@@ -13,10 +15,7 @@ import filodb.core.metadata.Column.ColumnType._
 import filodb.core.query.RawDataRangeVector
 import filodb.core.store.AllChunkScan
 import filodb.memory._
-import filodb.memory.format.{vectors => bv}
-import filodb.memory.format.{TupleRowReader, ZeroCopyUTF8String}
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
+import filodb.memory.format.{TupleRowReader, ZeroCopyUTF8String, vectors => bv}
 
 // scalastyle:off null
 class ShardDownsamplerSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
@@ -79,7 +78,7 @@ class ShardDownsamplerSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder, encode = true)
 //    part.encodeAndReleaseBuffers(ingestBlockHolder)
-    RawDataRangeVector(null, part, AllChunkScan, Array(0, 1), Kamon.counter("dummy").withoutTags())
+    RawDataRangeVector(null, part, AllChunkScan, Array(0, 1), new AtomicInteger())
   }
 
   val downsampleOps = new ShardDownsampler(promDataset.name, 0, promSchema, downsampleSchema,

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -3,7 +3,7 @@ package filodb.query
 import enumeratum.{Enum, EnumEntry}
 
 import filodb.core.{DatasetRef, NodeCommand, NodeResponse}
-import filodb.core.query.{RangeVector, ResultSchema}
+import filodb.core.query.{QueryStats, RangeVector, ResultSchema}
 
 trait QueryCommand extends NodeCommand with java.io.Serializable {
   def submitTime: Long
@@ -50,6 +50,7 @@ object QueryResultType extends Enum[QueryResultType] {
 final case class QueryResult(id: String,
                              resultSchema: ResultSchema,
                              result: Seq[RangeVector],
+                             queryStats: QueryStats = QueryStats(),
                              mayBePartial: Boolean = false,
                              partialResultReason: Option[String] = None) extends QueryResponse {
   def resultType: QueryResultType = {

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -27,7 +27,7 @@ trait ReduceAggregateExec extends NonLeafExecPlan {
                         firstSchema: Task[ResultSchema],
                         querySession: QuerySession): Observable[RangeVector] = {
     val results = childResponses.flatMap {
-        case (QueryResult(_, _, result, _, _), _) => Observable.fromIterable(result)
+        case (QueryResult(_, _, result, _, _, _), _) => Observable.fromIterable(result)
         case (QueryError(_, ex), _)         => throw ex
     }
 

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -67,12 +67,12 @@ final case class BinaryJoinExec(queryContext: QueryContext,
                               querySession: QuerySession): Observable[RangeVector] = {
     val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, _, result, _, _), _)
+      case (QueryResult(_, _, result, _, _, _), _)
         if (result.size  > queryContext.plannerParams.joinQueryCardLimit && cardinality == Cardinality.OneToOne) =>
         throw new BadQueryException(s"The join in this query has input cardinality of ${result.size} which" +
           s" is more than limit of ${queryContext.plannerParams.joinQueryCardLimit}." +
           s" Try applying more filters or reduce time range.")
-      case (QueryResult(_, _, result, _, _), i) => (result, i)
+      case (QueryResult(_, _, result, _, _, _), i) => (result, i)
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map { resp =>
       span.mark("binary-join-child-results-available")
@@ -199,9 +199,9 @@ final case class BinaryJoinExec(queryContext: QueryContext,
     */
   override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
     resp match {
-      case QueryResult(_, schema, _, _, _) if rs == ResultSchema.empty =>
+      case QueryResult(_, schema, _, _, _, _) if rs == ResultSchema.empty =>
         schema     /// First schema, take as is
-      case QueryResult(_, schema, _, _, _) =>
+      case QueryResult(_, schema, _, _, _, _) =>
         if (!rs.hasSameColumnsAs(schema)) throw SchemaMismatch(rs.toString, schema.toString)
         else rs
     }

--- a/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
@@ -18,7 +18,7 @@ trait DistConcatExec extends NonLeafExecPlan {
                         firstSchema: Task[ResultSchema],
                         querySession: QuerySession): Observable[RangeVector] = {
     childResponses.flatMap {
-      case (QueryResult(_, _, result, _, _), _) => Observable.fromIterable(result)
+      case (QueryResult(_, _, result, _, _, _), _) => Observable.fromIterable(result)
       case (QueryError(_, ex), _)         => throw ex
     }
   }

--- a/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
+++ b/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
@@ -5,7 +5,7 @@ import monix.execution.Scheduler
 
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{ColumnInfo, EmptyQueryConfig, QueryContext, QuerySession, ResultSchema}
+import filodb.core.query.{ColumnInfo, EmptyQueryConfig, QueryContext, QuerySession, QueryStats, ResultSchema}
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, QueryResult}
 
@@ -19,7 +19,7 @@ case class EmptyResultExec(queryContext: QueryContext,
     Task(QueryResult(queryContext.queryId,
       new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                            ColumnInfo("value", ColumnType.DoubleColumn)), 1),
-      Seq.empty, false, None))
+      Seq.empty, QueryStats(), false, None))
   }
 
   override def doExecute(source: ChunkSource,

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -11,7 +11,7 @@ import filodb.core.{DatasetRef, Types}
 import filodb.core.memstore.PartLookupResult
 import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
-import filodb.core.query.{QueryConfig, QuerySession}
+import filodb.core.query.{QueryConfig, QuerySession, QueryStats}
 import filodb.core.store._
 import filodb.query.QueryResponse
 
@@ -35,7 +35,7 @@ import filodb.query.QueryResponse
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       // translate implicit ExecutionContext to monix.Scheduler
-      val querySession = QuerySession(plan.queryContext, queryConfig)
+      val querySession = QuerySession(plan.queryContext, queryConfig, QueryStats())
       plan.execute(source, querySession)
     }
   }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -35,7 +35,7 @@ trait MetadataDistConcatExec extends NonLeafExecPlan {
                         querySession: QuerySession): Observable[RangeVector] = {
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, _, result, _, _), _) => result
+      case (QueryResult(_, _, result, _, _, _), _) => result
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map { resp =>
       var metadataResult = scala.collection.mutable.Set.empty[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -47,7 +47,8 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema,
                         queryWithPlanName(queryContext)))
 
-    QueryResult(id, resultSchema, srvSeq,
+    // FIXME need to send and parse query stats in remote calls
+    QueryResult(id, resultSchema, srvSeq, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 }

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -76,7 +76,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
   def toQueryResponse(response: SuccessResponse, id: String, parentSpan: kamon.trace.Span): QueryResponse = {
     val queryResponse = if (response.data.result.isEmpty) {
       logger.debug("PromQlRemoteExec generating empty QueryResult as result is empty")
-      QueryResult(id, ResultSchema.empty, Seq.empty,
+      QueryResult(id, ResultSchema.empty, Seq.empty, QueryStats(),
         if (response.partial.isDefined) response.partial.get else false, response.message)
     } else {
       if (response.data.result.head.aggregateResponse.isDefined) genAggregateResult(response, id)
@@ -84,7 +84,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
         val samples = response.data.result.head.values.getOrElse(Seq(response.data.result.head.value.get))
         if (samples.isEmpty) {
           logger.debug("PromQlRemoteExec generating empty QueryResult as samples is empty")
-          QueryResult(id, ResultSchema.empty, Seq.empty,
+          QueryResult(id, ResultSchema.empty, Seq.empty, QueryStats(),
             if (response.partial.isDefined) response.partial.get else false, response.message)
         } else {
           samples.head match {
@@ -102,7 +102,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
     val aggregateResponse = response.data.result.head.aggregateResponse.get
     if (aggregateResponse.aggregateSampl.isEmpty) {
-      QueryResult(id, ResultSchema.empty, Seq.empty,
+      // FIXME need to send and parse query stats in remote calls
+      QueryResult(id, ResultSchema.empty, Seq.empty, QueryStats(),
         if (response.partial.isDefined) response.partial.get else false, response.message)
     } else {
       aggregateResponse.aggregateSampl.head match {
@@ -139,7 +140,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
         queryWithPlanName(queryContext))
       // TODO: Handle stitching with verbose flag
     }
-    QueryResult(id, resultSchema.get("default").get, rangeVectors,
+    // FIXME need to send and parse query stats in remote calls
+    QueryResult(id, resultSchema.get("default").get, rangeVectors, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
@@ -178,7 +180,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
       SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, queryContext.origQueryParams.toString)
       // TODO: Handle stitching with verbose flag
     }
-    QueryResult(id, resultSchema.get("histogram").get, rangeVectors,
+    // FIXME need to send and parse query stats in remote calls
+    QueryResult(id, resultSchema.get("histogram").get, rangeVectors, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
@@ -209,7 +212,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
     }
 
     // TODO: Handle stitching with verbose flag
-    QueryResult(id, resultSchema.get(Avg.entryName).get, rangeVectors,
+    // FIXME need to send and parse query stats in remote calls
+    QueryResult(id, resultSchema.get(Avg.entryName).get, rangeVectors, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
@@ -241,7 +245,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
     }
 
     // TODO: Handle stitching with verbose flag
-    QueryResult(id, resultSchema.get("stdval").get, rangeVectors,
+    // FIXME need to send and parse query stats in remote calls
+    QueryResult(id, resultSchema.get("stdval").get, rangeVectors, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 }

--- a/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
@@ -58,7 +58,7 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
                       (implicit sched: Scheduler): Task[QueryResponse] = {
     val rangeVectors : Seq[RangeVector] = Seq(ScalarFixedDouble(params, evaluate))
     Task {
-      QueryResult(queryContext.queryId, resultSchema, rangeVectors, querySession.resultCouldBePartial,
+      QueryResult(queryContext.queryId, resultSchema, rangeVectors, QueryStats(), querySession.resultCouldBePartial,
         querySession.partialResultsReason)
     }
   }

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -59,7 +59,7 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          QueryResult(queryContext.queryId, resultSchema, _, querySession.resultCouldBePartial,
+          QueryResult(queryContext.queryId, resultSchema, _, QueryStats(), querySession.resultCouldBePartial,
             querySession.partialResultsReason)
         })
       }.flatten

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -55,7 +55,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
                               querySession: QuerySession): Observable[RangeVector] = {
     val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, schema, result, _, _), i) => (schema, result, i)
+      case (QueryResult(_, schema, result, _, _, _), i) => (schema, result, i)
       case (QueryError(_, ex), _)              => throw ex
     }.toListL.map { resp =>
       span.mark("binary-join-child-results-available")
@@ -271,9 +271,9 @@ final case class SetOperatorExec(queryContext: QueryContext,
     */
   override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema = {
     resp match {
-      case QueryResult(_, schema, _, _, _) if rs == ResultSchema.empty =>
+      case QueryResult(_, schema, _, _, _, _) if rs == ResultSchema.empty =>
         schema     /// First schema, take as is
-      case QueryResult(_, schema, _, _, _) =>
+      case QueryResult(_, schema, _, _, _, _) =>
         if (!rs.hasSameColumnsAs(schema)) throw SchemaMismatch(rs.toString, schema.toString)
         else rs
     }

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -76,7 +76,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
                         querySession: QuerySession): Observable[RangeVector] = {
     qLogger.debug(s"StitchRvsExec: Stitching results:")
     val stitched = childResponses.map {
-      case (QueryResult(_, _, result, _, _), _) => result
+      case (QueryResult(_, _, result, _, _, _), _) => result
       case (QueryError(_, ex), _)         => throw ex
     }.toListL.map(_.flatten).map { srvs =>
       val groups = srvs.groupBy(_.key.labelValues)

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -68,7 +68,7 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          QueryResult(queryContext.queryId, resultSchema, _, querySession.resultCouldBePartial,
+          QueryResult(queryContext.queryId, resultSchema, _, QueryStats(), querySession.resultCouldBePartial,
             querySession.partialResultsReason)
         })
       }.flatten

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -95,7 +95,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _) => {
+      case QueryResult(id, _, response, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
@@ -115,7 +115,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     (resp: @unchecked) match {
-      case QueryResult(_, _, results, _, _) => results.size shouldEqual 1
+      case QueryResult(_, _, results, _, _, _) => results.size shouldEqual 1
         results(0).rows.size shouldEqual 0
     }
   }
@@ -129,7 +129,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _) =>
+      case QueryResult(id, _, response, _, _, _) =>
         response.size shouldEqual 1
         response(0).rows.map { row =>
           val r = row.asInstanceOf[BinaryRecordRowReader]
@@ -150,7 +150,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _) => {
+      case QueryResult(id, _, response, _, _, _) => {
         response.size shouldEqual 1
         response(0).rows.map { row =>
           val r = row.asInstanceOf[BinaryRecordRowReader]
@@ -169,7 +169,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _) => {
+      case QueryResult(id, _, response, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -1,11 +1,14 @@
 package filodb.query.exec.rangefn
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 import com.typesafe.config.ConfigFactory
-import kamon.Kamon
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import filodb.core.{MetricsTestData, QueryTimeoutException, TestData, MachineMetricsData => MMD}
 import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesPartitionSpec, WriteBufferPool}
@@ -17,8 +20,6 @@ import filodb.memory.data.ChunkMap
 import filodb.memory.format.{TupleRowReader, vectors => bv}
 import filodb.memory.BinaryRegion.NativePointer
 import filodb.query.exec._
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
 
 /**
  * A common trait for windowing query tests which uses real chunks and real RawDataRangeVectors
@@ -161,7 +162,7 @@ trait RawDataWindowingSpec extends AnyFunSpec with Matchers with BeforeAndAfter 
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder, encode = true)
     // part.encodeAndReleaseBuffers(ingestBlockHolder)
-    RawDataRangeVector(null, part, AllChunkScan, Array(0, 1), Kamon.counter("dummy").withoutTags())
+    RawDataRangeVector(null, part, AllChunkScan, Array(0, 1), new AtomicInteger())
   }
 
   def timeValueRvDownsample(tuples: Seq[(Long, Double, Double, Double, Double, Double)],
@@ -175,7 +176,7 @@ trait RawDataWindowingSpec extends AnyFunSpec with Matchers with BeforeAndAfter 
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(ingestBlockHolder2, encode = true)
     // part.encodeAndReleaseBuffers(ingestBlockHolder)
-    RawDataRangeVector(null, part, AllChunkScan, colIds, Kamon.counter("dummy").withoutTags())
+    RawDataRangeVector(null, part, AllChunkScan, colIds, new AtomicInteger())
   }
 
   def timeValueRV(data: Seq[Double], startTS: Long = defaultStartTS): RawDataRangeVector = {

--- a/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
@@ -142,7 +142,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _) => {
+      case QueryResult(id, _, response, _, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[TimeScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList
@@ -157,7 +157,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _) => {
+      case QueryResult(id, _, response, _, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[HourScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList
@@ -173,7 +173,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _) => {
+      case QueryResult(id, _, response, _, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[DayOfWeekScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1,6 +1,22 @@
 package filodb.downsampler
 
+import java.io.File
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
 import com.typesafe.config.{ConfigException, ConfigFactory}
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import org.apache.spark.{SparkConf, SparkException}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+
 import filodb.cardbuster.CardinalityBuster
 import filodb.core.GlobalScheduler._
 import filodb.core.MachineMetricsData
@@ -18,21 +34,7 @@ import filodb.memory.format.{PrimitiveVectorReader, UnsafeUtils}
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.memory.format.vectors.{CustomBuckets, DoubleVector, LongHistogram}
 import filodb.query.{QueryError, QueryResult}
-import filodb.query.exec.{InProcessPlanDispatcher, InternalRangeFunction, MultiSchemaPartitionsExec, PeriodicSamplesMapper}
-import kamon.Kamon
-import monix.execution.Scheduler
-import monix.reactive.Observable
-import org.apache.spark.{SparkConf, SparkException}
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{Millis, Seconds, Span}
-
-import java.io.File
-import java.time.Instant
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import filodb.query.exec._
 
 /**
   * Spec tests downsampling round trip.
@@ -473,7 +475,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampledPart1.partKeyBytes shouldEqual dsGaugePartKeyBytes
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3, 4, 5),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val downsampledData1 = rv1.rows.map { r =>
       (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getDouble(3), r.getDouble(4), r.getDouble(5))
@@ -510,7 +512,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampledPart1.partKeyBytes shouldEqual dsGaugeLowFreqPartKeyBytes
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3, 4, 5),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val downsampledData1 = rv1.rows.map { r =>
       (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getDouble(3), r.getDouble(4), r.getDouble(5))
@@ -541,7 +543,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     PrimitiveVectorReader.dropped(ctrChunkInfo.vectorAccessor(1), ctrChunkInfo.vectorAddress(1)) shouldEqual true
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val downsampledData1 = rv1.rows.map { r =>
       (r.getLong(0), r.getDouble(1))
@@ -584,7 +586,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     PrimitiveVectorReader.dropped(ctrChunkInfo.vectorAccessor(2), ctrChunkInfo.vectorAddress(2)) shouldEqual true
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
     val downsampledData1 = rv1.rows.map { r =>
@@ -633,7 +635,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     PrimitiveVectorReader.dropped(acc, addr) shouldEqual true
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
     val downsampledData1 = rv1.rows.map { r =>
@@ -683,7 +685,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampledPart2.partKeyBytes shouldEqual dsGaugePartKeyBytes
 
     val rv2 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart2, AllChunkScan, Array(0, 1, 2, 3, 4, 5),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val downsampledData2 = rv2.rows.map { r =>
       (r.getLong(0), r.getDouble(1), r.getDouble(2), r.getDouble(3), r.getDouble(4), r.getDouble(5))
@@ -710,7 +712,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampledPart1.partKeyBytes shouldEqual counterPartKeyBytes
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val ctrChunkInfo = downsampledPart1.infos(AllChunkScan).nextInfoReader
     PrimitiveVectorReader.dropped(ctrChunkInfo.vectorAccessor(1), ctrChunkInfo.vectorAddress(1)) shouldEqual true
@@ -757,7 +759,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     PrimitiveVectorReader.dropped(acc, addr) shouldEqual true
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
     val downsampledData1 = rv1.rows.map { r =>
@@ -800,7 +802,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     PrimitiveVectorReader.dropped(acc, addr) shouldEqual true
 
     val rv1 = RawDataRangeVector(CustomRangeVectorKey.empty, downsampledPart1, AllChunkScan, Array(0, 1, 2, 3),
-      Kamon.counter("dummy").withoutTags())
+      new AtomicInteger())
 
     val bucketScheme = Seq(3d, 10d, Double.PositiveInfinity)
     val downsampledData1 = rv1.rows.map { r =>

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -191,7 +191,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",_ws_=\"demo\",_ns_=\"App-2\"})"
     val logicalPlan = Parser.queryRangeToLogicalPlan(chunkMetaQuery, TimeStepParams(0, 60, Int.MaxValue))
     client.logicalPlan2Query(dataset, logicalPlan) match {
-      case QueryResult2(_, _, result, _, _) => result.foreach(rv => println(rv.prettyPrint()))
+      case QueryResult2(_, _, result, _, _, _) => result.foreach(rv => println(rv.prettyPrint()))
       case e: QueryError => fail(e.t)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Query Statistics now included in query result broken down by shard key. We track:
* Number of time series scanned for query
* Number of chunks scanned for query
* Size of the query result (this translates to heap usage)

This can be used by Query API (Akka based) callers to track breakdown of resource utilization by workspace/namespace (aka shard key). This also offloads this work away from FiloDB since the tracking the breakdown by shard key can be memory intensive and needs to be done only if the situation demands.

In addition, this information can potentially be used for cost estimate of query used for planning purposes, or rate limiting of queries based on resource utilization.

```
❯ ./filo-cli '-Dakka.remote.netty.tcp.hostname=127.0.0.1' --host 127.0.0.1 --dataset prometheus --promql 'heap_usage{_ns_="App-0",_ws_="demo"}' --start 1630360115 --end 1630363715 --limit 15
...
QueryStats: TrieMap(List(raw, demo, App-0, heap_usage) -> (partsScanned=12, chunksScanned=12, resultSize=88934))
```


*This is a breaking change since new fields are added to QueryResult*