### PR TITLE
bug(sparkJobs): Sleep for 1m to ensure completion metrics publish

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -132,6 +132,7 @@ class Downsampler(settings: DownsamplerSettings, batchDownsampler: BatchDownsamp
     val downsampleHourStartGauge = Kamon.gauge("chunk-downsampler-period-start-hour")
       .withTag("downsamplePeriod", downsamplePeriodStr)
     downsampleHourStartGauge.update(userTimeStart / 1000 / 60 / 60)
+    Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
     spark
   }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -87,6 +87,7 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
       sparkTasksFailed.increment
       throw e
     }
+    Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
   }
 
   def migrateWithDownsamplePartKeys(partKeys: Observable[PartKeyRecord], shard: Int): Int = {

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -121,6 +121,7 @@ class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSInde
         .withTag("downsamplePeriod", downsamplePeriodStr)
       downsampleHourStartGauge.update(userTimeStart / 1000 / 60 / 60)
     }
+    Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
     spark
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

In some metrics publishers, final job metrics do not get published despite Kamon shutdown hook.
This is a quick "sleep" hack to ensure that metrics get published before driver and worker shutdown.