### PR TITLE
revert: misc(build): do not relocate google.common package

### DIFF
--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -218,7 +218,8 @@ object FiloSettings {
     },
     assemblyShadeRules in assembly := Seq(
       ShadeRule.rename("com.datastax.driver.**" -> "filodb.datastax.driver.@1").inAll,
-      ShadeRule.rename("org.apache.http.**" -> "filodb.org.apache.http.@1").inAll,
+      ShadeRule.rename("com.google.common.**" -> "filodb.com.google.common.@1").inAll,
+      ShadeRule.rename("org.apache.http.**" -> "filodb.org.apache.http.@1").inAll
     ),
     test in assembly := {} //noisy for end-user since the jar is not available and user needs to build the project locally
   )


### PR DESCRIPTION
Reverting #1212 since it is safe to leave it around.