### PR TITLE
feat(core): Query Statistics included in Query Errors

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -437,7 +437,9 @@ object CliMain extends FilodbClusterNode {
                                                    println(s"Number of Range Vectors: ${result.size}")
                                                    result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
                                                    println(s"QueryStats: $stats")
-            case QueryError(_, _, ex)               => println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")
+            case QueryError(_, stats, ex)  =>
+                                                   println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")
+                                                   println(s"QueryStats: $stats")
           }
         } catch {
           case e: ClientException =>  println(s"ClientException: ${e.getMessage}")

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -437,7 +437,7 @@ object CliMain extends FilodbClusterNode {
                                                    println(s"Number of Range Vectors: ${result.size}")
                                                    result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
                                                    println(s"QueryStats: $stats")
-            case QueryError(_,ex)               => println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")
+            case QueryError(_, _, ex)               => println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")
           }
         } catch {
           case e: ClientException =>  println(s"ClientException: ${e.getMessage}")

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -283,7 +283,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
   }
 
   it ("should serialize and deserialize QueryError") {
-    val err = QueryError("xdf", new IllegalStateException("Some message"))
+    val err = QueryError("xdf", QueryStats(), new IllegalStateException("Some message"))
     val deser1 = roundTrip(err).asInstanceOf[QueryError]
     val deser2 = roundTrip(deser1).asInstanceOf[QueryError]
     deser2.id shouldEqual err.id

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -245,7 +245,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
               case ColumnFilter(c, Filter.Equals(filtVal: String)) if c == col => filtVal
             }.getOrElse("unknown")
           }.toList
-          val chunksReadCounter = querySession.queryStats.getChunksScannedCounter(metricGroupBy)
+          val chunksReadCounter = querySession.queryStats.getDataBytesScannedCounter(metricGroupBy)
 
           PartLookupResult(shardNum, chunkMethod, debox.Buffer.empty,
             _schema, debox.Map.empty, debox.Buffer.empty, recs, chunksReadCounter)

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -113,12 +113,13 @@ case class QuerySession(qContext: QueryContext,
 
 case class Stat() {
   val partsScanned = new AtomicInteger
-  val chunksScanned = new AtomicInteger
+  val dataBytesScanned = new AtomicInteger
   val resultSize = new AtomicLong
-  override def toString: String = s"(partsScanned=$partsScanned, chunksScanned=$chunksScanned, resultSize=$resultSize)"
+  override def toString: String = s"(partsScanned=$partsScanned, " +
+    s"dataBytesScanned=$dataBytesScanned, resultSize=$resultSize)"
   def add(s: Stat): Unit = {
     partsScanned.addAndGet(s.partsScanned.get())
-    chunksScanned.addAndGet(s.chunksScanned.get())
+    dataBytesScanned.addAndGet(s.dataBytesScanned.get())
     resultSize.addAndGet(s.resultSize.get())
   }
 }
@@ -137,9 +138,9 @@ case class QueryStats() {
     stat.getOrElseUpdate(theNs, Stat()).partsScanned
   }
 
-  def getChunksScannedCounter(group: Seq[String] = Nil): AtomicInteger = {
+  def getDataBytesScannedCounter(group: Seq[String] = Nil): AtomicInteger = {
     val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
-    stat.getOrElseUpdate(theNs, Stat()).chunksScanned
+    stat.getOrElseUpdate(theNs, Stat()).dataBytesScanned
   }
 
   def getResultSizeCounter(group: Seq[String] = Nil): AtomicLong = {

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -280,13 +280,13 @@ final case class RawDataRangeVector(key: RangeVectorKey,
                                     partition: ReadablePartition,
                                     chunkMethod: ChunkScanMethod,
                                     columnIDs: Array[Int],
-                                    chunksQueriedMetric: AtomicInteger) extends RangeVector {
+                                    samplesQueriedMetric: AtomicInteger) extends RangeVector {
   // Iterators are stateful, for correct reuse make this a def
   def rows(): RangeVectorCursor = partition.timeRangeRows(chunkMethod, columnIDs)
 
   // Obtain ChunkSetInfos from specific window of time from partition
   def chunkInfos(windowStart: Long, windowEnd: Long): ChunkInfoIterator = {
-    new CountingChunkInfoIterator(partition.infos(windowStart, windowEnd), chunksQueriedMetric)
+    new CountingChunkInfoIterator(partition.infos(windowStart, windowEnd), columnIDs, samplesQueriedMetric)
   }
 
   // the query engine is based around one main data column to query, so it will always be the second column passed in

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -280,13 +280,13 @@ final case class RawDataRangeVector(key: RangeVectorKey,
                                     partition: ReadablePartition,
                                     chunkMethod: ChunkScanMethod,
                                     columnIDs: Array[Int],
-                                    samplesQueriedMetric: AtomicInteger) extends RangeVector {
+                                    dataBytesScannedCtr: AtomicInteger) extends RangeVector {
   // Iterators are stateful, for correct reuse make this a def
   def rows(): RangeVectorCursor = partition.timeRangeRows(chunkMethod, columnIDs)
 
   // Obtain ChunkSetInfos from specific window of time from partition
   def chunkInfos(windowStart: Long, windowEnd: Long): ChunkInfoIterator = {
-    new CountingChunkInfoIterator(partition.infos(windowStart, windowEnd), columnIDs, samplesQueriedMetric)
+    new CountingChunkInfoIterator(partition.infos(windowStart, windowEnd), columnIDs, dataBytesScannedCtr)
   }
 
   // the query engine is based around one main data column to query, so it will always be the second column passed in

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -7,6 +7,7 @@ import com.googlecode.javaewah.EWAHCompressedBitmap
 import com.typesafe.scalalogging.StrictLogging
 import debox.Buffer
 import kamon.Kamon
+import kamon.metric.MeasurementUnit
 
 import filodb.core.QueryTimeoutException
 import filodb.core.Types._
@@ -329,12 +330,12 @@ class ElementChunkInfoIterator(elIt: ElementIterator) extends ChunkInfoIterator 
 }
 
 object CountingChunkInfoIterator {
-  val queriedChunks = Kamon.counter("chunks-queried").withoutTags()
+  val dataBytesScannedCtr = Kamon.counter("data-scanned-by-queries", MeasurementUnit.information.bytes).withoutTags()
 }
 
 class CountingChunkInfoIterator(base: ChunkInfoIterator,
                                 columnIDs: Array[Int],
-                                queriedSamplesStat: AtomicInteger) extends ChunkInfoIterator {
+                                dataBytesScannedCtr: AtomicInteger) extends ChunkInfoIterator {
   override def close(): Unit = base.close()
   override def hasNext: Boolean = base.hasNext
   override def nextInfoReader: ChunkSetInfoReader = {
@@ -346,14 +347,14 @@ class CountingChunkInfoIterator(base: ChunkInfoIterator,
 
     // Why two counters ?
     // 1. query stats counter to meter usage by ws/ns. This will eventually be sent as part of query result.
-    queriedSamplesStat.addAndGet(bytesRead)
+    dataBytesScannedCtr.addAndGet(bytesRead)
 
     // 2. kamon counter to track per instance. It is not broken down by shard/dataset. Doing that needs more memory
-    CountingChunkInfoIterator.queriedChunks.increment()
+    CountingChunkInfoIterator.dataBytesScannedCtr.increment(bytesRead)
     reader
   }
   override def nextInfo: ChunkSetInfo = {
-    queriedSamplesStat.incrementAndGet()
+    dataBytesScannedCtr.incrementAndGet()
     base.nextInfo
   }
   override def lock(): Unit = base.lock()

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -188,7 +188,7 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       val key = PartitionRangeVectorKey(Left(partition),
                                         schema.partKeySchema, partCols, partition.shard,
                                         subgroup, partition.partID, schema.name)
-      RawDataRangeVector(key, partition, lookupRes.chunkMethod, ids, lookupRes.queriedChunksCounter)
+      RawDataRangeVector(key, partition, lookupRes.chunkMethod, ids, lookupRes.dataBytesScannedCtr)
     }
   }
 

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -14,7 +14,9 @@ sealed trait QueryResponse extends NodeResponse with java.io.Serializable {
   def id: String
 }
 
-final case class QueryError(id: String, t: Throwable) extends QueryResponse with filodb.core.ErrorResponse {
+final case class QueryError(id: String,
+                            queryStats: QueryStats,
+                            t: Throwable) extends QueryResponse with filodb.core.ErrorResponse {
   override def toString: String = s"QueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
     t.getStackTrace.map(_.toString).mkString("\n")
 }

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -28,7 +28,7 @@ trait ReduceAggregateExec extends NonLeafExecPlan {
                         querySession: QuerySession): Observable[RangeVector] = {
     val results = childResponses.flatMap {
         case (QueryResult(_, _, result, _, _, _), _) => Observable.fromIterable(result)
-        case (QueryError(_, ex), _)         => throw ex
+        case (QueryError(_, _, ex), _)         => throw ex
     }
 
     val task = for { schema <- firstSchema}

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -73,7 +73,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
           s" is more than limit of ${queryContext.plannerParams.joinQueryCardLimit}." +
           s" Try applying more filters or reduce time range.")
       case (QueryResult(_, _, result, _, _, _), i) => (result, i)
-      case (QueryError(_, ex), _)         => throw ex
+      case (QueryError(_, _, ex), _)         => throw ex
     }.toListL.map { resp =>
       span.mark("binary-join-child-results-available")
       Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",

--- a/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
@@ -19,7 +19,7 @@ trait DistConcatExec extends NonLeafExecPlan {
                         querySession: QuerySession): Observable[RangeVector] = {
     childResponses.flatMap {
       case (QueryResult(_, _, result, _, _, _), _) => Observable.fromIterable(result)
-      case (QueryError(_, ex), _)         => throw ex
+      case (QueryError(_, _, ex), _)         => throw ex
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -36,7 +36,7 @@ trait MetadataDistConcatExec extends NonLeafExecPlan {
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     val taskOfResults = childResponses.map {
       case (QueryResult(_, _, result, _, _, _), _) => result
-      case (QueryError(_, ex), _)         => throw ex
+      case (QueryError(_, _, ex), _)         => throw ex
     }.toListL.map { resp =>
       var metadataResult = scala.collection.mutable.Set.empty[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
       resp.foreach { rv =>

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -31,7 +31,8 @@ case class MetadataRemoteExec(queryEndpoint: String,
       httpTimeoutMs, queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
       .map { response =>
         response.unsafeBody match {
-          case Left(error) => QueryError(queryContext.queryId, error.error)
+          case Left(error) =>    // FIXME need to extract statistics from query error, aggregate them, send upstream
+                                 QueryError(queryContext.queryId, QueryStats(), error.error)
           case Right(successResponse) => toQueryResponse(successResponse, queryContext.queryId, execPlan2Span)
         }
       }

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -56,7 +56,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
     val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
       case (QueryResult(_, schema, result, _, _, _), i) => (schema, result, i)
-      case (QueryError(_, ex), _)              => throw ex
+      case (QueryError(_, _, ex), _)              => throw ex
     }.toListL.map { resp =>
       span.mark("binary-join-child-results-available")
       Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -77,7 +77,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
     qLogger.debug(s"StitchRvsExec: Stitching results:")
     val stitched = childResponses.map {
       case (QueryResult(_, _, result, _, _, _), _) => result
-      case (QueryError(_, ex), _)         => throw ex
+      case (QueryError(_, _, ex), _)         => throw ex
     }.toListL.map(_.flatten).map { srvs =>
       val groups = srvs.groupBy(_.key.labelValues)
       groups.mapValues { toMerge =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

1. Include QueryStat in errors too. 
2. Calculate dataBytesScanned instead of chunksScanned in QueryStats

Important Limitation to Know:
QueryStatistics for all errors are not aggregated up since we do not wait for all child results to arrive before propagating error upstream.
