### PR TITLE
maint(core): Catch coding errors due to setting lock multiple times on session

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -126,7 +126,7 @@ final class QueryActor(memStore: MemStore,
       Kamon.runWithSpan(queryExecuteSpan, false) {
         queryExecuteSpan.tag("query", q.getClass.getSimpleName)
         queryExecuteSpan.tag("query-id", q.queryContext.queryId)
-        val querySession = QuerySession(q.queryContext, queryConfig)
+        val querySession = QuerySession(q.queryContext, queryConfig, catchMultipleLockSetErrors = true)
         queryExecuteSpan.mark("query-actor-received-execute-start")
         q.execute(memStore, querySession)(queryScheduler)
           .foreach { res =>

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -86,6 +86,9 @@ object QueryContext {
 
 /**
   * Placeholder for query related information. Typically passed along query execution path.
+  *
+  * IMPORTANT: The param catchMultipleLockSetErrors should be false
+  * only in unit test code for ease of use.
   */
 case class QuerySession(qContext: QueryContext,
                         queryConfig: QueryConfig,

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -88,7 +88,8 @@ object QueryContext {
   * Placeholder for query related information. Typically passed along query execution path.
   */
 case class QuerySession(qContext: QueryContext,
-                        queryConfig: QueryConfig) {
+                        queryConfig: QueryConfig,
+                        catchMultipleLockSetErrors: Boolean = false) {
 
   val queryStats: QueryStats = QueryStats()
   private var lock: Option[EvictionLock] = None
@@ -96,9 +97,8 @@ case class QuerySession(qContext: QueryContext,
   var partialResultsReason: Option[String] = None
 
   def setLock(toSet: EvictionLock): Unit = {
-    // TODO we need to enable this check someday. I am not able to do now
-    // since unit tests widely reuse sessions for running multiple exec plans.
-//    if (lock.isDefined) throw new IllegalStateException(s"Assigning eviction lock to session two times $qContext")
+    if (catchMultipleLockSetErrors && lock.isDefined)
+      throw new IllegalStateException(s"Assigning eviction lock to session two times $qContext")
     lock = Some(toSet)
   }
 

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -34,7 +34,7 @@ import filodb.query.QueryResponse
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       // translate implicit ExecutionContext to monix.Scheduler
-      val querySession = QuerySession(plan.queryContext, queryConfig)
+      val querySession = QuerySession(plan.queryContext, queryConfig, catchMultipleLockSetErrors = true)
       plan.execute(source, querySession)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Safety check to ensure that eviction lock is not set multiple times on session.
Acquiring shared lock multiple times, but releasing only once will lead to system errors.