### PR TITLE
feat(query): reduce child timeout  and return partial result when any child does not finish within the time limit

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -22,7 +22,7 @@ import filodb.core.metadata.Schemas
 import filodb.core.query.{QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.CorruptVectorException
 import filodb.query._
-import filodb.query.exec.{ClientParams, DispatchedPlan}
+import filodb.query.exec.DispatchedPlan
 
 object QueryActor {
   final case class ThrowException(dataset: DatasetRef)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -1,9 +1,11 @@
 package filodb.coordinator.queryplanner
 
 import scala.concurrent.duration.FiniteDuration
+
 import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
+
 import filodb.core.query.QueryContext
 import filodb.query.{LogicalPlan, QueryResponse}
 import filodb.query.exec.{ClientParams, DispatchedPlan, ExecPlan}

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -1,14 +1,12 @@
 package filodb.coordinator.queryplanner
 
 import scala.concurrent.duration.FiniteDuration
-
 import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
-
 import filodb.core.query.QueryContext
 import filodb.query.{LogicalPlan, QueryResponse}
-import filodb.query.exec.{ClientParams, ExecPlan, RunTimePlanContainer}
+import filodb.query.exec.{ClientParams, DispatchedPlan, ExecPlan}
 
 /**
   * Abstraction for Query Planning. QueryPlanners can be composed using decorator pattern to add capabilities.
@@ -35,7 +33,7 @@ trait QueryPlanner {
     // kamon uses thread-locals.
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(parentSpan, false) {
-      execPlan.dispatcher.dispatch(RunTimePlanContainer(execPlan,
+      execPlan.dispatcher.dispatch(DispatchedPlan(execPlan,
         ClientParams(execPlan.queryContext.plannerParams.queryTimeoutMillis)))
     }
   }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -8,7 +8,7 @@ import monix.execution.Scheduler
 
 import filodb.core.query.QueryContext
 import filodb.query.{LogicalPlan, QueryResponse}
-import filodb.query.exec.ExecPlan
+import filodb.query.exec.{ClientParams, ExecPlan, RunTimePlanContainer}
 
 /**
   * Abstraction for Query Planning. QueryPlanners can be composed using decorator pattern to add capabilities.
@@ -35,7 +35,8 @@ trait QueryPlanner {
     // kamon uses thread-locals.
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(parentSpan, false) {
-      execPlan.dispatcher.dispatch(execPlan)
+      execPlan.dispatcher.dispatch(RunTimePlanContainer(execPlan,
+        ClientParams(execPlan.queryContext.plannerParams.queryTimeoutMillis)))
     }
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -438,7 +438,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     res.result.isEmpty shouldEqual true
   }
 
-  it("should materialize instant aqueries with lookback == retention correctly") {
+  it("should materialize instant queries with lookback == retention correctly") {
     val nowSeconds = System.currentTimeMillis() / 1000
     val planner = new SingleClusterPlanner(dsRef, schemas, mapperRef,
       earliestRetainedTimestampFn = nowSeconds * 1000 - 3.days.toMillis, queryConfig, "raw")
@@ -513,7 +513,6 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
     val logicalPlan1 = Parser.queryRangeToLogicalPlan("""sum(foo{_ns_="bar", _ws_="test"}) by (__name__)""",
       TimeStepParams(1000, 20, 2000))
-
     val execPlan1 = engine.materialize(logicalPlan1, QueryContext(origQueryParams = promQlQueryParams))
 
     execPlan1.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -433,7 +433,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val ep4 = planner.materialize(logicalPlan4, QueryContext())
     ep4.isInstanceOf[EmptyResultExec] shouldEqual true
     import GlobalScheduler._
-    val res = ep4.dispatcher.dispatch(RunTimePlanContainer(ep4, ClientParams
+    val res = ep4.dispatcher.dispatch(DispatchedPlan(ep4, ClientParams
     (ep4.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue.asInstanceOf[QueryResult]
     res.result.isEmpty shouldEqual true
   }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -475,6 +475,7 @@ gateway {
 
 akka {
 
+  http.server.request-timeout = 1m
   test.single-expect-default = 10s
 
   extensions = ["filodb.coordinator.FilodbCluster"]

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -89,6 +89,7 @@ object QueryContext {
   */
 case class QuerySession(qContext: QueryContext,
                         queryConfig: QueryConfig,
+                        deadline: Long = 30000,
                         queryStats: QueryStats = QueryStats(),
                         var lock: Option[EvictionLock] = None,
                         var resultCouldBePartial: Boolean = false,
@@ -138,5 +139,5 @@ case class QueryStats() {
 }
 
 object QuerySession {
-  def makeForTestingOnly(): QuerySession = QuerySession(QueryContext(), EmptyQueryConfig, QueryStats())
+  def makeForTestingOnly(): QuerySession = QuerySession(QueryContext(), EmptyQueryConfig)
 }

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -11,7 +11,7 @@ import filodb.core.{DatasetRef, Types}
 import filodb.core.memstore.PartLookupResult
 import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
-import filodb.core.query.{QueryConfig, QuerySession, QueryStats}
+import filodb.core.query.{QueryConfig, QuerySession}
 import filodb.core.store._
 import filodb.query.QueryResponse
 
@@ -25,7 +25,7 @@ import filodb.query.QueryResponse
   case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
 
   val clusterName = InetAddress.getLocalHost().getHostName()
-  override def dispatch(plan: RunTimePlanContainer)(implicit sched: Scheduler): Task[QueryResponse] = {
+  override def dispatch(plan: DispatchedPlan)(implicit sched: Scheduler): Task[QueryResponse] = {
     // unsupported source since its does not apply in case of non-leaf plans
     val source = UnsupportedChunkSource()
 
@@ -35,7 +35,7 @@ import filodb.query.QueryResponse
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       // translate implicit ExecutionContext to monix.Scheduler
-      val querySession = QuerySession(plan.execPlan.queryContext, queryConfig, QueryStats())
+      val querySession = QuerySession(plan.execPlan.queryContext, queryConfig)
       plan.execPlan.execute(source, querySession)
     }
   }

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -25,7 +25,7 @@ import filodb.query.QueryResponse
   case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
 
   val clusterName = InetAddress.getLocalHost().getHostName()
-  override def dispatch(plan: ExecPlan)(implicit sched: Scheduler): Task[QueryResponse] = {
+  override def dispatch(plan: RunTimePlanContainer)(implicit sched: Scheduler): Task[QueryResponse] = {
     // unsupported source since its does not apply in case of non-leaf plans
     val source = UnsupportedChunkSource()
 
@@ -35,8 +35,8 @@ import filodb.query.QueryResponse
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       // translate implicit ExecutionContext to monix.Scheduler
-      val querySession = QuerySession(plan.queryContext, queryConfig)
-      plan.execute(source, querySession)
+      val querySession = QuerySession(plan.execPlan.queryContext, queryConfig)
+      plan.execPlan.execute(source, querySession)
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
@@ -11,7 +11,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 
 import filodb.core.QueryTimeoutException
-import filodb.core.query.ResultSchema
+import filodb.core.query.{QueryStats, ResultSchema}
 import filodb.query.Query.qLogger
 import filodb.query.QueryResponse
 import filodb.query.QueryResult
@@ -50,7 +50,7 @@ case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends Pl
         case e: AskTimeoutException if (plan.execPlan.queryContext.plannerParams.allowPartialResults)
            =>
             qLogger.warn(s"Swallowed AskTimeoutException since partial result was enabled: ${e.getMessage}")
-            QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil, true,
+            QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil, QueryStats(), true,
               Some("Result may be partial since query on some shards timed out"))
       }
       Task.fromFuture(fut)

--- a/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
@@ -5,13 +5,16 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
 import akka.actor.ActorRef
-import akka.pattern.ask
+import akka.pattern.{ask, AskTimeoutException}
 import akka.util.Timeout
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import filodb.core.QueryTimeoutException
+import filodb.core.query.ResultSchema
+import filodb.query.Query.qLogger
 import filodb.query.QueryResponse
+import filodb.query.QueryResult
 
 /**
   * This trait externalizes distributed query execution strategy
@@ -19,7 +22,7 @@ import filodb.query.QueryResponse
   */
 trait PlanDispatcher extends java.io.Serializable {
   def clusterName: String
-  def dispatch(plan: ExecPlan)
+  def dispatch(plan: RunTimePlanContainer)
               (implicit sched: Scheduler): Task[QueryResponse]
   def isLocalCall: Boolean
 }
@@ -30,25 +33,26 @@ trait PlanDispatcher extends java.io.Serializable {
   */
 case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends PlanDispatcher {
 
-  def dispatch(plan: ExecPlan)(implicit sched: Scheduler): Task[QueryResponse] = {
-    val queryTimeElapsed = System.currentTimeMillis() - plan.queryContext.submitTime
-    val remainingTime = plan.queryContext.plannerParams.queryTimeoutMillis - queryTimeElapsed
+  def dispatch(plan: RunTimePlanContainer)(implicit sched: Scheduler): Task[QueryResponse] = {
+    val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
+    val remainingTime = plan.clientParams.timeout - queryTimeElapsed
     // Don't send if time left is very small
     if (remainingTime < 1) {
       Task.raiseError(QueryTimeoutException(queryTimeElapsed, this.getClass.getName))
     } else {
       val t = Timeout(FiniteDuration(remainingTime, TimeUnit.MILLISECONDS))
-      val fut = (target ? plan)(t).map {
+      val fut = (target ? plan.execPlan)(t).map {
         case resp: QueryResponse => resp
         case e =>  throw new IllegalStateException(s"Received bad response $e")
       }
       // TODO We can send partial results on timeout. Try later. Need to address QueryTimeoutException too.
-//        .recover { // if partial results allowed, then return empty result
-//        case e: AskTimeoutException if (plan.queryContext.plannerParams.allowPartialResults) =>
-//            Query.qLogger.warn(s"Swallowed AskTimeoutException since partial result was enabled: ${e.getMessage}")
-//            QueryResult(plan.queryContext.queryId, ResultSchema.empty, Nil, true,
-//              Some("Result may be partial since query on some shards timed out"))
-//      }
+        .recover { // if partial results allowed, then return empty result
+        case e: AskTimeoutException if (plan.execPlan.queryContext.plannerParams.allowPartialResults)
+           =>
+            qLogger.warn(s"Swallowed AskTimeoutException since partial result was enabled: ${e.getMessage}")
+            QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil, true,
+              Some("Result may be partial since query on some shards timed out"))
+      }
       Task.fromFuture(fut)
     }
   }

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -33,7 +33,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val tvSchemaTask = Task.now(tvSchema)
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: RunTimePlanContainer)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -33,7 +33,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val tvSchemaTask = Task.now(tvSchema)
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: RunTimePlanContainer)
+    override def dispatch(plan: DispatchedPlan)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -36,7 +36,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val rand = new Random()
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: RunTimePlanContainer)
+    override def dispatch(plan: DispatchedPlan)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -36,7 +36,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val rand = new Random()
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: RunTimePlanContainer)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???
@@ -327,7 +327,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
   }
 
   it("should have metric name when operator is not MathOperator") {
-    
+
     val sampleLhs: Array[RangeVector] = Array(
       new RangeVector {
         val key: RangeVectorKey = CustomRangeVectorKey(

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -37,7 +37,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
   val noKey = CustomRangeVectorKey(Map.empty)
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: RunTimePlanContainer)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -37,7 +37,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
   val noKey = CustomRangeVectorKey(Map.empty)
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: RunTimePlanContainer)
+    override def dispatch(plan: DispatchedPlan)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -107,7 +107,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
       0, filters, AllChunkScan,"_metric_")
 
     val sep = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan1, execPlan2))
-    val result = dispatcher.dispatch(RunTimePlanContainer(sep, ClientParams
+    val result = dispatcher.dispatch(DispatchedPlan(sep, ClientParams
     (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result match {
@@ -136,7 +136,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
       0, emptyFilters, AllChunkScan, "_metric_")
 
     val sep = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan1, execPlan2))
-    val result = dispatcher.dispatch(RunTimePlanContainer(sep, ClientParams
+    val result = dispatcher.dispatch(DispatchedPlan(sep, ClientParams
     (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result match {
@@ -149,7 +149,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
     // Switch the order and make sure it's OK if the first result doesn't have any data
     val sep2 = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan2, execPlan1))
-    val result2 = dispatcher.dispatch(RunTimePlanContainer(sep2, ClientParams
+    val result2 = dispatcher.dispatch(DispatchedPlan(sep2, ClientParams
     (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result2 match {
@@ -162,7 +162,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
     // Two children none of which returns data
     val sep3 = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan2, execPlan2))
-    val result3 = dispatcher.dispatch(RunTimePlanContainer(sep3, ClientParams
+    val result3 = dispatcher.dispatch(DispatchedPlan(sep3, ClientParams
     (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result3 match {
@@ -176,7 +176,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
 case class DummyDispatcher(memStore: TimeSeriesMemStore, querySession: QuerySession) extends PlanDispatcher {
   // run locally withing any check.
-  override def dispatch(plan: RunTimePlanContainer)
+  override def dispatch(plan: DispatchedPlan)
                        (implicit sched: Scheduler): Task[QueryResponse] = {
     plan.execPlan.execute(memStore, querySession)
   }

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -107,7 +107,8 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
       0, filters, AllChunkScan,"_metric_")
 
     val sep = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan1, execPlan2))
-    val result = dispatcher.dispatch(sep).runAsync.futureValue
+    val result = dispatcher.dispatch(RunTimePlanContainer(sep, ClientParams
+    (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result match {
       case e: QueryError => throw e.t
@@ -135,7 +136,8 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
       0, emptyFilters, AllChunkScan, "_metric_")
 
     val sep = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan1, execPlan2))
-    val result = dispatcher.dispatch(sep).runAsync.futureValue
+    val result = dispatcher.dispatch(RunTimePlanContainer(sep, ClientParams
+    (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result match {
       case e: QueryError => throw e.t
@@ -147,7 +149,8 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
     // Switch the order and make sure it's OK if the first result doesn't have any data
     val sep2 = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan2, execPlan1))
-    val result2 = dispatcher.dispatch(sep2).runAsync.futureValue
+    val result2 = dispatcher.dispatch(RunTimePlanContainer(sep2, ClientParams
+    (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result2 match {
       case e: QueryError => throw e.t
@@ -159,7 +162,8 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
     // Two children none of which returns data
     val sep3 = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan2, execPlan2))
-    val result3 = dispatcher.dispatch(sep3).runAsync.futureValue
+    val result3 = dispatcher.dispatch(RunTimePlanContainer(sep3, ClientParams
+    (sep.queryContext.plannerParams.queryTimeoutMillis))).runAsync.futureValue
 
     result3 match {
       case e: QueryError => throw e.t
@@ -172,9 +176,9 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
 case class DummyDispatcher(memStore: TimeSeriesMemStore, querySession: QuerySession) extends PlanDispatcher {
   // run locally withing any check.
-  override def dispatch(plan: ExecPlan)
+  override def dispatch(plan: RunTimePlanContainer)
                        (implicit sched: Scheduler): Task[QueryResponse] = {
-    plan.execute(memStore, querySession)
+    plan.execPlan.execute(memStore, querySession)
   }
 
   override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -77,7 +77,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
   }
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: RunTimePlanContainer)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -77,7 +77,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
   }
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: RunTimePlanContainer)
+    override def dispatch(plan: DispatchedPlan)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 
 object MultiSchemaPartitionsExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: RunTimePlanContainer)
+    override def dispatch(plan: DispatchedPlan)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 
 object MultiSchemaPartitionsExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: RunTimePlanContainer)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -20,7 +20,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     options = DatasetOptions(Seq("__name__", "job"), "__name__")).get
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: RunTimePlanContainer)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -20,7 +20,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     options = DatasetOptions(Seq("__name__", "job"), "__name__")).get
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: RunTimePlanContainer)
+    override def dispatch(plan: DispatchedPlan)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -25,7 +25,7 @@ import filodb.query.{QueryResponse, QueryResult}
 
 object SplitLocalPartitionDistConcatExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: RunTimePlanContainer)
+    override def dispatch(plan: DispatchedPlan)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -25,7 +25,7 @@ import filodb.query.{QueryResponse, QueryResult}
 
 object SplitLocalPartitionDistConcatExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: RunTimePlanContainer)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior:** 
Query timeout is same for all childeren and parents.

**New behavior :**
Add RunTimePlanContainer to dispatcher. It will have client params including timeout. DIspatch is called with timeout 1 second less than the parent timeout. If a child does not finish within the time limit, partial results are returned. This is helpful for multipartition queries when one partition is down