### PR TITLE
***WIP*** fix(gateway): limit InputRecord label value size

### DIFF
--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -59,9 +59,6 @@ import filodb.timeseries.TestTimeseriesProducer
 object GatewayServer extends StrictLogging {
   Kamon.init
 
-  val MAX_RECORD_TAG_VALUE_SIZE_BYTES = 16384  // 2^14; 2^15 is lucene limit
-  val RECORD_TAG_VALUE_BYTES_PER_CHAR = 2;
-
   // Get global configuration using universal FiloDB/Akka-based config
   val settings = new FilodbSettings()
   val config = settings.allConfig
@@ -239,6 +236,7 @@ object GatewayServer extends StrictLogging {
     (shardQueues, containerStream)
   }
 
+  private val labelSizeValidator = new LabelSizeValidatorVisitor()
   private def validateRecord(rec: InputRecord): Boolean = {
     for ((label, value) <- rec.tags) {
       val labelSizeBytes = value.size * RECORD_TAG_VALUE_BYTES_PER_CHAR

--- a/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InfluxRecord.scala
@@ -24,7 +24,7 @@ trait InfluxRecord extends InputRecord {
   def ts: Long
 
   import InfluxProtocolParser._
-  protected def endOfTags: Int = keyOffset(fieldDelims(0)) - 1
+  def endOfTags: Int = keyOffset(fieldDelims(0)) - 1
 
   // Iterate through the tags for shard keys, extract values and calculate shard hash
   private var tagsShardHash = 7
@@ -73,6 +73,10 @@ trait InfluxRecord extends InputRecord {
   val partitionKeyHash = {
     val firstTagIndex = keyOffset(tagDelims(0))
     BinaryRegion.hasher32.hash(bytes, firstTagIndex, endOfTags - firstTagIndex, BinaryRegion.Seed)
+  }
+
+  final def acceptValidator(validator: RecordValidatorVisitor): Boolean = {
+    validator.visit(this)
   }
 }
 

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -19,6 +19,9 @@ trait InputRecord {
   def shardKeyHash: Int
   def partitionKeyHash: Int
 
+  // tags are needed for validation (i.e. that label values do not exceed a size limit)
+  val tags: Map[String, String]
+
   /**
    * The values for each of the tag keys found in DatasetOptions.nonMetricShardColumns
    * @return the nonMetricShardColumns tag values, in the same order as nonMetricShardColumns

--- a/gateway/src/main/scala/filodb/gateway/conversion/RecordValidatorVisitor.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/RecordValidatorVisitor.scala
@@ -1,0 +1,51 @@
+package filodb.gateway.conversion
+
+trait RecordValidatorVisitor {
+  def visit(rec: InfluxRecord): Boolean
+  def visit(rec: PrometheusInputRecord): Boolean
+  def visit(rec: MetricTagInputRecord): Boolean
+}
+
+object LabelSizeValidatorVisitor {
+  val LABEL_VALUE_MAX_SIZE_BYTES = 16384  // 2^14; 2^15 is lucene limit
+  val BYTES_PER_CHAR = 2
+}
+
+class LabelSizeValidatorVisitor extends RecordValidatorVisitor {
+  import LabelSizeValidatorVisitor._
+
+  def validateLabelValueSize(size: Int): Boolean = {
+    (size * BYTES_PER_CHAR) < LABEL_VALUE_MAX_SIZE_BYTES
+  }
+
+  def visit(rec: InfluxRecord): Boolean = {
+    // once set true, cannot be switched back to false
+    class TripBool() {
+      private var tripped_ = false
+      def tripIfTrue(value: Boolean): Unit = {
+        if (!tripped_) {
+          tripped_ = value
+        }
+      }
+      def get(): Boolean = {
+        tripped_
+      }
+    }
+    // mark invalid if any of the label values are oversized
+    val isInvalid = new TripBool()
+    InfluxProtocolParser.parseKeyValues(rec.bytes, rec.tagDelims, rec.endOfTags, new KVVisitor {
+      override def apply(bytes: Array[Byte], keyIndex: Int, keyLen: Int, valueIndex: Int, valueLen: Int): Unit = {
+        isInvalid.tripIfTrue(!validateLabelValueSize(valueLen))
+      }
+    })
+    !isInvalid.get()
+  }
+
+  def visit(rec: PrometheusInputRecord): Boolean = {
+    rec.tags.values.forall(value => validateLabelValueSize(value.size))
+  }
+
+  def visit(rec: MetricTagInputRecord): Boolean = {
+    rec.tags.values.forall(value => value.numBytes < LABEL_VALUE_MAX_SIZE_BYTES)
+  }
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Label values too large will cause Lucene to throw exceptions.

**New behavior :**
Label values are capped at a specific size. When the gateway receives a record that exceeds this limit:
1. A warning is logged.
2. A counter is incremented for the ws/ns pair.
3. The record is dropped.