### PR TITLE
bug(query): Don't issue 0s for changes function over a subquery when no data

### DIFF
--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -158,20 +158,22 @@ object ChangesOverTimeFunction extends RangeFunction {
     var lastValue = Double.NaN
     var changes = Double.NaN
     if (window.size > 0) lastValue = window.head.getDouble(1)
+    if (!lastValue.isNaN) {
+      changes = 0
+    }
     var i = 1;
     while (i < window.size) {
       val curValue = window.apply(i).getDouble(1)
       if (!curValue.isNaN && !lastValue.isNaN) {
         if (curValue != lastValue) {
-          if (changes.isNaN) {
-            changes = 0
-          } else {
             changes = changes + 1
-          }
-         }
+        }
       }
       if (!curValue.isNaN) {
         lastValue = curValue
+        if (changes.isNaN) {
+          changes = 0
+        }
       }
       i = i + 1
     }

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -156,13 +156,19 @@ object ChangesOverTimeFunction extends RangeFunction {
     queryConfig: QueryConfig
   ): Unit = {
     var lastValue = Double.NaN
-    var changes = 0
+    var changes = Double.NaN
     if (window.size > 0) lastValue = window.head.getDouble(1)
     var i = 1;
     while (i < window.size) {
       val curValue = window.apply(i).getDouble(1)
       if (!curValue.isNaN && !lastValue.isNaN) {
-        if (curValue != lastValue) changes = changes + 1
+        if (curValue != lastValue) {
+          if (changes.isNaN) {
+            changes = 0
+          } else {
+            changes = changes + 1
+          }
+         }
       }
       if (!curValue.isNaN) {
         lastValue = curValue


### PR DESCRIPTION


**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: