### PR TITLE
fix(query): label value metadata typo fix

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -359,7 +359,7 @@ final case class LabelValuesExec(queryContext: QueryContext,
         case false if (columns.size == 1) =>
           val metadataMap = memStore.labelValuesWithFilters(dataset, shard, filters, columns, endMs, startMs,
             queryContext.plannerParams.sampleLimit)
-          val labels = metadataMap.map(_.head._1.toString).toSeq
+          val labels = metadataMap.map(_.head._2.toString).toSeq
           val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
             NoCloseCursor(StringArrayRowReader(labels)), None))
           val sch = if (labels.isEmpty) ResultSchema.empty


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
When only one label is provided to a label-values query with filters, the label itself is returned as the result.

**New behavior :**
A single tuple getter `._1` has been changed to `._2`, so values are now returned.