### PR TITLE
bug(prometheus): Enforce maximum regex length

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -190,8 +190,8 @@ sealed trait Vector extends Expression {
       labelMatch.labelMatchOp match {
         case EqualMatch      => ColumnFilter(labelMatch.label, query.Filter.Equals(labelValue))
         case NotRegexMatch   => ColumnFilter(labelMatch.label, query.Filter.NotEqualsRegex(labelValue))
-        case RegexMatch      => require(labelValue.length <= Parser.REGEX_MAX_LEN, "Regular expression filters should " +
-                                         s"be <= ${Parser.REGEX_MAX_LEN} characters")
+        case RegexMatch      => require(labelValue.length <= Parser.REGEX_MAX_LEN,
+                                         s"Regular expression filters should be <= ${Parser.REGEX_MAX_LEN} characters")
                                 ColumnFilter(labelMatch.label, query.Filter.EqualsRegex(labelValue))
         case NotEqual(false) => ColumnFilter(labelMatch.label, query.Filter.NotEquals(labelValue))
         case other: Any      => throw new IllegalArgumentException(s"Unknown match operator $other")

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -189,7 +189,9 @@ sealed trait Vector extends Expression {
       } else { labelVal }
       labelMatch.labelMatchOp match {
         case EqualMatch      => ColumnFilter(labelMatch.label, query.Filter.Equals(labelValue))
-        case NotRegexMatch   => ColumnFilter(labelMatch.label, query.Filter.NotEqualsRegex(labelValue))
+        case NotRegexMatch   => require(labelValue.length <= Parser.REGEX_MAX_LEN,
+                                         s"Regular expression filters should be <= ${Parser.REGEX_MAX_LEN} characters")
+                                ColumnFilter(labelMatch.label, query.Filter.NotEqualsRegex(labelValue))
         case RegexMatch      => require(labelValue.length <= Parser.REGEX_MAX_LEN,
                                          s"Regular expression filters should be <= ${Parser.REGEX_MAX_LEN} characters")
                                 ColumnFilter(labelMatch.label, query.Filter.EqualsRegex(labelValue))

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -121,7 +121,9 @@ object Parser extends StrictLogging {
         val columnFilters = parseLabelValueFilter(filter).map { l =>
           l.labelMatchOp match {
             case EqualMatch => ColumnFilter(l.label, Filter.Equals(l.value))
-            case NotRegexMatch => ColumnFilter(l.label, Filter.NotEqualsRegex(l.value))
+            case NotRegexMatch => require(l.value.length <= REGEX_MAX_LEN,
+                                   s"Regular expression filters should be <= $REGEX_MAX_LEN characters")
+                                  ColumnFilter(l.label, Filter.NotEqualsRegex(l.value))
             case RegexMatch =>  require(l.value.length <= REGEX_MAX_LEN,
                                    s"Regular expression filters should be <= $REGEX_MAX_LEN characters")
                                 ColumnFilter(l.label, Filter.EqualsRegex(l.value))

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -11,6 +11,9 @@ import filodb.query.{LabelValues, LogicalPlan}
   * Parser routes requests to LegacyParser or AntlrParser.
   */
 object Parser extends StrictLogging {
+
+  val REGEX_MAX_LEN = 1000
+
   sealed trait Mode
   case object Legacy extends Mode
   case object Antlr extends Mode
@@ -119,7 +122,9 @@ object Parser extends StrictLogging {
           l.labelMatchOp match {
             case EqualMatch => ColumnFilter(l.label, Filter.Equals(l.value))
             case NotRegexMatch => ColumnFilter(l.label, Filter.NotEqualsRegex(l.value))
-            case RegexMatch => ColumnFilter(l.label, Filter.EqualsRegex(l.value))
+            case RegexMatch =>  require(l.value.length <= REGEX_MAX_LEN,
+                                   s"Regular expression filters should be <= $REGEX_MAX_LEN characters")
+                                ColumnFilter(l.label, Filter.EqualsRegex(l.value))
             case NotEqual(false) => ColumnFilter(l.label, Filter.NotEquals(l.value))
             case other: Any => throw new IllegalArgumentException(s"Unknown match operator $other")
           }

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -7,6 +7,7 @@ import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.PartitionSchema
 import filodb.core.query.{Result => _, _}
+import filodb.prometheus.parse.Parser.REGEX_MAX_LEN
 import filodb.query.{QueryResult => FiloQueryResult, _}
 import filodb.query.AggregationOperator.Avg
 import filodb.query.exec.{ExecPlan, HistToPromSeriesMapper}
@@ -41,7 +42,8 @@ object PrometheusModel {
           case MatchType.EQUAL => Filter.Equals(m.getValue)
           case MatchType.NOT_EQUAL => Filter.NotEquals(m.getValue)
           case MatchType.REGEX_MATCH =>
-            require(m.getValue.length < 1000, "Regular expression filters should be < 1000 characters")
+            require(m.getValue.length <= REGEX_MAX_LEN, s"Regular expression filters should " +
+              s"be <= ${REGEX_MAX_LEN} characters")
             Filter.EqualsRegex(m.getValue)
           case MatchType.REGEX_NO_MATCH => Filter.NotEqualsRegex(m.getValue)
         }

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -42,10 +42,13 @@ object PrometheusModel {
           case MatchType.EQUAL => Filter.Equals(m.getValue)
           case MatchType.NOT_EQUAL => Filter.NotEquals(m.getValue)
           case MatchType.REGEX_MATCH =>
-            require(m.getValue.length <= REGEX_MAX_LEN, s"Regular expression filters should " +
-              s"be <= ${REGEX_MAX_LEN} characters")
-            Filter.EqualsRegex(m.getValue)
-          case MatchType.REGEX_NO_MATCH => Filter.NotEqualsRegex(m.getValue)
+                            require(m.getValue.length <= REGEX_MAX_LEN, s"Regular expression filters should " +
+                              s"be <= ${REGEX_MAX_LEN} characters")
+                            Filter.EqualsRegex(m.getValue)
+          case MatchType.REGEX_NO_MATCH =>
+                            require(m.getValue.length <= REGEX_MAX_LEN, s"Regular expression filters should " +
+                              s"be <= ${REGEX_MAX_LEN} characters")
+                            Filter.NotEqualsRegex(m.getValue)
         }
         ColumnFilter(m.getName, filter)
       }

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -40,7 +40,9 @@ object PrometheusModel {
         val filter = m.getType match {
           case MatchType.EQUAL => Filter.Equals(m.getValue)
           case MatchType.NOT_EQUAL => Filter.NotEquals(m.getValue)
-          case MatchType.REGEX_MATCH => Filter.EqualsRegex(m.getValue)
+          case MatchType.REGEX_MATCH =>
+            require(m.getValue.length < 1000, "Regular expression filters should be < 1000 characters")
+            Filter.EqualsRegex(m.getValue)
           case MatchType.REGEX_NO_MATCH => Filter.NotEqualsRegex(m.getValue)
         }
         ColumnFilter(m.getName, filter)

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -418,6 +418,9 @@ class ParserSpec extends AnyFunSpec with Matchers {
     parseError("sum_over_time(some_metric[5m], hello)") // reason : Expected only 1 arg, got 2
     parseError("sum_over_time(hello, some_metric[5m])") // reason : Expected range, got instant
 
+    // regexp length
+    parseError(s"sum_over_time(some_metric{longregex~='${"f"*1001}'})") // reason : Regex len > 1000
+
     //  Timestamp
     parseSuccessfully("timestamp(some_metric)")
     parseError("timestamp(some_metric[5m])") // reason : Expected instant vector, got range vector

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -420,6 +420,7 @@ class ParserSpec extends AnyFunSpec with Matchers {
 
     // regexp length
     parseError(s"sum_over_time(some_metric{longregex~='${"f"*1001}'})") // reason : Regex len > 1000
+    parseError(s"sum_over_time(some_metric{longregex~!'${"f"*1001}'})") // reason : Regex len > 1000
 
     //  Timestamp
     parseSuccessfully("timestamp(some_metric)")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Upon very long regular expression filters, lucene returns a StackOverflowError on every shard, and this has the potential to degrade performance of the cluster severely. The shard lock is not released and subsequent queries fail. The StackOverflowError has also been seen on ElasticSearch.

The stack overflow error we saw was for a regex filter of length 17k characters, and it was an unintentional regex which was not per intent. It used comma instead of pipe character to delimit list of possibilities. 

**New behavior :**
Since it is very hard to dive into the regex to explicitly allow and disallow certain regexes, we have to resort to enforcing a regular expression filter length limit - currently set to 1KB, which is same as ElasticSearch default.

**BREAKING CHANGES**

This can potentially affect existing queries that have regex > 1KB.