### PR TITLE
bug(core): Reset metric name in stats during histogram backward compat

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -136,7 +136,7 @@ case class QueryStats() {
   def clear(): Unit = {
     stat.clear()
   }
-  
+
   /**
    * Counter for number of time series scanned by query
    * @param group typically a tuple of (clusterType, dataset, WS, NS, metricName),

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -133,6 +133,10 @@ case class QueryStats() {
     s.stat.foreach(kv => stat.getOrElseUpdate(kv._1, Stat()).add(kv._2))
   }
 
+  def clear(): Unit = {
+    stat.clear()
+  }
+  
   /**
    * Counter for number of time series scanned by query
    * @param group typically a tuple of (clusterType, dataset, WS, NS, metricName),

--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -41,8 +41,8 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
   @transient // dont serialize the SelectRawPartitionsExec plan created for plan execution
   var finalPlan: SelectRawPartitionsExec = _
 
-  // Remove _columnName from metricColumn and generate PartLookupResult
-  private def removeColumnAndGenerateLookupResult(filters: Seq[ColumnFilter], metricName: String, columnName: String,
+  // Remove _columnName suffix from metricName and generate PartLookupResult
+  private def removeSuffixAndGenerateLookupResult(filters: Seq[ColumnFilter], metricName: String, columnName: String,
                                                   source: ChunkSource,
                                                   querySession: QuerySession) = {
     // Assume metric name has only equal filter
@@ -66,23 +66,20 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
     var newColName = colName
 
     /*
-     * Remove _sum & _count suffix. _bucket & le are removed in SingleClusterPlanner
-     * Metric name can have _sum & _count as suffix. So we remove the suffix only when partition lookup does not
-     * return any results
+     * As part of Histogram query compatibility with Prometheus format histograms, we
+     * remove _sum & _count suffix from metric name here. _bucket & le are already removed in SingleClusterPlanner.
+     * We remove the suffix only when partition lookup does not return any results
      */
-    if (lookupRes.firstSchemaId.isEmpty && querySession.queryConfig.translatePromToFilodbHistogram && colName.isEmpty) {
+    if (lookupRes.firstSchemaId.isEmpty && querySession.queryConfig.translatePromToFilodbHistogram &&
+        colName.isEmpty && metricName.isDefined) {
+      val res = if (metricName.get.endsWith("_sum"))
+        removeSuffixAndGenerateLookupResult(filters, metricName.get, "sum", source, querySession)
+      else if (metricName.get.endsWith("_count"))
+        removeSuffixAndGenerateLookupResult(filters, metricName.get, "count", source, querySession)
+      else (lookupRes, newColName)
 
-      if (metricName.isDefined) {
-        val res = if (metricName.get.endsWith("_sum"))
-          removeColumnAndGenerateLookupResult(filters, metricName.get, "sum", source, querySession)
-        else if (metricName.get.endsWith("_count"))
-          removeColumnAndGenerateLookupResult(filters, metricName.get, "count", source,
-            querySession)
-        else (lookupRes, newColName)
-
-        lookupRes = res._1
-        newColName = res._2
-      }
+      lookupRes = res._1
+      newColName = res._2
     }
 
     Kamon.currentSpan().mark("lookup-partitions-done")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

`lookupPartitions` initializes query stats object with the metric name for subsequent use. Histogram backward compat feature changes the metric name but does not clear the stats object. This commit helps with that.