### PR TITLE
feat(query): add Parser.queryToEqualLabelMap

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -1,7 +1,8 @@
 package filodb.prometheus.ast
 
 import scala.util.Try
-import filodb.core.{GlobalConfig, query}
+
+import filodb.core.{query, GlobalConfig}
 import filodb.core.query.{ColumnFilter, RangeParams}
 import filodb.prometheus.parse.Parser
 import filodb.query._
@@ -11,7 +12,6 @@ object Vectors {
   val TypeLabel       = "_type_"
   val BucketFilterLabel = "_bucket_"
 }
-
 
 object WindowConstants {
   val conf = GlobalConfig.systemConfig

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -109,12 +109,15 @@ object Parser extends StrictLogging {
   }
 
   /**
-   * Returns a mapping from selector labels to values.
+   * Returns a mapping from selector labels (including an explicit/implicit __name__) to values.
+   * A metric name need not be present in the query.
+   *
+   * @param query: must specify label values by equality without a regex
    */
-  def queryToLabelMap(query: String): Map[String, String] = {
+  def queryToEqualLabelMap(query: String): Map[String, String] = {
     val expression = parseQuery(query)
     expression match {
-      case p: InstantExpression => p.toLabelMap()
+      case p: InstantExpression => p.toEqualLabelMap()
       case _ => throw new UnsupportedOperationException()
     }
   }

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -108,6 +108,14 @@ object Parser extends StrictLogging {
     }
   }
 
+  def tsCardinalitiesMatcherToLogicalPlan(query: String): LogicalPlan = {
+    val expression = parseQuery(query).asInstanceOf[InstantExpression]
+    expression match {
+      case p: InstantExpression => p.toTsCardinalitiesMatcherPlan()
+      case _ => throw new UnsupportedOperationException()
+    }
+  }
+
   def labelCardinalityToLogicalPlan(query: String, timeParams: TimeRangeParams): LogicalPlan = parseQuery(query) match {
       case p: InstantExpression => p.toLabelCardinalityPlan(timeParams)
       case _ => throw new UnsupportedOperationException()

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -108,10 +108,13 @@ object Parser extends StrictLogging {
     }
   }
 
-  def tsCardinalitiesMatcherToLogicalPlan(query: String): LogicalPlan = {
-    val expression = parseQuery(query).asInstanceOf[InstantExpression]
+  /**
+   * Returns a mapping from selector labels to values.
+   */
+  def queryToLabelMap(query: String): Map[String, String] = {
+    val expression = parseQuery(query)
     expression match {
-      case p: InstantExpression => p.toTsCardinalitiesMatcherPlan()
+      case p: InstantExpression => p.toLabelMap()
       case _ => throw new UnsupportedOperationException()
     }
   }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -184,10 +184,6 @@ class ParserSpec extends AnyFunSpec with Matchers {
     parseError("foo::b{gibberish}")
     parseError("foo{1}")
     parseError("{}")
-    parseError("{x=\"\"}")
-    parseError("{x=~\".*\"}")
-    parseError("{x!~\".+\"}")
-    parseError("{x!=\"a\"}")
     parseError("foo{__name__=\"bar\"}")
 
     parseSuccessfully("test{a=\"b\"}[5y] OFFSET 3d")

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -738,11 +738,11 @@ class ParserSpec extends AnyFunSpec with Matchers {
     )
 
     queryMapPairs.foreach{case (query, expectedMap) =>
-      Parser.queryToLabelMap(query) shouldEqual expectedMap
+      Parser.queryToEqualLabelMap(query) shouldEqual expectedMap
     }
 
     queriesShouldFail.foreach{query =>
-      assertThrows[IllegalArgumentException](Parser.queryToLabelMap(query))
+      assertThrows[IllegalArgumentException](Parser.queryToEqualLabelMap(query))
     }
   }
 

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -738,6 +738,7 @@ class ParserSpec extends AnyFunSpec with Matchers {
     val queriesShouldFail = Seq(
       """foo{__name__="bar"}""",
       """foo{__name__="bar", bog="baz"}""",
+      """{}"""
     )
 
     queryMapPairs.foreach{case (query, expectedMap) =>

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -513,7 +513,8 @@ final case class TsCardExec(queryContext: QueryContext,
   require(numGroupByFields >= 1,
     "numGroupByFields must be positive")
   require(numGroupByFields >= shardKeyPrefix.size,
-    "numGroupByFields indicate a depth at least as deep as shardKeyPrefix")
+    s"numGroupByFields ($numGroupByFields) must indicate at least as many " +
+    s"fields as shardKeyPrefix.size (${shardKeyPrefix.size})")
 
   override def enforceLimit: Boolean = false
 


### PR DESCRIPTION
# Update

See #1314 for the alternative fix.

# Original Text

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**
Adds the method `Parser.queryToLabelMap(query: String): Map[String, String]` which parses an instant selector into a map of (label, value) pairs (including `__name__`).