### PR TITLE
bug(query, core): Shared lock was being acquired twice in one query

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -35,7 +35,7 @@ extends MemStore with StrictLogging {
   def checkReadyForQuery(ref: DatasetRef,
                          shard: Int,
                          querySession: QuerySession): Unit = {
-    if (getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
+    if (!getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
       if (!querySession.qContext.plannerParams.allowPartialResults) {
         throw new ServiceUnavailableException(s"Unable to answer query since shard $shard is still bootstrapping")
       }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -15,7 +15,7 @@ import filodb.core.{DatasetRef, Response, Types}
 import filodb.core.memstore._
 import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
-import filodb.core.query.{ColumnFilter, QuerySession}
+import filodb.core.query.{ColumnFilter, QuerySession, ServiceUnavailableException}
 import filodb.core.store._
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
 
@@ -32,8 +32,16 @@ extends MemStore with StrictLogging {
 
   override def isDownsampleStore: Boolean = true
 
-  def isReadyForQuery(ref: DatasetRef, shard: Int): Boolean = {
-    getShardE(ref: DatasetRef, shard: Int).isReadyForQuery
+  def checkReadyForQuery(ref: DatasetRef,
+                         shard: Int,
+                         querySession: QuerySession): Unit = {
+    if (getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
+      if (!querySession.qContext.plannerParams.allowPartialResults) {
+        throw new ServiceUnavailableException(s"Unable to answer query since shard $shard is still bootstrapping")
+      }
+      querySession.resultCouldBePartial = true
+      querySession.partialResultsReason = Some("Result may be partial since some shards are still bootstrapping")
+    }
   }
 
   override def metastore: MetaStore = ??? // Not needed
@@ -103,6 +111,12 @@ extends MemStore with StrictLogging {
         s"this node. Was it was recently reassigned to another node? Prolonged occurrence indicates an issue.")
     }
     shard.lookupPartitions(partMethod, chunkMethod, querySession)
+  }
+
+  def acquireSharedLock(ref: DatasetRef,
+                        shardNum: Int,
+                        querySession: QuerySession): Unit = {
+    // no op
   }
 
   def scanPartitions(ref: DatasetRef,

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -55,7 +55,7 @@ extends MemStore with StrictLogging {
   def checkReadyForQuery(ref: DatasetRef,
                          shard: Int,
                          querySession: QuerySession): Unit = {
-    if (getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
+    if (!getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
       if (!querySession.qContext.plannerParams.allowPartialResults) {
         throw new ServiceUnavailableException(s"Unable to answer query since shard $shard is still bootstrapping")
       }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -11,11 +11,11 @@ import monix.execution.{CancelableFuture, Scheduler}
 import monix.reactive.Observable
 import org.jctools.maps.NonBlockingHashMapLong
 
-import filodb.core.{DatasetRef, Response, Types}
+import filodb.core.{DatasetRef, QueryTimeoutException, Response, Types}
 import filodb.core.downsample.DownsampleConfig
 import filodb.core.memstore.ratelimit.{CardinalityRecord, ConfigQuotaSource}
 import filodb.core.metadata.Schemas
-import filodb.core.query.{ColumnFilter, QuerySession}
+import filodb.core.query.{ColumnFilter, PromQlQueryParams, QuerySession, ServiceUnavailableException}
 import filodb.core.store._
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String}
@@ -52,8 +52,16 @@ extends MemStore with StrictLogging {
 
   def isDownsampleStore: Boolean = false
 
-  override def isReadyForQuery(ref: DatasetRef, shard: Int): Boolean = {
-    getShardE(ref: DatasetRef, shard: Int).isReadyForQuery
+  def checkReadyForQuery(ref: DatasetRef,
+                         shard: Int,
+                         querySession: QuerySession): Unit = {
+    if (getShardE(ref: DatasetRef, shard: Int).isReadyForQuery) {
+      if (!querySession.qContext.plannerParams.allowPartialResults) {
+        throw new ServiceUnavailableException(s"Unable to answer query since shard $shard is still bootstrapping")
+      }
+      querySession.resultCouldBePartial = true
+      querySession.partialResultsReason = Some("Result may be partial since some shards are still bootstrapping")
+    }
   }
 
   // TODO: Change the API to return Unit Or ShardAlreadySetup, instead of throwing.  Make idempotent.
@@ -224,6 +232,24 @@ extends MemStore with StrictLogging {
         s"this node. Was it was recently reassigned to another node? Prolonged occurrence indicates an issue.")
     }
     shard.scanPartitions(iter, colIds, querySession)
+  }
+
+  def acquireSharedLock(ref: DatasetRef,
+                        shardNum: Int,
+                        querySession: QuerySession): Unit = {
+    val shard = datasets(ref).get(shardNum)
+    querySession.lock = Some(shard.evictionLock)
+    val promQl = querySession.qContext.origQueryParams match {
+      case p: PromQlQueryParams => p.promQl
+      case _ => "unknown"
+    }
+
+    val queryTimeElapsed = System.currentTimeMillis() - querySession.qContext.submitTime
+    val remainingTime = querySession.qContext.plannerParams.queryTimeoutMillis - queryTimeElapsed
+    if (remainingTime <= 0) throw QueryTimeoutException(queryTimeElapsed, "beforeAcquireSharedLock")
+    if (!shard.evictionLock.acquireSharedLock(remainingTime, querySession.qContext.queryId, promQl)) {
+      throw QueryTimeoutException(queryTimeElapsed, "acquireSharedLockTimeout")
+    }
   }
 
   def lookupPartitions(ref: DatasetRef,

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -30,7 +30,7 @@ import filodb.core.{ErrorResponse, _}
 import filodb.core.binaryrecord2._
 import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityTracker, QuotaSource, RocksDbCardinalityStore}
 import filodb.core.metadata.{Schema, Schemas}
-import filodb.core.query.{ColumnFilter, Filter, PromQlQueryParams, QuerySession}
+import filodb.core.query.{ColumnFilter, Filter, QuerySession}
 import filodb.core.store._
 import filodb.memory._
 import filodb.memory.data.Shutdown
@@ -1532,12 +1532,6 @@ class TimeSeriesShard(val ref: DatasetRef,
   def lookupPartitions(partMethod: PartitionScanMethod,
                        chunkMethod: ChunkScanMethod,
                        querySession: QuerySession): PartLookupResult = {
-    querySession.lock = Some(evictionLock)
-    val promQl = querySession.qContext.origQueryParams match {
-      case p: PromQlQueryParams => p.promQl
-      case _ => "unknown"
-    }
-    evictionLock.acquireSharedLock(querySession.qContext.queryId, promQl)
     // any exceptions thrown here should be caught by a wrapped Task.
     // At the end, MultiSchemaPartitionsExec.execute releases the lock when the task is complete
     partMethod match {

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -71,7 +71,6 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
     */
   def isDownsampleStore: Boolean
 
-  def isReadyForQuery(datasetRef: DatasetRef, shard: Int): Boolean
 
   /**
    * Scans and returns data in partitions according to the method.  The partitions are ready to be queried.
@@ -109,6 +108,28 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
    * Returns the schemas registered for a given dataset.
    */
   def schemas(ref: DatasetRef): Option[Schemas]
+
+  /**
+   * Acquire shared lock to shard(s) for given dataset/partMethod.
+   * Acquired lock is placed in querySession. It is the job of the client to release the lock.
+   *
+   * @throws QueryTimeoutException if shared lock was not acquired within timeoutMs
+   */
+  def acquireSharedLock(ref: DatasetRef,
+                        shardNum: Int,
+                        querySession: QuerySession): Unit
+
+  /**
+   * Check if shard is ready for query.
+   *
+   * If not and if partial results allowed, it allows query to continue
+   * by marking the session for partial results.
+   *
+   * If not and if partial results are not allowed, ServiceUnavailableException is thrown
+   */
+  def checkReadyForQuery(ref: DatasetRef,
+                         shard: Int,
+                         querySession: QuerySession): Unit
 
   /**
    * Looks up TSPartitions from filters.

--- a/memory/src/main/scala/filodb.memory/EvictionLock.scala
+++ b/memory/src/main/scala/filodb.memory/EvictionLock.scala
@@ -67,9 +67,9 @@ class EvictionLock(trackQueriesHoldingEvictionLock: Boolean = false,
 
   def releaseExclusive(): Unit = reclaimLock.releaseExclusive()
 
-  def acquireSharedLock(holderId: String, promQL: String): Unit = {
+  def acquireSharedLock(timeoutMs: Long, holderId: String, promQL: String): Boolean = {
     if (trackQueriesHoldingEvictionLock) runningQueries.put(holderId, promQL)
-    reclaimLock.lock()
+    reclaimLock.tryAcquireSharedNanos(timeoutMs * 1000000)
   }
 
   def releaseSharedLock(holderId: String): Unit = {

--- a/memory/src/main/scala/filodb.memory/EvictionLock.scala
+++ b/memory/src/main/scala/filodb.memory/EvictionLock.scala
@@ -69,7 +69,7 @@ class EvictionLock(trackQueriesHoldingEvictionLock: Boolean = false,
 
   def acquireSharedLock(timeoutMs: Long, holderId: String, promQL: String): Boolean = {
     if (trackQueriesHoldingEvictionLock) runningQueries.put(holderId, promQL)
-    reclaimLock.tryAcquireSharedNanos(timeoutMs * 1000000)
+    reclaimLock.tryAcquireSharedNanos(TimeUnit.MILLISECONDS.toNanos(timeoutMs))
   }
 
   def releaseSharedLock(holderId: String): Unit = {

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -77,13 +77,16 @@ case class UnsupportedChunkSource() extends ChunkSource {
 
   override def isDownsampleStore: Boolean = false
 
-  override def isReadyForQuery(ref: DatasetRef, shard: Int): Boolean = true
-
   override def topKCardinality(ref: DatasetRef,
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],
                                k: Int): scala.Seq[CardinalityRecord] =
     throw new UnsupportedOperationException("This operation is not supported")
 
+  override def acquireSharedLock(ref: DatasetRef, shardNum: Int, querySession: QuerySession): Unit =
+    throw new UnsupportedOperationException("This operation is not supported")
+
+  override def checkReadyForQuery(ref: DatasetRef, shard: Int, querySession: QuerySession): Unit =
+    throw new UnsupportedOperationException("This operation is not supported")
 }
 

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -6,7 +6,7 @@ import monix.execution.Scheduler
 import filodb.core.DatasetRef
 import filodb.core.memstore.TimeSeriesShard
 import filodb.core.metadata.Column
-import filodb.core.query.{ServiceUnavailableException, _}
+import filodb.core.query._
 import filodb.core.store._
 
 object SelectChunkInfosExec {
@@ -42,13 +42,8 @@ final case class SelectChunkInfosExec(queryContext: QueryContext,
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = {
-    if (!source.isReadyForQuery(dataset, shard)) {
-      if (!queryContext.plannerParams.allowPartialResults) {
-        throw new ServiceUnavailableException(s"Unable to answer query since shard $shard is still bootstrapping")
-      }
-      querySession.resultCouldBePartial = true
-      querySession.partialResultsReason = Some("Result may be partial since some shards are still bootstrapping")
-    }
+    source.checkReadyForQuery(dataset, shard, querySession)
+    source.acquireSharedLock(dataset, shard, querySession)
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     val lookupRes = source.lookupPartitions(dataset, partMethod, chunkMethod, querySession)
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

We acquire shared lock in `lookupPartitions` which is a deadly side-effect not known to callers. For a recent feature a new call was added to invoke `lookupPartitions`. Since the query path includes that call elsewhere, the shared lock for shard got acquired twice. However we release it only once causing problems. Load testing brought the shared to stand-still.

In addition, we do not have a timeout during shared lock acquisition.

**New behavior :**

* Refactor out shared lock into separate method, and call it from specific plans that need them.
* While at it, I have also refactored the duplicate code to check if shard is ready after bootstrapping.

