### PR TITLE
feat(query):  add hierarchical cardinality query infrastructure

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -177,8 +177,8 @@ object CliMain extends FilodbClusterNode {
           val (remote, ref) = getClientAndRef(args)
           val values = remote.getIndexValues(ref, args.indexname(), args.shards().head.toInt, args.limit())
           values.foreach { case (term, freq) => println(f"$term%40s\t$freq") }
-
         case Some("topkcardlocal") =>
+          // TODO(a_theimer): make sure actually returns topk
           require(args.host.isDefined && args.dataset.isDefined && args.k.isDefined,
             "--host, --dataset, --k must be defined")
           val (remote, ref) = getClientAndRef(args)

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -191,9 +191,11 @@ object CliMain extends FilodbClusterNode {
             printf("%40s %20s %20s %15s %15s\n", "Child", "TotalTimeSeries", "ActiveTimeSeries", "Children", "Children")
             printf("%40s %20s %20s %15s %15s\n", "Name", "Count", "Count", "Count", "Quota")
             println("==============================================================================================================================")
-            crs._2.sortBy(c => if (addInactive) c.tsCount else c.activeTsCount)(Ordering.Int.reverse).foreach { cr =>
-              printf("%40s %20d %20d %15d %15d\n", cr.childName, cr.tsCount, cr.activeTsCount, cr.childrenCount, cr.childrenQuota)
-            }
+            crs._2.sortBy(c => if (addInactive) c.card.tsCount else c.card.activeTsCount)(Ordering.Int.reverse)
+              .foreach { cr =>
+                printf("%40s %20d %20d %15d %15d\n", cr.card.prefix, cr.card.tsCount,
+                       cr.card.activeTsCount, cr.card.childrenCount, cr.card.childrenQuota)
+              }
           }
 
         case Some("status") =>

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -178,7 +178,6 @@ object CliMain extends FilodbClusterNode {
           val values = remote.getIndexValues(ref, args.indexname(), args.shards().head.toInt, args.limit())
           values.foreach { case (term, freq) => println(f"$term%40s\t$freq") }
         case Some("topkcardlocal") =>
-          // TODO(a_theimer): make sure actually returns topk
           require(args.host.isDefined && args.dataset.isDefined && args.k.isDefined,
             "--host, --dataset, --k must be defined")
           val (remote, ref) = getClientAndRef(args)

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -67,7 +67,7 @@ class Arguments(args: Seq[String]) extends ScallopConf(args) {
   val shards = opt[List[String]]()
   val spread = opt[Int]()
   val k = opt[Int]()
-  val groupdepth = opt[Int]()
+  val groupdepth = opt[String]()
   val active = opt[Boolean](default = Some(false))
   val shardkeyprefix = opt[List[String]](default = Some(List()))
   val queries = opt[List[String]](default = Some(List()))
@@ -110,7 +110,7 @@ object CliMain extends FilodbClusterNode {
     println("  --host <hostname/IP> [--port ...] --command status --dataset <dataset>")
     println("  --host <hostname/IP> [--port ...] --command labelvalues --labelnames <lable-names> --labelfilter <label-filter> --dataset <dataset>")
     println("  --host <hostname/IP> [--port ...] --command labels --labelfilter <label-filter> -dataset <dataset>")
-    println("  --host <hostname/IP> [--port ...] --command tscard --dataset <dataset> --shardkeyprefix <shard-key-prefix> --groupdepth {0,1,2}")
+    println("  --host <hostname/IP> [--port ...] --command tscard --dataset <dataset> --shardkeyprefix <shard-key-prefix> --groupdepth {ws,ns,metric}")
     println("  --host <hostname/IP> [--port ...] --command topkcardlocal --dataset prometheus --k 2 --shardkeyprefix demo App-0")
     println("  --host <hostname/IP> [--port ...] --command labelcardinality --labelfilter <label-filter> --dataset prometheus")
     println("  --host <hostname/IP> [--port ...] --command findqueryshards --queries <query> --spread <spread>")
@@ -260,7 +260,12 @@ object CliMain extends FilodbClusterNode {
           val remote = Client.standaloneClient(system, args.host(), args.port())
           val options = QOptions(args.limit(), args.samplelimit(), args.everynseconds.map(_.toInt).toOption,
             timeout, args.shards.map(_.map(_.toInt)).toOption, args.spread.toOption.map(Integer.valueOf))
-          parseTsCardQuery(remote, args.shardkeyprefix(), args.groupdepth(), args.dataset(), options)
+          val groupDepth = args.groupdepth() match {
+            case "ws" => GroupDepth.WS
+            case "ns" => GroupDepth.NS
+            case "metric" => GroupDepth.METRIC
+          }
+          parseTsCardQuery(remote, args.shardkeyprefix(), groupDepth, args.dataset(), options)
 
         case x: Any =>
           // This will soon be deprecated
@@ -384,7 +389,7 @@ object CliMain extends FilodbClusterNode {
 
   def parseTsCardQuery(client: LocalClient,
                        shardKeyPrefix: Seq[String],
-                       groupDepth: Int,
+                       groupDepth: GroupDepth.Value,
                        dataset: String,
                        options: QOptions): Unit = {
     val logicalPlan = TsCardinalities(shardKeyPrefix, groupDepth)

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -191,10 +191,10 @@ object CliMain extends FilodbClusterNode {
             printf("%40s %20s %20s %15s %15s\n", "Child", "TotalTimeSeries", "ActiveTimeSeries", "Children", "Children")
             printf("%40s %20s %20s %15s %15s\n", "Name", "Count", "Count", "Count", "Quota")
             println("==============================================================================================================================")
-            crs._2.sortBy(c => if (addInactive) c.card.tsCount else c.card.activeTsCount)(Ordering.Int.reverse)
+            crs._2.sortBy(c => if (addInactive) c.tsCount else c.activeTsCount)(Ordering.Int.reverse)
               .foreach { cr =>
-                printf("%40s %20d %20d %15d %15d\n", cr.card.prefix, cr.card.tsCount,
-                       cr.card.activeTsCount, cr.card.childrenCount, cr.card.childrenQuota)
+                printf("%40s %20d %20d %15d %15d\n", cr.prefix, cr.tsCount,
+                       cr.activeTsCount, cr.childrenCount, cr.childrenQuota)
               }
           }
 

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -67,6 +67,7 @@ class Arguments(args: Seq[String]) extends ScallopConf(args) {
   val shards = opt[List[String]]()
   val spread = opt[Int]()
   val k = opt[Int]()
+  val groupdepth = opt[Int]()
   val active = opt[Boolean](default = Some(false))
   val shardkeyprefix = opt[List[String]](default = Some(List()))
   val queries = opt[List[String]](default = Some(List()))
@@ -109,7 +110,7 @@ object CliMain extends FilodbClusterNode {
     println("  --host <hostname/IP> [--port ...] --command status --dataset <dataset>")
     println("  --host <hostname/IP> [--port ...] --command labelvalues --labelnames <lable-names> --labelfilter <label-filter> --dataset <dataset>")
     println("  --host <hostname/IP> [--port ...] --command labels --labelfilter <label-filter> -dataset <dataset>")
-    println("  --host <hostname/IP> [--port ...] --command tscard --dataset <dataset> --shardkeyprefix <shard-key-prefix> ")
+    println("  --host <hostname/IP> [--port ...] --command tscard --dataset <dataset> --shardkeyprefix <shard-key-prefix> --groupdepth {0,1,2}")
     println("  --host <hostname/IP> [--port ...] --command topkcardlocal --dataset prometheus --k 2 --shardkeyprefix demo App-0")
     println("  --host <hostname/IP> [--port ...] --command labelcardinality --labelfilter <label-filter> --dataset prometheus")
     println("  --host <hostname/IP> [--port ...] --command findqueryshards --queries <query> --spread <spread>")
@@ -259,7 +260,7 @@ object CliMain extends FilodbClusterNode {
           val remote = Client.standaloneClient(system, args.host(), args.port())
           val options = QOptions(args.limit(), args.samplelimit(), args.everynseconds.map(_.toInt).toOption,
             timeout, args.shards.map(_.map(_.toInt)).toOption, args.spread.toOption.map(Integer.valueOf))
-          parseTsCardQuery(remote, args.shardkeyprefix(), args.dataset(), options)
+          parseTsCardQuery(remote, args.shardkeyprefix(), args.groupdepth(), args.dataset(), options)
 
         case x: Any =>
           // This will soon be deprecated
@@ -383,9 +384,10 @@ object CliMain extends FilodbClusterNode {
 
   def parseTsCardQuery(client: LocalClient,
                        shardKeyPrefix: Seq[String],
+                       groupDepth: Int,
                        dataset: String,
                        options: QOptions): Unit = {
-    val logicalPlan = TsCardinalities(shardKeyPrefix)
+    val logicalPlan = TsCardinalities(shardKeyPrefix, groupDepth)
     executeQuery2(client, dataset, logicalPlan, options, UnavailablePromQlQueryParams)
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -2,7 +2,10 @@ package filodb.coordinator
 
 import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
+
+import scala.collection.mutable
 import scala.util.control.NonFatal
+
 import akka.actor.{ActorRef, Props}
 import akka.pattern.AskTimeoutException
 import kamon.Kamon
@@ -12,17 +15,16 @@ import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
+
 import filodb.coordinator.queryplanner.SingleClusterPlanner
 import filodb.core._
-import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.memstore.{FiloSchedulers, MemStore, TermInfo}
+import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.{Dataset, Schemas}
 import filodb.core.query.{QueryConfig, QueryContext, QuerySession, QueryStats}
 import filodb.core.store.CorruptVectorException
 import filodb.query._
 import filodb.query.exec.ExecPlan
-
-import scala.collection.mutable
 
 object QueryActor {
   final case class ThrowException(dataset: DatasetRef)

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -212,12 +212,17 @@ final class QueryActor(memStore: MemStore,
   }
 
   private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
-    try {
-      val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix, q.k, q.addInactive)
-      sender ! ret
-    } catch { case e: Exception =>
-      sender ! QueryError(s"Error Occurred", QueryStats(), e)
-    }
+    // TODO(a_theimer)
+    // scalastyle:off
+    println("========= TODO TODO TODO THIS IS DISABLED ============")
+//    try {
+//      val ret = memStore.topKCardinality(q.dataset, q.shards,
+//        q.shardKeyPrefix, 0, q.k, q.addInactive)
+//      sender ! ret
+//    } catch { case e: Exception =>
+//      sender ! QueryError(s"Error Occurred", QueryStats(), e)
+//    }
+    //scalastyle:on
   }
 
   def checkTimeout(queryContext: QueryContext, replyTo: ActorRef): Boolean = {

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -212,17 +212,13 @@ final class QueryActor(memStore: MemStore,
   }
 
   private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
-    // TODO(a_theimer)
-    // scalastyle:off
-    println("========= TODO TODO TODO THIS IS DISABLED ============")
-//    try {
-//      val ret = memStore.topKCardinality(q.dataset, q.shards,
-//        q.shardKeyPrefix, 0, q.k, q.addInactive)
-//      sender ! ret
-//    } catch { case e: Exception =>
-//      sender ! QueryError(s"Error Occurred", QueryStats(), e)
-//    }
-    //scalastyle:on
+    try {
+      val ret = memStore.topKCardinality(q.dataset, q.shards, q.shardKeyPrefix,
+                                         q.depth, q.k, q.addInactive)
+      sender ! ret
+    } catch { case e: Exception =>
+      sender ! QueryError(s"Error Occurred", QueryStats(), e)
+    }
   }
 
   def checkTimeout(queryContext: QueryContext, replyTo: ActorRef): Boolean = {

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryCommands.scala
@@ -35,6 +35,7 @@ object QueryCommands {
   final case class GetTopkCardinality(dataset: DatasetRef,
                                       shards: Seq[Int],
                                       shardKeyPrefix: Seq[String],
+                                      depth: Int,
                                       k: Int,
                                       addInactive: Boolean,
                                       submitTime: Long = System.currentTimeMillis()) extends QueryCommand

--- a/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/QueryOps.scala
@@ -51,7 +51,10 @@ trait QueryOps extends ClientBase with StrictLogging {
                      k: Int,
                      addInactive: Boolean,
                      timeout: FiniteDuration = 15.seconds): Seq[CardinalityRecord] =
-    askCoordinator(GetTopkCardinality(dataset, shards, shardKeyPrefix, k, addInactive), timeout) {
+    askCoordinator(
+      GetTopkCardinality(dataset, shards, shardKeyPrefix,
+                         shardKeyPrefix.size + 1, k, addInactive),
+      timeout) {
       case s: Seq[CardinalityRecord] @unchecked => s
       case e: QueryError => throw e.t
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -66,8 +66,7 @@ object LogicalPlanUtils extends StrictLogging {
       case lp: LabelValues                 => TimeRange(lp.startMs, lp.endMs)
       case lp: LabelCardinality            => TimeRange(lp.startMs, lp.endMs)
       case lp: LabelNames                  => TimeRange(lp.startMs, lp.endMs)
-      case lp: TopkCardinalities           => throw new IllegalArgumentException(
-                                                          "no time params for TopKCardinalitites")
+      case lp: TsCardinalities             => throw new IllegalArgumentException("no time params for TsCardinalitites")
       case lp: SeriesKeysByFilters         => TimeRange(lp.startMs, lp.endMs)
       case lp: ApplyInstantFunctionRaw     => getTimeFromLogicalPlan(lp.vectors)
       case lp: ScalarBinaryOperation       => TimeRange(lp.rangeParams.startSecs * 1000, lp.rangeParams.endSecs * 1000)
@@ -93,7 +92,7 @@ object LogicalPlanUtils extends StrictLogging {
       case lp: LabelValues              => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
       case lp: LabelNames               => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
       case lp: LabelCardinality         => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
-      case lp: TopkCardinalities        => lp.copy()
+      case lp: TsCardinalities          => lp.copy()
       case lp: SeriesKeysByFilters      => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
     }
   }
@@ -344,7 +343,7 @@ object LogicalPlanUtils extends StrictLogging {
       case lp: RawChunkMeta                => None
       case sq: SubqueryWithWindowing       => getPeriodicSeriesPlan(sq.innerPeriodicSeries)
       case tlsq: TopLevelSubquery          => getPeriodicSeriesPlan(tlsq.innerPeriodicSeries)
-      case lp: TopkCardinalities           => None
+      case lp: TsCardinalities             => None
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -92,7 +92,7 @@ object LogicalPlanUtils extends StrictLogging {
       case lp: LabelValues              => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
       case lp: LabelNames               => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
       case lp: LabelCardinality         => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
-      case lp: TsCardinalities          => lp.copy()
+      case lp: TsCardinalities          => lp  // immutable & no members need to be updated
       case lp: SeriesKeysByFilters      => lp.copy(startMs = timeRange.startMs, endMs = timeRange.endMs)
     }
   }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -170,8 +170,7 @@ import filodb.query.exec._
              _: ApplyInstantFunctionRaw |
              _: RawSeries |
              _: LabelNames |
-             _: TopkCardinalities          => rawClusterMaterialize(qContext, logicalPlan)
-
+             _: TsCardinalities            => rawClusterMaterialize(qContext, logicalPlan)
       }
     }
     else logicalPlan match {
@@ -185,7 +184,7 @@ import filodb.query.exec._
       case lp: BinaryJoin                  => materializeBinaryJoin(qContext, lp)
       case lp: ScalarVectorBinaryOperation => materializeScalarVectorBinOp(qContext, lp)
       case lp: LabelValues                 => rawClusterMaterialize(qContext, lp)
-      case lp: TopkCardinalities           => rawClusterMaterialize(qContext, lp)
+      case lp: TsCardinalities             => rawClusterMaterialize(qContext, lp)
       case lp: SeriesKeysByFilters         => rawClusterMaterialize(qContext, lp)
       case lp: ApplyMiscellaneousFunction  => materializeApplyMiscellaneousFunction(qContext, lp)
       case lp: ApplySortFunction           => materializeApplySortFunction(qContext, lp)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -134,6 +134,7 @@ class SingleClusterPlanner(val dataset: Dataset,
         many.head match {
           case _: LabelValuesExec => LabelValuesDistConcatExec(qContext, targetActor, many)
           case _: LabelNamesExec => LabelNamesDistConcatExec(qContext, targetActor, many)
+          case _: TsCardExec => TsCardReduceExec(qContext, targetActor, many)
           case _: LabelCardinalityExec => {
             val reduceExec = LabelCardinalityReduceExec(qContext, targetActor, many)
             // Presenter here is added separately which use the bytes representing the sketch to get an estimate
@@ -145,11 +146,6 @@ class SingleClusterPlanner(val dataset: Dataset,
               reduceExec.addRangeVectorTransformer(new LabelCardinalityPresenter())
             }
             reduceExec
-          }
-          case lce: TsCardExec => {
-            val reducer = TsCardReduceExec(qContext, targetActor, many)
-            reducer.addRangeVectorTransformer(TsCardPresenter(lce.groupDepth))
-            reducer
           }
           case ske: PartKeysExec => PartKeysDistConcatExec(qContext, targetActor, many)
           case ep: ExecPlan =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -146,9 +146,9 @@ class SingleClusterPlanner(val dataset: Dataset,
             }
             reduceExec
           }
-          case lce: TopkCardExec => {
-            val reducer = TopkCardReduceExec(qContext, targetActor, many, lce.k)
-            reducer.addRangeVectorTransformer(TopkCardPresenter(lce.k))
+          case lce: TsCardExec => {
+            val reducer = TsCardReduceExec(qContext, targetActor, many)
+            reducer.addRangeVectorTransformer(TsCardPresenter())
             reducer
           }
           case ske: PartKeysExec => PartKeysDistConcatExec(qContext, targetActor, many)
@@ -240,7 +240,7 @@ class SingleClusterPlanner(val dataset: Dataset,
       case lp: ScalarVectorBinaryOperation => materializeScalarVectorBinOp(qContext, lp)
       case lp: LabelValues                 => materializeLabelValues(qContext, lp)
       case lp: LabelNames                  => materializeLabelNames(qContext, lp)
-      case lp: TopkCardinalities           => materializeTopkCardinalities(qContext, lp)
+      case lp: TsCardinalities             => materializeTsCardinalities(qContext, lp)
       case lp: SeriesKeysByFilters         => materializeSeriesKeysByFilters(qContext, lp)
       case lp: ApplyMiscellaneousFunction  => materializeApplyMiscellaneousFunction(qContext, lp)
       case lp: ApplySortFunction           => materializeApplySortFunction(qContext, lp)
@@ -509,11 +509,11 @@ class SingleClusterPlanner(val dataset: Dataset,
     PlanResult(metaExec, false)
   }
 
-  private def materializeTopkCardinalities(qContext: QueryContext,
-                                           lp: TopkCardinalities): PlanResult = {
+  private def materializeTsCardinalities(qContext: QueryContext,
+                                           lp: TsCardinalities): PlanResult = {
     val metaExec = shardMapperFunc.assignedShards.map{ shard =>
       val dispatcher = dispatcherForShard(shard)
-      exec.TopkCardExec(qContext, dispatcher, dsRef, shard, lp.shardKeyPrefix, lp.k, lp.addInactive)
+      exec.TsCardExec(qContext, dispatcher, dsRef, shard, lp.shardKeyPrefix)
     }
     PlanResult(metaExec, false)
   }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -148,7 +148,7 @@ class SingleClusterPlanner(val dataset: Dataset,
           }
           case lce: TsCardExec => {
             val reducer = TsCardReduceExec(qContext, targetActor, many)
-            reducer.addRangeVectorTransformer(TsCardPresenter())
+            reducer.addRangeVectorTransformer(TsCardPresenter(lce.groupDepth))
             reducer
           }
           case ske: PartKeysExec => PartKeysDistConcatExec(qContext, targetActor, many)
@@ -510,10 +510,10 @@ class SingleClusterPlanner(val dataset: Dataset,
   }
 
   private def materializeTsCardinalities(qContext: QueryContext,
-                                           lp: TsCardinalities): PlanResult = {
+                                         lp: TsCardinalities): PlanResult = {
     val metaExec = shardMapperFunc.assignedShards.map{ shard =>
       val dispatcher = dispatcherForShard(shard)
-      exec.TsCardExec(qContext, dispatcher, dsRef, shard, lp.shardKeyPrefix)
+      exec.TsCardExec(qContext, dispatcher, dsRef, shard, lp.shardKeyPrefix, lp.groupDepth)
     }
     PlanResult(metaExec, false)
   }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -809,7 +809,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it ("should correctly materialize TsCardExec") {
     val shardKeyPrefix = Seq("foo", "bar")
-    val groupDepth = 2
+    val groupDepth = GroupDepth.METRIC
 
     val lp = TsCardinalities(shardKeyPrefix, groupDepth)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -809,7 +809,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it ("should correctly materialize TsCardExec") {
     val shardKeyPrefix = Seq("foo", "bar")
-    val groupDepth = GroupDepth.METRIC
+    val groupDepth = 2
 
     val lp = TsCardinalities(shardKeyPrefix, groupDepth)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -816,8 +816,6 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     execPlan.isInstanceOf[TsCardReduceExec] shouldEqual true
 
     val reducer = execPlan.asInstanceOf[TsCardReduceExec]
-    reducer.rangeVectorTransformers.size shouldEqual 1
-    reducer.rangeVectorTransformers(0).isInstanceOf[TsCardPresenter] shouldEqual true
     reducer.children.size shouldEqual mapper.numShards
     reducer.children.foreach{ child =>
       child.isInstanceOf[TsCardExec] shouldEqual true

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -808,24 +808,20 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   it ("should correctly materialize TopkCardExec") {
-    val k = 3
     val shardKeyPrefix = Seq("foo", "bar")
 
-    val addInactive = true
-    val lp = TopkCardinalities(shardKeyPrefix, k, addInactive)
+    val lp = TsCardinalities(shardKeyPrefix)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
-    execPlan.isInstanceOf[TopkCardReduceExec] shouldEqual true
+    execPlan.isInstanceOf[TsCardReduceExec] shouldEqual true
 
-    val reducer = execPlan.asInstanceOf[TopkCardReduceExec]
+    val reducer = execPlan.asInstanceOf[TsCardReduceExec]
     reducer.rangeVectorTransformers.size shouldEqual 1
-    reducer.rangeVectorTransformers(0).isInstanceOf[TopkCardPresenter] shouldEqual true
-    reducer.rangeVectorTransformers(0).asInstanceOf[TopkCardPresenter].k shouldEqual k
+    reducer.rangeVectorTransformers(0).isInstanceOf[TsCardPresenter] shouldEqual true
     reducer.children.size shouldEqual mapper.numShards
     reducer.children.foreach{ child =>
-      child.isInstanceOf[TopkCardExec] shouldEqual true
-      val leaf = child.asInstanceOf[TopkCardExec]
+      child.isInstanceOf[TsCardExec] shouldEqual true
+      val leaf = child.asInstanceOf[TsCardExec]
       leaf.shardKeyPrefix shouldEqual shardKeyPrefix
-      leaf.k shouldEqual k
     }
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -807,8 +807,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     validatePlan(execPlan, expected)
   }
 
-  // TODO(a_theimer)
-  it ("should correctly materialize TopkCardExec") {
+  it ("should correctly materialize TsCardExec") {
     val shardKeyPrefix = Seq("foo", "bar")
     val groupDepth = 2
 
@@ -824,6 +823,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       child.isInstanceOf[TsCardExec] shouldEqual true
       val leaf = child.asInstanceOf[TsCardExec]
       leaf.shardKeyPrefix shouldEqual shardKeyPrefix
+      leaf.groupDepth shouldEqual groupDepth
     }
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -807,10 +807,12 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     validatePlan(execPlan, expected)
   }
 
+  // TODO(a_theimer)
   it ("should correctly materialize TopkCardExec") {
     val shardKeyPrefix = Seq("foo", "bar")
+    val groupDepth = 2
 
-    val lp = TsCardinalities(shardKeyPrefix)
+    val lp = TsCardinalities(shardKeyPrefix, groupDepth)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[TsCardReduceExec] shouldEqual true
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -200,6 +200,7 @@ extends MemStore with StrictLogging {
   override def topKCardinality(ref: DatasetRef,
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],
+                               depth: Int,
                                k: Int,
                                addInactive: Boolean): scala.Seq[CardinalityRecord] = ???
 }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -197,10 +197,5 @@ extends MemStore with StrictLogging {
                                  chunkMethod: ChunkScanMethod): Observable[RawPartData] = ???
 
   // TODO we need breakdown for downsample store too, but in a less memory intensive way
-  override def topKCardinality(ref: DatasetRef,
-                               shards: Seq[Int],
-                               shardKeyPrefix: scala.Seq[String],
-                               depth: Int,
-                               k: Int,
-                               addInactive: Boolean): scala.Seq[CardinalityRecord] = ???
+  override def scanTsCardinalities(ref: DatasetRef, shards: Seq[Int], shardKeyPrefix: Seq[String], depth: Int): scala.Seq[CardinalityRecord] = ???
 }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -197,5 +197,6 @@ extends MemStore with StrictLogging {
                                  chunkMethod: ChunkScanMethod): Observable[RawPartData] = ???
 
   // TODO we need breakdown for downsample store too, but in a less memory intensive way
-  override def scanTsCardinalities(ref: DatasetRef, shards: Seq[Int], shardKeyPrefix: Seq[String], depth: Int): scala.Seq[CardinalityRecord] = ???
+  override def scanTsCardinalities(ref: DatasetRef, shards: Seq[Int],
+                                   shardKeyPrefix: Seq[String], depth: Int): scala.Seq[CardinalityRecord] = ???
 }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -79,13 +79,20 @@ extends MemStore with StrictLogging {
     }
   }
 
+  // TODO(a_theimer)
+  def topKCardinalityImmediate(ref: DatasetRef, shards: Seq[Int],
+                               shardKeyPrefix: Seq[String], k: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
+    topKCardinality(ref, shards, shardKeyPrefix, shardKeyPrefix.size + 1, k, addInactive)
+  }
+
   def topKCardinality(ref: DatasetRef, shards: Seq[Int],
-                      shardKeyPrefix: Seq[String], k: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
+                      shardKeyPrefix: Seq[String], depth: Int,
+                      k: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
     datasets.get(ref).toSeq
       .flatMap { ts =>
         ts.values().asScala
           .filter(s => shards.isEmpty || shards.contains(s.shardNum))
-          .flatMap(_.topKCardinality(k, shardKeyPrefix, addInactive))
+          .flatMap(_.topKCardinality(k, shardKeyPrefix, depth, addInactive))
       }
   }
   /**

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -79,12 +79,6 @@ extends MemStore with StrictLogging {
     }
   }
 
-  // TODO(a_theimer)
-  def topKCardinalityImmediate(ref: DatasetRef, shards: Seq[Int],
-                               shardKeyPrefix: Seq[String], k: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
-    topKCardinality(ref, shards, shardKeyPrefix, shardKeyPrefix.size + 1, k, addInactive)
-  }
-
   def topKCardinality(ref: DatasetRef, shards: Seq[Int],
                       shardKeyPrefix: Seq[String], depth: Int,
                       k: Int, addInactive: Boolean): Seq[CardinalityRecord] = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -79,16 +79,16 @@ extends MemStore with StrictLogging {
     }
   }
 
-  def topKCardinality(ref: DatasetRef, shards: Seq[Int],
-                      shardKeyPrefix: Seq[String], depth: Int,
-                      k: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
+  def scanTsCardinalities(ref: DatasetRef, shards: Seq[Int],
+                          shardKeyPrefix: Seq[String], depth: Int): Seq[CardinalityRecord] = {
     datasets.get(ref).toSeq
       .flatMap { ts =>
         ts.values().asScala
           .filter(s => shards.isEmpty || shards.contains(s.shardNum))
-          .flatMap(_.topKCardinality(k, shardKeyPrefix, depth, addInactive))
+          .flatMap(_.scanTsCardinalities(shardKeyPrefix, depth))
       }
   }
+
   /**
     * WARNING: use only for testing. Not performant
     */

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -598,22 +598,9 @@ class TimeSeriesShard(val ref: DatasetRef,
     _offset
   }
 
-  def topKCardinality(k: Int, shardKeyPrefix: Seq[String], depth: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
-    implicit val ord = new Ordering[CardinalityRecord]() {
-      override def compare(x: CardinalityRecord, y: CardinalityRecord): Int = {
-        if (addInactive) x.tsCount - y.tsCount
-        else x.activeTsCount - y.activeTsCount
-      }
-    }.reverse
-
+  def scanTsCardinalities(shardKeyPrefix: Seq[String], depth: Int): Seq[CardinalityRecord] = {
     if (storeConfig.meteringEnabled) {
-      val heap = mutable.PriorityQueue[CardinalityRecord]()
-      val childCards = cardTracker.scan(shardKeyPrefix, depth)
-      childCards.foreach { card =>
-        heap.enqueue(card)
-        if (heap.size > k) heap.dequeue()
-      }
-      heap.toSeq
+      cardTracker.scan(shardKeyPrefix, depth)
     } else {
       throw new IllegalArgumentException("Metering is not enabled")
     }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -598,9 +598,15 @@ class TimeSeriesShard(val ref: DatasetRef,
     _offset
   }
 
-  def topKCardinality(k: Int, shardKeyPrefix: Seq[String], addInactive: Boolean): Seq[CardinalityRecord] = {
-    if (storeConfig.meteringEnabled) cardTracker.topk(k, shardKeyPrefix, addInactive)
+  // TODO(a_theimer)
+  def topKCardinality(k: Int, shardKeyPrefix: Seq[String], depth: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
+    if (storeConfig.meteringEnabled) cardTracker.topk(k, shardKeyPrefix, depth, addInactive)
     else throw new IllegalArgumentException("Metering is not enabled")
+  }
+
+  // TODO(a_theimer)
+  def topKCardinalityImmediate(k: Int, shardKeyPrefix: Seq[String], addInactive: Boolean): Seq[CardinalityRecord] = {
+    topKCardinality(k, shardKeyPrefix, shardKeyPrefix.size + 1, addInactive)
   }
 
   def startFlushingIndex(): Unit =

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -598,15 +598,9 @@ class TimeSeriesShard(val ref: DatasetRef,
     _offset
   }
 
-  // TODO(a_theimer)
   def topKCardinality(k: Int, shardKeyPrefix: Seq[String], depth: Int, addInactive: Boolean): Seq[CardinalityRecord] = {
     if (storeConfig.meteringEnabled) cardTracker.topk(k, shardKeyPrefix, depth, addInactive)
     else throw new IllegalArgumentException("Metering is not enabled")
-  }
-
-  // TODO(a_theimer)
-  def topKCardinalityImmediate(k: Int, shardKeyPrefix: Seq[String], addInactive: Boolean): Seq[CardinalityRecord] = {
-    topKCardinality(k, shardKeyPrefix, shardKeyPrefix.size + 1, addInactive)
   }
 
   def startFlushingIndex(): Unit =

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -5,14 +5,14 @@ import java.io.Closeable
 /**
  * The data stored in each node of the Cardinality Store trie
  *
- * @param name name of the item in shardKeyPrefix
+ * @param prefix name of the item in shardKeyPrefix
  * @param tsCount total number of timeSeries under this shardKeyPrefix (example, number of timeseries under ws,ns)
  * @param activeTsCount number of actively ingesting timeSeries under this shardKeyPrefix
  *                      (example, number of timeseries under ws,ns)
  * @param childrenCount number of immediate children for this shardKey (example, number of ns under ws)
  * @param childrenQuota quota for number of immediate children
  */
-case class Cardinality(name: String, tsCount: Int, activeTsCount: Int, childrenCount: Int, childrenQuota: Int)
+case class Cardinality(prefix: Seq[String], tsCount: Int, activeTsCount: Int, childrenCount: Int, childrenQuota: Int)
 
 /**
  *
@@ -57,7 +57,7 @@ trait CardinalityStore {
    * This method will be called for each shard key prefix when a new time series is added
    * to the index.
    */
-  def store(shardKeyPrefix: Seq[String], card: Cardinality): Unit
+  def store(card: Cardinality): Unit
 
   /**
    * Read existing cardinality value, if one does not exist return the zero value

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -15,6 +15,16 @@ import java.io.Closeable
 case class Cardinality(prefix: Seq[String], tsCount: Int, activeTsCount: Int, childrenCount: Int, childrenQuota: Int)
 
 /**
+ * Interface for CardinalityStore iterator.
+ */
+trait CardIter extends Iterator[Cardinality] with Closeable {
+  /**
+   * Must be called before iteration.
+   */
+  def seek(): Unit
+}
+
+/**
  *
  * Abstracts storage of cardinality for each shard prefix.
  *
@@ -75,7 +85,7 @@ trait CardinalityStore {
    * Fetch children of the node for the given shard key prefix.
    * @param depth: only children of this size will be scanned.
    */
-  def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Iterator[Cardinality] with Closeable
+  def scanChildren(shardKeyPrefix: Seq[String], depth: Int): CardIter
 
   /**
    * Close store. Data will be thrown away

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -1,7 +1,10 @@
 package filodb.core.memstore.ratelimit
 
+import java.io.Closeable
+
 /**
  * The data stored in each node of the Cardinality Store trie
+ *
  * @param name name of the item in shardKeyPrefix
  * @param tsCount total number of timeSeries under this shardKeyPrefix (example, number of timeseries under ws,ns)
  * @param activeTsCount number of actively ingesting timeSeries under this shardKeyPrefix
@@ -72,7 +75,7 @@ trait CardinalityStore {
    * Fetch children of the node for the given shard key prefix.
    * @param depth: only children of this size will be scanned.
    */
-  def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Seq[Cardinality]
+  def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Iterator[Cardinality] with Closeable
 
   /**
    * Close store. Data will be thrown away

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -69,11 +69,9 @@ trait CardinalityStore {
   def remove(shardKeyPrefix: Seq[String]): Unit
 
   /**
-   * Fetch immediate children of the node for the given shard key prefix.
+   * Fetch children of the node for the given shard key prefix.
+   * @param depth: only children of this size will be scanned.
    */
-  def scanImmediateChildren(shardKeyPrefix: Seq[String]): Seq[Cardinality]
-
-  // TODO(a_theimer)
   def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Seq[Cardinality]
 
   /**

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -1,7 +1,5 @@
 package filodb.core.memstore.ratelimit
 
-import java.io.Closeable
-
 /**
  * The data stored in each node of the Cardinality Store trie
  *
@@ -77,7 +75,7 @@ trait CardinalityStore {
    * Fetch children of the node for the given shard key prefix.
    * @param depth: only children of this size will be scanned.
    */
-  def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Iterator[CardinalityRecord] with Closeable
+  def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Seq[CardinalityRecord]
 
   /**
    * Close store. Data will be thrown away

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -69,9 +69,12 @@ trait CardinalityStore {
   def remove(shardKeyPrefix: Seq[String]): Unit
 
   /**
-   * Fetch immediate children of the node for the given shard key prefix
+   * Fetch immediate children of the node for the given shard key prefix.
    */
-  def scanChildren(shardKeyPrefix: Seq[String]): Seq[Cardinality]
+  def scanImmediateChildren(shardKeyPrefix: Seq[String]): Seq[Cardinality]
+
+  // TODO(a_theimer)
+  def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Seq[Cardinality]
 
   /**
    * Close store. Data will be thrown away

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -5,7 +5,7 @@ import java.io.Closeable
 /**
  * The data stored in each node of the Cardinality Store trie
  *
- * @param prefix name of the item in shardKeyPrefix
+ * @param prefix the shard key prefix that corresponds with the cardinality data
  * @param tsCount total number of timeSeries under this shardKeyPrefix (example, number of timeseries under ws,ns)
  * @param activeTsCount number of actively ingesting timeSeries under this shardKeyPrefix
  *                      (example, number of timeseries under ws,ns)

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -73,6 +73,10 @@ trait CardinalityStore {
 
   /**
    * Fetch children of the node for the given shard key prefix.
+   * Result size is limited to MAX_RESULT_SIZE. If more children exist,
+   *   their counts summed into one additional CardinalityRecord with
+   *   prefix OVERFLOW_PREFIX.
+   *
    * @param depth: only children of this size will be scanned.
    */
   def scanChildren(shardKeyPrefix: Seq[String], depth: Int): Seq[CardinalityRecord]
@@ -81,4 +85,10 @@ trait CardinalityStore {
    * Close store. Data will be thrown away
    */
   def close(): Unit
+}
+
+object CardinalityStore {
+  // See scanChildren doc for details.
+  val MAX_RESULT_SIZE = 5000
+  val OVERFLOW_PREFIX = Seq("_overflow_")
 }

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -200,6 +200,7 @@ class CardinalityTracker(ref: DatasetRef,
     val heap = mutable.PriorityQueue[CardinalityRecord]()
     val it = store.scanChildren(shardKeyPrefix, depth)
     try {
+      it.seek()
       it.foreach { card =>
         heap.enqueue(CardinalityRecord(
           shard, card.prefix, card.tsCount,

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -72,7 +72,7 @@ class CardinalityTracker(ref: DatasetRef,
     // first make sure there is no breach for any prefix
     (0 to shardKey.length).foreach { i =>
       val prefix = shardKey.take(i)
-      val name = if (prefix.isEmpty) "" else prefix.mkString(NAME_DELIMITER)
+      val name = if (prefix.isEmpty) "" else prefix.last
       val old = store.getOrZero(prefix, Cardinality(name, 0, 0, 0, defaultChildrenQuota(i)))
       val neu = old.copy(tsCount = old.tsCount + totalDelta,
                          activeTsCount = old.activeTsCount + activeDelta,
@@ -108,7 +108,7 @@ class CardinalityTracker(ref: DatasetRef,
    */
   def getCardinality(shardKeyPrefix: Seq[String]): Cardinality = {
     require(shardKeyPrefix.length <= shardKeyLen, s"Too many shard keys in $shardKeyPrefix - max $shardKeyLen")
-    val name = if (shardKeyPrefix.isEmpty) "" else shardKeyPrefix.mkString(NAME_DELIMITER)
+    val name = if (shardKeyPrefix.isEmpty) "" else shardKeyPrefix.last
     store.getOrZero(shardKeyPrefix, Cardinality(name, 0, 0, 0, defaultChildrenQuota(shardKeyPrefix.length)))
   }
 
@@ -124,7 +124,7 @@ class CardinalityTracker(ref: DatasetRef,
     require(childrenQuota > 0 && childrenQuota < 2000000, "Children quota invalid. Provide [1, 2000000)")
 
     logger.debug(s"Setting children quota for $shardKeyPrefix as $childrenQuota")
-    val name = if (shardKeyPrefix.isEmpty) "" else shardKeyPrefix.mkString(NAME_DELIMITER)
+    val name = if (shardKeyPrefix.isEmpty) "" else shardKeyPrefix.last
     val old = store.getOrZero(shardKeyPrefix, Cardinality(name, 0, 0, 0, defaultChildrenQuota(shardKeyPrefix.length)))
     val neu = old.copy(childrenQuota = childrenQuota)
     store.store(shardKeyPrefix, neu)
@@ -156,7 +156,7 @@ class CardinalityTracker(ref: DatasetRef,
         (prefix, neu)
       }
       toStore.map { case (prefix, neu) =>
-        val name = if (prefix.isEmpty) "" else prefix.mkString(NAME_DELIMITER)
+        val name = if (prefix.isEmpty) "" else prefix.last
         if (neu == Cardinality(name, 0, 0, 0, defaultChildrenQuota(prefix.length))) {
           // node can be removed
           store.remove(prefix)

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -145,7 +145,7 @@ class CardinalityTracker(ref: DatasetRef,
       require(shardKey.length == shardKeyLen, "full shard key is needed")
       val toStore = (0 to shardKey.length).map { i =>
         val prefix = shardKey.take(i)
-        val old = store.getOrZero(prefix, Cardinality(Seq(""), 0, 0, 0, defaultChildrenQuota(i)))
+        val old = store.getOrZero(prefix, Cardinality(Nil, 0, 0, 0, defaultChildrenQuota(i)))
         if (old.tsCount == 0)
           throw new IllegalArgumentException(s"$prefix count is already zero - cannot reduce " +
             s"further. A double delete likely happened.")

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
@@ -19,7 +19,12 @@ import spire.syntax.cfor._
 import filodb.core.{DatasetRef, GlobalScheduler}
 import filodb.memory.format.UnsafeUtils
 
-case class CardinalityNode(name: String, tsCount: Int, activeTsCount: Int, childrenCount: Int, childrenQuota: Int)
+/**
+ * Stored as values in the RocksDb database.
+ * Identical to Cardinality, except that only the least-significant prefix name is stored.
+ */
+case class CardinalityNode(name: String, tsCount: Int, activeTsCount: Int,
+                           childrenCount: Int, childrenQuota: Int)
 
 case object CardinalityNode {
   def fromCardinality(card: Cardinality): CardinalityNode = {

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
@@ -18,8 +18,8 @@ import org.rocksdb._
 import spire.syntax.cfor._
 
 import filodb.core.{DatasetRef, GlobalScheduler}
+import filodb.core.memstore.ratelimit.CardinalityStore._
 import filodb.memory.format.UnsafeUtils
-
 
 /**
  * Stored as values in the RocksDb database.
@@ -268,12 +268,6 @@ class RocksDbCardinalityStore(ref: DatasetRef, shard: Int) extends CardinalitySt
 
     require(depth > shardKeyPrefix.size,
       s"scan depth $depth must be greater than the size of the prefix ${shardKeyPrefix.size}")
-
-    val MAX_RESULT_SIZE = 10000
-
-    // If MAX_RESULT_SIZE is reached, one extra CardinalityRecord is added
-    //   with this prefix. Its counts are the sum all the overflow counts.
-    val OVERFLOW_PREFIX = Seq("_overflow_")
 
     val it = db.newIterator()
     val buf = new ArrayBuffer[CardinalityRecord]()

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -192,8 +192,8 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
     }
   }
 
-  def topKCardinality(ref: DatasetRef, shard: Seq[Int], shardKeyPrefix: Seq[String],
-                      depth: Int, k: Int, addInactive: Boolean): Seq[CardinalityRecord]
+  def scanTsCardinalities(ref: DatasetRef, shard: Seq[Int],
+                          shardKeyPrefix: Seq[String], depth: Int): Seq[CardinalityRecord]
 
 }
 

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -192,8 +192,8 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
     }
   }
 
-  def topKCardinality(ref: DatasetRef, shard: Seq[Int],
-                      shardKeyPrefix: Seq[String], k: Int, addInactive: Boolean): Seq[CardinalityRecord]
+  def topKCardinality(ref: DatasetRef, shard: Seq[Int], shardKeyPrefix: Seq[String],
+                      depth: Int, k: Int, addInactive: Boolean): Seq[CardinalityRecord]
 
 }
 

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -15,26 +15,28 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should enforce quota when set explicitly for all levels") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
-    t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual Cardinality("aaa", 0, 0, 0, 1)
-    t.setQuota(Seq("a", "aa"), 2) shouldEqual Cardinality("aa", 0, 0, 0, 2)
-    t.setQuota(Seq("a"), 1) shouldEqual Cardinality("a",0, 0, 0, 1)
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 1) shouldEqual
-      Seq(Cardinality("", 1, 1, 1, 4),
-        Cardinality("a", 1, 1, 1, 1),
-        Cardinality("aa", 1, 1, 1, 2),
-        Cardinality("aaa", 1, 1, 1, 1))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 1) shouldEqual
-      Seq(Cardinality("", 2, 2, 1, 4),
-        Cardinality("a", 2, 2, 1, 1),
-        Cardinality("aa", 2, 2, 2, 2),
-        Cardinality("aab", 1, 1, 1, 4))
+    t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual  Cardinality(Seq("a", "aa", "aaa"), 0, 0, 0, 1)
+    t.setQuota(Seq("a", "aa"), 2) shouldEqual Cardinality(Seq("a", "aa"), 0, 0, 0, 2)
+    t.setQuota(Seq("a"), 1) shouldEqual Cardinality(Seq("a"), 0, 0, 0, 1)
+
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 1) should contain theSameElementsInOrderAs
+      Seq(Cardinality(Nil, 1, 1, 1, 4),
+        Cardinality(Seq("a"), 1, 1, 1, 1),
+        Cardinality(Seq("a", "aa"), 1, 1, 1, 2),
+        Cardinality(Seq("a", "aa", "aaa"), 1, 1, 1, 1))
+
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 1) should contain theSameElementsInOrderAs
+      Seq(Cardinality(Nil, 2, 2, 1, 4),
+        Cardinality(Seq("a"), 2, 2, 1, 1),
+        Cardinality(Seq("a", "aa"), 2, 2, 2, 2),
+        Cardinality(Seq("a", "aa", "aab"), 1, 1, 1, 4))
 
     // aab stopped ingesting
-    t.modifyCount(Seq("a", "aa", "aab"), 0, -1) shouldEqual
-      Seq(Cardinality("", 2, 1, 1, 4),
-        Cardinality("a", 2, 1, 1, 1),
-        Cardinality("aa", 2, 1, 2, 2),
-        Cardinality("aab", 1, 0, 1, 4))
+    t.modifyCount(Seq("a", "aa", "aab"), 0, -1) should contain theSameElementsInOrderAs
+      Seq(Cardinality(Nil, 2, 1, 1, 4),
+        Cardinality(Seq("a"), 2, 1, 1, 1),
+        Cardinality(Seq("a", "aa"), 2, 1, 2, 2),
+        Cardinality(Seq("a", "aa", "aab"), 1, 0, 1, 4))
 
     val ex = intercept[QuotaReachedException] {
       t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
@@ -42,16 +44,16 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     ex.prefix shouldEqual (Seq("a", "aa"))
 
     // increment should not have been applied for any prefix
-    t.getCardinality(Seq("a")) shouldEqual Cardinality("a", 2, 1, 1, 1)
-    t.getCardinality(Seq("a", "aa")) shouldEqual Cardinality("aa", 2, 1, 2, 2)
-    t.getCardinality(Seq("a", "aa", "aac")) shouldEqual Cardinality("aac", 0, 0, 0, 4)
+    t.getCardinality(Seq("a")) shouldEqual Cardinality(Seq("a"), 2, 1, 1, 1)
+    t.getCardinality(Seq("a", "aa")) shouldEqual Cardinality(Seq("a", "aa"), 2, 1, 2, 2)
+    t.getCardinality(Seq("a", "aa", "aac")) shouldEqual Cardinality(Seq("a", "aa", "aac"), 0, 0, 0, 4)
 
     // aab was purged
     t.decrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(Cardinality("", 1, 1, 1, 4),
-        Cardinality("a", 1, 1, 1, 1),
-        Cardinality("aa", 1, 1, 2, 2),
-        Cardinality("aab", 0, 0, 0, 4))
+      Seq(Cardinality(Nil, 1, 1, 1, 4),
+        Cardinality(Seq("a"), 1, 1, 1, 1),
+        Cardinality(Seq("a", "aa"), 1, 1, 2, 2),
+        Cardinality(Seq("a", "aa", "aab"), 0, 0, 0, 4))
 
     t.close()
   }
@@ -81,49 +83,49 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
   it("should enforce quota when not set for any level") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
     t.modifyCount(Seq("a", "ab", "aba"), 1, 0) shouldEqual
-      Seq(Cardinality("", 1, 0, 1, 4),
-        Cardinality("a", 1, 0, 1, 4),
-        Cardinality("ab", 1, 0, 1, 4),
-        Cardinality("aba", 1, 0, 1, 4))
+      Seq(Cardinality(Nil, 1, 0, 1, 4),
+        Cardinality(Seq("a"), 1, 0, 1, 4),
+        Cardinality(Seq("a", "ab"), 1, 0, 1, 4),
+        Cardinality(Seq("a", "ab", "aba"), 1, 0, 1, 4))
     t.close()
   }
 
   it("should be able to enforce for top 2 levels always, and enforce for 3rd level only in some cases") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 0, 10)
-    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality(Seq("a"), 0, 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality(Seq("a", "aa"), 0, 0, 0, 10)
     // enforce for 3rd level only for aaa
-    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 0, 2)
+    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality(Seq("a", "aa", "aaa"), 0, 0, 0, 2)
     t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(Cardinality("", 1, 0, 1, 20),
-        Cardinality("a", 1, 0, 1, 10),
-        Cardinality("aa", 1, 0, 1, 10),
-        Cardinality("aaa", 1, 0, 1, 2))
+      Seq(Cardinality(Nil, 1, 0, 1, 20),
+        Cardinality(Seq("a"), 1, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 1, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aaa"), 1, 0, 1, 2))
     t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(Cardinality("", 2, 0, 1, 20),
-        Cardinality("a", 2, 0, 1, 10),
-        Cardinality("aa", 2, 0, 1, 10),
-        Cardinality("aaa", 2, 0, 2, 2))
+      Seq(Cardinality(Nil, 2, 0, 1, 20),
+        Cardinality(Seq("a"), 2, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 2, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aaa"), 2, 0, 2, 2))
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 3, 0, 1, 20),
-        Cardinality("a", 3, 0, 1, 10),
-        Cardinality("aa", 3, 0, 2, 10),
-        Cardinality("aab", 1, 0, 1, 20))
+      Seq(Cardinality(Nil, 3, 0, 1, 20),
+        Cardinality(Seq("a"), 3, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 3, 0, 2, 10),
+        Cardinality(Seq("a", "aa", "aab"), 1, 0, 1, 20))
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 4, 0, 1, 20),
-        Cardinality("a", 4, 0, 1, 10),
-        Cardinality("aa", 4, 0, 2, 10),
-        Cardinality("aab", 2, 0, 2, 20))
+      Seq(Cardinality(Nil, 4, 0, 1, 20),
+        Cardinality(Seq("a"), 4, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 4, 0, 2, 10),
+        Cardinality(Seq("a", "aa", "aab"), 2, 0, 2, 20))
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 5, 0, 1, 20),
-        Cardinality("a", 5, 0, 1, 10),
-        Cardinality("aa", 5, 0, 2, 10),
-        Cardinality("aab", 3, 0, 3, 20))
+      Seq(Cardinality(Nil, 5, 0, 1, 20),
+        Cardinality(Seq("a"), 5, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 5, 0, 2, 10),
+        Cardinality(Seq("a", "aa", "aab"), 3, 0, 3, 20))
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 6, 0, 1, 20),
-        Cardinality("a", 6, 0, 1, 10),
-        Cardinality("aa", 6, 0, 2, 10),
-        Cardinality("aab", 4, 0, 4, 20))
+      Seq(Cardinality(Nil, 6, 0, 1, 20),
+        Cardinality(Seq("a"), 6, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 6, 0, 2, 10),
+        Cardinality(Seq("a", "aa", "aab"), 4, 0, 4, 20))
 
     val ex = intercept[QuotaReachedException] {
       t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
@@ -135,20 +137,20 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should be able to increase and decrease quota after it has been set before") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 0, 10)
-    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality(Seq("a"), 0, 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality(Seq("a", "aa"), 0, 0, 0, 10)
     // enforce for 3rd level only for aaa
-    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality("aaa", 0, 0, 0, 2)
+    t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual Cardinality(Seq("a", "aa", "aaa"), 0, 0, 0, 2)
     t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(Cardinality("", 1, 0, 1, 20),
-        Cardinality("a", 1, 0, 1, 10),
-        Cardinality("aa", 1, 0, 1, 10),
-        Cardinality("aaa", 1, 0, 1, 2))
+      Seq(Cardinality(Nil, 1, 0, 1, 20),
+        Cardinality(Seq("a"), 1, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 1, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aaa"), 1, 0, 1, 2))
     t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(Cardinality("", 2, 0, 1, 20),
-        Cardinality("a", 2, 0, 1, 10),
-        Cardinality("aa", 2, 0, 1, 10),
-        Cardinality("aaa", 2, 0, 2, 2))
+      Seq(Cardinality(Nil, 2, 0, 1, 20),
+        Cardinality(Seq("a"), 2, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 2, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aaa"), 2, 0, 2, 2))
 
     val ex = intercept[QuotaReachedException] {
       t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
@@ -156,20 +158,20 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     ex.prefix shouldEqual (Seq("a", "aa", "aaa"))
 
     // increase quota
-    t.setQuota(Seq("a", "aa", "aaa"), 5) shouldEqual Cardinality("aaa", 2, 0, 2, 5)
+    t.setQuota(Seq("a", "aa", "aaa"), 5) shouldEqual Cardinality(Seq("a", "aa", "aaa"), 2, 0, 2, 5)
     t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(Cardinality("", 3, 0, 1, 20),
-        Cardinality("a", 3, 0, 1, 10),
-        Cardinality("aa", 3, 0, 1, 10),
-        Cardinality("aaa", 3, 0, 3, 5))
+      Seq(Cardinality(Nil, 3, 0, 1, 20),
+        Cardinality(Seq("a"), 3, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 3, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aaa"), 3, 0, 3, 5))
 
     // decrease quota
-    t.setQuota(Seq("a", "aa", "aaa"), 4) shouldEqual Cardinality("aaa", 3, 0, 3, 4)
+    t.setQuota(Seq("a", "aa", "aaa"), 4) shouldEqual Cardinality(Seq("a", "aa", "aaa"), 3, 0, 3, 4)
     t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(Cardinality("", 4, 0, 1, 20),
-        Cardinality("a", 4, 0, 1, 10),
-        Cardinality("aa", 4, 0, 1, 10),
-        Cardinality("aaa", 4, 0, 4, 4))
+      Seq(Cardinality(Nil, 4, 0, 1, 20),
+        Cardinality(Seq("a"), 4, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 4, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aaa"), 4, 0, 4, 4))
     val ex2 = intercept[QuotaReachedException] {
       t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
     }
@@ -179,33 +181,33 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should be able to decrease quota if count is higher than new quota") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual Cardinality("a", 0, 0, 0, 10)
-    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality("aa", 0, 0, 0, 10)
+    t.setQuota(Seq("a"), 10) shouldEqual Cardinality(Seq("a"), 0, 0, 0, 10)
+    t.setQuota(Seq("a", "aa"), 10) shouldEqual Cardinality(Seq("a", "aa"), 0, 0, 0, 10)
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 1, 0, 1, 20),
-        Cardinality("a", 1, 0, 1, 10),
-        Cardinality("aa", 1, 0, 1, 10),
-        Cardinality("aab", 1, 0, 1, 20))
+      Seq(Cardinality(Nil, 1, 0, 1, 20),
+        Cardinality(Seq("a"), 1, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 1, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aab"), 1, 0, 1, 20))
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 2, 0, 1, 20),
-        Cardinality("a", 2, 0, 1, 10),
-        Cardinality("aa", 2, 0, 1, 10),
-        Cardinality("aab", 2, 0, 2, 20))
+      Seq(Cardinality(Nil, 2, 0, 1, 20),
+        Cardinality(Seq("a"), 2, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 2, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aab"), 2, 0, 2, 20))
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 3, 0, 1, 20),
-        Cardinality("a", 3, 0, 1, 10),
-        Cardinality("aa", 3, 0, 1, 10),
-        Cardinality("aab", 3, 0, 3, 20))
+      Seq(Cardinality(Nil, 3, 0, 1, 20),
+        Cardinality(Seq("a"), 3, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 3, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aab"), 3, 0, 3, 20))
     t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(Cardinality("", 4, 0, 1, 20),
-        Cardinality("a", 4, 0, 1, 10),
-        Cardinality("aa", 4, 0, 1, 10),
-        Cardinality("aab", 4, 0, 4, 20))
+      Seq(Cardinality(Nil, 4, 0, 1, 20),
+        Cardinality(Seq("a"), 4, 0, 1, 10),
+        Cardinality(Seq("a", "aa"), 4, 0, 1, 10),
+        Cardinality(Seq("a", "aa", "aab"), 4, 0, 4, 20))
 
-    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 0, 4, 20)
+    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality(Seq("a", "aa", "aab"), 4, 0, 4, 20)
 
     t.setQuota(Seq("a", "aa", "aab"), 3)
-    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality("aab", 4, 0, 4, 3)
+    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual Cardinality(Seq("a", "aa", "aab"), 4, 0, 4, 3)
     val ex2 = intercept[QuotaReachedException] {
       t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
     }
@@ -243,21 +245,21 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
 
     t.topk(3, Seq("a", "ac"), 3, true) shouldEqual Seq(
-      CardinalityRecord(0, "acc", 11, 0, 11, 100),
-      CardinalityRecord(0, "acg", 15, 0, 15, 100),
-      CardinalityRecord(0, "acb", 20, 0, 20, 100)
+      CardinalityRecord(0, Cardinality(Seq("a", "ac", "acc"), 11, 0, 11, 100)),
+      CardinalityRecord(0, Cardinality(Seq("a", "ac", "acg"), 15, 0, 15, 100)),
+      CardinalityRecord(0, Cardinality(Seq("a", "ac", "acb"), 20, 0, 20, 100))
     )
 
     t.topk(3, Seq("a"), 2, true) shouldEqual Seq(
-      CardinalityRecord(0, "aa", 4, 0, 4, 100),
-      CardinalityRecord(0, "ab", 5, 0, 5, 100),
-      CardinalityRecord(0, "ac", 72, 0, 7, 100)
+      CardinalityRecord(0, Cardinality(Seq("a", "aa"), 4, 0, 4, 100)),
+      CardinalityRecord(0, Cardinality(Seq("a", "ab"), 5, 0, 5, 100)),
+      CardinalityRecord(0, Cardinality(Seq("a", "ac"), 72, 0, 7, 100))
     )
 
     t.topk(3, Nil, 1, true) shouldEqual Seq(
-      CardinalityRecord(0, "c", 5, 0, 1, 100),
-      CardinalityRecord(0, "a", 81, 0, 3, 100),
-      CardinalityRecord(0, "b", 35, 0, 4, 100)
+      CardinalityRecord(0, Cardinality(Seq("c"), 5, 0, 1, 100)),
+      CardinalityRecord(0, Cardinality(Seq("a"), 81, 0, 3, 100)),
+      CardinalityRecord(0, Cardinality(Seq("b"), 35, 0, 4, 100))
     )
     t.close()
   }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -19,20 +19,20 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.setQuota(Seq("a", "aa"), 2) shouldEqual Cardinality(Seq("a", "aa"), 0, 0, 0, 2)
     t.setQuota(Seq("a"), 1) shouldEqual Cardinality(Seq("a"), 0, 0, 0, 1)
 
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 1) should contain theSameElementsInOrderAs
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 1) shouldEqual
       Seq(Cardinality(Nil, 1, 1, 1, 4),
         Cardinality(Seq("a"), 1, 1, 1, 1),
         Cardinality(Seq("a", "aa"), 1, 1, 1, 2),
         Cardinality(Seq("a", "aa", "aaa"), 1, 1, 1, 1))
 
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 1) should contain theSameElementsInOrderAs
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 1) shouldEqual
       Seq(Cardinality(Nil, 2, 2, 1, 4),
         Cardinality(Seq("a"), 2, 2, 1, 1),
         Cardinality(Seq("a", "aa"), 2, 2, 2, 2),
         Cardinality(Seq("a", "aa", "aab"), 1, 1, 1, 4))
 
     // aab stopped ingesting
-    t.modifyCount(Seq("a", "aa", "aab"), 0, -1) should contain theSameElementsInOrderAs
+    t.modifyCount(Seq("a", "aa", "aab"), 0, -1) shouldEqual
       Seq(Cardinality(Nil, 2, 1, 1, 4),
         Cardinality(Seq("a"), 2, 1, 1, 1),
         Cardinality(Seq("a", "aa"), 2, 1, 2, 2),

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -215,53 +215,57 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.close()
   }
 
-  // TODO(a_theimer)
-//  it ("should be able to do topk") {
-//    val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
-//    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
-//    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
-//    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
-//    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
-//    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
-//    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
-//    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
-//
-//    (1 to 15).foreach(_ => t.modifyCount(Seq("b", "bc", "bcg"), 1, 0))
-//    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bc", "bch"), 1, 0))
-//    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bd", "bdh"), 1, 0))
-//
-//    (1 to 3).foreach(_ => t.modifyCount(Seq("c", "cc", "ccg"), 1, 0))
-//    (1 to 2).foreach(_ => t.modifyCount(Seq("c", "cc", "cch"), 1, 0))
-//
-//    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
-//    t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
-//    t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
-//    t.modifyCount(Seq("a", "aa", "aad"), 1, 0)
-//    t.modifyCount(Seq("b", "ba", "baa"), 1, 0)
-//    t.modifyCount(Seq("b", "bb", "bba"), 1, 0)
-//    t.modifyCount(Seq("a", "ab", "aba"), 1, 0)
-//    t.modifyCount(Seq("a", "ab", "abb"), 1, 0)
-//    t.modifyCount(Seq("a", "ab", "abc"), 1, 0)
-//    t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
-//    t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
-//
-//    t.scan(3, Seq("a", "ac"), 3, true) shouldEqual Seq(
-//      CardinalityRecord(0, Seq("a", "ac", "acc"), 11, 0, 11, 100),
-//      CardinalityRecord(0, Seq("a", "ac", "acg"), 15, 0, 15, 100),
-//      CardinalityRecord(0, Seq("a", "ac", "acb"), 20, 0, 20, 100)
-//    )
-//
-//    t.scan(3, Seq("a"), 2, true) shouldEqual Seq(
-//      CardinalityRecord(0, Seq("a", "aa"), 4, 0, 4, 100),
-//      CardinalityRecord(0, Seq("a", "ab"), 5, 0, 5, 100),
-//      CardinalityRecord(0, Seq("a", "ac"), 72, 0, 7, 100)
-//    )
-//
-//    t.scan(3, Nil, 1, true) shouldEqual Seq(
-//      CardinalityRecord(0, Seq("c"), 5, 0, 1, 100),
-//      CardinalityRecord(0, Seq("a"), 81, 0, 3, 100),
-//      CardinalityRecord(0, Seq("b"), 35, 0, 4, 100)
-//    )
-//    t.close()
-//  }
+  it ("should be able to do scan") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
+    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
+    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
+    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
+    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
+    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
+    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
+
+    (1 to 15).foreach(_ => t.modifyCount(Seq("b", "bc", "bcg"), 1, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bc", "bch"), 1, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bd", "bdh"), 1, 0))
+
+    (1 to 3).foreach(_ => t.modifyCount(Seq("c", "cc", "ccg"), 1, 0))
+    (1 to 2).foreach(_ => t.modifyCount(Seq("c", "cc", "cch"), 1, 0))
+
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aad"), 1, 0)
+    t.modifyCount(Seq("b", "ba", "baa"), 1, 0)
+    t.modifyCount(Seq("b", "bb", "bba"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "aba"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abb"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abc"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
+    t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
+
+    t.scan(Seq("a", "ac"), 3) should contain theSameElementsAs Seq(
+      CardinalityRecord(0, Seq("a", "ac", "aca"), 10, 0, 10, 100),
+      CardinalityRecord(0, Seq("a", "ac", "acb"), 20, 0, 20, 100),
+      CardinalityRecord(0, Seq("a", "ac", "acc"), 11, 0, 11, 100),
+      CardinalityRecord(0, Seq("a", "ac", "acd"), 6, 0, 6, 100),
+      CardinalityRecord(0, Seq("a", "ac", "ace"), 1, 0, 1, 100),
+      CardinalityRecord(0, Seq("a", "ac", "acf"), 9, 0, 9, 100),
+      CardinalityRecord(0, Seq("a", "ac", "acg"), 15, 0, 15, 100),
+    )
+
+    t.scan(Seq("a"), 2) should contain theSameElementsAs Seq(
+      CardinalityRecord(0, Seq("a", "aa"), 4, 0, 4, 100),
+      CardinalityRecord(0, Seq("a", "ab"), 5, 0, 5, 100),
+      CardinalityRecord(0, Seq("a", "ac"), 72, 0, 7, 100)
+    )
+
+    t.scan(Nil, 1) should contain theSameElementsAs Seq(
+      CardinalityRecord(0, Seq("c"), 5, 0, 1, 100),
+      CardinalityRecord(0, Seq("a"), 81, 0, 3, 100),
+      CardinalityRecord(0, Seq("b"), 35, 0, 4, 100)
+    )
+
+    t.close()
+  }
 }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -242,24 +242,23 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
     t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
 
-    // TODO(a_theimer)
-//    t.topk(3, Seq("a", "ac"), true) shouldEqual Seq(
-//      CardinalityRecord(0, "acc", 11, 0, 11, 100),
-//      CardinalityRecord(0, "acg", 15, 0, 15, 100),
-//      CardinalityRecord(0, "acb", 20, 0, 20, 100)
-//    )
-//
-//    t.topk(3, Seq("a"), true) shouldEqual Seq(
-//      CardinalityRecord(0, "aa", 4, 0, 4, 100),
-//      CardinalityRecord(0, "ab", 5, 0, 5, 100),
-//      CardinalityRecord(0, "ac", 72, 0, 7, 100)
-//    )
-//
-//    t.topk(3, Nil, true) shouldEqual Seq(
-//      CardinalityRecord(0, "c", 5, 0, 1, 100),
-//      CardinalityRecord(0, "a", 81, 0, 3, 100),
-//      CardinalityRecord(0, "b", 35, 0, 4, 100)
-//    )
+    t.topk(3, Seq("a", "ac"), 3, true) shouldEqual Seq(
+      CardinalityRecord(0, "a,ac,acc", 11, 0, 11, 100),
+      CardinalityRecord(0, "a,ac,acg", 15, 0, 15, 100),
+      CardinalityRecord(0, "a,ac,acb", 20, 0, 20, 100)
+    )
+
+    t.topk(3, Seq("a"), 2, true) shouldEqual Seq(
+      CardinalityRecord(0, "a,aa", 4, 0, 4, 100),
+      CardinalityRecord(0, "a,ab", 5, 0, 5, 100),
+      CardinalityRecord(0, "a,ac", 72, 0, 7, 100)
+    )
+
+    t.topk(3, Nil, 1, true) shouldEqual Seq(
+      CardinalityRecord(0, "c", 5, 0, 1, 100),
+      CardinalityRecord(0, "a", 81, 0, 3, 100),
+      CardinalityRecord(0, "b", 35, 0, 4, 100)
+    )
     t.close()
   }
 }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -243,15 +243,15 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
 
     t.topk(3, Seq("a", "ac"), 3, true) shouldEqual Seq(
-      CardinalityRecord(0, "a,ac,acc", 11, 0, 11, 100),
-      CardinalityRecord(0, "a,ac,acg", 15, 0, 15, 100),
-      CardinalityRecord(0, "a,ac,acb", 20, 0, 20, 100)
+      CardinalityRecord(0, "acc", 11, 0, 11, 100),
+      CardinalityRecord(0, "acg", 15, 0, 15, 100),
+      CardinalityRecord(0, "acb", 20, 0, 20, 100)
     )
 
     t.topk(3, Seq("a"), 2, true) shouldEqual Seq(
-      CardinalityRecord(0, "a,aa", 4, 0, 4, 100),
-      CardinalityRecord(0, "a,ab", 5, 0, 5, 100),
-      CardinalityRecord(0, "a,ac", 72, 0, 7, 100)
+      CardinalityRecord(0, "aa", 4, 0, 4, 100),
+      CardinalityRecord(0, "ab", 5, 0, 5, 100),
+      CardinalityRecord(0, "ac", 72, 0, 7, 100)
     )
 
     t.topk(3, Nil, 1, true) shouldEqual Seq(

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -215,52 +215,53 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.close()
   }
 
-  it ("should be able to do topk") {
-    val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
-    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
-    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
-    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
-    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
-    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
-    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
-    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
-
-    (1 to 15).foreach(_ => t.modifyCount(Seq("b", "bc", "bcg"), 1, 0))
-    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bc", "bch"), 1, 0))
-    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bd", "bdh"), 1, 0))
-
-    (1 to 3).foreach(_ => t.modifyCount(Seq("c", "cc", "ccg"), 1, 0))
-    (1 to 2).foreach(_ => t.modifyCount(Seq("c", "cc", "cch"), 1, 0))
-
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
-    t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
-    t.modifyCount(Seq("a", "aa", "aad"), 1, 0)
-    t.modifyCount(Seq("b", "ba", "baa"), 1, 0)
-    t.modifyCount(Seq("b", "bb", "bba"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "aba"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abb"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abc"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
-
-    t.topk(3, Seq("a", "ac"), 3, true) shouldEqual Seq(
-      CardinalityRecord(0, Seq("a", "ac", "acc"), 11, 0, 11, 100),
-      CardinalityRecord(0, Seq("a", "ac", "acg"), 15, 0, 15, 100),
-      CardinalityRecord(0, Seq("a", "ac", "acb"), 20, 0, 20, 100)
-    )
-
-    t.topk(3, Seq("a"), 2, true) shouldEqual Seq(
-      CardinalityRecord(0, Seq("a", "aa"), 4, 0, 4, 100),
-      CardinalityRecord(0, Seq("a", "ab"), 5, 0, 5, 100),
-      CardinalityRecord(0, Seq("a", "ac"), 72, 0, 7, 100)
-    )
-
-    t.topk(3, Nil, 1, true) shouldEqual Seq(
-      CardinalityRecord(0, Seq("c"), 5, 0, 1, 100),
-      CardinalityRecord(0, Seq("a"), 81, 0, 3, 100),
-      CardinalityRecord(0, Seq("b"), 35, 0, 4, 100)
-    )
-    t.close()
-  }
+  // TODO(a_theimer)
+//  it ("should be able to do topk") {
+//    val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
+//    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
+//    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
+//    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
+//    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
+//    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
+//    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
+//    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
+//
+//    (1 to 15).foreach(_ => t.modifyCount(Seq("b", "bc", "bcg"), 1, 0))
+//    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bc", "bch"), 1, 0))
+//    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bd", "bdh"), 1, 0))
+//
+//    (1 to 3).foreach(_ => t.modifyCount(Seq("c", "cc", "ccg"), 1, 0))
+//    (1 to 2).foreach(_ => t.modifyCount(Seq("c", "cc", "cch"), 1, 0))
+//
+//    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+//    t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
+//    t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
+//    t.modifyCount(Seq("a", "aa", "aad"), 1, 0)
+//    t.modifyCount(Seq("b", "ba", "baa"), 1, 0)
+//    t.modifyCount(Seq("b", "bb", "bba"), 1, 0)
+//    t.modifyCount(Seq("a", "ab", "aba"), 1, 0)
+//    t.modifyCount(Seq("a", "ab", "abb"), 1, 0)
+//    t.modifyCount(Seq("a", "ab", "abc"), 1, 0)
+//    t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
+//    t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
+//
+//    t.scan(3, Seq("a", "ac"), 3, true) shouldEqual Seq(
+//      CardinalityRecord(0, Seq("a", "ac", "acc"), 11, 0, 11, 100),
+//      CardinalityRecord(0, Seq("a", "ac", "acg"), 15, 0, 15, 100),
+//      CardinalityRecord(0, Seq("a", "ac", "acb"), 20, 0, 20, 100)
+//    )
+//
+//    t.scan(3, Seq("a"), 2, true) shouldEqual Seq(
+//      CardinalityRecord(0, Seq("a", "aa"), 4, 0, 4, 100),
+//      CardinalityRecord(0, Seq("a", "ab"), 5, 0, 5, 100),
+//      CardinalityRecord(0, Seq("a", "ac"), 72, 0, 7, 100)
+//    )
+//
+//    t.scan(3, Nil, 1, true) shouldEqual Seq(
+//      CardinalityRecord(0, Seq("c"), 5, 0, 1, 100),
+//      CardinalityRecord(0, Seq("a"), 81, 0, 3, 100),
+//      CardinalityRecord(0, Seq("b"), 35, 0, 4, 100)
+//    )
+//    t.close()
+//  }
 }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -242,23 +242,24 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
     t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
 
-    t.topk(3, Seq("a", "ac"), true) shouldEqual Seq(
-      CardinalityRecord(0, "acc", 11, 0, 11, 100),
-      CardinalityRecord(0, "acg", 15, 0, 15, 100),
-      CardinalityRecord(0, "acb", 20, 0, 20, 100)
-    )
-
-    t.topk(3, Seq("a"), true) shouldEqual Seq(
-      CardinalityRecord(0, "aa", 4, 0, 4, 100),
-      CardinalityRecord(0, "ab", 5, 0, 5, 100),
-      CardinalityRecord(0, "ac", 72, 0, 7, 100)
-    )
-
-    t.topk(3, Nil, true) shouldEqual Seq(
-      CardinalityRecord(0, "c", 5, 0, 1, 100),
-      CardinalityRecord(0, "a", 81, 0, 3, 100),
-      CardinalityRecord(0, "b", 35, 0, 4, 100)
-    )
+    // TODO(a_theimer)
+//    t.topk(3, Seq("a", "ac"), true) shouldEqual Seq(
+//      CardinalityRecord(0, "acc", 11, 0, 11, 100),
+//      CardinalityRecord(0, "acg", 15, 0, 15, 100),
+//      CardinalityRecord(0, "acb", 20, 0, 20, 100)
+//    )
+//
+//    t.topk(3, Seq("a"), true) shouldEqual Seq(
+//      CardinalityRecord(0, "aa", 4, 0, 4, 100),
+//      CardinalityRecord(0, "ab", 5, 0, 5, 100),
+//      CardinalityRecord(0, "ac", 72, 0, 7, 100)
+//    )
+//
+//    t.topk(3, Nil, true) shouldEqual Seq(
+//      CardinalityRecord(0, "c", 5, 0, 1, 100),
+//      CardinalityRecord(0, "a", 81, 0, 3, 100),
+//      CardinalityRecord(0, "b", 35, 0, 4, 100)
+//    )
     t.close()
   }
 }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -245,21 +245,21 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
 
     t.topk(3, Seq("a", "ac"), 3, true) shouldEqual Seq(
-      CardinalityRecord(0, Cardinality(Seq("a", "ac", "acc"), 11, 0, 11, 100)),
-      CardinalityRecord(0, Cardinality(Seq("a", "ac", "acg"), 15, 0, 15, 100)),
-      CardinalityRecord(0, Cardinality(Seq("a", "ac", "acb"), 20, 0, 20, 100))
+      CardinalityRecord(0, Seq("a", "ac", "acc"), 11, 0, 11, 100),
+      CardinalityRecord(0, Seq("a", "ac", "acg"), 15, 0, 15, 100),
+      CardinalityRecord(0, Seq("a", "ac", "acb"), 20, 0, 20, 100)
     )
 
     t.topk(3, Seq("a"), 2, true) shouldEqual Seq(
-      CardinalityRecord(0, Cardinality(Seq("a", "aa"), 4, 0, 4, 100)),
-      CardinalityRecord(0, Cardinality(Seq("a", "ab"), 5, 0, 5, 100)),
-      CardinalityRecord(0, Cardinality(Seq("a", "ac"), 72, 0, 7, 100))
+      CardinalityRecord(0, Seq("a", "aa"), 4, 0, 4, 100),
+      CardinalityRecord(0, Seq("a", "ab"), 5, 0, 5, 100),
+      CardinalityRecord(0, Seq("a", "ac"), 72, 0, 7, 100)
     )
 
     t.topk(3, Nil, 1, true) shouldEqual Seq(
-      CardinalityRecord(0, Cardinality(Seq("c"), 5, 0, 1, 100)),
-      CardinalityRecord(0, Cardinality(Seq("a"), 81, 0, 3, 100)),
-      CardinalityRecord(0, Cardinality(Seq("b"), 35, 0, 4, 100))
+      CardinalityRecord(0, Seq("c"), 5, 0, 1, 100),
+      CardinalityRecord(0, Seq("a"), 81, 0, 3, 100),
+      CardinalityRecord(0, Seq("b"), 35, 0, 4, 100)
     )
     t.close()
   }

--- a/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
+++ b/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
@@ -115,8 +115,7 @@ object ZeroCopyBinary {
  */
 // scalastyle:off
 // FIXME Needs to use MemoryAccessor
-final class ZeroCopyUTF8String(val base: Any, val offset: Long, val numBytes: Int
-                  ) extends ZeroCopyBinary with Serializable {  // TODO(a_theimer): does this actually work?
+final class ZeroCopyUTF8String(val base: Any, val offset: Long, val numBytes: Int) extends ZeroCopyBinary {
   import ZeroCopyUTF8String._
   import filodb.memory.UTF8String._
 

--- a/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
+++ b/memory/src/main/scala/filodb.memory/format/ZeroCopyBinary.scala
@@ -115,7 +115,8 @@ object ZeroCopyBinary {
  */
 // scalastyle:off
 // FIXME Needs to use MemoryAccessor
-final class ZeroCopyUTF8String(val base: Any, val offset: Long, val numBytes: Int) extends ZeroCopyBinary {
+final class ZeroCopyUTF8String(val base: Any, val offset: Long, val numBytes: Int
+                  ) extends ZeroCopyBinary with Serializable {  // TODO(a_theimer): does this actually work?
   import ZeroCopyUTF8String._
   import filodb.memory.UTF8String._
 

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -126,12 +126,47 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
                                endMs: Long) extends MetadataQueryPlan
 
 /**
- * TODO(a_theimer): outdated
- * Given a shard key prefix, estimates the set of label values with the top k cardinalities.
- * See TopkCardExec for more some implementation-specific information
- *   about what "estimate" implies how that estimate can be tuned.
+ * Plan to answer queries of the abstract form:
+ *
+ * Find (active, total) cardinality pairs for all time series with <shard-key-prefix>,
+ *   then group them by ns[, ws[, metric]].
+ *
+ * Examples:
+ *
+ *  { prefix=[], groupDepth=1 } -> {
+ *      prefix=["ws_a", "ns_a"] -> (4, 6),
+ *      prefix=["ws_a", "ns_b"] -> (2, 4),
+ *      prefix=["ws_b", "ns_c"] -> (3, 5) }
+ *
+ *  { prefix=["ws_a", "ns_a"], groupDepth=2 } -> {
+ *      prefix=["ws_a", "ns_a", "met_a"] -> (4, 6),
+ *      prefix=["ws_a", "ns_a", "met_b"] -> (3, 5) }
+ *
+ *  { prefix=["ws_a"], groupDepth=0 } -> {
+ *      prefix=["ws_a"] -> (3, 5) }
+ *
+ * @param groupDepth: indicates "hierarchical depth" at which to group cardinalities:
+ *     0 -> workspace
+ *     1 -> namespace
+ *     2 -> metric
+ *   Must indicate a depth:
+ *     (1) at least as deep as shardKeyPrefix
+ *     (2) less than '2' when the prefix does not contain ws and ns
+ *   Specifically:
+ *     shardKeyPrefix     groupDepth
+ *     []                 { 0, 1 }
+ *     [ws]               { 0, 1 }
+ *     [ws, ns]           { 1, 2 }
+ *     [ws, ns, metric]   { 2 }
  */
-case class TsCardinalities(shardKeyPrefix: Seq[String]) extends LogicalPlan
+case class TsCardinalities(shardKeyPrefix: Seq[String], groupDepth: Int) extends LogicalPlan {
+  require(groupDepth >= 0 && groupDepth < 3,
+    "groupDepth must lie on [0, 2]")
+  require(1 + groupDepth >= shardKeyPrefix.size,
+    "groupDepth indicate a depth at least as deep as shardKeyPrefix")
+  require(groupDepth < 2 || shardKeyPrefix.size == 2,
+    "cannot group at the metric level when prefix does not contain ws and ns")
+}
 
 /**
  * Concrete logical plan to query for chunk metadata from raw time series in a given range

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -29,7 +29,7 @@ sealed trait LogicalPlan {
       case l: LabelValues              => l.copy(filters = filters)
       case n: LabelNames               => n.copy(filters = filters)
       case s: SeriesKeysByFilters      => s.copy(filters = filters)
-      case c: TopkCardinalities        => c.copy()
+      case c: TsCardinalities          => c.copy()
     }
   }
 }
@@ -126,11 +126,12 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
                                endMs: Long) extends MetadataQueryPlan
 
 /**
+ * TODO(a_theimer): outdated
  * Given a shard key prefix, estimates the set of label values with the top k cardinalities.
  * See TopkCardExec for more some implementation-specific information
  *   about what "estimate" implies how that estimate can be tuned.
  */
-case class TopkCardinalities(shardKeyPrefix: Seq[String], k: Int, addInactive: Boolean) extends LogicalPlan
+case class TsCardinalities(shardKeyPrefix: Seq[String]) extends LogicalPlan
 
 /**
  * Concrete logical plan to query for chunk metadata from raw time series in a given range
@@ -554,7 +555,7 @@ object LogicalPlan {
      // Find leaf logical plans for all children and concatenate results
      case lp: NonLeafLogicalPlan          => lp.children.flatMap(findLeafLogicalPlans)
      case lp: MetadataQueryPlan           => Seq(lp)
-     case lp: TopkCardinalities           => Seq(lp)
+     case lp: TsCardinalities             => Seq(lp)
      case lp: ScalarBinaryOperation       => val lhsLeafs = if (lp.lhs.isRight) findLeafLogicalPlans(lp.lhs.right.get)
                                                              else Nil
                                              val rhsLeafs = if (lp.rhs.isRight) findLeafLogicalPlans(lp.rhs.right.get)

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -126,6 +126,20 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
                                endMs: Long) extends MetadataQueryPlan
 
 /**
+ * Used to identify how a TsCardinalities result should be grouped.
+ */
+object GroupDepth extends Enumeration {
+  protected case class GroupDepthVal(prefixIndex: Int) extends super.Val
+
+  import scala.language.implicitConversions
+  implicit def valueToGroupDepthVal(v: Value): GroupDepthVal = v.asInstanceOf[GroupDepthVal]
+
+  val WS = GroupDepthVal(0)
+  val NS = GroupDepthVal(1)
+  val METRIC = GroupDepthVal(2)
+}
+
+/**
  * Plan to answer queries of the abstract form:
  *
  * Find (active, total) cardinality pairs for all time series with <shard-key-prefix>,
@@ -133,38 +147,33 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
  *
  * Examples:
  *
- *  { prefix=[], groupDepth=1 } -> {
+ *  { prefix=[], groupDepth=NS } -> {
  *      prefix=["ws_a", "ns_a"] -> (4, 6),
  *      prefix=["ws_a", "ns_b"] -> (2, 4),
  *      prefix=["ws_b", "ns_c"] -> (3, 5) }
  *
- *  { prefix=["ws_a", "ns_a"], groupDepth=2 } -> {
+ *  { prefix=["ws_a", "ns_a"], groupDepth=METRIC } -> {
  *      prefix=["ws_a", "ns_a", "met_a"] -> (4, 6),
  *      prefix=["ws_a", "ns_a", "met_b"] -> (3, 5) }
  *
- *  { prefix=["ws_a"], groupDepth=0 } -> {
+ *  { prefix=["ws_a"], groupDepth=WS } -> {
  *      prefix=["ws_a"] -> (3, 5) }
  *
  * @param groupDepth: indicates "hierarchical depth" at which to group cardinalities:
- *     0 -> workspace
- *     1 -> namespace
- *     2 -> metric
  *   Must indicate a depth:
  *     (1) at least as deep as shardKeyPrefix
- *     (2) less than '2' when the prefix does not contain ws and ns
+ *     (2) less than METRIC when the prefix does not contain ws and ns
  *   Specifically:
  *     shardKeyPrefix     groupDepth
- *     []                 { 0, 1 }
- *     [ws]               { 0, 1 }
- *     [ws, ns]           { 1, 2 }
- *     [ws, ns, metric]   { 2 }
+ *     []                 { WS, NS }
+ *     [ws]               { WS, NS }
+ *     [ws, ns]           { NS, METRIC }
+ *     [ws, ns, metric]   { METRIC }
  */
-case class TsCardinalities(shardKeyPrefix: Seq[String], groupDepth: Int) extends LogicalPlan {
-  require(groupDepth >= 0 && groupDepth < 3,
-    "groupDepth must lie on [0, 2]")
-  require(1 + groupDepth >= shardKeyPrefix.size,
-    "groupDepth indicate a depth at least as deep as shardKeyPrefix")
-  require(groupDepth < 2 || shardKeyPrefix.size == 2,
+case class TsCardinalities(shardKeyPrefix: Seq[String], groupDepth: GroupDepth.Value) extends LogicalPlan {
+  require(1 + groupDepth.prefixIndex >= shardKeyPrefix.size,
+    "groupDepth must indicate a depth at least as deep as shardKeyPrefix")
+  require(groupDepth != GroupDepth.METRIC || shardKeyPrefix.size == 2,
     "cannot group at the metric level when prefix does not contain ws and ns")
 }
 

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -29,7 +29,7 @@ sealed trait LogicalPlan {
       case l: LabelValues              => l.copy(filters = filters)
       case n: LabelNames               => n.copy(filters = filters)
       case s: SeriesKeysByFilters      => s.copy(filters = filters)
-      case c: TsCardinalities          => c.copy()
+      case c: TsCardinalities          => c  // immutable & no members need to be updated
     }
   }
 }

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -129,7 +129,7 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
  * Plan to answer queries of the abstract form:
  *
  * Find (active, total) cardinality pairs for all time series with <shard-key-prefix>,
- *   then group them by ns[, ws[, metric]].
+ *   then group them by { key[:1], key[:2], key[:3], ... }.
  *
  * Examples:
  *
@@ -145,14 +145,15 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
  *  { prefix=["ws_a"], groupDepth=0 } -> {
  *      prefix=["ws_a"] -> (3, 5) }
  *
- * @param groupDepth: indicates "hierarchical depth" at which to group cardinalities:
+ * @param groupDepth: indicates "hierarchical depth" at which to group cardinalities.
+ *   For example:
  *     0 -> workspace
  *     1 -> namespace
  *     2 -> metric
  *   Must indicate a depth:
- *     (1) at least as deep as shardKeyPrefix
- *     (2) less than '2' when the prefix does not contain ws and ns
- *   Specifically:
+ *     (1) at least as deep as shardKeyPrefix.
+ *     (2) less than '2' when the prefix does not contain values for all lesser depths.
+ *   Example (if shard keys specify a ws, ns, and metric):
  *     shardKeyPrefix     groupDepth
  *     []                 { 0, 1 }
  *     [ws]               { 0, 1 }

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -76,7 +76,8 @@ case class UnsupportedChunkSource() extends ChunkSource {
 
   override def isDownsampleStore: Boolean = false
 
-  override def scanTsCardinalities(ref: DatasetRef, shards: Seq[Int], shardKeyPrefix: Seq[String], depth: Int): scala.Seq[CardinalityRecord] =
+  override def scanTsCardinalities(ref: DatasetRef, shards: Seq[Int],
+                                   shardKeyPrefix: Seq[String], depth: Int): scala.Seq[CardinalityRecord] =
     throw new UnsupportedOperationException("This operation is not supported")
 
   override def acquireSharedLock(ref: DatasetRef, shardNum: Int, querySession: QuerySession): Unit =

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -79,6 +79,7 @@ case class UnsupportedChunkSource() extends ChunkSource {
   override def topKCardinality(ref: DatasetRef,
                                shards: Seq[Int],
                                shardKeyPrefix: scala.Seq[String],
+                               depth: Int,
                                k: Int,
                                addInactive: Boolean): scala.Seq[CardinalityRecord] =
     throw new UnsupportedOperationException("This operation is not supported")

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -76,12 +76,7 @@ case class UnsupportedChunkSource() extends ChunkSource {
 
   override def isDownsampleStore: Boolean = false
 
-  override def topKCardinality(ref: DatasetRef,
-                               shards: Seq[Int],
-                               shardKeyPrefix: scala.Seq[String],
-                               depth: Int,
-                               k: Int,
-                               addInactive: Boolean): scala.Seq[CardinalityRecord] =
+  override def scanTsCardinalities(ref: DatasetRef, shards: Seq[Int], shardKeyPrefix: Seq[String], depth: Int): scala.Seq[CardinalityRecord] =
     throw new UnsupportedOperationException("This operation is not supported")
 
   override def acquireSharedLock(ref: DatasetRef, shardNum: Int, querySession: QuerySession): Unit =

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -410,17 +410,17 @@ final case class TsCardExec(queryContext: QueryContext,
     source.checkReadyForQuery(dataset, shard, querySession)
     source.acquireSharedLock(dataset, shard, querySession)
 
-    // TODO(a_theimer): cleanup
     val rvs = source match {
       case tsMemStore: TimeSeriesMemStore =>
         Observable.eval {
           val it =
-            tsMemStore.topKCardinality(dataset, Seq(shard),
-              shardKeyPrefix, groupDepth + 1,
-              MAX_RESPONSE_SIZE, ADD_INACTIVE).map{ card =>
+            tsMemStore.topKCardinality(
+              dataset, Seq(shard), shardKeyPrefix, groupDepth + 1,
+              MAX_RESPONSE_SIZE, ADD_INACTIVE)
+            .map{ card =>
               RowData(card.card.prefix.mkString(PREFIX_DELIM).utf8,
                       CardCounts(card.card.activeTsCount, card.card.tsCount))
-                .toRowReader()
+              .toRowReader()
             }.iterator
 
           IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty), NoCloseCursor(it), None)

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -144,7 +144,7 @@ final case class TsCardReduceExec(queryContext: QueryContext,
   * Dynamically packages the (prefix -> cardinalities) map into a RangeVector,
   *   where its width and column names depend upon the size of each shard key prefix.
   */
-final case class TsCardPresenter(groupDepth: Int) extends RangeVectorTransformer {
+final case class TsCardPresenter(groupDepth: GroupDepth.Value) extends RangeVectorTransformer {
   import TsCardExec._
 
   override def funcParams: Seq[FuncArgs] = Nil
@@ -173,10 +173,10 @@ final case class TsCardPresenter(groupDepth: Int) extends RangeVectorTransformer
 
   override def schema(source: ResultSchema): ResultSchema = {
     // append the appropriate columns according to groupDepth
-    val nameColSeq = new mutable.ArrayBuffer[String](1 + groupDepth)
+    val nameColSeq = new mutable.ArrayBuffer[String](1 + groupDepth.prefixIndex)
     nameColSeq.append("ws")
-    if (groupDepth > 0) nameColSeq.append("ns")
-    if (groupDepth > 1) nameColSeq.append("metric")
+    if (groupDepth.prefixIndex > 0) nameColSeq.append("ns")
+    if (groupDepth.prefixIndex > 1) nameColSeq.append("metric")
     ResultSchema(
       Seq(
         nameColSeq.map(s => ColumnInfo(s, ColumnType.StringColumn)),
@@ -446,10 +446,8 @@ final case class TsCardExec(queryContext: QueryContext,
                             dataset: DatasetRef,
                             shard: Int,
                             shardKeyPrefix: Seq[String],
-                            groupDepth: Int) extends LeafExecPlan {
-  require(groupDepth >= 0,
-    "groupDepth must be non-negative")
-  require(1 + groupDepth >= shardKeyPrefix.size,
+                            groupDepth: GroupDepth.Value) extends LeafExecPlan {
+  require(1 + groupDepth.prefixIndex >= shardKeyPrefix.size,
     "groupDepth indicate a depth at least as deep as shardKeyPrefix")
 
   override def enforceLimit: Boolean = false
@@ -576,7 +574,7 @@ final case class TsCardExec(queryContext: QueryContext,
     val rvs = source match {
       case tsMemStore: TimeSeriesMemStore =>
         Observable.eval {
-          val countMap = if (groupDepth == shardKeyPrefix.size - 1) {
+          val countMap = if (groupDepth.prefixIndex == shardKeyPrefix.size - 1) {
             // shardKeyPrefix is as deep as the groupDepth; we execute only a single topKCardinality
             //   call on the "prefix's prefix", then map the prefix to its cardinality iff the
             //   "deepest" prefix label is found in the results.
@@ -591,14 +589,14 @@ final case class TsCardExec(queryContext: QueryContext,
             }
           } else {
             // groupDepth is deeper than shardKeyPrefix.
-            // We will "expand" shardKeyPrefix into all of its child prefixes at groupDepth - 1,
+            // We will "expand" shardKeyPrefix into all of its child prefixes at groupDepth.prefixIndex - 1,
             //   then we'll pass the children to memstore.topKCardinality and map the results.
 
             // The conditional exists because PrefixIterator currently
             //   needs to extend a prefix to a size > 0
-            val prefixIter = if (groupDepth > 0) {
-              // Note: groupDepth equals the length of the prefix to extend to (at groupDepth - 1)
-              new PrefixIterator(tsMemStore, shardKeyPrefix, groupDepth)
+            val prefixIter = if (groupDepth.prefixIndex > 0) {
+              // Note: groupDepth.prefixIndex equals the length of the prefix to extend to (at groupDepth - 1)
+              new PrefixIterator(tsMemStore, shardKeyPrefix, groupDepth.prefixIndex)
             } else {
               Seq(Seq()).iterator
             }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -132,7 +132,7 @@ final case class TsCardReduceExec(queryContext: QueryContext,
     }.flatten
       .foldLeftL(new mutable.HashMap[Seq[ZeroCopyUTF8String], CardCounts])(mapFold)
       .map{ aggMap =>
-        val serMap = ZeroCopyUTF8String(SerializeUtils.serialize(aggMap.toMap))  // TODO(a_theimer): toMap needed?
+        val serMap = ZeroCopyUTF8String(SerializeUtils.serialize(aggMap.toMap))
         val it = Seq(SingleValueRowReader(serMap)).iterator
         IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty), NoCloseCursor(it), None)
       }
@@ -431,7 +431,6 @@ final case object TsCardExec {
 
   val OVERFLOW_NAME = "_overflow_".utf8
 
-  // TODO(a_theimer): Int? Long?
   case class CardCounts(active: Int, total: Int) {
     require(total >= active, "total must be at least as large as active")
   }
@@ -482,7 +481,6 @@ final case class TsCardExec(queryContext: QueryContext,
 
     private var iFirstEmptyQueue = -1
 
-    // TODO(a_theimer): this feels gross
     initialize()
 
     private def initialize(): Unit = {
@@ -541,7 +539,6 @@ final case class TsCardExec(queryContext: QueryContext,
         // Fill each successive queue with the topKCardinality result such that
         //   its argument prefix is defined by the preceding queue front labels.
         for (iempty <- iFirstEmptyQueue until extendToSize) {
-          // TODO(a_theimer): MAX_RESPONSE_SIZE works, but not exactly the same meaning
           tsMemStore.topKCardinality(dataset, Seq(shard), currPrefix,
             MAX_RESPONSE_SIZE, ADD_INACTIVE).foreach{ card =>
             spaceQueues(iempty).enqueue(card.childName)

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -414,9 +414,7 @@ final case class TsCardExec(queryContext: QueryContext,
       case tsMemStore: TimeSeriesMemStore =>
         Observable.eval {
           val it =
-            tsMemStore.topKCardinality(
-              dataset, Seq(shard), shardKeyPrefix, groupDepth + 1,
-              MAX_RESPONSE_SIZE, ADD_INACTIVE)
+            tsMemStore.scanTsCardinalities(dataset, Seq(shard), shardKeyPrefix, groupDepth + 1)
             .map{ card =>
               RowData(card.prefix.mkString(PREFIX_DELIM).utf8,
                       CardCounts(card.activeTsCount, card.tsCount))

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -447,6 +447,10 @@ final case class TsCardExec(queryContext: QueryContext,
                             shard: Int,
                             shardKeyPrefix: Seq[String],
                             groupDepth: Int) extends LeafExecPlan {
+  require(groupDepth >= 0,
+    "groupDepth must be non-negative")
+  require(1 + groupDepth >= shardKeyPrefix.size,
+    "groupDepth indicate a depth at least as deep as shardKeyPrefix")
 
   override def enforceLimit: Boolean = false
 
@@ -458,11 +462,16 @@ final case class TsCardExec(queryContext: QueryContext,
    *
    * @param tsMemStore contains the shard keys over which to iterate
    * @param initPrefix shard key prefix to resolve
-   * @param extendToSize the length of the prefix children to iterate through
+   * @param extendToSize the length of the prefix children to iterate through.
+   *   Must be at (1) least initPrefix.size and (2) greater than zero.
    */
   class PrefixIterator (tsMemStore: TimeSeriesMemStore,
                         initPrefix: Seq[String],
                         extendToSize: Int) extends Iterator[Seq[String]]{
+    require(extendToSize > 0,
+      "extendToSize must be positive")
+    require(extendToSize >= initPrefix.size,
+      "extendToSize must be at least initPrefix.size")
 
     // A queue for each set of "space" (i.e. namespace, workspace, metric) labels.
     // Spaces are stored in descending precedence, and each successive queue

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -418,8 +418,8 @@ final case class TsCardExec(queryContext: QueryContext,
               dataset, Seq(shard), shardKeyPrefix, groupDepth + 1,
               MAX_RESPONSE_SIZE, ADD_INACTIVE)
             .map{ card =>
-              RowData(card.card.prefix.mkString(PREFIX_DELIM).utf8,
-                      CardCounts(card.card.activeTsCount, card.card.tsCount))
+              RowData(card.prefix.mkString(PREFIX_DELIM).utf8,
+                      CardCounts(card.activeTsCount, card.tsCount))
               .toRowReader()
             }.iterator
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -1,8 +1,9 @@
 package filodb.query.exec
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
 import scala.collection.mutable
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -17,7 +18,7 @@ import filodb.core.query.NoCloseCursor.NoCloseCursor
 import filodb.core.store.ChunkSource
 import filodb.memory.{UTF8StringMedium, UTF8StringShort}
 import filodb.memory.format.{SeqRowReader, SingleValueRowReader, StringArrayRowReader,
-                             UTF8MapIteratorRowReader, UnsafeUtils, ZeroCopyUTF8String}
+                             UnsafeUtils, UTF8MapIteratorRowReader, ZeroCopyUTF8String}
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 import filodb.query.Query.qLogger
@@ -545,7 +546,7 @@ final case class TsCardExec(queryContext: QueryContext,
     }
   }
 
-  // scalastyle:off cyclomatic.complexity
+  // scalastyle:off method.length
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = {
@@ -607,7 +608,7 @@ final case class TsCardExec(queryContext: QueryContext,
     val sch = ResultSchema(Seq(ColumnInfo("TsCardMap", ColumnType.StringColumn)), 1)
     ExecResult(rvs, Task.eval(sch))
   }
-  // scalastyle:on cyclomatic.complexity
+  // scalastyle:on method.length
 
   def args: String = s"shard=$shard, shardKeyPrefix=$shardKeyPrefix, " +
     s"limit=${queryContext.plannerParams.sampleLimit}"

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -418,7 +418,9 @@ final case class TsCardExec(queryContext: QueryContext,
             tsMemStore.topKCardinality(dataset, Seq(shard),
               shardKeyPrefix, groupDepth + 1,
               MAX_RESPONSE_SIZE, ADD_INACTIVE).map{ card =>
-              RowData(card.childName.utf8, CardCounts(card.activeTsCount, card.tsCount)).toRowReader()
+              RowData(card.card.prefix.mkString(PREFIX_DELIM).utf8,
+                      CardCounts(card.card.activeTsCount, card.card.tsCount))
+                .toRowReader()
             }.iterator
 
           IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty), NoCloseCursor(it), None)

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -537,6 +537,7 @@ final case class TsCardExec(queryContext: QueryContext,
       } else {
         currPrefix.reduceToSize(iFirstEmptyQueue)
         if (iFirstEmptyQueue > 0) {
+          // this space name is still unused
           currPrefix(iFirstEmptyQueue - 1) = spaceQueues(iFirstEmptyQueue - 1).front
         }
         // Fill each successive queue with the topKCardinality result such that
@@ -547,7 +548,7 @@ final case class TsCardExec(queryContext: QueryContext,
             MAX_RESPONSE_SIZE, ADD_INACTIVE).foreach{ card =>
             spaceQueues(iempty).enqueue(card.childName)
           }
-          // currPrefix will contain all front labels
+          // currPrefix will contain all front labels, so we store them as we iterate
           currPrefix.append(spaceQueues(iempty).front)
         }
       }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -576,7 +576,7 @@ final case class TsCardExec(queryContext: QueryContext,
                                                  MAX_RESPONSE_SIZE, ADD_INACTIVE)
               .find(card => card.childName == shardKeyPrefix.last)
             if (res.nonEmpty) {
-              Map(shardKeyPrefix -> CardCounts(res.get.activeTsCount, res.get.tsCount))
+              Map(shardKeyPrefix.map(_.utf8).toSeq -> CardCounts(res.get.activeTsCount, res.get.tsCount))
             } else {
               Map()
             }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -447,7 +447,7 @@ final case class TsCardExec(queryContext: QueryContext,
         Observable.eval {
           val cards = tsMemStore.scanTsCardinalities(
             dataset, Seq(shard), shardKeyPrefix, groupDepth + 1)
-          val it = cards.take(MAX_RESULT_SIZE).map{ card =>
+          val it = cards.map{ card =>
             CardRowReader(prefixToGroup(card.prefix),
                           CardCounts(card.activeTsCount, card.tsCount))
             }.iterator

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -54,7 +54,9 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
       ("http_req_total", Map("instance"->"someHost:9090", "job"->"myCoolService",
                              "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo", "_ns_" -> "App-0")),
       ("http_bar_total", Map("instance"->"someHost:8787", "job"->"myCoolService",
-                             "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo", "_ns_" -> "App-0"))
+                             "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo", "_ns_" -> "App-0")),
+      ("http_req_total-A", Map("instance"->"someHost:9090", "job"->"myCoolService",
+                             "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo-A", "_ns_" -> "App-A")),
     )
   )
 
@@ -288,38 +290,32 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     // Note: these strings are eventually converted to ZeroCopyUTF8Strings.
     Seq(
       TestSpec(Seq(), 0, Map(
-        Seq("demo") -> CardCounts(4,4)
-      )),
+        Seq("demo-A") -> CardCounts(1,1),
+        Seq("demo") -> CardCounts(4,4))),
       TestSpec(Seq(), 1, Map(
-        Seq("demo", "App-0") -> CardCounts(4,4)
-      )),
+        Seq("demo", "App-0") -> CardCounts(4,4),
+        Seq("demo-A", "App-A") -> CardCounts(1,1))),
       TestSpec(Seq(), 2, Map(
         Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1),
         Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2),
-        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1)
-      )),
+        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1),
+        Seq("demo-A", "App-A", "http_req_total-A") -> CardCounts(1,1))),
       TestSpec(Seq("demo"), 0, Map(
-        Seq("demo") -> CardCounts(4,4)
-      )),
+        Seq("demo") -> CardCounts(4,4))),
       TestSpec(Seq("demo"), 1, Map(
-        Seq("demo", "App-0") -> CardCounts(4,4)
-      )),
+        Seq("demo", "App-0") -> CardCounts(4,4))),
       TestSpec(Seq("demo"), 2, Map(
         Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1),
         Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2),
-        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1)
-      )),
+        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1))),
       TestSpec(Seq("demo", "App-0"), 1, Map(
-        Seq("demo", "App-0") -> CardCounts(4,4)
-      )),
+        Seq("demo", "App-0") -> CardCounts(4,4))),
       TestSpec(Seq("demo", "App-0"), 2, Map(
         Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1),
         Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2),
-        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1)
-      )),
+        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1))),
       TestSpec(Seq("demo", "App-0", "http_req_total"), 2, Map(
-        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2)
-      ))
+        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2)))
     ).foreach{ testSpec =>
 
       val leaves = (0 until shardPartKeyLabelValues.size).map{ ishard =>

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -340,7 +340,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
           }.toMap
 
           resultMap shouldEqual testSpec.exp.map { case (prefix, counts) =>
-            prefix.mkString(PREFIX_DELIM).utf8 -> counts
+            prefixToGroup(prefix) -> counts
           }.toMap
       }
     }

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -285,36 +285,36 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
   }
 
   it ("should correctly execute TsCardExec") {
-    case class TestSpec(shardKeyPrefix: Seq[String], groupDepth: Int, exp: Map[Seq[String], CardCounts])
+    case class TestSpec(shardKeyPrefix: Seq[String], groupDepth: GroupDepth.Value, exp: Map[Seq[String], CardCounts])
 
     // Note: these strings are eventually converted to ZeroCopyUTF8Strings.
     Seq(
-      TestSpec(Seq(), 0, Map(
+      TestSpec(Seq(), GroupDepth.WS, Map(
         Seq("demo-A") -> CardCounts(1,1),
         Seq("demo") -> CardCounts(4,4))),
-      TestSpec(Seq(), 1, Map(
+      TestSpec(Seq(), GroupDepth.NS, Map(
         Seq("demo", "App-0") -> CardCounts(4,4),
         Seq("demo-A", "App-A") -> CardCounts(1,1))),
-      TestSpec(Seq(), 2, Map(
+      TestSpec(Seq(), GroupDepth.METRIC, Map(
         Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1),
         Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2),
         Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1),
         Seq("demo-A", "App-A", "http_req_total-A") -> CardCounts(1,1))),
-      TestSpec(Seq("demo"), 0, Map(
+      TestSpec(Seq("demo"), GroupDepth.WS, Map(
         Seq("demo") -> CardCounts(4,4))),
-      TestSpec(Seq("demo"), 1, Map(
+      TestSpec(Seq("demo"), GroupDepth.NS, Map(
         Seq("demo", "App-0") -> CardCounts(4,4))),
-      TestSpec(Seq("demo"), 2, Map(
+      TestSpec(Seq("demo"), GroupDepth.METRIC, Map(
         Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1),
         Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2),
         Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1))),
-      TestSpec(Seq("demo", "App-0"), 1, Map(
+      TestSpec(Seq("demo", "App-0"), GroupDepth.NS, Map(
         Seq("demo", "App-0") -> CardCounts(4,4))),
-      TestSpec(Seq("demo", "App-0"), 2, Map(
+      TestSpec(Seq("demo", "App-0"), GroupDepth.METRIC, Map(
         Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1),
         Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2),
         Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1))),
-      TestSpec(Seq("demo", "App-0", "http_req_total"), 2, Map(
+      TestSpec(Seq("demo", "App-0", "http_req_total"), GroupDepth.METRIC, Map(
         Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2)))
     ).foreach{ testSpec =>
 
@@ -333,8 +333,10 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
           response.size shouldEqual 1
 
           val resultMap = response(0).rows().map{r =>
-            val prefix = (0 to testSpec.groupDepth).map(i => r.getAny(i).asInstanceOf[ZeroCopyUTF8String]).toSeq
-            val counts = CardCounts(r.getInt(testSpec.groupDepth + 1), r.getInt(testSpec.groupDepth + 2))
+            val prefix = (0 to testSpec.groupDepth.prefixIndex)
+              .map(i => r.getAny(i).asInstanceOf[ZeroCopyUTF8String]).toSeq
+            val counts = CardCounts(r.getInt(testSpec.groupDepth.prefixIndex + 1),
+                                    r.getInt(testSpec.groupDepth.prefixIndex + 2))
             prefix -> counts
           }.toMap
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**
This infrastructure supports hierarchical cardinality queries of the abstract form:
```
Find (active, total) cardinality pairs for all time series with <shard-key-prefix>,
  then group them by { key[:1], key[:2], key[:3], ... }.
```

## `TsCardinalities extends LogicalPlan`
Initialized with a `shardKeyPrefix` and an integer `groupDepth`, which specifies the "hierarchical depth" at which to aggregate the cardinalities.

Examples:
```
{ prefix=[], groupDepth=1 } -> {
    prefix=["ws_a", "ns_a"] -> (4, 6),
    prefix=["ws_a", "ns_b"] -> (2, 4),
    prefix=["ws_b", "ns_c"] -> (3, 5) }

{ prefix=["ws_a", "ns_a"], groupDepth=2 } -> {
    prefix=["ws_a", "ns_a", "met_a"] -> (4, 6),
    prefix=["ws_a", "ns_a", "met_b"] -> (3, 5) }

{ prefix=["ws_a"], groupDepth=0 } -> {
    prefix=["ws_a"] -> (3, 5) }
```

Note that `groupDepth` must specify a hierarchical depth that's:

1. at least as deep as shardKeyPrefix
2. less than '2' when the prefix does not contain values for all lesser depths.

Example (if shard keys specify a ws, ns, and metric):
```
  shardKeyPrefix     groupDepth
  []                 { WS, NS }
  [ws]               { WS, NS }
  [ws, ns]           { NS, METRIC }
  [ws, ns, metric]   { METRIC }                                                         
```

## `TsCardExec extends ExecPlan` (and `TsCardReduceExec`)

The `RangeVector` produced by `execute` has the schema:
```
[group:String, active:Int, total:Int]
```
where:
- the "group" column contains the group-by prefix values concatenated by a `,` delimiter.
- the "active" and "total" columns give the cardinalities for (1) only the actively-ingesting timeseries and (2) all timeseries, respectively.

Note that, during aggregation, an aggregator `TsCardReduceExec` with a pending result of size `MAX_RESPONSE_SIZE=5000` will count subsequent cardinalities of previously-unseen prefixes into an overflow bucket. The count for this bucket is specified by the result row with `group=_overflow_`.

## `tscard` CLI command

Invoke the CLI command as:
```
--host <hostname/IP> [--port ...] --command tscard --dataset <dataset> --shardkeyprefix <shard-key-prefix> --groupdepth {0, 1, 2}
```

Examples:
```
$ ./filo-cli --host 127.0.0.1 --dataset prometheus --command tscard --shardkeyprefix --groupdepth ws
Output schema: ResultSchema(List(ColumnInfo(group,StringColumn), ColumnInfo(active,IntColumn), ColumnInfo(total,IntColumn)),1,Map(),None,List())
Number of Range Vectors: 1
/shard:/Map()
	demo-1	500	500
	demo-0	500	500

$ ./filo-cli --host 127.0.0.1 --dataset prometheus --command tscard --shardkeyprefix --groupdepth 1
Output schema: ResultSchema(List(ColumnInfo(group,StringColumn), ColumnInfo(active,IntColumn), ColumnInfo(total,IntColumn)),1,Map(),None,List())
Number of Range Vectors: 1
/shard:/Map()
	demo-0,App-3	124	124
	demo-1,App-1	124	124
	demo-1,App-3	124	124
	demo-0,App-1	124	124
	demo-0,App-2	124	124
	demo-1,App-2	124	124
	demo-0,App-0	128	128
	demo-1,App-0	128	128

$ ./filo-cli --host 127.0.0.1 --dataset prometheus --command tscard --shardkeyprefix demo-0 --groupdepth 0
Output schema: ResultSchema(List(ColumnInfo(group,StringColumn), ColumnInfo(active,IntColumn), ColumnInfo(total,IntColumn)),1,Map(),None,List())
Number of Range Vectors: 1
/shard:/Map()
	demo-0	500	500

$ ./filo-cli --host 127.0.0.1 --dataset prometheus --command tscard --shardkeyprefix demo-0 --groupdepth 1
Output schema: ResultSchema(List(ColumnInfo(group,StringColumn), ColumnInfo(active,IntColumn), ColumnInfo(total,IntColumn)),1,Map(),None,List())
Number of Range Vectors: 1
/shard:/Map()
	demo-0,App-3	124	124
	demo-0,App-2	124	124
	demo-0,App-0	128	128
	demo-0,App-1	124	124

$ ./filo-cli --host 127.0.0.1 --dataset prometheus --command tscard --shardkeyprefix demo-0 App-0 --groupdepth 2
Output schema: ResultSchema(List(ColumnInfo(group,StringColumn), ColumnInfo(active,IntColumn), ColumnInfo(total,IntColumn)),1,Map(),None,List())
Number of Range Vectors: 1
/shard:/Map()
	demo-0,App-0,heap_usage-3	32	32
	demo-0,App-0,heap_usage-1	32	32
	demo-0,App-0,heap_usage-2	32	32
	demo-0,App-0,heap_usage-0	32	32
```

### Important Notes:
- The `LogicalPlan` and `ExecPlan` infrastructure to support `topkcard` (i.e. all `ItemsSketch`-related code) has been removed.