### PR TITLE
feat(query) Enhance LabelCardinality query response to provide keys allowing multiple groups to be returned 

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -105,6 +105,11 @@ object Parser extends StrictLogging {
     }
   }
 
+  def labelCardinalityToLogicalPlan(query: String, timeParams: TimeRangeParams): LogicalPlan = parseQuery(query) match {
+      case p: InstantExpression => p.toLabelCardinalityPlan(timeParams)
+      case _ => throw new UnsupportedOperationException()
+  }
+
   // Only called by tests.
   def labelValuesQueryToLogicalPlan(labelNames: Seq[String], filterQuery: Option[String],
                                     timeParams: TimeRangeParams): LogicalPlan = {

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -266,22 +266,38 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     execPlan.addRangeVectorTransformer(new LabelCardinalityPresenter())
 
     val resp = execPlan.execute(memStore, querySession).runAsync.futureValue
-    val result = (resp: @unchecked) match {
+    (resp: @unchecked) match {
       case QueryResult(id, _, response, _, _, _) => {
-        response.size shouldEqual 1
-        val rv = response(0)
-        rv.rows.size shouldEqual 1
-        val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
-        rv.asInstanceOf[SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset).toMap
+        response.size shouldEqual 2
+        val rv1 = response(0)
+        val rv2 = response(1)
+        rv1.rows.size shouldEqual 1
+        rv2.rows.size shouldEqual 1
+        val record1 = rv1.rows.next().asInstanceOf[BinaryRecordRowReader]
+        val result1 = rv1.asInstanceOf[SerializedRangeVector]
+                          .schema.toStringPairs(record1.recordBase, record1.recordOffset).toMap
+
+        val record2 = rv2.rows.next().asInstanceOf[BinaryRecordRowReader]
+        val result2 = rv2.asInstanceOf[SerializedRangeVector]
+                            .schema.toStringPairs(record2.recordBase, record2.recordOffset).toMap
+
+        result1 shouldEqual Map("_ns_" -> "1",
+          "unicode_tag" -> "1",
+          "_type_" -> "1",
+          "job" -> "1",
+          "instance" -> "1",
+          "_metric_" -> "1",
+          "_ws_" -> "1")
+
+        result2 shouldEqual Map("_ns_" -> "1",
+          "unicode_tag" -> "1",
+          "_type_" -> "1",
+          "job" -> "1",
+          "instance" -> "1",
+          "_metric_" -> "1",
+          "_ws_" -> "1")
       }
     }
-    result shouldEqual Map("_ns_" -> "1",
-                           "unicode_tag" -> "2",
-                           "_type_" -> "1",
-                           "job" -> "1",
-                           "instance" -> "1",
-                           "_metric_" -> "3",
-                           "_ws_" -> "1")
   }
 
   it ("should correctly execute TsCardExec") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
The key is an empty map
```
/shard:/Map()
        Map(_ns_ -> 1, host -> 1, _type_ -> 1, version -> 1, _metric_ -> 1, app -> 1, _ws_ -> 1)
```

**New behavior :**

Key contains the ws, ns and metric name

```
/shard:/Map(_ns_ -> filodb, _metric_ -> go_info, _ws_ -> local_test)
        Map(_ns_ -> 1, host -> 1, _type_ -> 1, version -> 1, _metric_ -> 1, app -> 1, _ws_ -> 1)
```

