### PR TITLE
fix(query): MultiPartitionPlanner: Create series match query from logicalplan

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -2,6 +2,7 @@ package filodb.coordinator.queryplanner
 
 import org.apache.commons.text.StringEscapeUtils
 
+import filodb.core.query.ColumnFilter
 import filodb.prometheus.ast.Vectors.PromMetricLabel
 import filodb.prometheus.ast.WindowConstants
 import filodb.query._
@@ -25,8 +26,12 @@ object QueryConstants {
 object LogicalPlanParser {
   import QueryConstants._
 
-  private def getFiltersFromRawSeries(lp: RawSeries)= lp.filters.map(f => (f.column, f.filter.operatorString,
-    Quotes + StringEscapeUtils.escapeJava(f.filter.valuesStrings.head.toString) + Quotes))
+  private def getFiltersFromRawSeries(lp: RawSeries)= getFiltersFromColumnFilters(lp.filters)
+
+  private def getFiltersFromColumnFilters(filters: Seq[ColumnFilter]) = {
+    filters.map(f => (f.column, f.filter.operatorString,
+      Quotes + StringEscapeUtils.escapeJava(f.filter.valuesStrings.head.toString) + Quotes))
+  }
 
   private def filtersToQuery(filters: Seq[(String, String, String)], columns: Seq[String],
                              lookback: Option[Long], offset: Option[Long], addWindow: Boolean): String = {
@@ -186,6 +191,16 @@ object LogicalPlanParser {
     val sqClause =
       s"${OpeningSquareBracket}${(tlsq.orginalLookbackMs)/1000}s:${tlsq.stepMs/1000}s$ClosingSquareBracket"
     s"${periodicSeriesQuery}${sqClause}${offset}"
+  }
+
+  def metatadataMatchToQuery(lp: MetadataQueryPlan): String = {
+    lp match {
+      case lp: SeriesKeysByFilters    => filtersToQuery(
+        getFiltersFromColumnFilters(lp.filters), Seq.empty, Option.empty, Option.empty, false)
+      case lp: LabelNames             => filtersToQuery(
+        getFiltersFromColumnFilters(lp.filters), Seq.empty, Option.empty, Option.empty, false)
+      case _                          => throw new UnsupportedOperationException(s"$lp can't be converted to Query")
+    }
   }
 
   def convertToQuery(logicalPlan: LogicalPlan): String = {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -299,7 +299,8 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
         if (p.partitionName.equals(localPartitionName))
           localPartitionPlanner.materialize(lp.copy(startMs = p.timeRange.startMs, endMs = p.timeRange.endMs), qContext)
         else
-          createMetadataRemoteExec(qContext, queryParams, p, Map("match[]" -> queryParams.promQl))
+          createMetadataRemoteExec(qContext, queryParams, p,
+            Map("match[]" -> LogicalPlanParser.metatadataMatchToQuery(lp)))
       }
       if (execPlans.size == 1) execPlans.head
       else PartKeysDistConcatExec(qContext, inProcessPlanDispatcher,
@@ -341,7 +342,8 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
         if (p.partitionName.equals(localPartitionName))
           localPartitionPlanner.materialize(lp.copy(startMs = p.timeRange.startMs, endMs = p.timeRange.endMs), qContext)
         else
-          createMetadataRemoteExec(qContext, queryParams, p, Map("match[]" -> queryParams.promQl))
+          createMetadataRemoteExec(qContext, queryParams, p,
+            Map("match[]" -> LogicalPlanParser.metatadataMatchToQuery(lp)))
       }
       if (execPlans.size == 1) execPlans.head
       else LabelNamesDistConcatExec(qContext, inProcessPlanDispatcher,

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -3,7 +3,9 @@ package filodb.coordinator.queryplanner
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
+import filodb.query.SeriesKeysByFilters
 
 class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
 
@@ -120,6 +122,20 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
     val res = LogicalPlanParser.convertToQuery(lp)
     res shouldEqual "(1.0 / (2.0 + foo))"
+  }
+
+  it("should convert metadata series match query1") {
+    val query = """http_requests_total{job="app"}"""
+    val lp = Parser.metadataQueryToLogicalPlan(query, TimeStepParams(1000, 10, 2000))
+    val res = LogicalPlanParser.metatadataMatchToQuery(lp.asInstanceOf[SeriesKeysByFilters])
+    res shouldEqual "http_requests_total{job=\"app\"}"
+  }
+
+  it("should convert metadata series match query2") {
+    val query = """{__name__="http_requests_total", job=~"app|job"}"""
+    val lp = Parser.metadataQueryToLogicalPlan(query, TimeStepParams(1000, 10, 2000))
+    val res = LogicalPlanParser.metatadataMatchToQuery(lp.asInstanceOf[SeriesKeysByFilters])
+    res shouldEqual "http_requests_total{job=~\"app|job\"}"
   }
 
   it("should convert scalar vector operation query") {


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
In MultiPartitionPlanner, we are not converting logicalplan back to promql query string. This is creating issues where the logical plan is modified to add new filters for authentication requirements.

**New behavior :**
Convert logicalplan back to promql query string instead of using promql direclty in MultiPartitionPlanner.

