### PR TITLE
fix(prometheus) Metric name should not be set twice

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -8,9 +8,10 @@ import filodb.prometheus.parse.Parser
 import filodb.query._
 
 object Vectors {
-  val PromMetricLabel = "__name__"
-  val TypeLabel       = "_type_"
-  val BucketFilterLabel = "_bucket_"
+  val PromMetricLabel         = "__name__"
+  val PromInternalMetricLabel = "_metric_"
+  val TypeLabel               = "_type_"
+  val BucketFilterLabel       = "_bucket_"
 }
 
 object WindowConstants {
@@ -151,7 +152,7 @@ sealed trait Vector extends Expression {
    *   (2) at least one label matcher exists.
    */
   def applyPromqlConstraints(): Unit = {
-    val nameLabel = labelSelection.find(_.label == PromMetricLabel)
+    val nameLabel = labelSelection.find(lm => lm.label == PromMetricLabel || lm.label == PromInternalMetricLabel)
     if (metricName.nonEmpty) {
       if (nameLabel.nonEmpty) {
         throw new IllegalArgumentException(

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -185,6 +185,9 @@ class ParserSpec extends AnyFunSpec with Matchers {
     parseError("foo{1}")
     parseError("{}")
     parseError("foo{__name__=\"bar\"}")
+    parseError("foo{__name__=\"foo\"}")
+    parseError("foo{_metric_=\"bar\"}")
+    parseError("foo{_metric_=\"foo\"}")
 
     parseSuccessfully("test{a=\"b\"}[5y] OFFSET 3d")
     parseSuccessfully("test{a=\"b\"}[5y] LIMIT 3")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**  Following prom expressions are valid

```foo{_metric_="foo"}``` but ```foo{__name__="foo"}``` will fail to parse


**New behavior :**
both ```foo{_metric_="foo"}```  and ``` foo{__name__="foo"}``` will fail to parse

