### PR TITLE
fix(query): Label values/names query to use String column type in ResultSchema

### DIFF
--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -21,7 +21,7 @@ final case class QueryStatistics(group: Seq[String], timeSeriesScanned: Long,
 
 final case class Data(resultType: String, result: Seq[Result])
 
-final case class MetadataSuccessResponse(data: Seq[Map[String, String]],
+final case class MetadataSuccessResponse(data: Seq[DataSampl],
                                          status: String = "success",
                                          partial: Option[Boolean]= None,
                                          message: Option[String]= None) extends PromQueryResponse

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -14,12 +14,12 @@ import filodb.core.DatasetRef
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, MapItemConsumer}
 import filodb.core.memstore.{MemStore, TimeSeriesMemStore}
 import filodb.core.metadata.Column.ColumnType
+import filodb.core.metadata.Column.ColumnType.MapColumn
 import filodb.core.query._
 import filodb.core.query.NoCloseCursor.NoCloseCursor
 import filodb.core.store.ChunkSource
 import filodb.memory.{UTF8StringMedium, UTF8StringShort}
-import filodb.memory.format.{RowReader, SeqRowReader, SingleValueRowReader, StringArrayRowReader,
-                             UnsafeUtils, UTF8MapIteratorRowReader, ZeroCopyUTF8String}
+import filodb.memory.format._
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 import filodb.query.Query.qLogger
@@ -49,7 +49,7 @@ trait MetadataDistConcatExec extends NonLeafExecPlan {
     }.toListL.map { resp =>
       val metadataResult = scala.collection.mutable.Set.empty[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
       resp.foreach { rv =>
-        metadataResult ++= rv.head.rows().map { rowReader =>
+        metadataResult ++= rv.head.rows.map { rowReader =>
           val binaryRowReader = rowReader.asInstanceOf[BinaryRecordRowReader]
           rv.head match {
             case srv: SerializedRangeVector =>
@@ -164,7 +164,56 @@ final case class TopkCardPresenter(k: Int) extends RangeVectorTransformer {
 
 final case class LabelValuesDistConcatExec(queryContext: QueryContext,
                                            dispatcher: PlanDispatcher,
-                                           children: Seq[ExecPlan]) extends MetadataDistConcatExec
+                                           children: Seq[ExecPlan]) extends MetadataDistConcatExec {
+  /**
+   * Compose the sub-query/leaf results here.
+   */
+  override final def compose(childResponses: Observable[(QueryResponse, Int)],
+                        firstSchema: Task[ResultSchema],
+                        querySession: QuerySession): Observable[RangeVector] = {
+    qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
+    val taskOfResults = childResponses.map {
+      case (QueryResult(_, schema, result, _, _, _), _) => (schema, result)
+      case (QueryError(_, _, ex), _)         => throw ex
+    }.toListL.map { resp =>
+      val colType = resp.head._1.columns.head.colType
+      if (colType == MapColumn) {
+        val metadataResult = scala.collection.mutable.Set.empty[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
+        resp.foreach { result =>
+          val rv = result._2
+          metadataResult ++= rv.head.rows.map { rowReader =>
+            val binaryRowReader = rowReader.asInstanceOf[BinaryRecordRowReader]
+            rv.head match {
+              case srv: SerializedRangeVector =>
+                srv.schema.toStringPairs (binaryRowReader.recordBase, binaryRowReader.recordOffset)
+                  .map (pair => pair._1.utf8 -> pair._2.utf8).toMap
+              case _ => throw new UnsupportedOperationException("Metadata query currently needs SRV results")
+            }
+          }
+        }
+        IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
+          UTF8MapIteratorRowReader(metadataResult.toIterator), None)
+      } else {
+        val metadataResult = scala.collection.mutable.Set.empty[String]
+        resp.foreach { result =>
+          val rv = result._2
+          metadataResult ++= rv.head.rows.map { rowReader =>
+            val binaryRowReader = rowReader.asInstanceOf[BinaryRecordRowReader]
+            rv.head match {
+              case srv: SerializedRangeVector =>
+                srv.schema.toStringPairs (binaryRowReader.recordBase, binaryRowReader.recordOffset)
+                  .map (_._2).head
+              case _ => throw new UnsupportedOperationException("Metadata query currently needs SRV results")
+            }
+          }
+        }
+        IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
+          NoCloseCursor(StringArrayRowReader(metadataResult.toSeq)), None)
+      }
+    }
+    Observable.fromTask(taskOfResults)
+  }
+}
 
 final class LabelCardinalityPresenter(val funcParams: Seq[FuncArgs]  = Nil) extends RangeVectorTransformer {
 
@@ -191,18 +240,18 @@ final class LabelCardinalityPresenter(val funcParams: Seq[FuncArgs]  = Nil) exte
 
 final case class LabelNamesDistConcatExec(queryContext: QueryContext,
                                            dispatcher: PlanDispatcher,
-                                           children: Seq[ExecPlan]) extends DistConcatExec {
+                                           children: Seq[ExecPlan]) extends MetadataDistConcatExec {
   /**
    * Pick first non empty result from child.
    */
-  override protected def compose(childResponses: Observable[(QueryResponse, Int)],
+  override final def compose(childResponses: Observable[(QueryResponse, Int)],
                         firstSchema: Task[ResultSchema],
                         querySession: QuerySession): Observable[RangeVector] = {
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     childResponses.map {
       case (QueryResult(_, _, result, _, _, _), _) => result
       case (QueryError(_, _, ex), _)         => throw ex
-    }.filter(s => s.head.numRows.getOrElse(1) > 0).headF.map(_.head)
+    }.filter(s => s.nonEmpty && s.head.numRows.getOrElse(1) > 0).headF.map(_.head)
   }
 }
 
@@ -325,24 +374,33 @@ final case class LabelValuesExec(queryContext: QueryContext,
                (implicit sched: Scheduler): ExecResult = {
     source.checkReadyForQuery(dataset, shard, querySession)
     source.acquireSharedLock(dataset, shard, querySession)
-    val rvs = if (source.isInstanceOf[MemStore]) {
+    val execResult = if (source.isInstanceOf[MemStore]) {
       val memStore = source.asInstanceOf[MemStore]
-      val response = filters.isEmpty match {
+      filters.isEmpty match {
         // retrieves label values for a single label - no column filter
-        case true if columns.size == 1 => memStore.labelValues(dataset, shard, columns.head, queryContext.
-          plannerParams.sampleLimit).map(termInfo => Map(columns.head.utf8 -> termInfo.term)).toIterator
+        case true if (columns.size == 1) =>
+          val labels = memStore.labelValues(dataset, shard, columns.head,
+            queryContext.plannerParams.sampleLimit).map(_.term.toString)
+          val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
+            NoCloseCursor(StringArrayRowReader(labels)), None))
+          val sch = ResultSchema(Seq(ColumnInfo("Labels", ColumnType.StringColumn)), 1)
+          ExecResult(resp, Task.eval(sch))
         case true => throw new BadQueryException("either label name is missing " +
           "or there are multiple label names without filter")
-        case false => memStore.labelValuesWithFilters(dataset, shard, filters, columns, endMs, startMs,
+        case false =>
+          val metadataMap = memStore.labelValuesWithFilters(dataset, shard, filters, columns, endMs, startMs,
           queryContext.plannerParams.sampleLimit)
+          val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
+            UTF8MapIteratorRowReader(metadataMap), None))
+          val sch = ResultSchema(Seq(ColumnInfo("Series", ColumnType.MapColumn)), 1)
+          ExecResult(resp, Task.eval(sch))
       }
-      Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-        UTF8MapIteratorRowReader(response), None))
     } else {
-      Observable.empty
+      val resp = Observable.empty
+      val sch = ResultSchema(Seq(ColumnInfo("Series", ColumnType.MapColumn)), 1)
+      ExecResult(resp, Task.eval(sch))
     }
-    val sch = ResultSchema(Seq(ColumnInfo("Labels", ColumnType.MapColumn)), 1)
-    ExecResult(rvs, Task.eval(sch))
+    execResult
   }
 
   def args: String = s"shard=$shard, filters=$filters, col=$columns, limit=${queryContext.plannerParams.sampleLimit}," +

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -8,7 +8,7 @@ import monix.execution.Scheduler
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
-import filodb.memory.format.UTF8MapIteratorRowReader
+import filodb.memory.format.{StringArrayRowReader, UTF8MapIteratorRowReader}
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 
@@ -20,9 +20,14 @@ case class MetadataRemoteExec(queryEndpoint: String,
                               dataset: DatasetRef,
                               remoteExecHttpClient: RemoteExecHttpClient) extends RemoteExec {
 
-  private val columns = Seq(ColumnInfo("Labels", ColumnType.MapColumn))
-  private val resultSchema = ResultSchema(columns, 1)
-  private val recordSchema = SerializedRangeVector.toSchema(columns)
+  private val lvColumns = Seq(ColumnInfo("LabelValues", ColumnType.MapColumn))
+  private val resultSchema = ResultSchema(lvColumns, 1)
+  private val recordSchema = SerializedRangeVector.toSchema(lvColumns)
+
+  private val labelColumns = Seq(ColumnInfo("Labels", ColumnType.StringColumn))
+  private val labelsResultSchema = ResultSchema(labelColumns, 1)
+  private val labelsRecordSchema = SerializedRangeVector.toSchema(labelColumns)
+
   private val builder = SerializedRangeVector.newBuilder()
 
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
@@ -39,17 +44,42 @@ case class MetadataRemoteExec(queryEndpoint: String,
   }
 
   def toQueryResponse(response: MetadataSuccessResponse, id: String, parentSpan: kamon.trace.Span): QueryResponse = {
-    val iteratorMap = response.data.map { r => r.map { v => (v._1.utf8, v._2.utf8) }}
+      if (response.data.isEmpty) mapTypeQueryResponse(response, id)
+      else response.data.head match {
+        case _: MetadataSampl => mapTypeQueryResponse(response, id)
+        case _ => labelsQueryResponse(response, id)
+      }
+  }
+
+  def mapTypeQueryResponse(response: MetadataSuccessResponse, id: String): QueryResponse = {
+    val data = response.data.asInstanceOf[Seq[MetadataSampl]]
+    val iteratorMap = data.map { r => r.values.map { v => (v._1.utf8, v._2.utf8) }}
 
     import NoCloseCursor._
     val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-      UTF8MapIteratorRowReader(iteratorMap.toIterator), None)
+        UTF8MapIteratorRowReader(iteratorMap.toIterator), None)
 
     val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema,
-                        queryWithPlanName(queryContext)))
+      queryWithPlanName(queryContext)))
 
     // FIXME need to send and parse query stats in remote calls
     QueryResult(id, resultSchema, srvSeq, QueryStats(),
+      if (response.partial.isDefined) response.partial.get else false, response.message)
+  }
+
+  def labelsQueryResponse(response: MetadataSuccessResponse, id: String): QueryResponse = {
+    val data = response.data.asInstanceOf[Seq[LabelSampl]]
+    val iteratorMap = data.flatMap { r => r.values}
+
+    import NoCloseCursor._
+    val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
+      NoCloseCursor(StringArrayRowReader(iteratorMap)), None)
+
+    val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, labelsRecordSchema,
+      queryWithPlanName(queryContext)))
+
+    // FIXME need to send and parse query stats in remote calls
+    QueryResult(id, labelsResultSchema, srvSeq, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 }

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -6,7 +6,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.sys.ShutdownHookThread
 
-import com.softwaremill.sttp.{DeserializationError, Response, SttpBackendOptions}
+import com.softwaremill.sttp.{DeserializationError, Response, SttpBackend, SttpBackendOptions}
 import com.softwaremill.sttp.SttpBackendOptions.ProxyType.{Http, Socks}
 import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
 import com.softwaremill.sttp.circe.asJson
@@ -104,15 +104,17 @@ trait RemoteExecHttpClient extends StrictLogging {
 
 }
 
-class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig) extends RemoteExecHttpClient {
+// scalastyle:off
+import com.softwaremill.sttp._
+import io.circe.generic.auto._
 
-  import com.softwaremill.sttp._
-  import io.circe.generic.auto._
-
-  // DO NOT REMOVE PromCirceSupport import below assuming it is unused - Intellij removes it in auto-imports :( .
-  // Needed to override Sampl case class Encoder.
-  import PromCirceSupport._
-  private implicit val backend = AsyncHttpClientFutureBackend.usingConfig(asyncHttpClientConfig)
+// DO NOT REMOVE PromCirceSupport import below assuming it is unused - Intellij removes it in auto-imports :( .
+// Needed to override Sampl case class Encoder.
+import PromCirceSupport._
+class RemoteHttpClient private(asyncHttpClientConfig: AsyncHttpClientConfig)
+                              (implicit backend: SttpBackend[Future, Nothing]
+                                = AsyncHttpClientFutureBackend.usingConfig(asyncHttpClientConfig))
+    extends RemoteExecHttpClient {
 
   ShutdownHookThread(shutdown())
 
@@ -191,5 +193,8 @@ object RemoteHttpClient {
 
   def apply(asyncHttpClientConfig: AsyncHttpClientConfig): RemoteHttpClient =
     new RemoteHttpClient(asyncHttpClientConfig)
+  def apply(asyncHttpClientConfig: AsyncHttpClientConfig,
+            sttpBackend: SttpBackend[Future, Nothing]): RemoteHttpClient =
+    new RemoteHttpClient(asyncHttpClientConfig)(sttpBackend)
 
 }

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -10,7 +10,7 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
 import filodb.core.query.{PromQlQueryParams, QueryContext}
 import filodb.memory.format.vectors.MutableHistogram
 import filodb.query
-import filodb.query.{Data, HistSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, SuccessResponse}
+import filodb.query.{Data, HistSampl, MetadataSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, SuccessResponse}
 
 
 class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
@@ -61,7 +61,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       queryContext, dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
     val map1 = Map("instance" -> "inst-1", "last-sample" -> "6377838" )
     val map2 = Map("instance" -> "inst-2", "last-sample" -> "6377834" )
-    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(map1, map2)), "id", Kamon.currentSpan())
+    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataSampl(map1), MetadataSampl(map2))), "id", Kamon.currentSpan())
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     val data = queryResult.result.flatMap(x=>x.rows.map{ r => r.getAny(0) }.toList)
@@ -74,7 +74,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
     val map1 = Map("instance" -> "inst-1", "last-sample" -> "6377838" )
     val map2 = Map("instance" -> "inst-2", "last-sample" -> "6377834" )
-    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(map1, map2)), "id", Kamon.currentSpan())
+    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataSampl(map1), MetadataSampl(map2))), "id", Kamon.currentSpan())
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     val data = queryResult.result.flatMap(x => x.rows.map(r => r.getAny(0)).toList)

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -1,0 +1,113 @@
+package filodb.query.exec
+
+import com.softwaremill.sttp.{Response, StatusCodes, SttpBackend}
+import com.softwaremill.sttp.testing.SttpBackendStub
+import com.typesafe.config.ConfigFactory
+import filodb.core.MetricsTestData._
+import filodb.core.binaryrecord2.BinaryRecordRowReader
+import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, TimeSeriesMemStore}
+import filodb.core.query._
+import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
+import filodb.query._
+import filodb.query.exec.RemoteHttpClient.configBuilder
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.Future
+
+class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
+
+  val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
+  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val querySession = QuerySession(QueryContext(), queryConfig)
+
+  val policy = new FixedMaxPartitionsEvictionPolicy(20)
+  val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
+
+  val jobQueryResult1 = ArrayBuffer(("job", "myCoolService"), ("unicode_tag", "uni\u03BCtag"))
+  val jobQueryResult2 = Array("http_req_total", "http_resp_time")
+  val jobQueryResult3 = Array("job", "__name__", "unicode_tag", "instance")
+
+  implicit val testingBackend: SttpBackend[Future, Nothing] = SttpBackendStub.asynchronousFuture
+    .whenRequestMatches(request =>
+      request.uri.path.startsWith(List("api","v1","label")) && request.uri.path.last == "values"
+    )
+    .thenRespondWrapped(Future {
+      Response(Right(Right(MetadataSuccessResponse(Seq(LabelSampl(Seq("http_req_total", "http_resp_time"))), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
+    })
+    .whenRequestMatches(request =>
+      request.uri.path.startsWith(List("api","v1","series"))
+    )
+    .thenRespondWrapped(Future {
+      Response(Right(Right(MetadataSuccessResponse(Seq(MetadataSampl(Map(("job" -> "myCoolService"), ("unicode_tag" -> "uniμtag")))), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
+    })
+    .whenRequestMatches(_.uri.path.startsWith(List("api","v1","labels"))
+    )
+    .thenRespondWrapped(Future {
+      Response(Right(Right(MetadataSuccessResponse(Seq(LabelSampl(Seq("job", "__name__", "unicode_tag", "instance"))), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
+    })
+
+  it ("series matcher remote exec") {
+    val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/series", 10000L, Map("filter" -> "a=b,c=d"),
+      QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/series"))),
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+
+    val resp = exec.execute(memStore, querySession).runAsync.futureValue
+    val result = (resp: @unchecked) match {
+      case QueryResult(id, _, response, _, _, _) => {
+        val rv = response(0)
+        rv.rows.size shouldEqual 1
+        val record = rv.rows.next.asInstanceOf[BinaryRecordRowReader]
+        rv.asInstanceOf[SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset)
+      }
+    }
+    result shouldEqual jobQueryResult1
+  }
+
+  it ("label values remote metadata exec") {
+    val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/label/__name__/values", 10000L, Map("filter" -> "a=b,c=d"),
+      QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/label"))),
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+
+    val resp = exec.execute(memStore, querySession).runAsync.futureValue
+    val result = (resp: @unchecked) match {
+      case QueryResult(id, _, response, _, _, _) => {
+        val rv = response(0)
+        rv.rows.size shouldEqual 2
+        rv.rows.map(row => {
+          val record = row.asInstanceOf[BinaryRecordRowReader]
+          rv.asInstanceOf[SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset).head._2
+        })
+      }
+    }
+    result.toArray shouldEqual jobQueryResult2
+  }
+
+  it ("labels metadata remote exec") {
+    val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/labels", 10000L, Map("filter" -> "a=b,c=d"),
+      QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/labels"))),
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+
+    val resp = exec.execute(memStore, querySession).runAsync.futureValue
+    val result = (resp: @unchecked) match {
+      case QueryResult(id, _, response, _, _, _) => {
+        val rv = response(0)
+        rv.rows.size shouldEqual 4
+        rv.rows.map(row => {
+          val record = row.asInstanceOf[BinaryRecordRowReader]
+          rv.asInstanceOf[SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset).head._2
+        })
+      }
+    }
+    result.toArray shouldEqual jobQueryResult3
+  }
+
+}
+


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?


- Metadata queries LabelValues/LabelNames have result type as String where as `Series` has Map type. This is causing MetadataRemoteExec to break as it is assumed that all metadata queries return map type result. The changes in PR make sure that depending on result type, appropriate result schema is set at the ExecPlan level. In MetadataRemoteExec, appropriate response is generated based on the query/result schema,