### PR TITLE
feat(query): utilize traceinfo map for remote-exec

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -27,8 +27,8 @@ case class MetadataRemoteExec(queryEndpoint: String,
 
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
                               (implicit sched: Scheduler): Future[QueryResponse] = {
-    remoteExecHttpClient.httpMetadataGet(queryContext.plannerParams.applicationId, queryEndpoint,
-      httpTimeoutMs, queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
+    remoteExecHttpClient.httpMetadataGet(queryEndpoint, httpTimeoutMs,
+      queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
       .map { response =>
         response.unsafeBody match {
           case Left(error) =>    // FIXME need to extract statistics from query error, aggregate them, send upstream

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -48,8 +48,8 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
     import PromCirceSupport._
     import io.circe.parser
-    remoteExecHttpClient.httpGet(queryContext.plannerParams.applicationId, queryEndpoint,
-      requestTimeoutMs, queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
+    remoteExecHttpClient.httpGet(queryEndpoint, requestTimeoutMs,
+      queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
       .map { response =>
         // Error response from remote partition is a nested json present in response.body
         // as response status code is not 2xx

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -91,12 +91,12 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
  */
 trait RemoteExecHttpClient extends StrictLogging {
 
-  def httpGet(applicationId: String, httpEndpoint: String,
+  def httpGet(httpEndpoint: String,
               httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any], traceInfo: Map[String, String])
              (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], SuccessResponse]]]
 
-  def httpMetadataGet(applicationId: String, httpEndpoint: String,
+  def httpMetadataGet(httpEndpoint: String,
                       httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any],
                       traceInfo: Map[String, String])
                      (implicit scheduler: Scheduler):
@@ -116,7 +116,7 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
 
   ShutdownHookThread(shutdown())
 
-  def httpGet(applicationId: String, httpEndpoint: String,
+  def httpGet(httpEndpoint: String,
               httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any], traceInfo: Map[String, String])
              (implicit scheduler: Scheduler):
   Future[Response[scala.Either[DeserializationError[io.circe.Error], SuccessResponse]]] = {
@@ -125,7 +125,6 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
     val url = uri"$httpEndpoint?$urlParams"
     logger.debug("promQlExec url={}  traceInfo={}", url, traceInfo)
     sttp
-      .header(HeaderNames.UserAgent, applicationId)
       .headers(traceInfo)
       .get(url)
       .readTimeout(readTimeout)
@@ -133,7 +132,7 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
       .send()
   }
 
-  def httpMetadataGet(applicationId: String, httpEndpoint: String,
+  def httpMetadataGet(httpEndpoint: String,
                       httpTimeoutMs: Long, submitTime: Long, urlParams: Map[String, Any],
                       traceInfo: Map[String, String])
                      (implicit scheduler: Scheduler):
@@ -143,7 +142,6 @@ class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) ext
     val url = uri"$httpEndpoint?$urlParams"
     logger.debug("promMetadataExec url={} traceInfo={}", url, traceInfo)
     sttp
-      .header(HeaderNames.UserAgent, applicationId)
       .headers(traceInfo)
       .get(url)
       .readTimeout(readTimeout)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently we are having traceInfo map but the userAgent is being explicitly set still from queryParams. Fixing the same.