### PR TITLE
misc(query) use http post in RemoteExec client

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -14,7 +14,7 @@ import filodb.query._
 
 case class MetadataRemoteExec(queryEndpoint: String,
                               requestTimeoutMs: Long,
-                              urlParams: Map[String, Any],
+                              urlParams: Map[String, String],
                               queryContext: QueryContext,
                               dispatcher: PlanDispatcher,
                               dataset: DatasetRef,
@@ -27,7 +27,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
 
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
                               (implicit sched: Scheduler): Future[QueryResponse] = {
-    remoteExecHttpClient.httpMetadataGet(queryEndpoint, httpTimeoutMs,
+    remoteExecHttpClient.httpMetadataPost(queryEndpoint, httpTimeoutMs,
       queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
       .map { response =>
         response.unsafeBody match {

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -48,7 +48,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
 
     import PromCirceSupport._
     import io.circe.parser
-    remoteExecHttpClient.httpGet(queryEndpoint, requestTimeoutMs,
+    remoteExecHttpClient.httpPost(queryEndpoint, requestTimeoutMs,
       queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
       .map { response =>
         // Error response from remote partition is a nested json present in response.body


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Switch to http POST in RemoteExec to support bigger payload in query params.