### PR TITLE
bug(query) Fix invalid start/end parameters for PeriodicSamplesMapper for subqueries in MultiPartitionPlanner

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.StrictLogging
 import filodb.coordinator.queryplanner.LogicalPlanUtils._
 import filodb.core.metadata.Dataset
 import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext}
-import filodb.query.{BinaryJoin, LabelNames, LabelValues, LogicalPlan, SeriesKeysByFilters, SetOperator}
+import filodb.query.{BinaryJoin, LabelNames, LabelValues, LogicalPlan, SeriesKeysByFilters, SetOperator, TopLevelSubquery}
 import filodb.query.exec._
 
 case class PartitionAssignment(partitionName: String, endPoint: String, timeRange: TimeRange)
@@ -39,10 +39,11 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
 
     if(!tsdbQueryParams.isInstanceOf[PromQlQueryParams] || // We don't know the promql issued (unusual)
       (tsdbQueryParams.isInstanceOf[PromQlQueryParams]
-        && !qContext.plannerParams.processMultiPartition)) // Query was part of routing
+        && !qContext.plannerParams.processMultiPartition)) { // Query was part of routing
       localPartitionPlanner.materialize(logicalPlan, qContext)
-
-    else logicalPlan match {
+    }  else if (LogicalPlan.hasSubqueryWithWindowing(logicalPlan) || logicalPlan.isInstanceOf[TopLevelSubquery]) {
+      materializeSubqery(logicalPlan, qContext)
+    } else logicalPlan match {
       case lp: BinaryJoin          => materializeBinaryJoin(lp, qContext)
       case lp: LabelValues         => materializeLabelValues(lp, qContext)
       case lp: LabelNames          => materializeLabelNames(lp, qContext)
@@ -95,6 +96,27 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
       logger.warn(s"No partitions found for routing keys: $routingKeys")
 
     (partitions, lookBackMs, offsetMs, routingKeys)
+  }
+
+  /**
+   *
+   * @param logicalPlan Logical plan
+   * @param queryParams PromQlQueryParams having query details
+   * @return Returns PartitionAssignment and routing keys
+   */
+  private def partitionUtilSubquery(logicalPlan: LogicalPlan, queryParams: PromQlQueryParams) = {
+    val routingKeys = getRoutingKeys(logicalPlan)
+    val lastPoint = TimeRange(queryParams.endSecs * 1000, queryParams.endSecs * 1000)
+    val partitions =
+      if (routingKeys.isEmpty) {
+        List.empty
+      } else {
+        val routingKeyMap = routingKeys.map(x => (x._1, x._2.head)).toMap
+        partitionLocationProvider.getPartitions(routingKeyMap, lastPoint).sortBy(_.timeRange.startMs)
+      }
+    if (partitions.isEmpty && !routingKeys.isEmpty)
+      logger.warn(s"No partitions found for routing keys: $routingKeys")
+    (partitions, routingKeys)
   }
   /**
     * @param queryParams PromQlQueryParams having query details
@@ -160,6 +182,49 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
       if (execPlans.size == 1) execPlans.head
       else StitchRvsExec(qContext, inProcessPlanDispatcher,
         execPlans.sortWith((x, y) => !x.isInstanceOf[PromQlRemoteExec]))
+      // ^^ Stitch RemoteExec plan results with local using InProcessPlanDispatcher
+      // Sort to move RemoteExec in end as it does not have schema
+    }
+  }
+
+
+  /**
+   * Materialize queries having subqueries in them.
+   * Here, we don't stitch across partitions and we assume for a given
+   * set of routingKeys we will have only ONE partition. We do not try to find multiple
+   * partitions that cover our time range or find one that has the best overlap, we just
+   * choose one partition that has the end of our interval.
+   */
+  def materializeSubqery(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
+
+    val queryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams]
+    val (partitions, routingKeys) = partitionUtilSubquery(logicalPlan, queryParams)
+    if (partitions.isEmpty || routingKeys.forall(_._2.isEmpty)) {
+      localPartitionPlanner.materialize(logicalPlan, qContext)
+    } else {
+      val execPlans = partitions.zipWithIndex.map { case (p, i) =>
+        val startMs = queryParams.startSecs * 1000
+        val endMs = queryParams.endSecs * 1000
+        logger.debug(s"partitionInfo=$p; updated startMs=$startMs, endMs=$endMs")
+        if (p.partitionName.equals(localPartitionName))
+          localPartitionPlanner.materialize(logicalPlan, qContext)
+        else {
+          val httpEndpoint = p.endPoint + queryParams.remoteQueryPath.getOrElse("")
+          PromQlRemoteExec(
+            httpEndpoint, remoteHttpTimeoutMs, generateRemoteExecParams(qContext, startMs, endMs),
+            inProcessPlanDispatcher, dataset.ref, remoteExecHttpClient
+          )
+        }
+      }
+      if (execPlans.size == 1) {
+        execPlans.head
+      } else {
+        StitchRvsExec(
+          qContext,
+          inProcessPlanDispatcher,
+          execPlans.sortWith((x, y) => !x.isInstanceOf[PromQlRemoteExec])
+        )
+      }
       // ^^ Stitch RemoteExec plan results with local using InProcessPlanDispatcher
       // Sort to move RemoteExec in end as it does not have schema
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -5,7 +5,8 @@ import com.typesafe.scalalogging.StrictLogging
 import filodb.coordinator.queryplanner.LogicalPlanUtils._
 import filodb.core.metadata.Dataset
 import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext}
-import filodb.query.{BinaryJoin, LabelNames, LabelValues, LogicalPlan, SeriesKeysByFilters, SetOperator, TopLevelSubquery}
+import filodb.query.{BinaryJoin, LabelNames, LabelValues, LogicalPlan, SeriesKeysByFilters, SetOperator}
+import filodb.query.TopLevelSubquery
 import filodb.query.exec._
 
 case class PartitionAssignment(partitionName: String, endPoint: String, timeRange: TimeRange)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -184,13 +184,16 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers {
         List(PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs)))
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(
+      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+    )
+    val query = """test{job = "app"}[100m:10m]"""
     val lp = Parser.queryRangeToLogicalPlan(
-      "test{job = \"app\"}[100m:10m]",
+      query,
       TimeStepParams(endSeconds, step, endSeconds)
     )
 
-    val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", endSeconds, step, endSeconds)
+    val promQlQueryParams = PromQlQueryParams(query, endSeconds, step, endSeconds)
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams,  plannerParams =
       PlannerParams(processMultiPartition = true)))
@@ -237,13 +240,16 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers {
         List(PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs)))
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(
+      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+    )
+    val query = """test{job = "app"}[100m:10m]"""
     val lp = Parser.queryRangeToLogicalPlan(
-      "test{job = \"app\"}[100m:10m]",
+      query,
       TimeStepParams(endSeconds, step, endSeconds)
     )
 
-    val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", endSeconds, step, endSeconds)
+    val promQlQueryParams = PromQlQueryParams(query, endSeconds, step, endSeconds)
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams,  plannerParams =
       PlannerParams(processMultiPartition = true)))

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -175,6 +175,105 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers {
 
   }
 
+  it ("should not generate PromQlExec plan when partitions are local for TopLevelSubquery") {
+    val partitionLocationProvider = new PartitionLocationProvider {
+      override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] =
+        List(PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs)))
+
+      override def getAuthorizedPartitions(timeRange: TimeRange): List[PartitionAssignment] =
+        List(PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs)))
+    }
+
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val lp = Parser.queryRangeToLogicalPlan(
+      "test{job = \"app\"}[100m:10m]",
+      TimeStepParams(endSeconds, step, endSeconds)
+    )
+
+    val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", endSeconds, step, endSeconds)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams,  plannerParams =
+      PlannerParams(processMultiPartition = true)))
+
+    execPlan.printTree()
+
+    execPlan.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual (true)
+    execPlan.children.length shouldEqual 2
+    execPlan.children.head.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
+    execPlan.children.head.rangeVectorTransformers.head.isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+
+    val distConcatPlan = execPlan.asInstanceOf[LocalPartitionDistConcatExec]
+
+    val localExec1 = distConcatPlan.children(0).asInstanceOf[MultiSchemaPartitionsExec]
+    val queryParams1 = localExec1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
+    queryParams1.startSecs shouldEqual endSeconds
+    queryParams1.endSecs shouldEqual endSeconds
+    queryParams1.stepSecs shouldEqual step
+    val samplesMapper1 = localExec1.rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
+    samplesMapper1.startMs shouldEqual 4200000
+    samplesMapper1.endMs shouldEqual 9600000
+    samplesMapper1.stepMs shouldEqual 10*60*1000
+
+    val localExec2 = distConcatPlan.children(1).asInstanceOf[MultiSchemaPartitionsExec]
+    val queryParams2 = localExec2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
+    queryParams2.startSecs shouldEqual endSeconds
+    queryParams2.endSecs shouldEqual endSeconds
+    queryParams2.stepSecs shouldEqual step
+    val samplesMapper2 = localExec2.rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
+    samplesMapper2.startMs shouldEqual 4200000
+    samplesMapper2.endMs shouldEqual 9600000
+    samplesMapper2.stepMs shouldEqual 10*60*1000
+  }
+
+  it ("should generate both PromQlExec and MultiSchemaPartitionsExec for TopLevelSubquery") {
+    val partitionLocationProvider = new PartitionLocationProvider {
+      override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] =
+        List(
+          PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs)),
+          PartitionAssignment("remote", "remote-url", TimeRange(timeRange.startMs, timeRange.endMs))
+        )
+
+      override def getAuthorizedPartitions(timeRange: TimeRange): List[PartitionAssignment] =
+        List(PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs)))
+    }
+
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val lp = Parser.queryRangeToLogicalPlan(
+      "test{job = \"app\"}[100m:10m]",
+      TimeStepParams(endSeconds, step, endSeconds)
+    )
+
+    val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", endSeconds, step, endSeconds)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams,  plannerParams =
+      PlannerParams(processMultiPartition = true)))
+
+    println(execPlan.printTree())
+
+    execPlan.isInstanceOf[StitchRvsExec] shouldEqual (true)
+    execPlan.children.length shouldEqual 2
+    execPlan.children(0).isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+    execPlan.children(1).isInstanceOf[PromQlRemoteExec] shouldEqual true
+
+    val distConcatPlan = execPlan.children(0).asInstanceOf[LocalPartitionDistConcatExec]
+
+    val localExec = distConcatPlan.children(0).asInstanceOf[MultiSchemaPartitionsExec]
+    val localQueryParams = localExec.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
+    localQueryParams.startSecs shouldEqual endSeconds
+    localQueryParams.endSecs shouldEqual endSeconds
+    localQueryParams.stepSecs shouldEqual step
+    val localSamplesMapper = localExec.rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
+    localSamplesMapper.startMs shouldEqual 4200000
+    localSamplesMapper.endMs shouldEqual 9600000
+    localSamplesMapper.stepMs shouldEqual 10*60*1000
+
+    val remoteExec = execPlan.children(1).asInstanceOf[PromQlRemoteExec]
+    val remoteQueryParams = remoteExec.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
+    remoteQueryParams.startSecs shouldEqual endSeconds
+    remoteQueryParams.endSecs shouldEqual endSeconds
+    remoteQueryParams.stepSecs shouldEqual step
+  }
+
   it ("one partition should work for SubqueryWithWindowing") {
 
     def onePartition(timeRange: TimeRange): List[PartitionAssignment] = List(


### PR DESCRIPTION
… for subqueries in MultiPartitionPlanner

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: