### PR TITLE
feat(core): Cardinality Tracker tracks active timeseries by shard key

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -180,16 +180,16 @@ object CliMain extends FilodbClusterNode {
           require(args.host.isDefined && args.dataset.isDefined && args.k.isDefined,
             "--host, --dataset, --k must be defined")
           val (remote, ref) = getClientAndRef(args)
-          val totalNotActive = !args.active()
+          val addInactive = !args.active()
           val res = remote.getTopkCardinality(ref, args.shards.getOrElse(Nil).map(_.toInt),
-                                                 args.shardkeyprefix(), args.k(), totalNotActive)
+                                                 args.shardkeyprefix(), args.k(), addInactive)
           println(s"ShardKeyPrefix: ${args.shardkeyprefix}")
           res.groupBy(_.shard).foreach { crs =>
             println(s"Shard: ${crs._1}")
             printf("%40s %20s %20s %15s %15s\n", "Child", "TotalTimeSeries", "ActiveTimeSeries", "Children", "Children")
             printf("%40s %20s %20s %15s %15s\n", "Name", "Count", "Count", "Count", "Quota")
             println("==============================================================================================================================")
-            crs._2.sortBy(c => if (totalNotActive) c.tsCount else c.activeTsCount)(Ordering.Int.reverse).foreach { cr =>
+            crs._2.sortBy(c => if (addInactive) c.tsCount else c.activeTsCount)(Ordering.Int.reverse).foreach { cr =>
               printf("%40s %20d %20d %15d %15d\n", cr.childName, cr.tsCount, cr.activeTsCount, cr.childrenCount, cr.childrenQuota)
             }
           }

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -180,16 +180,17 @@ object CliMain extends FilodbClusterNode {
           require(args.host.isDefined && args.dataset.isDefined && args.k.isDefined,
             "--host, --dataset, --k must be defined")
           val (remote, ref) = getClientAndRef(args)
+          val totalNotActive = !args.active()
           val res = remote.getTopkCardinality(ref, args.shards.getOrElse(Nil).map(_.toInt),
-                                                 args.shardkeyprefix(), args.k(), !args.active())
+                                                 args.shardkeyprefix(), args.k(), totalNotActive)
           println(s"ShardKeyPrefix: ${args.shardkeyprefix}")
           res.groupBy(_.shard).foreach { crs =>
             println(s"Shard: ${crs._1}")
-            printf("%40s %12s %10s %10s\n", "Child", "TimeSeries", "Children", "Children")
-            printf("%40s %12s %10s %10s\n", "Name", "Count", "Count", "Quota")
-            println("===================================================================================")
-            crs._2.sortBy(_.tsCount)(Ordering.Int.reverse).foreach { cr =>
-              printf("%40s %12d %10d %10d\n", cr.childName, cr.tsCount, cr.childrenCount, cr.childrenQuota)
+            printf("%40s %20s %20s %15s %15s\n", "Child", "TotalTimeSeries", "ActiveTimeSeries", "Children", "Children")
+            printf("%40s %20s %20s %15s %15s\n", "Name", "Count", "Count", "Count", "Quota")
+            println("==============================================================================================================================")
+            crs._2.sortBy(c => if (totalNotActive) c.tsCount else c.activeTsCount)(Ordering.Int.reverse).foreach { cr =>
+              printf("%40s %20d %20d %15d %15d\n", cr.childName, cr.tsCount, cr.activeTsCount, cr.childrenCount, cr.childrenQuota)
             }
           }
 

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -213,7 +213,7 @@ final class QueryActor(memStore: MemStore,
 
   private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
     try {
-      val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k)
+      val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k, q.totalNotActive)
       sender ! ret
     } catch { case e: Exception =>
       sender ! QueryError(s"Error Occurred", QueryStats(), e)

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -213,7 +213,7 @@ final class QueryActor(memStore: MemStore,
 
   private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
     try {
-      val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k, q.totalNotActive)
+      val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k, q.addInactive)
       sender ! ret
     } catch { case e: Exception =>
       sender ! QueryError(s"Error Occurred", QueryStats(), e)

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -36,7 +36,7 @@ object QueryCommands {
                                       shards: Seq[Int],
                                       shardKeyPrefix: Seq[String],
                                       k: Int,
-                                      totalNotActive: Boolean,
+                                      addInactive: Boolean,
                                       submitTime: Long = System.currentTimeMillis()) extends QueryCommand
 
   final case class StaticSpreadProvider(spreadChange: SpreadChange = SpreadChange()) extends SpreadProvider {

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -36,6 +36,7 @@ object QueryCommands {
                                       shards: Seq[Int],
                                       shardKeyPrefix: Seq[String],
                                       k: Int,
+                                      totalNotActive: Boolean,
                                       submitTime: Long = System.currentTimeMillis()) extends QueryCommand
 
   final case class StaticSpreadProvider(spreadChange: SpreadChange = SpreadChange()) extends SpreadProvider {

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
@@ -49,8 +49,9 @@ trait QueryOps extends ClientBase with StrictLogging {
                      shards: Seq[Int],
                      shardKeyPrefix: Seq[String],
                      k: Int,
+                     totalNotActive: Boolean,
                      timeout: FiniteDuration = 15.seconds): Seq[CardinalityRecord] =
-    askCoordinator(GetTopkCardinality(dataset, shards, shardKeyPrefix, k), timeout) {
+    askCoordinator(GetTopkCardinality(dataset, shards, shardKeyPrefix, k, totalNotActive), timeout) {
       case s: Seq[CardinalityRecord] @unchecked => s
       case e: QueryError => throw e.t
     }

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
@@ -49,9 +49,9 @@ trait QueryOps extends ClientBase with StrictLogging {
                      shards: Seq[Int],
                      shardKeyPrefix: Seq[String],
                      k: Int,
-                     totalNotActive: Boolean,
+                     addInactive: Boolean,
                      timeout: FiniteDuration = 15.seconds): Seq[CardinalityRecord] =
-    askCoordinator(GetTopkCardinality(dataset, shards, shardKeyPrefix, k, totalNotActive), timeout) {
+    askCoordinator(GetTopkCardinality(dataset, shards, shardKeyPrefix, k, addInactive), timeout) {
       case s: Seq[CardinalityRecord] @unchecked => s
       case e: QueryError => throw e.t
     }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -201,5 +201,5 @@ extends MemStore with StrictLogging {
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],
                                k: Int,
-                               totalNotActive: Boolean): scala.Seq[CardinalityRecord] = ???
+                               addInactive: Boolean): scala.Seq[CardinalityRecord] = ???
 }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -200,5 +200,6 @@ extends MemStore with StrictLogging {
   override def topKCardinality(ref: DatasetRef,
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],
-                               k: Int): scala.Seq[CardinalityRecord] = ???
+                               k: Int,
+                               totalNotActive: Boolean): scala.Seq[CardinalityRecord] = ???
 }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -80,12 +80,12 @@ extends MemStore with StrictLogging {
   }
 
   def topKCardinality(ref: DatasetRef, shards: Seq[Int],
-                      shardKeyPrefix: Seq[String], k: Int, totalNotActive: Boolean): Seq[CardinalityRecord] = {
+                      shardKeyPrefix: Seq[String], k: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
     datasets.get(ref).toSeq
       .flatMap { ts =>
         ts.values().asScala
           .filter(s => shards.isEmpty || shards.contains(s.shardNum))
-          .flatMap(_.topKCardinality(k, shardKeyPrefix, totalNotActive))
+          .flatMap(_.topKCardinality(k, shardKeyPrefix, addInactive))
       }
   }
   /**

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -80,12 +80,12 @@ extends MemStore with StrictLogging {
   }
 
   def topKCardinality(ref: DatasetRef, shards: Seq[Int],
-                      shardKeyPrefix: Seq[String], k: Int): Seq[CardinalityRecord] = {
+                      shardKeyPrefix: Seq[String], k: Int, totalNotActive: Boolean): Seq[CardinalityRecord] = {
     datasets.get(ref).toSeq
       .flatMap { ts =>
         ts.values().asScala
           .filter(s => shards.isEmpty || shards.contains(s.shardNum))
-          .flatMap(_.topKCardinality(k, shardKeyPrefix))
+          .flatMap(_.topKCardinality(k, shardKeyPrefix, totalNotActive))
       }
   }
   /**

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -675,7 +675,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     shardStats.indexRecoveryNumRecordsProcessed.increment()
     if (schema != Schemas.UnknownSchema) {
       if (storeConfig.meteringEnabled) {
-        cardTracker.incrementCount(shardKey, 1, if (pk.endTime == Long.MaxValue) 1 else 0)
+        cardTracker.modifyCount(shardKey, 1, if (pk.endTime == Long.MaxValue) 1 else 0)
       }
     }
     partId
@@ -1148,7 +1148,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         val shardKey = p.schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset,
                                                         p.schema.options.shardKeyColumns)
         if (storeConfig.meteringEnabled) {
-          cardTracker.incrementCount(shardKey, 0, -1)
+          cardTracker.modifyCount(shardKey, 0, -1)
         }
       }
     }
@@ -1255,7 +1255,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         // causes endTime to be set to Long.MaxValue
         partKeyIndex.addPartKey(newPart.partKeyBytes, partId, startTime)()
         if (storeConfig.meteringEnabled) {
-          cardTracker.incrementCount(shardKey, 1, 1)
+          cardTracker.modifyCount(shardKey, 1, 1)
         }
       } else {
         // newly created partition is re-ingesting now, so update endTime
@@ -1317,7 +1317,7 @@ class TimeSeriesShard(val ref: DatasetRef,
               val shardKey = tsp.schema.partKeySchema.colValues(tsp.partKeyBase, tsp.partKeyOffset,
                 tsp.schema.options.shardKeyColumns)
               if (storeConfig.meteringEnabled) {
-                cardTracker.incrementCount(shardKey, 0, 1)
+                cardTracker.modifyCount(shardKey, 0, 1)
               }
             }
           }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -598,8 +598,8 @@ class TimeSeriesShard(val ref: DatasetRef,
     _offset
   }
 
-  def topKCardinality(k: Int, shardKeyPrefix: Seq[String], totalNotActive: Boolean): Seq[CardinalityRecord] = {
-    if (storeConfig.meteringEnabled) cardTracker.topk(k, shardKeyPrefix, totalNotActive)
+  def topKCardinality(k: Int, shardKeyPrefix: Seq[String], addInactive: Boolean): Seq[CardinalityRecord] = {
+    if (storeConfig.meteringEnabled) cardTracker.topk(k, shardKeyPrefix, addInactive)
     else throw new IllegalArgumentException("Metering is not enabled")
   }
 

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -1,6 +1,15 @@
 package filodb.core.memstore.ratelimit
 
-case class Cardinality(name: String, timeSeriesCount: Int, childrenCount: Int, childrenQuota: Int)
+/**
+ * The data stored in each node of the Cardinality Store trie
+ * @param name name of the item in shardKeyPrefix
+ * @param tsCount total number of timeSeries under this shardKeyPrefix (example, number of timeseries under ws,ns)
+ * @param activeTsCount number of actively ingesting timeSeries under this shardKeyPrefix
+ *                      (example, number of timeseries under ws,ns)
+ * @param childrenCount number of immediate children for this shardKey (example, number of ns under ws)
+ * @param childrenQuota quota for number of immediate children
+ */
+case class Cardinality(name: String, tsCount: Int, activeTsCount: Int, childrenCount: Int, childrenQuota: Int)
 
 /**
  *

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -171,11 +171,11 @@ class CardinalityTracker(ref: DatasetRef,
    * @param shardKeyPrefix zero or more elements that form a valid shard key prefix
    * @return Top-K records, can the less than K if fewer children
    */
-  def topk(k: Int, shardKeyPrefix: Seq[String], totalNotActive: Boolean): Seq[CardinalityRecord] = {
+  def topk(k: Int, shardKeyPrefix: Seq[String], addInactive: Boolean): Seq[CardinalityRecord] = {
     require(shardKeyPrefix.length <= shardKeyLen, s"Too many shard keys in $shardKeyPrefix - max $shardKeyLen")
     implicit val ord = new Ordering[CardinalityRecord]() {
       override def compare(x: CardinalityRecord, y: CardinalityRecord): Int = {
-        if (totalNotActive) x.tsCount - y.tsCount
+        if (addInactive) x.tsCount - y.tsCount
         else x.activeTsCount - y.activeTsCount
       }
     }.reverse

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -57,8 +57,12 @@ class CardinalityTracker(ref: DatasetRef,
    * @return current cardinality for each shard key prefix. There
    *         will be shardKeyLen + 1 items in the return value
    */
-  def incrementCount(shardKey: Seq[String], totalDelta: Int, activeDelta: Int): Seq[Cardinality] = {
+  def modifyCount(shardKey: Seq[String], totalDelta: Int, activeDelta: Int): Seq[Cardinality] = {
     require(shardKey.length == shardKeyLen, "full shard key is needed")
+    require(totalDelta == 1 && activeDelta == 0 ||   // new ts but inactive
+            totalDelta == 1 && activeDelta == 1 ||   // new ts and active
+            totalDelta == 0 && activeDelta == -1,    // existing ts that became inactive
+            "invalid values for totalDelta / activeDelta")
 
     val toStore = ArrayBuffer[(Seq[String], Cardinality)]()
     // first make sure there is no breach for any prefix

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -61,7 +61,8 @@ class CardinalityTracker(ref: DatasetRef,
     require(shardKey.length == shardKeyLen, "full shard key is needed")
     require(totalDelta == 1 && activeDelta == 0 ||   // new ts but inactive
             totalDelta == 1 && activeDelta == 1 ||   // new ts and active
-            totalDelta == 0 && activeDelta == -1,    // existing ts that became inactive
+            totalDelta == 0 && activeDelta == 1 ||   // // existing inactive ts that became active
+            totalDelta == 0 && activeDelta == -1,    // existing active ts that became inactive
             "invalid values for totalDelta / activeDelta")
 
     val toStore = ArrayBuffer[(Seq[String], Cardinality)]()

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
@@ -23,13 +23,15 @@ import filodb.memory.format.UnsafeUtils
 class CardinalitySerializer extends Serializer[Cardinality] {
   def write(kryo: Kryo, output: Output, card: Cardinality): Unit = {
     output.writeString(card.name)
-    output.writeInt(card.timeSeriesCount, true)
+    output.writeInt(card.tsCount, true)
+    output.writeInt(card.activeTsCount, true)
     output.writeInt(card.childrenCount, true)
     output.writeInt(card.childrenQuota, true)
   }
 
   def read(kryo: Kryo, input: Input, t: Class[Cardinality]): Cardinality = {
-    Cardinality(input.readString(), input.readInt(true), input.readInt(true), input.readInt(true))
+    Cardinality(input.readString(), input.readInt(true), input.readInt(true),
+      input.readInt(true), input.readInt(true))
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -193,7 +193,7 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
   }
 
   def topKCardinality(ref: DatasetRef, shard: Seq[Int],
-                      shardKeyPrefix: Seq[String], k: Int, totalNotActive: Boolean): Seq[CardinalityRecord]
+                      shardKeyPrefix: Seq[String], k: Int, addInactive: Boolean): Seq[CardinalityRecord]
 
 }
 

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -192,7 +192,8 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
     }
   }
 
-  def topKCardinality(ref: DatasetRef, shard: Seq[Int], shardKeyPrefix: Seq[String], k: Int): Seq[CardinalityRecord]
+  def topKCardinality(ref: DatasetRef, shard: Seq[Int],
+                      shardKeyPrefix: Seq[String], k: Int, totalNotActive: Boolean): Seq[CardinalityRecord]
 
 }
 

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -15,29 +15,44 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should enforce quota when set explicitly for all levels") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
-    t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual Cardinality("aaa", 0, 0, 1)
-    t.setQuota(Seq("a", "aa"), 2) shouldEqual Cardinality("aa", 0, 0, 2)
-    t.setQuota(Seq("a"), 1) shouldEqual Cardinality("a",0, 0, 1)
-    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
-      Seq(Cardinality("", 1, 1, 4),
-        Cardinality("a", 1, 1, 1),
-        Cardinality("aa", 1, 1, 2),
-        Cardinality("aaa", 1, 1, 1))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 2, 1, 4),
-        Cardinality("a", 2, 1, 1),
-        Cardinality("aa", 2, 2, 2),
-        Cardinality("aab", 1, 1, 4))
+    t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual Cardinality("aaa", 0, 0, 0, 1)
+    t.setQuota(Seq("a", "aa"), 2) shouldEqual Cardinality("aa", 0, 0, 0, 2)
+    t.setQuota(Seq("a"), 1) shouldEqual Cardinality("a",0, 0, 0, 1)
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 1) shouldEqual
+      Seq(Cardinality("", 1, 1, 1, 4),
+        Cardinality("a", 1, 1, 1, 1),
+        Cardinality("aa", 1, 1, 1, 2),
+        Cardinality("aaa", 1, 1, 1, 1))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 1) shouldEqual
+      Seq(Cardinality("", 2, 2, 1, 4),
+        Cardinality("a", 2, 2, 1, 1),
+        Cardinality("aa", 2, 2, 2, 2),
+        Cardinality("aab", 1, 1, 1, 4))
+
+    // aab stopped ingesting
+    t.incrementCount(Seq("a", "aa", "aab"), 0, -1) shouldEqual
+      Seq(Cardinality("", 2, 1, 1, 4),
+        Cardinality("a", 2, 1, 1, 1),
+        Cardinality("aa", 2, 1, 2, 2),
+        Cardinality("aab", 1, 0, 1, 4))
 
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aac"))
+      t.incrementCount(Seq("a", "aa", "aac"), 1, 0)
     }
     ex.prefix shouldEqual (Seq("a", "aa"))
 
     // increment should not have been applied for any prefix
-    t.getCardinality(Seq("a")) shouldEqual Cardinality("a", 2, 1, 1)
-    t.getCardinality(Seq("a", "aa")) shouldEqual Cardinality("aa", 2, 2, 2)
-    t.getCardinality(Seq("a", "aa", "aac")) shouldEqual Cardinality("aac", 0, 0, 4)
+    t.getCardinality(Seq("a")) shouldEqual Cardinality("a", 2, 1, 1, 1)
+    t.getCardinality(Seq("a", "aa")) shouldEqual Cardinality("aa", 2, 1, 2, 2)
+    t.getCardinality(Seq("a", "aa", "aac")) shouldEqual Cardinality("aac", 0, 0, 0, 4)
+
+    // aab was purged
+    t.decrementCount(Seq("a", "aa", "aab")) shouldEqual
+      Seq(Cardinality("", 1, 1, 1, 4),
+        Cardinality("a", 1, 1, 1, 1),
+        Cardinality("aa", 1, 1, 2, 2),
+        Cardinality("aab", 0, 0, 0, 4))
+
     t.close()
   }
 
@@ -54,9 +69,9 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
     val qp = new MyQEP
     val t = new CardinalityTracker(ref, 0, 3, Seq(1, 1, 1, 1), newCardStore, qp)
-    t.incrementCount(Seq("a", "aa", "aaa"))
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"))
+      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
     }
     qp.breachedQuota shouldEqual 1
     qp.breachedPrefix shouldEqual Seq("a", "aa", "aaa")
@@ -65,53 +80,53 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should enforce quota when not set for any level") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
-    t.incrementCount(Seq("a", "ab", "aba")) shouldEqual
-      Seq(Cardinality("", 1, 1, 4),
-        Cardinality("a", 1, 1, 4),
-        Cardinality("ab", 1, 1, 4),
-        Cardinality("aba", 1, 1, 4))
+    t.incrementCount(Seq("a", "ab", "aba"), 1, 0) shouldEqual
+      Seq(Cardinality("", 1, 0, 1, 4),
+        Cardinality("a", 1, 0, 1, 4),
+        Cardinality("ab", 1, 0, 1, 4),
+        Cardinality("aba", 1, 0, 1, 4))
     t.close()
   }
 
   it("should be able to enforce for top 2 levels always, and enforce for 3rd level only in some cases") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 10)
-    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 10)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
     // enforce for 3rd level only for aaa
-    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 2)
-    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
-      Seq(Cardinality("", 1, 1, 20),
-        Cardinality("a", 1, 1, 10),
-        Cardinality("aa", 1, 1, 10),
-        Cardinality("aaa", 1, 1, 2))
-    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
-      Seq(Cardinality("", 2, 1, 20),
-        Cardinality("a", 2, 1, 10),
-        Cardinality("aa", 2, 1, 10),
-        Cardinality("aaa", 2, 2, 2))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 3, 1, 20),
-        Cardinality("a", 3, 1, 10),
-        Cardinality("aa", 3, 2, 10),
-        Cardinality("aab", 1, 1, 20))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 4, 1, 20),
-        Cardinality("a", 4, 1, 10),
-        Cardinality("aa", 4, 2, 10),
-        Cardinality("aab", 2, 2, 20))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 5, 1, 20),
-        Cardinality("a", 5, 1, 10),
-        Cardinality("aa", 5, 2, 10),
-        Cardinality("aab", 3, 3, 20))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 6, 1, 20),
-        Cardinality("a", 6, 1, 10),
-        Cardinality("aa", 6, 2, 10),
-        Cardinality("aab", 4, 4, 20))
+    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 0, 2)
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+      Seq(Cardinality("", 1, 0, 1, 20),
+        Cardinality("a", 1, 0, 1, 10),
+        Cardinality("aa", 1, 0, 1, 10),
+        Cardinality("aaa", 1, 0, 1, 2))
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+      Seq(Cardinality("", 2, 0, 1, 20),
+        Cardinality("a", 2, 0, 1, 10),
+        Cardinality("aa", 2, 0, 1, 10),
+        Cardinality("aaa", 2, 0, 2, 2))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 3, 0, 1, 20),
+        Cardinality("a", 3, 0, 1, 10),
+        Cardinality("aa", 3, 0, 2, 10),
+        Cardinality("aab", 1, 0, 1, 20))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 4, 0, 1, 20),
+        Cardinality("a", 4, 0, 1, 10),
+        Cardinality("aa", 4, 0, 2, 10),
+        Cardinality("aab", 2, 0, 2, 20))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 5, 0, 1, 20),
+        Cardinality("a", 5, 0, 1, 10),
+        Cardinality("aa", 5, 0, 2, 10),
+        Cardinality("aab", 3, 0, 3, 20))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 6, 0, 1, 20),
+        Cardinality("a", 6, 0, 1, 10),
+        Cardinality("aa", 6, 0, 2, 10),
+        Cardinality("aab", 4, 0, 4, 20))
 
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"))
+      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
     }
      ex.prefix shouldEqual Seq("a", "aa", "aaa")
     t.close()
@@ -120,43 +135,43 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should be able to increase and decrease quota after it has been set before") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 10)
-    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 10)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
     // enforce for 3rd level only for aaa
-    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 2)
-    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
-      Seq(Cardinality("", 1, 1, 20),
-        Cardinality("a", 1, 1, 10),
-        Cardinality("aa", 1, 1, 10),
-        Cardinality("aaa", 1, 1, 2))
-    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
-      Seq(Cardinality("", 2, 1, 20),
-        Cardinality("a", 2, 1, 10),
-        Cardinality("aa", 2, 1, 10),
-        Cardinality("aaa", 2, 2, 2))
+    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 0, 2)
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+      Seq(Cardinality("", 1, 0, 1, 20),
+        Cardinality("a", 1, 0, 1, 10),
+        Cardinality("aa", 1, 0, 1, 10),
+        Cardinality("aaa", 1, 0, 1, 2))
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+      Seq(Cardinality("", 2, 0, 1, 20),
+        Cardinality("a", 2, 0, 1, 10),
+        Cardinality("aa", 2, 0, 1, 10),
+        Cardinality("aaa", 2, 0, 2, 2))
 
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"))
+      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
     }
     ex.prefix shouldEqual (Seq("a", "aa", "aaa"))
 
     // increase quota
-    t.setQuota(Seq("a", "aa", "aaa"), 5) shouldEqual Cardinality("aaa", 2, 2, 5)
-    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
-      Seq(Cardinality("", 3, 1, 20),
-        Cardinality("a", 3, 1, 10),
-        Cardinality("aa", 3, 1, 10),
-        Cardinality("aaa", 3, 3, 5))
+    t.setQuota(Seq("a", "aa", "aaa"), 5) shouldEqual Cardinality("aaa", 2, 0, 2, 5)
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+      Seq(Cardinality("", 3, 0, 1, 20),
+        Cardinality("a", 3, 0, 1, 10),
+        Cardinality("aa", 3, 0, 1, 10),
+        Cardinality("aaa", 3, 0, 3, 5))
 
     // decrease quota
-    t.setQuota(Seq("a", "aa", "aaa"), 4) shouldEqual Cardinality("aaa", 3, 3, 4)
-    t.incrementCount(Seq("a", "aa", "aaa")) shouldEqual
-      Seq(Cardinality("", 4, 1, 20),
-        Cardinality("a", 4, 1, 10),
-        Cardinality("aa", 4, 1, 10),
-        Cardinality("aaa", 4, 4, 4))
+    t.setQuota(Seq("a", "aa", "aaa"), 4) shouldEqual Cardinality("aaa", 3, 0, 3, 4)
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+      Seq(Cardinality("", 4, 0, 1, 20),
+        Cardinality("a", 4, 0, 1, 10),
+        Cardinality("aa", 4, 0, 1, 10),
+        Cardinality("aaa", 4, 0, 4, 4))
     val ex2 = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"))
+      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
     }
     ex2.prefix shouldEqual Seq("a", "aa", "aaa")
     t.close()
@@ -164,35 +179,35 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should be able to decrease quota if count is higher than new quota") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 10)
-    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 10)
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 1, 1, 20),
-        Cardinality("a", 1, 1, 10),
-        Cardinality("aa", 1, 1, 10),
-        Cardinality("aab", 1, 1, 20))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 2, 1, 20),
-        Cardinality("a", 2, 1, 10),
-        Cardinality("aa", 2, 1, 10),
-        Cardinality("aab", 2, 2, 20))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 3, 1, 20),
-        Cardinality("a", 3, 1, 10),
-        Cardinality("aa", 3, 1, 10),
-        Cardinality("aab", 3, 3, 20))
-    t.incrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 4, 1, 20),
-        Cardinality("a", 4, 1, 10),
-        Cardinality("aa", 4, 1, 10),
-        Cardinality("aab", 4, 4, 20))
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 1, 0, 1, 20),
+        Cardinality("a", 1, 0, 1, 10),
+        Cardinality("aa", 1, 0, 1, 10),
+        Cardinality("aab", 1, 0, 1, 20))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 2, 0, 1, 20),
+        Cardinality("a", 2, 0, 1, 10),
+        Cardinality("aa", 2, 0, 1, 10),
+        Cardinality("aab", 2, 0, 2, 20))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 3, 0, 1, 20),
+        Cardinality("a", 3, 0, 1, 10),
+        Cardinality("aa", 3, 0, 1, 10),
+        Cardinality("aab", 3, 0, 3, 20))
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+      Seq(Cardinality("", 4, 0, 1, 20),
+        Cardinality("a", 4, 0, 1, 10),
+        Cardinality("aa", 4, 0, 1, 10),
+        Cardinality("aab", 4, 0, 4, 20))
 
-    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 4, 20)
+    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 0, 4, 20)
 
     t.setQuota(Seq("a", "aa", "aab"), 3)
-    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 4, 3)
+    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 0, 4, 3)
     val ex2 = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aab"))
+      t.incrementCount(Seq("a", "aa", "aab"), 1, 0)
     }
     ex2.prefix shouldEqual Seq("a", "aa", "aab")
     t.close()
@@ -200,49 +215,49 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it ("should be able to do topk") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
-    (1 to 10).foreach(_ => t.incrementCount(Seq("a", "ac", "aca")))
-    (1 to 20).foreach(_ => t.incrementCount(Seq("a", "ac", "acb")))
-    (1 to 11).foreach(_ => t.incrementCount(Seq("a", "ac", "acc")))
-    (1 to 6).foreach(_ => t.incrementCount(Seq("a", "ac", "acd")))
-    (1 to 1).foreach(_ => t.incrementCount(Seq("a", "ac", "ace")))
-    (1 to 9).foreach(_ => t.incrementCount(Seq("a", "ac", "acf")))
-    (1 to 15).foreach(_ => t.incrementCount(Seq("a", "ac", "acg")))
+    (1 to 10).foreach(_ => t.incrementCount(Seq("a", "ac", "aca"), 1, 0))
+    (1 to 20).foreach(_ => t.incrementCount(Seq("a", "ac", "acb"), 1, 0))
+    (1 to 11).foreach(_ => t.incrementCount(Seq("a", "ac", "acc"), 1, 0))
+    (1 to 6).foreach(_ => t.incrementCount(Seq("a", "ac", "acd"), 1, 0))
+    (1 to 1).foreach(_ => t.incrementCount(Seq("a", "ac", "ace"), 1, 0))
+    (1 to 9).foreach(_ => t.incrementCount(Seq("a", "ac", "acf"), 1, 0))
+    (1 to 15).foreach(_ => t.incrementCount(Seq("a", "ac", "acg"), 1, 0))
 
-    (1 to 15).foreach(_ => t.incrementCount(Seq("b", "bc", "bcg")))
-    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bc", "bch")))
-    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bd", "bdh")))
+    (1 to 15).foreach(_ => t.incrementCount(Seq("b", "bc", "bcg"), 1, 0))
+    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bc", "bch"), 1, 0))
+    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bd", "bdh"), 1, 0))
 
-    (1 to 3).foreach(_ => t.incrementCount(Seq("c", "cc", "ccg")))
-    (1 to 2).foreach(_ => t.incrementCount(Seq("c", "cc", "cch")))
+    (1 to 3).foreach(_ => t.incrementCount(Seq("c", "cc", "ccg"), 1, 0))
+    (1 to 2).foreach(_ => t.incrementCount(Seq("c", "cc", "cch"), 1, 0))
 
-    t.incrementCount(Seq("a", "aa", "aaa"))
-    t.incrementCount(Seq("a", "aa", "aab"))
-    t.incrementCount(Seq("a", "aa", "aac"))
-    t.incrementCount(Seq("a", "aa", "aad"))
-    t.incrementCount(Seq("b", "ba", "baa"))
-    t.incrementCount(Seq("b", "bb", "bba"))
-    t.incrementCount(Seq("a", "ab", "aba"))
-    t.incrementCount(Seq("a", "ab", "abb"))
-    t.incrementCount(Seq("a", "ab", "abc"))
-    t.incrementCount(Seq("a", "ab", "abd"))
-    t.incrementCount(Seq("a", "ab", "abe"))
+    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
+    t.incrementCount(Seq("a", "aa", "aab"), 1, 0)
+    t.incrementCount(Seq("a", "aa", "aac"), 1, 0)
+    t.incrementCount(Seq("a", "aa", "aad"), 1, 0)
+    t.incrementCount(Seq("b", "ba", "baa"), 1, 0)
+    t.incrementCount(Seq("b", "bb", "bba"), 1, 0)
+    t.incrementCount(Seq("a", "ab", "aba"), 1, 0)
+    t.incrementCount(Seq("a", "ab", "abb"), 1, 0)
+    t.incrementCount(Seq("a", "ab", "abc"), 1, 0)
+    t.incrementCount(Seq("a", "ab", "abd"), 1, 0)
+    t.incrementCount(Seq("a", "ab", "abe"), 1, 0)
 
-    t.topk(3, Seq("a", "ac")) shouldEqual Seq(
-      CardinalityRecord(0, "acc", 11, 11, 100),
-      CardinalityRecord(0, "acg", 15, 15, 100),
-      CardinalityRecord(0, "acb", 20, 20, 100)
+    t.topk(3, Seq("a", "ac"), true) shouldEqual Seq(
+      CardinalityRecord(0, "acc", 11, 0, 11, 100),
+      CardinalityRecord(0, "acg", 15, 0, 15, 100),
+      CardinalityRecord(0, "acb", 20, 0, 20, 100)
     )
 
-    t.topk(3, Seq("a")) shouldEqual Seq(
-      CardinalityRecord(0, "aa", 4, 4, 100),
-      CardinalityRecord(0, "ab", 5, 5, 100),
-      CardinalityRecord(0, "ac", 72, 7, 100)
+    t.topk(3, Seq("a"), true) shouldEqual Seq(
+      CardinalityRecord(0, "aa", 4, 0, 4, 100),
+      CardinalityRecord(0, "ab", 5, 0, 5, 100),
+      CardinalityRecord(0, "ac", 72, 0, 7, 100)
     )
 
-    t.topk(3, Nil) shouldEqual Seq(
-      CardinalityRecord(0, "c", 5, 1, 100),
-      CardinalityRecord(0, "a", 81, 3, 100),
-      CardinalityRecord(0, "b", 35, 4, 100)
+    t.topk(3, Nil, true) shouldEqual Seq(
+      CardinalityRecord(0, "c", 5, 0, 1, 100),
+      CardinalityRecord(0, "a", 81, 0, 3, 100),
+      CardinalityRecord(0, "b", 35, 0, 4, 100)
     )
     t.close()
   }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -18,26 +18,26 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual Cardinality("aaa", 0, 0, 0, 1)
     t.setQuota(Seq("a", "aa"), 2) shouldEqual Cardinality("aa", 0, 0, 0, 2)
     t.setQuota(Seq("a"), 1) shouldEqual Cardinality("a",0, 0, 0, 1)
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 1) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 1) shouldEqual
       Seq(Cardinality("", 1, 1, 1, 4),
         Cardinality("a", 1, 1, 1, 1),
         Cardinality("aa", 1, 1, 1, 2),
         Cardinality("aaa", 1, 1, 1, 1))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 1) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 1) shouldEqual
       Seq(Cardinality("", 2, 2, 1, 4),
         Cardinality("a", 2, 2, 1, 1),
         Cardinality("aa", 2, 2, 2, 2),
         Cardinality("aab", 1, 1, 1, 4))
 
     // aab stopped ingesting
-    t.incrementCount(Seq("a", "aa", "aab"), 0, -1) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 0, -1) shouldEqual
       Seq(Cardinality("", 2, 1, 1, 4),
         Cardinality("a", 2, 1, 1, 1),
         Cardinality("aa", 2, 1, 2, 2),
         Cardinality("aab", 1, 0, 1, 4))
 
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aac"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
     }
     ex.prefix shouldEqual (Seq("a", "aa"))
 
@@ -69,9 +69,9 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
     val qp = new MyQEP
     val t = new CardinalityTracker(ref, 0, 3, Seq(1, 1, 1, 1), newCardStore, qp)
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
     }
     qp.breachedQuota shouldEqual 1
     qp.breachedPrefix shouldEqual Seq("a", "aa", "aaa")
@@ -80,7 +80,7 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should enforce quota when not set for any level") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
-    t.incrementCount(Seq("a", "ab", "aba"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "ab", "aba"), 1, 0) shouldEqual
       Seq(Cardinality("", 1, 0, 1, 4),
         Cardinality("a", 1, 0, 1, 4),
         Cardinality("ab", 1, 0, 1, 4),
@@ -94,39 +94,39 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
     // enforce for 3rd level only for aaa
     t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 0, 2)
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
       Seq(Cardinality("", 1, 0, 1, 20),
         Cardinality("a", 1, 0, 1, 10),
         Cardinality("aa", 1, 0, 1, 10),
         Cardinality("aaa", 1, 0, 1, 2))
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
       Seq(Cardinality("", 2, 0, 1, 20),
         Cardinality("a", 2, 0, 1, 10),
         Cardinality("aa", 2, 0, 1, 10),
         Cardinality("aaa", 2, 0, 2, 2))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 3, 0, 1, 20),
         Cardinality("a", 3, 0, 1, 10),
         Cardinality("aa", 3, 0, 2, 10),
         Cardinality("aab", 1, 0, 1, 20))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 4, 0, 1, 20),
         Cardinality("a", 4, 0, 1, 10),
         Cardinality("aa", 4, 0, 2, 10),
         Cardinality("aab", 2, 0, 2, 20))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 5, 0, 1, 20),
         Cardinality("a", 5, 0, 1, 10),
         Cardinality("aa", 5, 0, 2, 10),
         Cardinality("aab", 3, 0, 3, 20))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 6, 0, 1, 20),
         Cardinality("a", 6, 0, 1, 10),
         Cardinality("aa", 6, 0, 2, 10),
         Cardinality("aab", 4, 0, 4, 20))
 
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
     }
      ex.prefix shouldEqual Seq("a", "aa", "aaa")
     t.close()
@@ -139,25 +139,25 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
     // enforce for 3rd level only for aaa
     t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 0, 2)
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
       Seq(Cardinality("", 1, 0, 1, 20),
         Cardinality("a", 1, 0, 1, 10),
         Cardinality("aa", 1, 0, 1, 10),
         Cardinality("aaa", 1, 0, 1, 2))
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
       Seq(Cardinality("", 2, 0, 1, 20),
         Cardinality("a", 2, 0, 1, 10),
         Cardinality("aa", 2, 0, 1, 10),
         Cardinality("aaa", 2, 0, 2, 2))
 
     val ex = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
     }
     ex.prefix shouldEqual (Seq("a", "aa", "aaa"))
 
     // increase quota
     t.setQuota(Seq("a", "aa", "aaa"), 5) shouldEqual Cardinality("aaa", 2, 0, 2, 5)
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
       Seq(Cardinality("", 3, 0, 1, 20),
         Cardinality("a", 3, 0, 1, 10),
         Cardinality("aa", 3, 0, 1, 10),
@@ -165,13 +165,13 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
     // decrease quota
     t.setQuota(Seq("a", "aa", "aaa"), 4) shouldEqual Cardinality("aaa", 3, 0, 3, 4)
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
       Seq(Cardinality("", 4, 0, 1, 20),
         Cardinality("a", 4, 0, 1, 10),
         Cardinality("aa", 4, 0, 1, 10),
         Cardinality("aaa", 4, 0, 4, 4))
     val ex2 = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
     }
     ex2.prefix shouldEqual Seq("a", "aa", "aaa")
     t.close()
@@ -181,22 +181,22 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
     t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 0, 10)
     t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 1, 0, 1, 20),
         Cardinality("a", 1, 0, 1, 10),
         Cardinality("aa", 1, 0, 1, 10),
         Cardinality("aab", 1, 0, 1, 20))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 2, 0, 1, 20),
         Cardinality("a", 2, 0, 1, 10),
         Cardinality("aa", 2, 0, 1, 10),
         Cardinality("aab", 2, 0, 2, 20))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 3, 0, 1, 20),
         Cardinality("a", 3, 0, 1, 10),
         Cardinality("aa", 3, 0, 1, 10),
         Cardinality("aab", 3, 0, 3, 20))
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
       Seq(Cardinality("", 4, 0, 1, 20),
         Cardinality("a", 4, 0, 1, 10),
         Cardinality("aa", 4, 0, 1, 10),
@@ -207,7 +207,7 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.setQuota(Seq("a", "aa", "aab"), 3)
     t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 0, 4, 3)
     val ex2 = intercept[QuotaReachedException] {
-      t.incrementCount(Seq("a", "aa", "aab"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
     }
     ex2.prefix shouldEqual Seq("a", "aa", "aab")
     t.close()
@@ -215,32 +215,32 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it ("should be able to do topk") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
-    (1 to 10).foreach(_ => t.incrementCount(Seq("a", "ac", "aca"), 1, 0))
-    (1 to 20).foreach(_ => t.incrementCount(Seq("a", "ac", "acb"), 1, 0))
-    (1 to 11).foreach(_ => t.incrementCount(Seq("a", "ac", "acc"), 1, 0))
-    (1 to 6).foreach(_ => t.incrementCount(Seq("a", "ac", "acd"), 1, 0))
-    (1 to 1).foreach(_ => t.incrementCount(Seq("a", "ac", "ace"), 1, 0))
-    (1 to 9).foreach(_ => t.incrementCount(Seq("a", "ac", "acf"), 1, 0))
-    (1 to 15).foreach(_ => t.incrementCount(Seq("a", "ac", "acg"), 1, 0))
+    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
+    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
+    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
+    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
+    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
+    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
 
-    (1 to 15).foreach(_ => t.incrementCount(Seq("b", "bc", "bcg"), 1, 0))
-    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bc", "bch"), 1, 0))
-    (1 to 9).foreach(_ => t.incrementCount(Seq("b", "bd", "bdh"), 1, 0))
+    (1 to 15).foreach(_ => t.modifyCount(Seq("b", "bc", "bcg"), 1, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bc", "bch"), 1, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bd", "bdh"), 1, 0))
 
-    (1 to 3).foreach(_ => t.incrementCount(Seq("c", "cc", "ccg"), 1, 0))
-    (1 to 2).foreach(_ => t.incrementCount(Seq("c", "cc", "cch"), 1, 0))
+    (1 to 3).foreach(_ => t.modifyCount(Seq("c", "cc", "ccg"), 1, 0))
+    (1 to 2).foreach(_ => t.modifyCount(Seq("c", "cc", "cch"), 1, 0))
 
-    t.incrementCount(Seq("a", "aa", "aaa"), 1, 0)
-    t.incrementCount(Seq("a", "aa", "aab"), 1, 0)
-    t.incrementCount(Seq("a", "aa", "aac"), 1, 0)
-    t.incrementCount(Seq("a", "aa", "aad"), 1, 0)
-    t.incrementCount(Seq("b", "ba", "baa"), 1, 0)
-    t.incrementCount(Seq("b", "bb", "bba"), 1, 0)
-    t.incrementCount(Seq("a", "ab", "aba"), 1, 0)
-    t.incrementCount(Seq("a", "ab", "abb"), 1, 0)
-    t.incrementCount(Seq("a", "ab", "abc"), 1, 0)
-    t.incrementCount(Seq("a", "ab", "abd"), 1, 0)
-    t.incrementCount(Seq("a", "ab", "abe"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aad"), 1, 0)
+    t.modifyCount(Seq("b", "ba", "baa"), 1, 0)
+    t.modifyCount(Seq("b", "bb", "bba"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "aba"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abb"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abc"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
 
     t.topk(3, Seq("a", "ac"), true) shouldEqual Seq(
       CardinalityRecord(0, "acc", 11, 0, 11, 100),

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
@@ -36,7 +36,7 @@ class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
           name <- 0 until 50
           ts <- 0 until 100 } {
       val mName = s"name_really_really_really_really_very_really_long_metric_name_$name"
-      tracker.incrementCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName))
+      tracker.incrementCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName), 1, 0)
       if (name == 0 && ts ==0 ) assertStats()
     }
     val end = System.nanoTime()

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
@@ -36,7 +36,7 @@ class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
           name <- 0 until 50
           ts <- 0 until 100 } {
       val mName = s"name_really_really_really_really_very_really_long_metric_name_$name"
-      tracker.incrementCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName), 1, 0)
+      tracker.modifyCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName), 1, 0)
       if (name == 0 && ts ==0 ) assertStats()
     }
     val end = System.nanoTime()

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -79,7 +79,8 @@ case class UnsupportedChunkSource() extends ChunkSource {
   override def topKCardinality(ref: DatasetRef,
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],
-                               k: Int): scala.Seq[CardinalityRecord] =
+                               k: Int,
+                               totalNotActive: Boolean): scala.Seq[CardinalityRecord] =
     throw new UnsupportedOperationException("This operation is not supported")
 
   override def acquireSharedLock(ref: DatasetRef, shardNum: Int, querySession: QuerySession): Unit =

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -80,7 +80,7 @@ case class UnsupportedChunkSource() extends ChunkSource {
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],
                                k: Int,
-                               totalNotActive: Boolean): scala.Seq[CardinalityRecord] =
+                               addInactive: Boolean): scala.Seq[CardinalityRecord] =
     throw new UnsupportedOperationException("This operation is not supported")
 
   override def acquireSharedLock(ref: DatasetRef, shardNum: Int, querySession: QuerySession): Unit =


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

RocksDB cardinality tracker is now able to track actively ingesting time series broken down by shard key in addition to total time series 

Removed kamon metrics based active/total cardinality reporting since it generates high cardinality time series.