### PR TITLE
feat(query) Allow supporting MultiPartition planning for LabelCardinality API

### DIFF
--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -51,3 +51,9 @@ final case class LabelSampl(values: Seq[String]) extends DataSampl
 final case class AvgSampl(timestamp: Long, value: Double, count: Long) extends AggregateSampl
 
 final case class StdValSampl(timestamp: Long, stddev: Double, mean: Double, count: Long) extends AggregateSampl
+
+// Note: Its ok to have ns, ws and metric as columns as these are not assuming any specific shard key. LabelCardinality
+// by definition is the cardinality of the metric in a given ws/ns combination. It does not make any assumptions
+// on the shard key.
+final case class LabelCardinalitySampl(ns: String, ws: String, metric: String,
+                                       cardinality: Seq[Map[String, String]])  extends DataSampl

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -52,8 +52,5 @@ final case class AvgSampl(timestamp: Long, value: Double, count: Long) extends A
 
 final case class StdValSampl(timestamp: Long, stddev: Double, mean: Double, count: Long) extends AggregateSampl
 
-// Note: Its ok to have ns, ws and metric as columns as these are not assuming any specific shard key. LabelCardinality
-// by definition is the cardinality of the metric in a given ws/ns combination. It does not make any assumptions
-// on the shard key.
-final case class LabelCardinalitySampl(ns: String, ws: String, metric: String,
-                                       cardinality: Seq[Map[String, String]])  extends DataSampl
+final case class LabelCardinalitySampl(metric: Map[String, String],
+                                       cardinality: Seq[Map[String, String]]) extends DataSampl


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**

Multi partition calls not supported

**New behavior :**

Label cardinality calls to support Multi partition calls, following two are the plans when the query is pushed down to local partition vs routed to remote partition

Call routed to remote partition
```
E~MetadataRemoteExec(PromQlQueryParams(go_info{_ws_=\"filodb-demo\",_ns_=\"App-0\"},1639513266,1,1639513566,Some(/api/v1/metering/cardinality/label),false), PlannerParams(filodb-query-service-local,None,None,None,10000,50000,12000,25000,false,0,0,false,false,false,true), queryEndpoint=http://localhost:9900/singlepartition/prometheus/api/v1/metering/cardinality/label, requestTimeoutMs=90000) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@60992e88
```
Call pushed down to local planner

```
T~LabelCardinalityPresenter(LabelCardinalityPresenter)
-E~LabelCardinalityReduceExec() on ActorPlanDispatcher(Actor[akka.tcp://filo-standalone@127.0.0.1:2552/user/node/coordinator#1927110923],raw)
--E~LabelCardinalityExec(shard=1, filters=List(ColumnFilter(_ws_,Equals(filodb-demo)), ColumnFilter(_ns_,Equals(App-1)), ColumnFilter(_metric_,Equals(go_info))), limit=50000, startMs=1639513678000, endMs=1639513978000) on ActorPlanDispatcher(Actor[akka.tcp://filo-standalone@127.0.0.1:2552/user/node/coordinator#1927110923],raw)
--E~LabelCardinalityExec(shard=3, filters=List(ColumnFilter(_ws_,Equals(filodb-demo)), ColumnFilter(_ns_,Equals(App-1)), ColumnFilter(_metric_,Equals(go_info))), limit=50000, startMs=1639513678000, endMs=1639513978000) on ActorPlanDispatcher(Actor[akka.tcp://filo-standalone@127.0.0.1:50327/user/node/coordinator#-514403052],raw)
```
