### PR TITLE
fix(query) Fix issues with multi-partition aggregation's in process aggregation

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -143,12 +143,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
     // using the wrapped planner
     val plan = if (LogicalPlanUtils.hasDescendantAggregate(aggregate.vectors)) {
         val childPlan = materialize(aggregate.vectors, queryContext)
-        val reducer = LocalPartitionReduceAggregateExec(queryContext, inProcessPlanDispatcher,
-          Seq(childPlan), aggregate.operator, aggregate.params)
-        val promQlQueryParams = queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
-        reducer.addRangeVectorTransformer(AggregatePresenter(aggregate.operator, aggregate.params,
-          RangeParams(promQlQueryParams.startSecs, promQlQueryParams.stepSecs, promQlQueryParams.endSecs)))
-        reducer
+        addAggregator(aggregate, queryContext, PlanResult(Seq(childPlan)), Seq.empty)
     } else {
       val execPlans = generateExecWithoutRegex(aggregate,
         LogicalPlan.getNonMetricShardKeyFilters(aggregate, dataset.options.nonMetricShardColumns).head, queryContext)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -143,6 +143,10 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
     // using the wrapped planner
     val plan = if (LogicalPlanUtils.hasDescendantAggregate(aggregate.vectors)) {
         val childPlan = materialize(aggregate.vectors, queryContext)
+        // We are here because we have descendent aggregate, if that was multi-partition, the dispatcher will
+        // be InProcessPlanDispatcher and adding the current aggregate using addAggregate will use the same dispatcher
+        // If the underlying plan however is not multi partition, adding the aggregator using addAggregator will
+        // use the same dispatcher
         addAggregator(aggregate, queryContext, PlanResult(Seq(childPlan)), Seq.empty)
     } else {
       val execPlans = generateExecWithoutRegex(aggregate,

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -511,6 +511,10 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val mpExec = execPlan.children.head
     mpExec.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual true
     mpExec.asInstanceOf[MultiPartitionReduceAggregateExec].aggrOp shouldEqual Count
+    mpExec.rangeVectorTransformers.find(_.isInstanceOf[AggregateMapReduce]) match {
+      case Some(AggregateMapReduce(op, _, _, _, _)) => op shouldEqual Sum
+      case _ => fail("Expected AggregateMapReduce for the sum operation")
+    }
     mpExec.children match {
       case plan1::plan2::Nil =>
         (plan2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl ::


### PR DESCRIPTION
**Review only PR**
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

After PR #1232, the in process aggregation needs to be added using addAggregator to ensure both Mapper and Reducer are added correctly. The fix changes this code to include ``addAggregator``

**New behavior :**

New query plan should correctly have both mapper and reducer, consider the following query

``sum(count by(foo)(test1{_ws_ = "demo", _ns_ =~ "App-.*"}))``

With regex resolving to two namespaces, the query plan generated with a ``SingleClusterPlanner`` as the underlying planner  is as follows

```
T~AggregatePresenter(aggrOp=Sum, aggrParams=List(), rangeParams=RangeParams(1000,1000,1000))
-E~LocalPartitionReduceAggregateExec(aggrOp=Sum, aggrParams=List()) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@12ad1b2a)
--T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
---T~AggregatePresenter(aggrOp=Count, aggrParams=List(), rangeParams=RangeParams(100,1,1000))
----E~MultiPartitionReduceAggregateExec(aggrOp=Count, aggrParams=List()) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@12ad1b2a)
-----E~LocalPartitionReduceAggregateExec(aggrOp=Count, aggrParams=List()) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#551318372],raw)
------T~AggregateMapReduce(aggrOp=Count, aggrParams=List(), without=List(), by=List(foo))
-------T~PeriodicSamplesMapper(start=1000000, step=1000000, end=1000000, window=None, functionId=None, rawSource=true, offsetMs=None)
--------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=8, chunkMethod=TimeRangeChunkScan(700000,1000000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(App2)), ColumnFilter(_metric_,Equals(test1))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#551318372],raw) 
------T~AggregateMapReduce(aggrOp=Count, aggrParams=List(), without=List(), by=List(foo))
-------T~PeriodicSamplesMapper(start=1000000, step=1000000, end=1000000, window=None, functionId=None, rawSource=true, offsetMs=None)
--------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=24, chunkMethod=TimeRangeChunkScan(700000,1000000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(App2)), ColumnFilter(_metric_,Equals(test1))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#551318372],raw) 
-----E~LocalPartitionReduceAggregateExec(aggrOp=Count, aggrParams=List()) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#551318372],raw)
------T~AggregateMapReduce(aggrOp=Count, aggrParams=List(), without=List(), by=List(foo))
-------T~PeriodicSamplesMapper(start=1000000, step=1000000, end=1000000, window=None, functionId=None, rawSource=true, offsetMs=None)
--------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=4, chunkMethod=TimeRangeChunkScan(700000,1000000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(App1)), ColumnFilter(_metric_,Equals(test1))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#551318372],raw) 
------T~AggregateMapReduce(aggrOp=Count, aggrParams=List(), without=List(), by=List(foo))
-------T~PeriodicSamplesMapper(start=1000000, step=1000000, end=1000000, window=None, functionId=None, rawSource=true, offsetMs=None)
--------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=20, chunkMethod=TimeRangeChunkScan(700000,1000000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(App1)), ColumnFilter(_metric_,Equals(test1))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#551318372],raw)
 ```



**BREAKING CHANGES**

None