### PR TITLE
fix(query): add circe decoder to labelvalues and series-matcher query results

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -3,7 +3,7 @@ package filodb.prometheus.query
 import remote.RemoteStorage._
 
 import filodb.core.GlobalConfig
-import filodb.core.binaryrecord2.BinaryRecordRowReader
+import filodb.core.binaryrecord2.{BinaryRecordRowReader, StringifyMapItemConsumer}
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.PartitionSchema
 import filodb.core.query.{Result => _, _}
@@ -90,8 +90,6 @@ object PrometheusModel {
     val results = if (qr.resultSchema.columns.nonEmpty && qr.resultSchema.columns.length > 1 &&
                       qr.resultSchema.columns(1).colType == ColumnType.HistogramColumn)
                     qr.result.map(toHistResult(_, verbose, qr.resultType))
-                  else if (qr.resultSchema.columns.length == 1)
-                    qr.result.map(toMetadataResult(_, verbose, qr.resultType))
                   else
                     qr.result.map(toPromResult(_, verbose, qr.resultType))
     SuccessResponse(Data(toPromResultType(qr.resultType), results.filter(r => r.values.nonEmpty || r.value.isDefined)),
@@ -110,15 +108,24 @@ object PrometheusModel {
     }
   }
 
-  def toMetadataResult(srv: RangeVector, verbose: Boolean, typ: QueryResultType): Result = {
-    val tags = srv.key.labelValues.map { case (k, v) => (k.toString, v.toString)} ++
-      (if (verbose) makeVerboseLabels(srv.key)
-      else Map.empty)
-    val values = srv.rows.map(row => {
+  def toLabelValuesResponse(qr: FiloQueryResult, verbose: Boolean, typ: QueryResultType,
+                         mayBePartial: Option[Boolean]): MetadataSuccessResponse = {
+    val values = qr.result.flatMap(srv => srv.rows.map(row => {
       val br = row.asInstanceOf[BinaryRecordRowReader]
-      br.schema.colValues(br.recordBase, br.recordOffset, br.schema.colNames).head
-    })
-    Result(tags, Option(Seq(LabelSampl(values.toSeq))), None)
+      LabelSampl(br.schema.colValues(br.recordBase, br.recordOffset, br.schema.colNames).head)
+    }))
+    MetadataSuccessResponse(values, "success", mayBePartial)
+  }
+
+  def toMetadataMapResponse(qr: FiloQueryResult, verbose: Boolean, typ: QueryResultType,
+                         mayBePartial: Option[Boolean]): MetadataSuccessResponse = {
+    val values = qr.result.flatMap(srv => srv.rows.map(row => {
+      val br = row.asInstanceOf[BinaryRecordRowReader]
+      val consumer = new StringifyMapItemConsumer
+      br.schema.consumeMapItems(br.recordBase, br.recordOffset, 0, consumer)
+      MetadataMapSampl(consumer.stringPairs.toMap)
+    }))
+    MetadataSuccessResponse(values, "success", mayBePartial)
   }
 
   /**

--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -62,7 +62,7 @@ object PromCirceSupport {
     }
   }
 
-  implicit val decodeFoo: Decoder[DataSampl] = new Decoder[DataSampl] {
+  implicit val decodeDataSampl: Decoder[DataSampl] = new Decoder[DataSampl] {
     final def apply(c: HCursor): Decoder.Result[DataSampl] = {
       val tsResult = c.downArray.as[Long]
       val rightCurs = c.downArray.right

--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -11,11 +11,13 @@ object PromCirceSupport {
   implicit val encodeSampl: Encoder[DataSampl] = Encoder.instance {
     case s @ Sampl(t, v)                                => Json.fromValues(Seq(t.asJson, v.toString.asJson))
     case h @ HistSampl(t, b)                            => Json.fromValues(Seq(t.asJson, b.asJson))
-    case m @ MetadataSampl(v)                           => Json.fromValues(Seq(v.asJson))
-    case l @ LabelSampl(v)                              => Json.fromValues(Seq(v.asJson))
+  }
+
+  implicit val encodeMetadataSampl: Encoder[MetadataSampl] = Encoder.instance {
+    case m @ MetadataMapSampl(v) => Json.fromValues(Seq(v.asJson))
+    case l @ LabelSampl(v) => Json.fromValues(Seq(v.asJson))
     // Where are these used? added to make compiler happy
     case l @ LabelCardinalitySampl(group, cardinality)  => Json.fromValues(Seq(group.asJson, cardinality.asJson))
-
   }
 
   implicit val decodeAvgSample: Decoder[AvgSampl] = new Decoder[AvgSampl] {
@@ -41,29 +43,39 @@ object PromCirceSupport {
       }
     }
 
-  implicit val decodeFoo: Decoder[DataSampl] = new Decoder[DataSampl] {
-    final def apply(c: HCursor): Decoder.Result[DataSampl] = {
+  implicit val decodeMetadataSampl: Decoder[MetadataSampl] = new Decoder[MetadataSampl] {
+    def apply(c: HCursor): Decoder.Result[MetadataSampl] = {
       c.downField("cardinality").focus match {
         case Some(_) =>
           // TODO: Not the best way to find if this is a label cardinality response, is there a better way?
-          for {metric     <- c.get[Map[String, String]]("metric")
-               card      <- c.get[Seq[Map[String, String]]]("cardinality")
-               } yield LabelCardinalitySampl(metric, card)
+          for {
+            metric <- c.get[Map[String, String]]("metric")
+            card <- c.get[Seq[Map[String, String]]]("cardinality")
+          } yield LabelCardinalitySampl(metric, card)
 
-        case None              =>
-          val tsResult = c.downArray.as[Long]
-          val rightCurs = c.downArray.right
-          if (rightCurs.focus.get.isObject) {
-            for { timestamp <- tsResult
-                  buckets   <- rightCurs.as[Map[String, Double]] } yield {
-              HistSampl(timestamp, buckets)
-            }
-          } else {
-            for { timestamp <- tsResult
-                  value     <- rightCurs.as[String] } yield {
-              Sampl(timestamp, value.toDouble)
-            }
-          }
+        case None =>
+          if (c.value.isString)
+            for { label <- c.as[String] } yield LabelSampl(label)
+          else
+            for { metadataMap <- c.as[Map[String, String]] } yield MetadataMapSampl(metadataMap)
+      }
+    }
+  }
+
+  implicit val decodeFoo: Decoder[DataSampl] = new Decoder[DataSampl] {
+    final def apply(c: HCursor): Decoder.Result[DataSampl] = {
+      val tsResult = c.downArray.as[Long]
+      val rightCurs = c.downArray.right
+      if (rightCurs.focus.get.isObject) {
+        for { timestamp <- tsResult
+              buckets   <- rightCurs.as[Map[String, Double]] } yield {
+          HistSampl(timestamp, buckets)
+        }
+      } else {
+        for { timestamp <- tsResult
+              value     <- rightCurs.as[String] } yield {
+          Sampl(timestamp, value.toDouble)
+        }
       }
     }
   }

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -21,7 +21,7 @@ final case class QueryStatistics(group: Seq[String], timeSeriesScanned: Long,
 
 final case class Data(resultType: String, result: Seq[Result])
 
-final case class MetadataSuccessResponse(data: Seq[DataSampl],
+final case class MetadataSuccessResponse(data: Seq[MetadataSampl],
                                          status: String = "success",
                                          partial: Option[Boolean]= None,
                                          message: Option[String]= None) extends PromQueryResponse
@@ -30,6 +30,8 @@ final case class Result(metric: Map[String, String], values: Option[Seq[DataSamp
                         aggregateResponse: Option[AggregateResponse] = None)
 
 sealed trait DataSampl
+
+sealed trait MetadataSampl
 
 sealed trait AggregateSampl
 
@@ -44,13 +46,13 @@ final case class Sampl(timestamp: Long, value: Double) extends DataSampl
 
 final case class HistSampl(timestamp: Long, buckets: Map[String, Double]) extends DataSampl
 
-final case class MetadataSampl(values: Map[String, String]) extends DataSampl
+final case class MetadataMapSampl(value: Map[String, String]) extends MetadataSampl
 
-final case class LabelSampl(values: Seq[String]) extends DataSampl
+final case class LabelSampl(value: String) extends MetadataSampl
 
 final case class AvgSampl(timestamp: Long, value: Double, count: Long) extends AggregateSampl
 
 final case class StdValSampl(timestamp: Long, stddev: Double, mean: Double, count: Long) extends AggregateSampl
 
-final case class LabelCardinalitySampl(metric: Map[String, String],
-                                       cardinality: Seq[Map[String, String]]) extends DataSampl
+  final case class LabelCardinalitySampl(metric: Map[String, String],
+                                       cardinality: Seq[Map[String, String]]) extends MetadataSampl

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -351,7 +351,8 @@ final case class LabelValuesExec(queryContext: QueryContext,
             queryContext.plannerParams.sampleLimit).map(_.term.toString)
           val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
             NoCloseCursor(StringArrayRowReader(labels)), None))
-          val sch = ResultSchema(Seq(ColumnInfo("Labels", ColumnType.StringColumn)), 1)
+          val sch = if (labels.isEmpty) ResultSchema.empty
+                    else ResultSchema(Seq(ColumnInfo("Labels", ColumnType.StringColumn)), 1)
           ExecResult(resp, Task.eval(sch))
         case true => throw new BadQueryException("either label name is missing " +
           "or there are multiple label names without filter")
@@ -361,19 +362,21 @@ final case class LabelValuesExec(queryContext: QueryContext,
           val labels = metadataMap.map(_.head._1.toString).toSeq
           val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
             NoCloseCursor(StringArrayRowReader(labels)), None))
-          val sch = ResultSchema(Seq(ColumnInfo("Labels", ColumnType.StringColumn)), 1)
+          val sch = if (labels.isEmpty) ResultSchema.empty
+                    else ResultSchema(Seq(ColumnInfo("Labels", ColumnType.StringColumn)), 1)
           ExecResult(resp, Task.eval(sch))
         case false =>
           val metadataMap = memStore.labelValuesWithFilters(dataset, shard, filters, columns, endMs, startMs,
           queryContext.plannerParams.sampleLimit)
           val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
             UTF8MapIteratorRowReader(metadataMap), None))
-          val sch = ResultSchema(Seq(ColumnInfo("metadataMap", ColumnType.MapColumn)), 1)
+          val sch = if (metadataMap.isEmpty) ResultSchema.empty
+                    else ResultSchema(Seq(ColumnInfo("metadataMap", ColumnType.MapColumn)), 1)
           ExecResult(resp, Task.eval(sch))
       }
     } else {
       val resp = Observable.empty
-      val sch = ResultSchema(Seq(ColumnInfo("metadataMap", ColumnType.MapColumn)), 1)
+      val sch = ResultSchema.empty
       ExecResult(resp, Task.eval(sch))
     }
     execResult

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -95,8 +95,9 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, recordSchema,
       queryWithPlanName(queryContext)))
 
+    val schema = if (data.isEmpty) ResultSchema.empty else resultSchema
     // FIXME need to send and parse query stats in remote calls
-    QueryResult(id, resultSchema, srvSeq, QueryStats(),
+    QueryResult(id, schema, srvSeq, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
@@ -111,8 +112,9 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, labelsRecordSchema,
       queryWithPlanName(queryContext)))
 
+    val schema = if (data.isEmpty) ResultSchema.empty else labelsResultSchema
     // FIXME need to send and parse query stats in remote calls
-    QueryResult(id, labelsResultSchema, srvSeq, QueryStats(),
+    QueryResult(id, schema, srvSeq, QueryStats(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 }

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -63,7 +63,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
   def toQueryResponse(response: MetadataSuccessResponse, id: String, parentSpan: kamon.trace.Span): QueryResponse = {
       if (response.data.isEmpty) mapTypeQueryResponse(response, id)
       else response.data.head match {
-        case _: MetadataSampl            => mapTypeQueryResponse(response, id)
+        case _: MetadataMapSampl         => mapTypeQueryResponse(response, id)
         case _: LabelCardinalitySampl    => mapLabelCardinalityResponse(response, id)
         case _                           => labelsQueryResponse(response, id)
       }
@@ -85,8 +85,8 @@ case class MetadataRemoteExec(queryEndpoint: String,
   }
 
   def mapTypeQueryResponse(response: MetadataSuccessResponse, id: String): QueryResponse = {
-    val data = response.data.asInstanceOf[Seq[MetadataSampl]]
-    val iteratorMap = data.map { r => r.values.map { v => (v._1.utf8, v._2.utf8) }}
+    val data = response.data.asInstanceOf[Seq[MetadataMapSampl]]
+    val iteratorMap = data.map { r => r.value.map { v => (v._1.utf8, v._2.utf8) }}
 
     import NoCloseCursor._
     val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
@@ -102,7 +102,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
 
   def labelsQueryResponse(response: MetadataSuccessResponse, id: String): QueryResponse = {
     val data = response.data.asInstanceOf[Seq[LabelSampl]]
-    val iteratorMap = data.flatMap { r => r.values}
+    val iteratorMap = data.map { r => r.value}
 
     import NoCloseCursor._
     val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),

--- a/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
+++ b/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
@@ -30,6 +30,126 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
    parseAndValidate(inputString, List(Sampl(1600102672,1.2), Sampl(1600102687,3.1)))
   }
 
+  it("should parse LabelSampl") {
+    val inputString = """{
+                         |    "status": "success",
+                         |    "data": ["data1","data2","data3"]
+                         |}""".stripMargin
+
+    parser.decode[MetadataSuccessResponse](inputString) match {
+      case Right(labels) => labels shouldEqual
+        MetadataSuccessResponse(List(LabelSampl("data1"), LabelSampl("data2"), LabelSampl("data3")), "success", None, None)
+      case Left(ex) => throw ex
+    }
+  }
+
+  it("should parse MetadataMapSampl") {
+    val expected = Seq(
+      MetadataMapSampl(Map("tag1" -> "value1", "tag2" -> "value2", "tag3" -> "value3")),
+      MetadataMapSampl(Map("tag11" -> "value11", "tag22" -> "value22", "tag33" -> "value33"))
+    )
+    val inputString =
+      """{
+        |    "status": "success",
+        |    "data": [
+        |       {
+        |		      "tag1": "value1",
+        |		      "tag2": "value2",
+        |		      "tag3": "value3"
+        |       },
+        |       {
+        |		      "tag11": "value11",
+        |		      "tag22": "value22",
+        |		      "tag33": "value33"
+        |       }
+        |     ]
+        |}""".stripMargin
+
+    parser.decode[MetadataSuccessResponse](inputString) match {
+      case Right(response) => response shouldEqual MetadataSuccessResponse(expected)
+      case Left(ex) => throw ex
+    }
+  }
+
+  /**
+   *   final case class LabelCardinalitySampl(metric: Map[String, String],
+                                       cardinality: Seq[Map[String, String]]) extends MetadataSampl
+   */
+
+  it("should parse LabelCardinalitySampl") {
+    val expected = Seq(
+      LabelCardinalitySampl(
+        Map("_ws_" -> "demo", "_ns_" -> "App-0", "_metric_" -> "heap_usage"),
+        Seq(
+          Map("tag" -> "instance", "count" -> "10"),
+          Map("tag" -> "host", "count" -> "5"),
+          Map("tag" -> "datacenter", "count" -> "2")
+        )
+      ),
+      LabelCardinalitySampl(Map("_ws_" -> "demo", "_ns_" -> "App-1", "_metric_" -> "request_latency"),
+        Seq(
+          Map("tag" -> "instance", "count" -> "6"),
+          Map("tag" -> "host", "count" -> "2"),
+          Map("tag" -> "datacenter", "count" -> "2")
+        ))
+    )
+    val inputString =
+      """{
+        |    "status": "success",
+        |    "data": [
+        |       {
+        |		      "metric": {
+        |           "_ws_": "demo",
+        |		        "_ns_": "App-0",
+        |		        "_metric_": "heap_usage"
+        |          },
+        |          "cardinality":
+        |             [
+        |               {
+        |                 "tag": "instance",
+        |                 "count": "10"
+        |               },
+        |               {
+        |                 "tag": "host",
+        |                 "count": "5"
+        |               },
+        |               {
+        |                 "tag": "datacenter",
+        |                 "count": "2"
+        |               }
+        |             ]
+        |       },
+        |       {
+        |		      "metric": {
+        |           "_ws_": "demo",
+        |		        "_ns_": "App-1",
+        |		        "_metric_": "request_latency"
+        |          },
+        |          "cardinality":
+        |             [
+        |               {
+        |                 "tag": "instance",
+        |                 "count": "6"
+        |               },
+        |               {
+        |                 "tag": "host",
+        |                 "count": "2"
+        |               },
+        |               {
+        |                 "tag": "datacenter",
+        |                 "count": "2"
+        |               }
+        |             ]
+        |       }
+        |     ]
+        |}""".stripMargin
+
+    parser.decode[MetadataSuccessResponse](inputString) match {
+      case Right(response) => response shouldEqual MetadataSuccessResponse(expected)
+      case Left(ex) => throw ex
+    }
+  }
+
   it("should parse aggregateResponse") {
     val input = """[{
                   |	"status": "success",

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -10,7 +10,7 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
 import filodb.core.query.{PromQlQueryParams, QueryContext}
 import filodb.memory.format.vectors.MutableHistogram
 import filodb.query
-import filodb.query.{Data, HistSampl, MetadataSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, SuccessResponse}
+import filodb.query.{Data, HistSampl, MetadataMapSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, SuccessResponse}
 
 
 class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
@@ -61,7 +61,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       queryContext, dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
     val map1 = Map("instance" -> "inst-1", "last-sample" -> "6377838" )
     val map2 = Map("instance" -> "inst-2", "last-sample" -> "6377834" )
-    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataSampl(map1), MetadataSampl(map2))), "id", Kamon.currentSpan())
+    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataMapSampl(map1), MetadataMapSampl(map2))), "id", Kamon.currentSpan())
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     val data = queryResult.result.flatMap(x=>x.rows.map{ r => r.getAny(0) }.toList)
@@ -74,7 +74,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
     val map1 = Map("instance" -> "inst-1", "last-sample" -> "6377838" )
     val map2 = Map("instance" -> "inst-2", "last-sample" -> "6377834" )
-    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataSampl(map1), MetadataSampl(map2))), "id", Kamon.currentSpan())
+    val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataMapSampl(map1), MetadataMapSampl(map2))), "id", Kamon.currentSpan())
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     val data = queryResult.result.flatMap(x => x.rows.map(r => r.getAny(0)).toList)

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -5,20 +5,28 @@ import com.softwaremill.sttp.testing.SttpBackendStub
 import com.typesafe.config.ConfigFactory
 import filodb.core.MetricsTestData._
 import filodb.core.binaryrecord2.BinaryRecordRowReader
-import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, TimeSeriesMemStore}
+import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
+import filodb.core.metadata.Schemas
 import filodb.core.query._
+import filodb.core.query.Filter.Equals
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
+import filodb.core.TestData
+import filodb.memory.format.SeqRowReader
 import filodb.query._
 import filodb.query.exec.RemoteHttpClient.configBuilder
+import monix.eval.Task
+import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
+import filodb.memory.format.ZeroCopyUTF8String._
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
 
@@ -31,27 +39,94 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
 
+  val now = System.currentTimeMillis()
+  val numRawSamples = 1000
+  val reportingInterval = 10000
+  val limit = 2
+  val tuples = (numRawSamples until 0).by(-1).map { n =>
+    (now - n * reportingInterval, n.toDouble)
+  }
+
+  val shardPartKeyLabelValues = Seq(
+    Seq(  // shard 0
+      ("http_req_total", Map("instance"->"someHost:8787", "job"->"myCoolService",
+        "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo", "_ns_" -> "App-0")),
+      ("http_foo_total", Map("instance"->"someHost:8787", "job"->"myCoolService",
+        "unicode_tag" -> "uni\u03BCtag", "_ws_" -> "demo", "_ns_" -> "App-0"))
+    ),
+    Seq (  // shard 1
+      ("http_req_total", Map("instance"->"someHost:9090", "job"->"myCoolService",
+        "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo", "_ns_" -> "App-0")),
+      ("http_bar_total", Map("instance"->"someHost:8787", "job"->"myCoolService",
+        "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo", "_ns_" -> "App-0")),
+      ("http_req_total-A", Map("instance"->"someHost:9090", "job"->"myCoolService",
+        "unicode_tag" -> "uni\u03C0tag", "_ws_" -> "demo-A", "_ns_" -> "App-A")),
+    )
+  )
+
+  val addlLabels = Map("_type_" -> "prom-counter")
+  val expectedLabelValues = shardPartKeyLabelValues.flatMap { shardSeq =>
+    shardSeq.map(pair => pair._2 + ("_metric_" -> pair._1) ++ addlLabels)
+  }
+
+  implicit val execTimeout = 5.seconds
+
+  def initShard(memStore: TimeSeriesMemStore,
+                partKeyLabelValues: Seq[Tuple2[String, Map[String, String]]],
+                ishard: Int): Unit = {
+    val partTagsUTF8s = partKeyLabelValues.map{case (m, t) => (m,  t.map { case (k, v) => (k.utf8, v.utf8)})}
+    // NOTE: due to max-chunk-size in storeConf = 100, this will make (numRawSamples / 100) chunks
+    // Be sure to reset the builder; it is in an Object so static and shared amongst tests
+    builder.reset()
+    partTagsUTF8s.map { case (metric, partTagsUTF8) =>
+      tuples.map { t => SeqRowReader(Seq(t._1, t._2, metric, partTagsUTF8)) }
+        .foreach(builder.addFromReader(_, Schemas.promCounter))
+    }
+    memStore.setup(timeseriesDatasetMultipleShardKeys.ref, Schemas(Schemas.promCounter), ishard, TestData.storeConf)
+    memStore.ingest(timeseriesDatasetMultipleShardKeys.ref, ishard, SomeData(builder.allContainers.head, 0))
+  }
+
   val jobQueryResult1 = ArrayBuffer(("job", "myCoolService"), ("unicode_tag", "uni\u03BCtag"))
   val jobQueryResult2 = Array("http_req_total", "http_resp_time")
   val jobQueryResult3 = Array("job", "__name__", "unicode_tag", "instance")
+
+  override def beforeAll(): Unit = {
+    for (ishard <- 0 until shardPartKeyLabelValues.size) {
+      initShard(memStore, shardPartKeyLabelValues(ishard), ishard)
+    }
+    memStore.refreshIndexForTesting(timeseriesDatasetMultipleShardKeys.ref)
+  }
+
+  override def afterAll(): Unit = {
+    memStore.shutdown()
+  }
+
+  val executeDispatcher = new PlanDispatcher {
+    override def isLocalCall: Boolean = ???
+    override def clusterName: String = ???
+    override def dispatch(plan: ExecPlan)
+                         (implicit sched: Scheduler): Task[QueryResponse] = {
+      plan.execute(memStore, querySession)(sched)
+    }
+  }
 
   implicit val testingBackend: SttpBackend[Future, Nothing] = SttpBackendStub.asynchronousFuture
     .whenRequestMatches(request =>
       request.uri.path.startsWith(List("api","v1","label")) && request.uri.path.last == "values"
     )
     .thenRespondWrapped(Future {
-      Response(Right(Right(MetadataSuccessResponse(Seq(LabelSampl(Seq("http_req_total", "http_resp_time"))), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
+      Response(Right(Right(MetadataSuccessResponse(Seq(LabelSampl("http_req_total"), LabelSampl("http_resp_time")), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
     })
     .whenRequestMatches(request =>
       request.uri.path.startsWith(List("api","v1","series"))
     )
     .thenRespondWrapped(Future {
-      Response(Right(Right(MetadataSuccessResponse(Seq(MetadataSampl(Map(("job" -> "myCoolService"), ("unicode_tag" -> "uniμtag")))), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
+      Response(Right(Right(MetadataSuccessResponse(Seq(MetadataMapSampl(Map(("job" -> "myCoolService"), ("unicode_tag" -> "uniμtag")))), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
     })
     .whenRequestMatches(_.uri.path.startsWith(List("api","v1","labels"))
     )
     .thenRespondWrapped(Future {
-      Response(Right(Right(MetadataSuccessResponse(Seq(LabelSampl(Seq("job", "__name__", "unicode_tag", "instance"))), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
+      Response(Right(Right(MetadataSuccessResponse(Seq(LabelSampl("job"), LabelSampl("__name__"), LabelSampl("unicode_tag"), LabelSampl("instance")), "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
     })
 
   it ("series matcher remote exec") {
@@ -76,7 +151,12 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
       QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/label"))),
       InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
 
-    val resp = exec.execute(memStore, querySession).runAsync.futureValue
+    val exec2: LabelValuesExec = LabelValuesExec(QueryContext(), executeDispatcher,
+      timeseriesDataset.ref, 1, Seq(ColumnFilter("a", Equals("b"))), Seq("__name__"), 123L, 234L)
+    val distConcatExec: LabelValuesDistConcatExec = LabelValuesDistConcatExec(QueryContext(), InProcessPlanDispatcher(queryConfig), Seq(exec2))
+
+    val rootDistConcatExec: LabelValuesDistConcatExec = LabelValuesDistConcatExec(QueryContext(), InProcessPlanDispatcher(queryConfig) , Seq(distConcatExec, exec))
+    val resp = rootDistConcatExec.execute(memStore, querySession).runAsync.futureValue
     val result = (resp: @unchecked) match {
       case QueryResult(id, _, response, _, _, _) => {
         val rv = response(0)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

- add circe decoder to labelvalues and series-matcher query results to support multi-partition queries
- bug fix to return an array of tag values, instead of map, when the metadata query is only for single column