### PR TITLE
fix(query): topkcard incorrect string cast

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -82,7 +82,7 @@ final case class TopkCardReduceExec(queryContext: QueryContext,
   private def sketchFold(acc: ItemsSketch[String], rv: RangeVector):
             ItemsSketch[String] = {
     rv.rows().foreach{ r =>
-      val sketchSer = r.getString(0).getBytes
+      val sketchSer = r.getAny(0).asInstanceOf[ZeroCopyUTF8String].bytes
       val sketch = ItemsSketch.getInstance(Memory.wrap(sketchSer), new ArrayOfStringsSerDe)
       acc.merge(sketch)
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
As `TopkCardReduceExec` merges `ItemsSketch`es, the serialized sketches are interpreted as `String` instances before their bytes are read. The cast succeeds, but the sketch was originally serialized as a `ZeroCopyUTF8String`. When a query result's cardinality is sufficiently large, the string's size is incorrectly read during deserialization, and a `SketchesArgumentException` is thrown.

**New behavior :**
The sketches are now interpreted as `ZeroCopyUTF8String`s before their bytes are read. The string's size is correctly read.