### PR TITLE
bug(query) Fix issues with multi-partition aggregation operation

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -27,6 +27,16 @@ object LogicalPlanUtils extends StrictLogging {
   }
 
   /**
+   * Given a LogicalPlan check if any descendent of plan is an aggregate operation
+   * @param lp the LogicalPlan instance
+   * @return true if a descendent is an aggregate else false
+   */
+  def hasDescendantAggregate(lp: LogicalPlan): Boolean = lp match {
+    case _: Aggregate                 => true
+    case nonLeaf: NonLeafLogicalPlan  => nonLeaf.children.exists(hasDescendantAggregate(_))
+    case _                            => false
+  }
+  /**
     * Retrieve start and end time from LogicalPlan
     */
   // scalastyle:off cyclomatic.complexity

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
@@ -38,9 +38,11 @@ trait  PlannerHelper {
     def materializeFunctionArgs(functionParams: Seq[FunctionArgsPlan],
                                 qContext: QueryContext): Seq[FuncArgs] = functionParams map {
         case num: ScalarFixedDoublePlan => StaticFuncArgs(num.scalar, num.timeStepParams)
-        case s: ScalarVaryingDoublePlan => ExecPlanFuncArgs(materialize(s, qContext), RangeParams(s.startMs, s.stepMs, s.endMs))
+        case s: ScalarVaryingDoublePlan => ExecPlanFuncArgs(materialize(s, qContext),
+                                           RangeParams(s.startMs, s.stepMs, s.endMs))
         case t: ScalarTimeBasedPlan     => TimeFuncArgs(t.rangeParams)
-        case s: ScalarBinaryOperation   => ExecPlanFuncArgs(materialize(s, qContext), RangeParams(s.startMs, s.stepMs, s.endMs))
+        case s: ScalarBinaryOperation   => ExecPlanFuncArgs(materialize(s, qContext),
+                                           RangeParams(s.startMs, s.stepMs, s.endMs))
     }
 
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
@@ -33,16 +33,14 @@ trait  PlannerHelper {
     }
 
     def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan
+
+
     def materializeFunctionArgs(functionParams: Seq[FunctionArgsPlan],
                                 qContext: QueryContext): Seq[FuncArgs] = functionParams map {
-      _ match {
         case num: ScalarFixedDoublePlan => StaticFuncArgs(num.scalar, num.timeStepParams)
-        case s: ScalarVaryingDoublePlan => ExecPlanFuncArgs(materialize(s, qContext),
-          RangeParams(s.startMs, s.stepMs, s.endMs))
-        case t: ScalarTimeBasedPlan => TimeFuncArgs(t.rangeParams)
-        case s: ScalarBinaryOperation => ExecPlanFuncArgs(materialize(s, qContext),
-          RangeParams(s.startMs, s.stepMs, s.endMs))
-      }
+        case s: ScalarVaryingDoublePlan => ExecPlanFuncArgs(materialize(s, qContext), RangeParams(s.startMs, s.stepMs, s.endMs))
+        case t: ScalarTimeBasedPlan     => TimeFuncArgs(t.rangeParams)
+        case s: ScalarBinaryOperation   => ExecPlanFuncArgs(materialize(s, qContext), RangeParams(s.startMs, s.stepMs, s.endMs))
     }
 
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
@@ -34,22 +34,18 @@ trait  PlannerHelper {
 
     def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan
     def materializeFunctionArgs(functionParams: Seq[FunctionArgsPlan],
-                                qContext: QueryContext): Seq[FuncArgs] = {
-      if (functionParams.isEmpty) {
-        Nil
-      } else {
-        functionParams.map { param =>
-          param match {
-            case num: ScalarFixedDoublePlan => StaticFuncArgs(num.scalar, num.timeStepParams)
-            case s: ScalarVaryingDoublePlan => ExecPlanFuncArgs(materialize(s, qContext),
-                                               RangeParams(s.startMs, s.stepMs, s.endMs))
-            case  t: ScalarTimeBasedPlan    => TimeFuncArgs(t.rangeParams)
-            case s: ScalarBinaryOperation   => ExecPlanFuncArgs(materialize(s, qContext),
-                                               RangeParams(s.startMs, s.stepMs, s.endMs))
-          }
-        }
+                                qContext: QueryContext): Seq[FuncArgs] = functionParams map {
+      _ match {
+        case num: ScalarFixedDoublePlan => StaticFuncArgs(num.scalar, num.timeStepParams)
+        case s: ScalarVaryingDoublePlan => ExecPlanFuncArgs(materialize(s, qContext),
+          RangeParams(s.startMs, s.stepMs, s.endMs))
+        case t: ScalarTimeBasedPlan => TimeFuncArgs(t.rangeParams)
+        case s: ScalarBinaryOperation => ExecPlanFuncArgs(materialize(s, qContext),
+          RangeParams(s.startMs, s.stepMs, s.endMs))
       }
     }
+
+
 
     def walkLogicalPlanTree(logicalPlan: LogicalPlan,
                             qContext: QueryContext): PlanResult

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -1,7 +1,7 @@
 package filodb.coordinator.queryplanner
 
 import filodb.core.metadata.Dataset
-import filodb.core.query.{ColumnFilter, PromQlQueryParams, QueryConfig, QueryContext, RangeParams}
+import filodb.core.query.{ColumnFilter, PromQlQueryParams, QueryConfig, QueryContext}
 import filodb.query._
 import filodb.query.exec._
 
@@ -73,7 +73,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
       case lp: ScalarVaryingDoublePlan     => materializeScalarPlan(qContext, lp)
       case lp: ApplyAbsentFunction         => materializeAbsentFunction(qContext, lp)
       case lp: VectorPlan                  => materializeVectorPlan(qContext, lp)
-      case lp: Aggregate                   => materializeAggregate(lp, qContext)
+      case lp: Aggregate                   => materializeAggregate(qContext, lp)
       case lp: BinaryJoin                  => materializeBinaryJoin(lp, qContext)
       case lp: LabelValues                 => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
       case lp: LabelNames                  => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
@@ -126,6 +126,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
      PlanResult(Seq(execPlan))
   }
 
+  /*
   /***
     * For aggregate queries like sum(test{_ws_ = "demo", _ns_ =~ "App.*"})
     * It will be broken down to sum(test{_ws_ = "demo", _ns_ = "App-1"}), sum(test{_ws_ = "demo", _ns_ = "App-2"}) etc
@@ -148,7 +149,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
     }
     PlanResult(Seq(exec))
   }
-
+*/
   /***
     * For non aggregate & non binary join queries like test{_ws_ = "demo", _ns_ =~ "App.*"}
     * It will be broken down to test{_ws_ = "demo", _ns_ = "App-1"}, test{_ws_ = "demo", _ns_ = "App-2"} etc

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -109,6 +109,8 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
     val rhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].
       copy(promQl = LogicalPlanParser.convertToQuery(logicalPlan.rhs)))
 
+    // FIXME, Optimize and push the lhs and rhs to wrapped planner if they belong to same partition
+
     val lhsExec = materialize(logicalPlan.lhs, lhsQueryContext)
     val rhsExec = materialize(logicalPlan.rhs, rhsQueryContext)
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -9,12 +9,16 @@ import org.scalatest.matchers.should.Matchers
 import filodb.coordinator.ShardMapper
 import filodb.core.MetricsTestData
 import filodb.core.metadata.Schemas
+import filodb.prometheus.ast.TimeStepParams
+import filodb.query.{BinaryOperator, InstantFunctionId, MiscellaneousFunctionId, SortFunctionId}
 import filodb.core.query.{ColumnFilter, PlannerParams, PromQlQueryParams, QueryConfig, QueryContext}
 import filodb.core.query.Filter.Equals
-import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
 import filodb.query.InstantFunctionId.{Exp, HistogramQuantile}
 import filodb.query.exec._
+import filodb.query.AggregationOperator._
+
+import scala.language.postfixOps
 
 class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
@@ -91,7 +95,9 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   it("should generate Exec plan for subquery with windowing with aggregate") {
-    val lp = Parser.queryToLogicalPlan("""sum(avg_over_time(test{_ws_ = "demo", _ns_ =~ "App.*", instance = "Inst-1" }[5m:1m]))""",
+    val lp = Parser.queryToLogicalPlan(
+      """sum(avg_over_time(test{_ws_ = "demo", _ns_ =~ "App.*",
+        |instance = "Inst-1" }[5m:1m]))""".stripMargin,
       1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
@@ -218,7 +224,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       asInstanceOf[InstantVectorFunctionMapper].function shouldEqual HistogramQuantile
     execPlan.children(0).children.head.isInstanceOf[MultiSchemaPartitionsExec]
 
-    //Plan for each map should not have histogram quantile
+    // Plan for each map should not have histogram quantile
     execPlan.children(0).children.head.rangeVectorTransformers.length shouldEqual 2
     execPlan.children(0).children.head.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
     execPlan.children(0).children.head.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
@@ -252,7 +258,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       asInstanceOf[InstantVectorFunctionMapper].function shouldEqual Exp
     execPlan.children(0).children.head.isInstanceOf[MultiSchemaPartitionsExec]
 
-    //Plan for each map should not have exp
+    // Plan for each map should not have exp
     execPlan.children(0).children.head.rangeVectorTransformers.length shouldEqual 2
     execPlan.children(0).children.head.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
     execPlan.children(0).children.head.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
@@ -271,8 +277,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   it("should generate local Exec plan for query without regex") {
     val lp = Parser.queryToLogicalPlan("""test{_ws_ = "demo", _ns_ = "App-1" }""", 1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
-      ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
-      ColumnFilter("_ns_", Equals("App-2"))))}
+      ColumnFilter("_ns_", Equals("App-1"))))}
     val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual(true)
@@ -290,6 +295,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       ColumnFilter("_ns_", Equals("App-2"))))}
     val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, queryConfig)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    // val execPlan = engine.walkLogicalPlanTree(lp, QueryContext(origQueryParams = promQlQueryParams)).plans.head
     execPlan.isInstanceOf[TimeScalarGeneratorExec] shouldEqual(true)
     execPlan.rangeVectorTransformers.head.isInstanceOf[ScalarOperationMapper] shouldEqual true
     execPlan.rangeVectorTransformers.head.asInstanceOf[ScalarOperationMapper].funcParams.head.
@@ -304,10 +310,10 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     multiPartitionExec.rangeVectorTransformers.head.isInstanceOf[ScalarFunctionMapper] shouldEqual true
 
     // Child plans should have only inner query in PromQlQueryParams
-    multiPartitionExec.children(1).children.head.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
-      "test{_ws_=\"demo\",_ns_=\"App-1\"}"
-    multiPartitionExec.children(0).children.head.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
-      "test{_ws_=\"demo\",_ns_=\"App-2\"}"
+    multiPartitionExec.children(1).children.head.queryContext.origQueryParams
+      .asInstanceOf[PromQlQueryParams].promQl shouldEqual "test{_ws_=\"demo\",_ns_=\"App-1\"}"
+    multiPartitionExec.children(0).children.head.queryContext.origQueryParams
+      .asInstanceOf[PromQlQueryParams].promQl shouldEqual "test{_ws_=\"demo\",_ns_=\"App-2\"}"
   }
 
   it ("should generate Exec plan for Metadata Label values query") {
@@ -351,10 +357,11 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
 
+
   it("should generate Exec plan for Binary join of subqueries with regex") {
     val lp = Parser.queryToLogicalPlan(
       """avg_over_time(test{_ws_ = "demo", _ns_ =~ "App.*", instance = "Inst-1" }[5m:1m]) + """ +
-      """avg_over_time(test{_ws_ = "demo", _ns_ =~ "App.*", instance = "Inst-1" }[5m:1m])""",
+        """avg_over_time(test{_ws_ = "demo", _ns_ =~ "App.*", instance = "Inst-1" }[5m:1m])""",
       1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
@@ -412,21 +419,22 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
   }
-
-  it("should throw UnsupportedOperationException for topk query with multiple matching values for regex") {
-    val lp = Parser.queryToLogicalPlan(s"""topk(2, test{_ws_ = "demo", _ns_ =~ "App.*"})""",
-      1000, 1000)
-    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
-      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
-        ColumnFilter("_ns_", Equals("App-1"))),
-        Seq(ColumnFilter("_ws_", Equals("demo")),
-          ColumnFilter("_ns_", Equals("App-2"))))
+  /*
+    it("should throw UnsupportedOperationException for topk query with multiple matching values for regex") {
+      val lp = Parser.queryToLogicalPlan(s"""topk(2, test{_ws_ = "demo", _ns_ =~ "App.*"})""",
+        1000, 1000)
+      val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+        Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-1"))),
+          Seq(ColumnFilter("_ws_", Equals("demo")),
+            ColumnFilter("_ns_", Equals("App-2"))))
+      }
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+      the[UnsupportedOperationException] thrownBy {
+        val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+      } should have message "Shard Key regex not supported for TopK"
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
-    the[UnsupportedOperationException] thrownBy {
-      val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
-    } should have message "Shard Key regex not supported for TopK"
-  }
+   */
 
   it("should generate Exec plan for histogram quantile for Aggregate query having single matching regex value") {
     val lp = Parser.queryToLogicalPlan("histogram_quantile(0.2, sum(test{_ws_ = \"demo\", _ns_ =~ \"App-1\"}))",
@@ -481,22 +489,472 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       ("""(sum(test1{_ws_="demo",_ns_="App"}) / (sum(test2{_ws_="demo",_ns_="App"}) + sum(test3{_ws_="demo",_ns_="App"})))""")
   }
 
-  it("should generate Exec plan for instant query") {
-    val lp = Parser.queryToLogicalPlan("test{_ws_ = \"demo\", _ns_ =~ \"App.*\", instance = \"Inst-1\" } [10m]", 1000, 1000)
-    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
-      ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
-      ColumnFilter("_ns_", Equals("App-2"))))}
+  it("should handle push down aggregation to right level case 1") {
+    // Case 1 of Push down tests  when regex resolves to two different namespaces
+    val lp = Parser.queryToLogicalPlan("sum(count by(foo)(test1{_ws_ = \"demo\", _ns_ =~ \"App-.*\"}))",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App2"))
+        )
+      )
+    }
     val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
-    execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual(true)
-    execPlan.children(0).children.head.isInstanceOf[MultiSchemaPartitionsExec]
-    execPlan.children(1).children.head.asInstanceOf[MultiSchemaPartitionsExec].filters.
-      contains(ColumnFilter("_ns_", Equals("App-1"))) shouldEqual(true)
-    execPlan.children(0).children.head.asInstanceOf[MultiSchemaPartitionsExec].filters.
-      contains(ColumnFilter("_ns_", Equals("App-2"))) shouldEqual(true)
-    execPlan.children(0).children.head.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
-    ("test{instance=\"Inst-1\",_ws_=\"demo\",_ns_=\"App-2\"}[600s]")
-    execPlan.children(1).children.head.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
-      ("test{instance=\"Inst-1\",_ws_=\"demo\",_ns_=\"App-1\"}[600s]")
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
+    execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].aggrOp shouldEqual Sum
+    val mpExec = execPlan.children.head
+    mpExec.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual true
+    mpExec.asInstanceOf[MultiPartitionReduceAggregateExec].aggrOp shouldEqual Count
+    mpExec.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("count(test1{_ws_=\"demo\",_ns_=\"App2\"}) by (foo)",
+            "count(test1{_ws_=\"demo\",_ns_=\"App1\"}) by (foo)")
+        plan1.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
+      case _ => fail("Expected two children")
+    }
+  }
+
+
+  it("should handle push down aggregation to right level case 2") {
+    // Case 2 of Push down tests  when regex resolves to only one namespace
+    val lp = Parser.queryToLogicalPlan("sum(count by(foo)(test1{_ws_ = \"demo\", _ns_ =~ \"App-.*\"}))",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App1")))
+      )
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    // Since we resolve to just one namespace, the entire plan should be materialized by the wrapped planner
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
+    execPlan.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual true
+    execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      "sum(count(test1{_ws_=\"demo\",_ns_=\"App1\"}) by (foo))"
+  }
+
+  it("should handle multiple binary joins appropriately, case 1") {
+
+    // Case 1: Binary join uses metrics from same partition, entire plan should be materialized by
+    // the queryPlanner and nothing in ShardKeyPlanner
+
+    val lp = Parser.queryToLogicalPlan("test1{_ws_ = \"demo\", _ns_ = \"App-1\"}" +
+      " + test2{_ws_ = \"demo\", _ns_ = \"App-1\"}",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App1")))
+      )
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(
+      origQueryParams = PromQlQueryParams("test1{_ws_=\"demo\",_ns_=\"App-1\"} + test2{_ws_=\"demo\",_ns_=\"App-1\"}",
+        100, 1, 1000)))
+    execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
+    // Since the dispatcher is ActorDispatcher, its materialized by the underlying queryPlanner
+    execPlan.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+    execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      ("test1{_ws_=\"demo\",_ns_=\"App-1\"} + test2{_ws_=\"demo\",_ns_=\"App-1\"}")
+  }
+
+
+  it("should handle multi partition multi level binary join appropriately") {
+
+    // LHS of the Binary Join is on one partition, RHS is another binary join that has data on same partition
+
+    val lp = Parser.queryToLogicalPlan("test1{_ws_ = \"demo\", _ns_ = \"App-1\"}" +
+      " + (test2{_ws_ = \"demo\", _ns_ = \"App-2\"} * test3{_ws_ = \"demo\", _ns_ = \"App-2\"})",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
+
+    // Top level plan to be done in-process, both left & right operations will be executed by the wrapped query planner
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    execPlan.isInstanceOf[BinaryJoinExec] shouldEqual true
+    val (lhs, rhs) = (execPlan.children.head, execPlan.children.tail.head)
+    execPlan.asInstanceOf[BinaryJoinExec].binaryOp shouldEqual BinaryOperator.ADD
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual true
+    lhs.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+    lhs.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual true
+    rhs.isInstanceOf[BinaryJoinExec] shouldEqual true
+    rhs.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual true
+
+    lhs.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      ("test1{_ws_=\"demo\",_ns_=\"App-1\"}")
+
+    rhs.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      ("(test2{_ws_=\"demo\",_ns_=\"App-2\"} * test3{_ws_=\"demo\",_ns_=\"App-2\"})")
+
+  }
+
+
+  it("should handle multi partition multi level binary join appropriately with instant fn") {
+
+    val lp = Parser.queryToLogicalPlan("ln(test1{_ws_ = \"demo\", _ns_ =~ \"App-1\"})", 1000, 1000)
+
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App2"))
+        )
+      )
+    }
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.walkLogicalPlanTree(lp, QueryContext(origQueryParams = promQlQueryParams)).plans.head
+    execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
+    // Since we get data from multiple partitions, the dispatcher will be in process
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    execPlan.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("test1{_ws_=\"demo\",_ns_=\"App1\"}",
+            "test1{_ws_=\"demo\",_ns_=\"App2\"}")
+        plan1.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+      case _ => fail("Expected two children")
+    }
+    execPlan.rangeVectorTransformers.size shouldEqual 1
+    val transformer = execPlan.rangeVectorTransformers.head
+    transformer.isInstanceOf[InstantVectorFunctionMapper] shouldEqual true
+    transformer.asInstanceOf[InstantVectorFunctionMapper].function shouldEqual InstantFunctionId.Ln
+
+
+  }
+
+
+  it("should handle simple instant function applied to single partition raw series with regex") {
+    // Given the raw series is multi partition, the Final operation is done in process for query service
+    val lp = Parser.queryToLogicalPlan("ln(test1{_ws_ = \"demo\", _ns_ =~ \"App-*\"})",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))
+        )
+      )
+    }
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
+    // Since the dispatcher is ActorDispatcher, its materialized by the underlying queryPlanner
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    execPlan.rangeVectorTransformers.size shouldEqual 1
+    execPlan.rangeVectorTransformers.head.isInstanceOf[InstantVectorFunctionMapper] shouldEqual true
+    execPlan.rangeVectorTransformers.head.asInstanceOf[InstantVectorFunctionMapper].function shouldEqual
+      InstantFunctionId.Ln
+    execPlan.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("test1{_ws_=\"demo\",_ns_=\"App-1\"}",
+            "test1{_ws_=\"demo\",_ns_=\"App-2\"}")
+        plan1.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+      case _ => fail("Expected two children")
+    }
+  }
+
+  it("should handle simple instant function applied to single partition raw series w/o regex") {
+    val lp = Parser.queryToLogicalPlan("ln(test1{_ws_ = \"demo\", _ns_ = \"App-1\"})",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
+      PromQlQueryParams("ln(test1{_ws_=\"demo\",_ns_=\"App-1\"})", 100, 1, 1000)))
+    execPlan.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual (true)
+    // Since the dispatcher is ActorDispatcher, its materialized by the underlying queryPlanner
+    execPlan.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+    execPlan.rangeVectorTransformers.size shouldEqual 1
+    execPlan.rangeVectorTransformers.head.isInstanceOf[InstantVectorFunctionMapper] shouldEqual true
+    execPlan.rangeVectorTransformers.head.asInstanceOf[InstantVectorFunctionMapper].function shouldEqual
+      InstantFunctionId.Ln
+    execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      ("ln(test1{_ws_=\"demo\",_ns_=\"App-1\"})")
+  }
+
+  it("should handle simple instant function applied to single partition raw series w/o regex and sum") {
+    val lp = Parser.queryToLogicalPlan("sum(ln(test1{_ws_ = \"demo\", _ns_ = \"App-1\"}))",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
+      PromQlQueryParams("sum(ln(test1{_ws_=\"demo\",_ns_=\"App-1\"}))", 100, 1, 1000)))
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
+    // Since the dispatcher is ActorDispatcher, its materialized by the underlying queryPlanner
+    execPlan.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+    execPlan.children.isEmpty shouldEqual false
+    execPlan.children.head.rangeVectorTransformers.find( _.isInstanceOf[InstantVectorFunctionMapper]) match {
+      case Some(x: InstantVectorFunctionMapper) => x.function shouldEqual InstantFunctionId.Ln
+      case _ => fail("Expected to see an InstantVectorFunctionMapper")
+    }
+    execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      ("sum(ln(test1{_ws_=\"demo\",_ns_=\"App-1\"}))")
+  }
+
+  it("should generate the appropriate plan with label_join") {
+    val lp = Parser.queryToLogicalPlan("label_join(foo{_ws_=\"Demo\", _ns_ =~ \"App*\"}" +
+      ", \"foo\", " + "\",\", \"instance\", \"job\")",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))
+        )
+      )
+    }
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    execPlan.children.size shouldEqual 2
+    execPlan.rangeVectorTransformers.find(_.isInstanceOf[MiscellaneousFunctionMapper]) match {
+      case Some(x: MiscellaneousFunctionMapper) => x.function shouldEqual MiscellaneousFunctionId.LabelJoin
+      case _ => fail("Expected to see an MiscellaneousFunctionMapper")
+    }
+    execPlan.children.foreach( x => {
+      x.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+      x.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+      // TODO: Should the LocalPartitionDistConcatExec have range transformers and just send the required data?
+      x.rangeVectorTransformers.isEmpty shouldEqual true
+    })
+    execPlan.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("foo{_ws_=\"demo\",_ns_=\"App-2\"}",
+            "foo{_ws_=\"demo\",_ns_=\"App-1\"}")
+        plan1.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+      case _ => fail("Expected two children")
+    }
+  }
+  it("should generate the appropriate plan with sort") {
+    val lp = Parser.queryToLogicalPlan("sort(foo{_ws_=\"Demo\", _ns_ =~ \"App*\"}" +
+      ", \"foo\", " + "\",\", \"instance\", \"job\")",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))
+        )
+      )
+    }
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    execPlan.children.size shouldEqual 2
+    execPlan.rangeVectorTransformers.find(_.isInstanceOf[SortFunctionMapper]) match {
+      case Some(x: SortFunctionMapper) => x.function shouldEqual SortFunctionId.Sort
+      case _ => fail("Expected to see an SortFunctionMapper")
+    }
+    execPlan.children.foreach( x => {
+      x.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+      x.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+      x.rangeVectorTransformers.isEmpty shouldEqual true
+    })
+    execPlan.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("foo{_ws_=\"demo\",_ns_=\"App-2\"}",
+            "foo{_ws_=\"demo\",_ns_=\"App-1\"}")
+        plan1.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+      case _ => fail("Expected two children")
+    }
+  }
+
+
+  it("should push down absent function appropriately to individual partitions") {
+    val lp = Parser.queryToLogicalPlan("sum(absent(foo{_ws_=\"Demo\", _ns_ =~ \"App*\"}" +
+      ", \"foo\", " + "\",\", \"instance\", \"job\"))",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))
+        )
+      )
+    }
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    // val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    val execPlan = engine.walkLogicalPlanTree(lp, QueryContext(origQueryParams = promQlQueryParams)).plans.head
+
+    execPlan.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual (true)
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    execPlan.asInstanceOf[ReduceAggregateExec].aggrOp shouldEqual Sum
+    execPlan.children.size shouldEqual 2
+    execPlan.rangeVectorTransformers.find(_.isInstanceOf[AggregatePresenter]) match {
+      case Some(x: AggregatePresenter) => x.aggrOp shouldEqual Sum
+      case _ => fail("Expected to see an AggregatePresenter")
+    }
+    execPlan.children.foreach( x => {
+      x.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
+      x.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+      x.rangeVectorTransformers.isEmpty shouldEqual true
+      x.asInstanceOf[ReduceAggregateExec].aggrOp shouldEqual Sum
+
+    })
+    execPlan.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("sum(absent(foo{_ws_=\"demo\",_ns_=\"App-2\"}))",
+            "sum(absent(foo{_ws_=\"demo\",_ns_=\"App-1\"}))")
+      case _ => fail("Expected two children")
+    }
+  }
+
+
+  it("should execute absent in-process") {
+    val lp = Parser.queryToLogicalPlan("absent(foo{_ws_=\"Demo\", _ns_ =~ \"App*\"}" +
+      ", \"foo\", " + "\",\", \"instance\", \"job\")",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))
+        )
+      )
+    }
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    // val execPlan = engine.walkLogicalPlanTree(lp, QueryContext(origQueryParams = promQlQueryParams)).plans.head
+
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    execPlan.asInstanceOf[ReduceAggregateExec].aggrOp shouldEqual Sum
+    execPlan.children.size shouldEqual 1
+    execPlan.rangeVectorTransformers.find(_.isInstanceOf[AbsentFunctionMapper]) match {
+      case Some(_: AbsentFunctionMapper) =>
+      case _ => fail("Expected to see an AbsentFunctionMapper")
+    }
+    val child = execPlan.children.head
+    child.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual true
+    child.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    child.rangeVectorTransformers.find(_.isInstanceOf[AggregateMapReduce]) match {
+      case Some(x: AggregateMapReduce) => x.aggrOp shouldEqual Sum
+      case _ => fail("Expected to see an AggregateMapReduce")
+    }
+
+    child.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("foo{_ws_=\"demo\",_ns_=\"App-2\"}",
+            "foo{_ws_=\"demo\",_ns_=\"App-1\"}")
+      case _ => fail("Expected two children")
+    }
+  }
+
+
+  it("should execute absent function using wrapped planner") {
+    val lp = Parser.queryToLogicalPlan("absent(foo{_ws_=\"Demo\", _ns_ = \"App-1\"}" +
+      ", \"foo\", " + "\",\", \"instance\", \"job\")",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))))
+    }
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
+      PromQlQueryParams("absent(foo{_ws_=\"Demo\", _ns_ = \"App-1\"} , \"foo\", \",\", \"instance\", \"job\")",
+        100, 1, 1000)))
+
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
+    execPlan.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+    execPlan.asInstanceOf[ReduceAggregateExec].aggrOp shouldEqual Sum
+    execPlan.children.size shouldEqual 1
+    execPlan.rangeVectorTransformers.find(_.isInstanceOf[AbsentFunctionMapper]) match {
+      case Some(x: AbsentFunctionMapper) =>
+      case _ => fail("Expected to see an AggregatePresenter")
+    }
+    execPlan.children.foreach( x => {
+      x.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
+      x.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+      x.rangeVectorTransformers.size shouldEqual 1
+      x.rangeVectorTransformers.head.asInstanceOf[AggregateMapReduce].aggrOp shouldEqual Sum
+
+    })
+    execPlan.children.head.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl  shouldEqual
+      "absent(foo{_ws_=\"Demo\", _ns_ = \"App-1\"} , \"foo\", \",\", \"instance\", \"job\")"
+  }
+
+  it("should materialize vector appropriately for single partition") {
+    val lp = Parser.queryToLogicalPlan("vector(scalar(sum(foo{_ws_=\"demo\", _ns_ = \"App-1\"})))",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
+      PromQlQueryParams("vector(scalar(sum(foo{_ws_=\"demo\",_ns_=\"App-1\"})))", 100, 1, 1000)))
+
+    // Aggregate operation will be materialized on the wrapped planner, everything else in process
+
+    execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
+    execPlan.dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual (true)
+    execPlan.asInstanceOf[ReduceAggregateExec].aggrOp shouldEqual Sum
+    execPlan.children.size shouldEqual 2
+    execPlan.rangeVectorTransformers.contains(VectorFunctionMapper()) shouldEqual true
+    execPlan.rangeVectorTransformers.find(_.isInstanceOf[ScalarFunctionMapper]) match {
+      case Some(x: ScalarFunctionMapper) =>
+      case _ => fail("Expected to see an ScalarFunctionMapper")
+    }
+    execPlan.children.head.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
+      "vector(scalar(sum(foo{_ws_=\"demo\",_ns_=\"App-1\"})))"
+  }
+
+  it("should materialize vector appropriately for multi partition") {
+    val lp = Parser.queryToLogicalPlan("vector(scalar(sum(foo{_ws_=\"demo\", _ns_ =~ \"App*\"})))",
+      1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
+      Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+        ColumnFilter("_ns_", Equals("App-1"))),
+        Seq(ColumnFilter("_ws_", Equals("demo")),
+          ColumnFilter("_ns_", Equals("App-2"))
+        )
+      )
+    }
+
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    // Entre Plan should be materialized on the wrapped
+    execPlan.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual (true)
+    execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
+    execPlan.asInstanceOf[ReduceAggregateExec].aggrOp shouldEqual Sum
+    execPlan.children.size shouldEqual 2
+    execPlan.rangeVectorTransformers.contains(VectorFunctionMapper()) shouldEqual true
+    execPlan.rangeVectorTransformers.find(_.isInstanceOf[ScalarFunctionMapper]) match {
+      case Some(x: ScalarFunctionMapper) =>
+      case _ => fail("Expected to see an ScalarFunctionMapper")
+    }
+
+    execPlan.children match {
+      case plan1::plan2::Nil =>
+        (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::
+          plan1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl :: Nil toSet) shouldEqual
+          Set("sum(foo{_ws_=\"demo\",_ns_=\"App-1\"})",
+            "sum(foo{_ws_=\"demo\",_ns_=\"App-2\"})")
+      case _ => fail("Expected two children")
+    }
   }
 }


### PR DESCRIPTION
**Review only PR**
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Multi partition queries behave incorrectly . Consider the following multi-partition query 

``count(sum by(metric_ws_tag)(foo{_ws_ = "demo", _ns_ =~ "App-.*"}))``

The inner aggregation ``sum by(metric_ws_tag)(foo{_ws_ = "demo", _ns_ =~ "App-.*"})`` may have same`` metric_ws_tag``  and the sum operation will reduce them to 1 row with the corresponding sums added up. The ``count`` of this result should return the same number as the number of rows returned by the ``sum1` aggregation operation.  Current behavior pushes the high level ``count(sum by(metric_ws_tag)(foo{...}))`` aggregation to all partitions and sums the counts which double counts results giving an incorrect count than expected


**New behavior :**

The new behavior is to check from the leaf of the ``LogicalPlan`` and materialize the query the first time we encounter at any level an aggregation that accesses data across different partitions. All other aggregation operations then need to be done in memory of the calling process. Continuing with above given example, only the ``sum by(metric_ws_tag)(foo{_ws_ = "demo", _ns_ =~ "App-.*"})`` operation will be materialized and executed in various partitions, the aggregated sum is then counted in process of the process executing the ``count`` operation.


**BREAKING CHANGES**

None