### PR TITLE
fix(query): TsCardinalities requirement bug

### DIFF
--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -165,7 +165,7 @@ case class TsCardinalities(shardKeyPrefix: Seq[String], groupDepth: Int) extends
     "groupDepth must lie on [0, 2]")
   require(1 + groupDepth >= shardKeyPrefix.size,
     "groupDepth indicate a depth at least as deep as shardKeyPrefix")
-  require(groupDepth < 2 || shardKeyPrefix.size == 2,
+  require(groupDepth < 2 || shardKeyPrefix.size >= 2,
     "cannot group at the metric level when prefix does not contain ws and ns")
 }
 

--- a/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
@@ -294,4 +294,33 @@ class LogicalPlanSpec extends AnyFunSpec with Matchers {
     res2(0).size.shouldEqual(2)
     res1.hashCode() shouldEqual res2.hashCode()
   }
+
+  it ("should construct TsCardinalities only when args are valid") {
+    // TODO: these tests (and TsCardinalities construction requirements)
+    //   are designed for a ws/ns/metric shard key prefix. If/when a more
+    //   general setup is needed, these tests/requirements need to be updated.
+    assertThrows[IllegalArgumentException] {
+      // need ws/ns in order to group by metric
+      TsCardinalities(Seq(), 2)
+    }
+    assertThrows[IllegalArgumentException] {
+      // need ws/ns in order to group by metric
+      TsCardinalities(Seq("a"), 2)
+    }
+    assertThrows[IllegalArgumentException] {
+      // insufficient group depth
+      TsCardinalities(Seq("a", "b"), 0)
+    }
+    assertThrows[IllegalArgumentException] {
+      // insufficient group depth
+      TsCardinalities(Seq("a", "b", "c"), 1)
+    }
+    TsCardinalities(Seq(), 0)
+    TsCardinalities(Seq(), 1)
+    TsCardinalities(Seq("a"), 0)
+    TsCardinalities(Seq("a"), 1)
+    TsCardinalities(Seq("a", "b"), 1)
+    TsCardinalities(Seq("a", "b"), 2)
+    TsCardinalities(Seq("a", "b", "c"), 2)
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Fixes bug where:
```
TsCardinalities(Seq("a", "b", "c"), 2)
```
throws an `IllegalArgumentException` because `TsCardinalities` construction `require`d :
```
shardKeyPrefix.size > 2
```
instead of:
```
shardKeyPrefix.size >=2
```

Tests are now added to ensure `TsCardinalities` constructs/throws when appropriate.