### PR TITLE
fix(query) StitchRVS to accept RVRange for the entire user provided start/step/end

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -28,6 +28,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
   import net.ceedubs.ficus.Ficus._
   import LogicalPlanUtils._
   import QueryFailureRoutingStrategy._
+  import LogicalPlan._
 
   val remoteHttpEndpoint: String = queryConfig.routingConfig.getString("remote.http.endpoint")
 
@@ -47,6 +48,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
         case lp: SeriesKeysByFilters => PartKeysDistConcatExec(queryContext, inProcessPlanDispatcher,
                                         execPlans.sortWith((x, y) => !x.isInstanceOf[MetadataRemoteExec]))
         case _                       => StitchRvsExec(queryContext, inProcessPlanDispatcher,
+                                         rvRangeFromPlan(rootLogicalPlan),
                                          execPlans.sortWith((x, y) => !x.isInstanceOf[PromQlRemoteExec]))
       // ^^ Stitch RemoteExec plan results with local using InProcessPlanDispatcher
       // Sort to move RemoteExec in end as it does not have schema

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -40,6 +40,7 @@ import filodb.query.exec._
 
   // scalastyle:off method.length
   private def materializePeriodicSeriesPlan(qContext: QueryContext, periodicSeriesPlan: PeriodicSeriesPlan) = {
+    import LogicalPlan._
     val earliestRawTime = earliestRawTimestampFn
     lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(periodicSeriesPlan)
     lazy val lookbackMs = LogicalPlanUtils.getLookBackMillis(periodicSeriesPlan).max
@@ -96,7 +97,8 @@ import filodb.query.exec._
       val rawLp = copyLogicalPlanWithUpdatedTimeRange(periodicSeriesPlan, TimeRange(firstInstantInRaw,
         periodicSeriesPlan.endMs))
       val rawEp = rawClusterPlanner.materialize(rawLp, qContext)
-      StitchRvsExec(qContext, stitchDispatcher, Seq(rawEp, downsampleEp))
+      StitchRvsExec(qContext, stitchDispatcher, rvRangeFromPlan(periodicSeriesPlan),
+        Seq(rawEp, downsampleEp))
     }
     PlanResult(Seq(execPlan))
   }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/PlannerHelper.scala
@@ -7,6 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
 import filodb.core.query._
 import filodb.query._
+import filodb.query.LogicalPlan._
 import filodb.query.exec._
 
 /**
@@ -338,11 +339,11 @@ trait  PlannerHelper {
     } else inProcessPlanDispatcher
 
     val stitchedLhs = if (lhs.needsStitch) Seq(StitchRvsExec(qContext,
-      dispatcher, lhs.plans))
+      dispatcher, rvRangeFromPlan(logicalPlan), lhs.plans))
     else lhs.plans
 
     val stitchedRhs = if (rhs.needsStitch) Seq(StitchRvsExec(qContext,
-      dispatcher, rhs.plans))
+      dispatcher, rvRangeFromPlan(logicalPlan), rhs.plans))
     else rhs.plans
 
     val execPlan =

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -196,7 +196,7 @@ class SingleClusterPlanner(val dataset: Dataset,
       case AllChunksSelector          => AllChunkScan
       case WriteBufferSelector        => WriteBufferChunkScan
       case InMemoryChunksSelector     => InMemoryChunkScan
-      case _                          => throw new IllegalArgumentException("Unsupported range selector found")
+      case x @ _                      => throw new IllegalArgumentException(s"Unsupported range selector '$x' found")
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -18,6 +18,7 @@ import filodb.prometheus.ast.Vectors.{PromMetricLabel, TypeLabel}
 import filodb.prometheus.ast.WindowConstants
 import filodb.query.{exec, _}
 import filodb.query.InstantFunctionId.HistogramBucket
+import filodb.query.LogicalPlan._
 import filodb.query.exec.{LocalPartitionDistConcatExec, _}
 import filodb.query.exec.InternalRangeFunction.Last
 
@@ -259,11 +260,11 @@ class SingleClusterPlanner(val dataset: Dataset,
                                      lp: BinaryJoin): PlanResult = {
     val lhs = walkLogicalPlanTree(lp.lhs, qContext)
     val stitchedLhs = if (lhs.needsStitch) Seq(StitchRvsExec(qContext,
-      PlannerUtil.pickDispatcher(lhs.plans), lhs.plans))
+      PlannerUtil.pickDispatcher(lhs.plans), rvRangeFromPlan(lp), lhs.plans))
     else lhs.plans
     val rhs = walkLogicalPlanTree(lp.rhs, qContext)
     val stitchedRhs = if (rhs.needsStitch) Seq(StitchRvsExec(qContext,
-      PlannerUtil.pickDispatcher(rhs.plans), rhs.plans))
+      PlannerUtil.pickDispatcher(rhs.plans), rvRangeFromPlan(lp), rhs.plans))
     else rhs.plans
 
     // TODO Currently we create separate exec plan node for stitching.

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -119,15 +119,6 @@ object CustomRangeVectorKey {
 
 case class RvRange(startMs: Long, stepMs: Long, endMs: Long)
 
-object RvRange {
-  def union(v1: Option[RvRange], v2: Option[RvRange]): Option[RvRange] = {
-    require(v1.map(_.stepMs) == v2.map(_.stepMs), s"Steps for Rvs being stitched were not equal: $v1 and $v2")
-    if (v1.isDefined && v2.isDefined) {
-      Some(RvRange(Math.min(v1.get.startMs, v2.get.startMs), v1.get.stepMs, Math.max(v1.get.endMs, v2.get.endMs)))
-    } else None
-  }
-}
-
 /**
   * Represents a single result of any FiloDB Query.
   */

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -718,7 +718,9 @@ object LogicalPlan {
    */
   def rvRangeFromPlan(plan: LogicalPlan): Option[RvRange] = {
     plan match {
-      case p: PeriodicSeriesPlan   => Some(RvRange(startMs = p.startMs, endMs = p.endMs, stepMs = p.stepMs))
+      case p: PeriodicSeriesPlan   => Some(RvRange( startMs = p.startMs,
+                                                    endMs = p.endMs,
+                                                    stepMs = Math.max(p.stepMs, 1)))
       case _                       => None
     }
   }

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -1,6 +1,6 @@
 package filodb.query
 
-import filodb.core.query.{ColumnFilter, RangeParams}
+import filodb.core.query.{ColumnFilter, RangeParams, RvRange}
 import filodb.core.query.Filter.Equals
 
 //scalastyle:off number.of.types
@@ -707,5 +707,21 @@ object LogicalPlan {
     getNonMetricShardKeyFilters(logicalPlan: LogicalPlan, nonMetricShardColumns: Seq[String]).
       forall(_.forall(f => f.filter.isInstanceOf[filodb.core.query.Filter.Equals]))
 
+  /**
+   *  Given a Logical Plan, the method returns a RVRange, there are two cases possible
+   *  1. The given plan is a PeriodicPlan in which case the start, end and step are retrieved from the plan instance
+   *  2. If plan is not a PeriodicPlan then start step and end are irrelevant for the plan and None is returned
+   *
+   * @param plan: The Logical Plan instance
+   * @param qContext: The query context
+   * @return: Option of the RVRange instance
+   */
+  def rvRangeFromPlan(plan: LogicalPlan): Option[RvRange] = {
+    plan match {
+      case p: PeriodicSeriesPlan   => Some(RvRange(startMs = p.startMs, endMs = p.endMs, stepMs = p.stepMs))
+      case _                   => None  //TODO: Do we infer RVRange from queryContext?
+    }
+  }
 }
+
 //scalastyle:on number.of.types

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -719,7 +719,7 @@ object LogicalPlan {
   def rvRangeFromPlan(plan: LogicalPlan): Option[RvRange] = {
     plan match {
       case p: PeriodicSeriesPlan   => Some(RvRange(startMs = p.startMs, endMs = p.endMs, stepMs = p.stepMs))
-      case _                   => None  //TODO: Do we infer RVRange from queryContext?
+      case _                       => None
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
@@ -37,10 +37,10 @@ final case class LocalPartitionDistConcatExec(queryContext: QueryContext,
   */
 final case class SplitLocalPartitionDistConcatExec(queryContext: QueryContext,
                                      dispatcher: PlanDispatcher,
-                                     children: Seq[ExecPlan],
+                                     children: Seq[ExecPlan], outputRvRange: Option[RvRange],
                                     override val parallelChildTasks: Boolean = false) extends DistConcatExec {
 
-  addRangeVectorTransformer(StitchRvsMapper())
+  addRangeVectorTransformer(StitchRvsMapper(outputRvRange))
 
   // overriden since it can reduce schemas with different vector lengths as long as the columns are same
   override def reduceSchemas(rs: ResultSchema, resp: QueryResult): ResultSchema =

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -12,41 +12,47 @@ import filodb.query.Query.qLogger
 
 object StitchRvsExec {
 
-  def stitch(v1: RangeVector, v2: RangeVector): RangeVector = {
-    val rows = StitchRvsExec.merge(Seq(v1.rows(), v2.rows()))
-    IteratorBackedRangeVector(v1.key, rows, RvRange.union(v1.outputRange, v2.outputRange))
-  }
+  private class RVCursorImpl(vectors: Iterable[RangeVectorCursor], outputRange: Option[RvRange])
+    extends RangeVectorCursor {
+    private val bVectors = vectors.map(_.buffered)
+    val mins = new mutable.ArrayBuffer[BufferedIterator[RowReader]](2)
+    val nanResult = new TransientRow(0, Double.NaN)
+    val tsIter: BufferedIterator[Long] = outputRange match {
+      case Some(RvRange(startMs, stepMs, endMs)) =>
+        Iterator.iterate(startMs){_ + stepMs}.takeWhile( _ <= endMs).buffered
+      case None                                  => Iterator.iterate(Long.MaxValue)(_ =>Long.MaxValue).buffered
+    }
+    override def hasNext: Boolean = tsIter.hasNext
 
-  def merge(vectors: Iterable[RangeVectorCursor]): RangeVectorCursor = {
-    // This is an n-way merge without using a heap.
-    // Heap is not used since n is expected to be very small (almost always just 1 or 2)
-    new RangeVectorCursor {
-      val bVectors = vectors.map(_.buffered)
-      val mins = new mutable.ArrayBuffer[BufferedIterator[RowReader]](2)
-      val nanResult = new TransientRow(0, Double.NaN)
-      override def hasNext: Boolean = bVectors.exists(_.hasNext)
+    override def next(): RowReader = {
 
-      override def next(): RowReader = {
-        mins.clear()
-        var minTime = Long.MaxValue
-        bVectors.foreach { r =>
-          if (r.hasNext) {
-            val t = r.head.getLong(0)
-            if (mins.isEmpty) {
-              minTime = t
-              mins += r
-            }
-            else if (t < minTime) {
-              mins.clear()
-              mins += r
-              minTime = t
-            } else if (t == minTime) {
-              mins += r
-            }
+      mins.clear()
+      var minTime = Long.MaxValue
+      bVectors.foreach { r =>
+        if (r.hasNext) {
+          val t = r.head.getLong(0)
+          if (mins.isEmpty) {
+            minTime = t
+            mins += r
+          }
+          else if (t < minTime) {
+            mins.clear()
+            mins += r
+            minTime = t
+          } else if (t == minTime) {
+            mins += r
           }
         }
+      }
+      if (mins.isEmpty && tsIter.isEmpty) throw new IllegalStateException("next was called when no element")
+      if (minTime > tsIter.head) {
+        nanResult.timestamp = tsIter.next()
+        nanResult
+      } else {
+        if (minTime == tsIter.head)
+          tsIter.next()
+
         if (mins.size == 1) mins.head.next()
-        else if (mins.isEmpty) throw new IllegalStateException("next was called when no element")
         else {
           nanResult.timestamp = minTime
           // until we have a different indicator for "unable-to-calculate", use NaN when multiple values seen
@@ -56,10 +62,23 @@ object StitchRvsExec {
         }
       }
 
-      override def close(): Unit = vectors.foreach(_.close())
     }
+
+    override def close(): Unit = vectors.foreach(_.close())
+  }
+
+  def stitch(v1: RangeVector, v2: RangeVector, outputRvRange: Option[RvRange]): RangeVector = {
+    val rows = StitchRvsExec.merge(Seq(v1.rows(), v2.rows()), outputRvRange)
+    IteratorBackedRangeVector(v1.key, rows, outputRvRange)
+  }
+
+  def merge(vectors: Iterable[RangeVectorCursor], outputRange: Option[RvRange]): RangeVectorCursor = {
+    // This is an n-way merge without using a heap.
+    // Heap is not used since n is expected to be very small (almost always just 1 or 2)
+    new RVCursorImpl(vectors, outputRange)
   }
 }
+
 
 /**
   * Use when data for same time series spans multiple shards, or clusters.
@@ -82,7 +101,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
     }.toListL.map(_.flatten).map { srvs =>
       val groups = srvs.groupBy(_.key.labelValues)
       groups.mapValues { toMerge =>
-        val rows = StitchRvsExec.merge(toMerge.map(_.rows()))
+        val rows = StitchRvsExec.merge(toMerge.map(_.rows()), outputRvRange)
         val key = toMerge.head.key
         IteratorBackedRangeVector(key, rows, outputRvRange)
       }.values
@@ -98,7 +117,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
 /**
   * Range Vector Transformer version of StitchRvsExec
   */
-final case class StitchRvsMapper() extends RangeVectorTransformer {
+final case class StitchRvsMapper(outputRvRange: Option[RvRange]) extends RangeVectorTransformer {
 
   def apply(source: Observable[RangeVector],
             querySession: QuerySession,
@@ -108,12 +127,9 @@ final case class StitchRvsMapper() extends RangeVectorTransformer {
     val stitched = source.toListL.map { rvs =>
       val groups = rvs.groupBy(_.key)
       groups.mapValues { toMerge =>
-        val rows = StitchRvsExec.merge(toMerge.map(_.rows))
+        val rows = StitchRvsExec.merge(toMerge.map(_.rows()), outputRvRange)
         val key = toMerge.head.key
-        val outputRange = toMerge.map(_.outputRange).reduce { (rv1Range, rv2Range) =>
-          RvRange.union(rv1Range, rv2Range)
-        }
-        IteratorBackedRangeVector(key, rows, outputRange)
+        IteratorBackedRangeVector(key, rows, outputRvRange)
       }.values
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -66,6 +66,7 @@ object StitchRvsExec {
   */
 final case class StitchRvsExec(queryContext: QueryContext,
                                dispatcher: PlanDispatcher,
+                               outputRvRange: Option[RvRange],
                                children: Seq[ExecPlan]) extends NonLeafExecPlan {
   require(children.nonEmpty)
 
@@ -83,10 +84,7 @@ final case class StitchRvsExec(queryContext: QueryContext,
       groups.mapValues { toMerge =>
         val rows = StitchRvsExec.merge(toMerge.map(_.rows()))
         val key = toMerge.head.key
-        val outputRange = toMerge.map(_.outputRange).reduce { (rv1Range, rv2Range) =>
-          RvRange.union(rv1Range, rv2Range)
-        }
-        IteratorBackedRangeVector(key, rows, outputRange)
+        IteratorBackedRangeVector(key, rows, outputRvRange)
       }.values
     }.map(Observable.fromIterable)
     Observable.fromTask(stitched).flatten

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -22,7 +22,15 @@ object StitchRvsExec {
         Iterator.iterate(startMs){_ + stepMs}.takeWhile( _ <= endMs).buffered
       case None                                  => Iterator.iterate(Long.MaxValue)(_ =>Long.MaxValue).buffered
     }
-    override def hasNext: Boolean = tsIter.hasNext
+    override def hasNext: Boolean = outputRange match {
+                // In case outputRange is provided, the merging will honor the provided range, that is, the
+                // result of metrging will have a range provided by outputRange. In case outputRange is not provided
+                // i.e. None, then hasNext should be determined by the vectors it merges. The none handling is just done
+                // for matching both possibilities and in reality for a given periodic series with a range, the
+                // outputRange should never be none
+                case Some(_)      => tsIter.hasNext
+                case None         => bVectors.exists(_.hasNext)
+    }
 
     override def next(): RowReader = {
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -104,7 +104,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Nil, Nil, "__name__")
+      Nil, Nil, Nil, "__name__", Some(RvRange(startMs = 0, endMs =  19, stepMs = 1)))
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
@@ -134,7 +134,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Nil, Nil, "__name__")
+      Nil, Nil, Nil, "__name__", Some(RvRange(startMs = 0, endMs = 99, stepMs = 1)))
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
@@ -192,7 +192,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Array(dummyPlan), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Seq("_step_", "_pi_"), Nil, Nil, "__name__")
+      Seq("_step_", "_pi_"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema)))
@@ -266,7 +266,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Array(dummyPlan), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToMany,
-      Nil, ignoring = Seq("tag1"), include = Seq("tag2"), "__name__")
+      Nil, ignoring = Seq("tag1"), include = Seq("tag2"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema)))
@@ -301,7 +301,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Seq("tag1"), Nil, "__name__")
+      Nil, Seq("tag1"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
@@ -334,7 +334,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Seq("tag1"), Nil, "__name__")
+      Nil, Seq("tag1"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs2.map(rv => SerializedRangeVector(rv, schema)))
@@ -355,7 +355,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Seq("tag2"), Nil, "__name__")
+      Nil, Seq("tag2"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
@@ -384,7 +384,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Seq("tag1", "job"), Nil, Nil, "__name__")
+      Seq("tag1", "job"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
@@ -411,7 +411,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Nil, Nil, "metric")
+      Nil, Nil, Nil, "metric", None)
 
     val samplesLhs: Array[RangeVector] = Array.tabulate(200) { i =>
       new RangeVector {
@@ -488,7 +488,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.GTR,
       Cardinality.OneToOne,
-      Nil, Seq("tag2"), Nil, "metric")
+      Nil, Seq("tag2"), Nil, "metric", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
@@ -514,7 +514,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Nil, Seq("tag2"), Nil, "__name__")
+      Nil, Seq("tag2"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
@@ -539,7 +539,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.ADD,
       Cardinality.OneToOne,
-      Seq("tag1", "job"), Nil, Nil, "__name__")
+      Seq("tag1", "job"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
@@ -666,7 +666,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Cardinality.OneToMany,
       Seq("exported_namespace", "exported_pod"),
       Nil,
-      Nil, "__name__")
+      Nil, "__name__", None)
 
     val result = execPlan.compose(Observable.fromIterable(Seq((lhs, 0), (rhs, 1))), tvSchemaTask, querySession)
       .toListL.runAsync.futureValue

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -137,7 +137,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
-      Seq("instance"), Nil, Seq("role"), "__name__")
+      Seq("instance"), Nil, Seq("role"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
@@ -172,7 +172,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1),
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
-      Nil, Seq("role", "mode"), Seq("role"), "__name__")
+      Nil, Seq("role", "mode"), Seq("role"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
@@ -212,7 +212,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1),
       BinaryOperator.DIV,
       Cardinality.ManyToOne,
-      Seq("instance"), Nil, Nil, "__name__")
+      Seq("instance"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
@@ -257,7 +257,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       BinaryOperator.MUL,
       Cardinality.OneToMany,
       Nil, Seq("role"),
-      Seq("role"), "__name__")
+      Seq("role"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeRole.map(rv => SerializedRangeVector(rv, schema)))
@@ -291,7 +291,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1),
       BinaryOperator.DIV,
       Cardinality.ManyToOne, Nil,
-      Seq("mode"), Seq("dummy"), "__name__")
+      Seq("mode"), Seq("dummy"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
@@ -377,7 +377,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.GTR,
       Cardinality.ManyToOne,
-      Seq("instance"), Nil, Seq("role"), "metric")
+      Seq("instance"), Nil, Seq("role"), "metric", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleLhs.map(rv => SerializedRangeVector(rv, schema)))
@@ -412,7 +412,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
-      Seq("instance"), Nil, Seq("role"), "__name__")
+      Seq("instance"), Nil, Seq("role"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
@@ -439,7 +439,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1),
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
-      Nil, Seq("role", "mode"), Seq("role"), "__name__")
+      Nil, Seq("role", "mode"), Seq("role"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
@@ -471,7 +471,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       new Array[ExecPlan](1),
       BinaryOperator.DIV,
       Cardinality.ManyToOne,
-      Seq("instance"), Nil, Nil, "__name__")
+      Seq("instance"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -284,7 +284,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
@@ -319,7 +319,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -356,7 +356,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Seq("instance", "job"), Nil, "__name__")
+      Seq("instance", "job"), Nil, "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -393,7 +393,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Seq("instance"), Nil, "__name__")
+      Seq("instance"), Nil, "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -429,7 +429,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Seq("group"), "__name__")
+      Nil, Seq("group"), "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -464,7 +464,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Seq("group", "job"), "__name__")
+      Nil, Seq("group", "job"), "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -499,7 +499,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Seq("dummy"), Nil, "__name__")
+      Seq("dummy"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
@@ -521,7 +521,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Seq("group", "instance", "job"), "__name__")
+      Nil, Seq("group", "instance", "job"), "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
@@ -543,7 +543,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
@@ -571,7 +571,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -631,7 +631,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -646,7 +646,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Seq("instance"), Nil, "__name__")
+      Seq("instance"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs2 = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
@@ -702,7 +702,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runAsync.futureValue
@@ -717,7 +717,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LOR,
-      Nil, Seq("l", "group", "job"), "__name__")
+      Nil, Seq("l", "group", "job"), "__name__", None)
 
     // scalastyle:off
     val lhs2 = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
@@ -772,7 +772,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
@@ -805,7 +805,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job"), Nil, "__name__")
+      Seq("job"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
@@ -836,7 +836,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job", "instance"), Nil, "__name__")
+      Seq("job", "instance"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
@@ -871,7 +871,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job"), Nil, "__name__")
+      Seq("job"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
@@ -903,7 +903,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LUnless,
-      Seq("job", "instance"), Nil, "__name__")
+      Seq("job", "instance"), Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
@@ -937,7 +937,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
@@ -966,7 +966,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
@@ -992,7 +992,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan),
       new Array[ExecPlan](1),
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     // scalastyle:off
     val lhs = QueryResult("someId", tvSchema, sampleMultipleRows.map(rv => SerializedRangeVector(rv, schema)))
@@ -1024,7 +1024,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
      BinaryOperator.LOR,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     import NoCloseCursor._
     val lhsRv = new RangeVector {
@@ -1073,7 +1073,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.LOR,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     import NoCloseCursor._
     val rhsRv = new RangeVector {
@@ -1121,7 +1121,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     import NoCloseCursor._
     val lhsRv = new RangeVector {
@@ -1168,7 +1168,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     import NoCloseCursor._
     val rhsRv = new RangeVector {
@@ -1214,7 +1214,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.LUnless,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     import NoCloseCursor._
     val rhsRv = new RangeVector {
@@ -1260,7 +1260,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.LUnless,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
     import NoCloseCursor._
     val lhsRv = new RangeVector {
@@ -1352,7 +1352,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Array(dummyPlan), // cannot be empty as some compose's rely on the schema
       new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
       BinaryOperator.LAND,
-      Nil, Nil, "__name__")
+      Nil, Nil, "__name__", None)
 
 
     val lhs = QueryResult("someId", tvSchema, (lhs2 ++ lhs1).map(rv => SerializedRangeVector(rv, schema)))

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -107,7 +107,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     val execPlan2 = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher, timeseriesDataset.ref,
       0, filters, AllChunkScan,"_metric_")
 
-    val sep = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan1, execPlan2))
+    val sep = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan1, execPlan2))
     val result = dispatcher.dispatch(sep).runAsync.futureValue
 
     result match {
@@ -135,7 +135,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     val execPlan2 = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher, timeseriesDataset.ref,
       0, emptyFilters, AllChunkScan, "_metric_")
 
-    val sep = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan1, execPlan2))
+    val sep = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan1, execPlan2))
     val result = dispatcher.dispatch(sep).runAsync.futureValue
 
     result match {
@@ -147,7 +147,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     }
 
     // Switch the order and make sure it's OK if the first result doesn't have any data
-    val sep2 = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan2, execPlan1))
+    val sep2 = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan2, execPlan1))
     val result2 = dispatcher.dispatch(sep2).runAsync.futureValue
 
     result2 match {
@@ -159,7 +159,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     }
 
     // Two children none of which returns data
-    val sep3 = StitchRvsExec(QueryContext(), dispatcher, Seq(execPlan2, execPlan2))
+    val sep3 = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan2, execPlan2))
     val result3 = dispatcher.dispatch(sep3).runAsync.futureValue
 
     result3 match {

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -118,7 +118,7 @@ class SplitLocalPartitionDistConcatExecSpec extends AnyFunSpec with Matchers wit
     execPlan2.addRangeVectorTransformer(new PeriodicSamplesMapper(start2, step, end2, Some(reportingInterval * 100),
       Some(InternalRangeFunction.SumOverTime), QueryContext()))
 
-    val distConcatExec = SplitLocalPartitionDistConcatExec(QueryContext(), dispacher, Seq(execPlan1, execPlan2))
+    val distConcatExec = SplitLocalPartitionDistConcatExec(QueryContext(), dispacher, Seq(execPlan1, execPlan2), None)
 
     val resp = distConcatExec.execute(memStore, querySession).runAsync.futureValue
     val result = resp.asInstanceOf[QueryResult]

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -172,7 +172,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       )
 
     // null needed below since there is a require in code that prevents empty children
-    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig),
+    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig), Some(RvRange(0, 10, 150)),
       Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
     val rs = ResultSchema(List(ColumnInfo("timestamp",
       TimestampColumn), ColumnInfo("value", DoubleColumn)), 1)
@@ -185,14 +185,16 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       .toListL.runAsync.futureValue
     output.size shouldEqual 1
     output.head.rows().map(r => (r.getLong(0), r.getDouble(1))).toList shouldEqual expected
-    output.head.outputRange shouldEqual Some(RvRange(10, 10, 100))
+
+    // Notice how the output RVRange is same as the one passed during initialition of the StitchRvsExec
+    output.head.outputRange shouldEqual Some(RvRange(0, 10, 150))
   }
 
   it ("should reduce result schemas with different fixedVecLengths without error") {
 
     // null needed below since there is a require in code that prevents empty children
     val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig),
-                             Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
+                             None, Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
 
     val rs1 = ResultSchema(List(ColumnInfo("timestamp",
       TimestampColumn), ColumnInfo("value", DoubleColumn)), 1, Map(), Some(430), List(0, 1))
@@ -339,6 +341,5 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     }
 
   }
-
 }
 

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -198,7 +198,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   }
 
 
-  it ("should output range passed in to StitchRvsExec") {
+  it ("should merge RVs despite passing None for RvRange to StitchRvsExec") {
 
     val rvsData = Seq (
       Seq(  (10L, 3d),
@@ -244,7 +244,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     output.size shouldEqual 1
 
     // Notice how the output RVRange is same as the one passed during initialization of the StitchRvsExec
-    output.head.outputRange shouldEqual Some(RvRange(0, 10, 150))
+    output.head.outputRange shouldEqual None
     compareIter(output.head.rows().map(r => (r.getLong(0), r.getDouble(1))) , expected.toIterator)
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
   
Stitch creates an ``RvRange`` using a union of the children's ``RvRange``. This causes issues when Stitch is not the the top level operation and is under a ``BinaryJoinExec`` The lhs and rhs of Binary joins will not match causing inconsistent query results. 

**New behavior :**
``StitchRVSExec`` has been updated to now accept a ``RvRange`` that the user query expects. The union of ``RvRange`` therefore is not needed.
