### PR TITLE
bug(query):  absent over time with shard key regex

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -2,6 +2,7 @@ package filodb.coordinator.queryplanner
 
 import filodb.core.metadata.{Dataset, Schemas}
 import filodb.core.query.{ColumnFilter, PromQlQueryParams, QueryConfig, QueryContext, RangeParams}
+import filodb.query.exec.InternalRangeFunction.Last
 import filodb.query._
 import filodb.query.exec._
 
@@ -79,6 +80,9 @@ class ShardKeyRegexPlanner(dataset: Dataset,
       case lp: LabelValues                 => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
       case lp: LabelNames                  => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
       case lp: SeriesKeysByFilters         => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
+      case lp: PeriodicSeriesWithWindowing => if (lp.function == RangeFunctionId.AbsentOverTime)
+                                              materializeAbsentOverTime(lp, qContext)
+                                             else materializeOthers(logicalPlan, qContext)
       case _                               => materializeOthers(logicalPlan, qContext)
     }
   }
@@ -167,4 +171,39 @@ class ShardKeyRegexPlanner(dataset: Dataset,
     }
     PlanResult(Seq(exec))
   }
+
+  private def materializeAbsentOverTime(logicalPlan: PeriodicSeriesWithWindowing, queryContext: QueryContext):
+  PlanResult = {
+    val vectors = walkLogicalPlanTree(logicalPlan.series, queryContext)
+    val paramsExec = materializeFunctionArgs(logicalPlan.functionArgs, queryContext)
+    // For queries which don't have RawSeries filters like metadata and fixed scalar queries
+    val aggregate = Aggregate(AggregationOperator.Sum, logicalPlan, Nil, Seq("job"))
+      vectors.plans.
+        map {
+        e => if (!e.isInstanceOf[PromQlRemoteExec]) {
+          e.children.foreach(c => c.children.foreach(_.addRangeVectorTransformer(
+            PeriodicSamplesMapper(logicalPlan.startMs,
+            logicalPlan.stepMs, logicalPlan.endMs, Some(logicalPlan.window), Some(Last), queryContext,
+            logicalPlan.stepMultipleNotationUsed,
+            paramsExec, logicalPlan.offsetMs, logicalPlan.series.isRaw))))
+
+
+          PlanResult(e.children)
+        } else
+         PlanResult(Seq(e))
+      }
+
+
+    val aggregatePlanResult = PlanResult (Seq(addAggregator(aggregate, queryContext.copy(plannerParams =
+      queryContext.plannerParams.copy(skipAggregatePresent = true)), vectors, Seq.empty)))
+      // Add sum to aggregate all child responses
+      // If all children have NaN value, sum will yield NaN and AbsentFunctionMapper will yield 1
+
+
+      addAbsentFunctionMapper(aggregatePlanResult, logicalPlan.columnFilters,
+        RangeParams(logicalPlan.startMs / 1000, logicalPlan.stepMs / 1000,
+          logicalPlan.endMs / 1000), queryContext)
+      aggregatePlanResult
+    }
+
 }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -199,7 +199,6 @@ class ShardKeyRegexPlanner(dataset: Dataset,
       // Add sum to aggregate all child responses
       // If all children have NaN value, sum will yield NaN and AbsentFunctionMapper will yield 1
 
-
       addAbsentFunctionMapper(aggregatePlanResult, logicalPlan.columnFilters,
         RangeParams(logicalPlan.startMs / 1000, logicalPlan.stepMs / 1000,
           logicalPlan.endMs / 1000), queryContext)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -480,4 +480,64 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
       ("""(sum(test1{_ws_="demo",_ns_="App"}) / (sum(test2{_ws_="demo",_ns_="App"}) + sum(test3{_ws_="demo",_ns_="App"})))""")
   }
+
+
+  it("should absent_ over_time") {
+    val lp = Parser.queryToLogicalPlan("""absent_over_time(test1{_ws_="demo",_ns_=~"App.*"}[10m])""", 1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))))
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
+    execPlan.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
+    execPlan.children.size shouldEqual 1
+    execPlan.children.head.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual true
+    execPlan.children.head.rangeVectorTransformers.head.isInstanceOf[AggregateMapReduce] shouldEqual true
+    execPlan.children.head.children.head.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+    execPlan.children.head.children.head.children.head.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
+    execPlan.children.head.children.head.children.head.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
+    execPlan.children.head.children.head.children.head.rangeVectorTransformers.head.
+      isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+//    execPlan.children.head.children.head.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
+    //execPlan.children.head.children.head.rangeVectorTransformers.head.isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+    println("FInal plan:")
+    println(execPlan.printTree())
+
+  }
+
+  it("should absent") {
+    val lp = Parser.queryToLogicalPlan("""absent(test1{_ws_="demo",_ns_=~"App.*"})""", 1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))))
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    println("FInal plan:")
+    println(execPlan.printTree())
+
+  }
+
+  it("should absent_ over_time2") {
+    val lp = Parser.queryToLogicalPlan("""absent_over_time(test1{_ws_="demo",_ns_="App-1"}[10m])""", 1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))))
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    println("FInal plan:")
+    println(execPlan.printTree())
+
+  }
+
+
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -641,8 +641,6 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val lp = Parser.queryRangeToLogicalPlan("""absent_over_time(http_requests_total{job = "app"}[10m])""", t)
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
-    println("final plan:")
-    println(execPlan.printTree())
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
     execPlan.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
     execPlan.children(0).isInstanceOf[MultiSchemaPartitionsExec] shouldEqual(true)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -641,6 +641,8 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val lp = Parser.queryRangeToLogicalPlan("""absent_over_time(http_requests_total{job = "app"}[10m])""", t)
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    println("final plan:")
+    println(execPlan.printTree())
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
     execPlan.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
     execPlan.children(0).isInstanceOf[MultiSchemaPartitionsExec] shouldEqual(true)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Absent over time with shard key regex does not yield all shard keys in the result

**New behavior :**
Material inner plan first then add aggregator and absent function mapper to child plans
