### PR TITLE
feat(core): Lucene faceting for 300x more efficient label-value queries

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -435,6 +435,9 @@ filodb {
     # At the cost of some extra heap memory, we can track queries holding shared lock for a long time
     # and starving the exclusive access of lock for eviction
     track-queries-holding-eviction-lock = true
+
+    # Whether or not in TimeSeriesShard, faceting is enabled for lucene index
+    index-faceting-enabled = true
   }
 
   # for standalone worker cluster configuration, see akka-bootstrapper

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -71,7 +71,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   private val stats = new DownsampledTimeSeriesShardStats(rawDatasetRef, shardNum)
 
-  private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, shardNum, indexTtlMs)
+  private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, false, shardNum, indexTtlMs)
 
   private val indexUpdatedHour = new AtomicLong(0)
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -303,12 +303,11 @@ class PartKeyLuceneIndex(ref: DatasetRef,
             new DefaultSortedSetDocValuesReaderState(reader, FACET_FIELD_PREFIX + colName))
         val fc = new FacetsCollector
         val query = colFiltersToQuery(colFilters, startTime, endTime)
-        FacetsCollector.search(searcher, query, 10, fc)
+        FacetsCollector.search(searcher, query, limit, fc)
         val facets = new SortedSetDocValuesFacetCounts(state, fc)
         val result = facets.getTopChildren(limit, colName)
-        if (result != null) {
-          for (i <- 0 until Math.min(result.childCount, limit)) {
-            val lv = result.labelValues(i)
+        if (result != null && result.labelValues != null) {
+          result.labelValues.foreach { lv =>
             labelValues += lv.label
           }
         }
@@ -404,7 +403,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
                     endTime: Long = Long.MaxValue,
                     partKeyBytesRefOffset: Int = 0)
                    (partKeyNumBytes: Int = partKeyOnHeapBytes.length): Unit = {
-    val document = makeDocument(partKeyOnHeapBytes, partKeyBytesRefOffset, partKeyNumBytes, partId, startTime, endTime)
+    makeDocument(partKeyOnHeapBytes, partKeyBytesRefOffset, partKeyNumBytes, partId, startTime, endTime)
     logger.debug(s"Upserting document ${partKeyString(partId, partKeyOnHeapBytes, partKeyBytesRefOffset)} " +
                  s"with startTime=$startTime endTime=$endTime into dataset=$ref shard=$shardNum")
     val doc = luceneDocument.get()

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -289,7 +289,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     * Used to answer queries not involving the full partition key.
     * Maintained using a high-performance bitmap index.
     */
-  private[memstore] final val partKeyIndex = new PartKeyLuceneIndex(ref, schemas.part, shardNum,
+  private[memstore] final val partKeyIndex = new PartKeyLuceneIndex(ref, schemas.part, true, shardNum,
     storeConfig.diskTTLSeconds * 1000)
 
   private val cardTracker: CardinalityTracker = if (storeConfig.meteringEnabled) {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -56,6 +56,7 @@ filodb {
     max-partitions-on-heap-per-shard = 10000
     ingestion-buffer-mem-size = 80MB
     track-queries-holding-eviction-lock = false
+    index-faceting-enabled = true
   }
 
   tasks {

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -395,5 +395,8 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val labelValues3 = index3.shardKeyColValues(filters3, 0, Long.MaxValue, "_metric_")
     labelValues3 shouldEqual Seq("counter1")
 
+    val labelValues4 = index3.shardKeyColValues(filters1, 0, Long.MaxValue, "instance", 1000)
+    labelValues4.toSet shouldEqual (0 until 1000).map(c => s"instance$c").toSet
+
   }
 }

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -122,12 +122,15 @@ object TestTimeseriesProducer extends StrictLogging {
       val timestamp = startTime + (n.toLong / numTimeSeries) * 10000 // generate 1 sample every 10s for each instance
       val value = 15 + Math.sin(n + 1) + rand.nextGaussian()
 
-      val tags = Map("dc"       -> s"DC$dc",
-                     "_ws_"      -> "demo",
-                     "_ns_"      -> s"App-$app",
-                     "partition" -> s"partition-$partition",
-                     "host"     -> s"H$host",
-                     "instance" -> s"Instance-$instance")
+      val tags = Map("dc"         -> s"DC$dc",
+                     "_ws_"       -> "demo",
+                     "_ns_"       -> s"App-$app",
+                     "partition"  -> s"partition-$partition",
+                     "partitionAl"-> s"partition-$partition",
+                     "longTag"    -> "AlonglonglonglonglonglonglonglonglonglonglonglonglonglongTag",
+                     "host"       -> s"H$host",
+                     "hostAlias"  -> s"H$host",
+                     "instance"   -> s"Instance-$instance")
 
       PrometheusInputRecord(tags, "heap_usage", timestamp, value)
     }

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -28,7 +28,7 @@ class PartKeyIndexBenchmark {
 
   println(s"Building Part Keys")
   val ref = DatasetRef("prometheus")
-  val partKeyIndex = new PartKeyLuceneIndex(ref, untyped.partition, 0, 1.hour.toMillis)
+  val partKeyIndex = new PartKeyLuceneIndex(ref, untyped.partition, true, 0, 1.hour.toMillis)
   val numSeries = 1000000
   val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.DefaultContainerSize, false)
   val untypedData = TestTimeseriesProducer.timeSeriesData(0, numSeries) take numSeries
@@ -148,7 +148,7 @@ class PartKeyIndexBenchmark {
     cforRange ( 0 until 8 ) { i =>
       val filter = Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
         ColumnFilter("_ws_", Filter.Equals("demo")))
-      partKeyIndex.shardKeyColValues(filter, now, now + 1000, "_metric_", 10000)
+      partKeyIndex.labelValuesEfficient(filter, now, now + 1000, "_metric_", 10000)
     }
   }
 

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -1,5 +1,6 @@
 package filodb.jmh
 
+import java.lang.management.{BufferPoolMXBean, ManagementFactory}
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration._
@@ -21,20 +22,21 @@ class PartKeyIndexBenchmark {
 
   org.slf4j.LoggerFactory.getLogger("filodb").asInstanceOf[Logger].setLevel(Level.ERROR)
 
+  println(s"Building Part Keys")
   val ref = DatasetRef("prometheus")
   val partKeyIndex = new PartKeyLuceneIndex(ref, untyped.partition, 0, 1.hour.toMillis)
   val numSeries = 1000000
-  val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory)
+  val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.DefaultContainerSize, false)
   val untypedData = TestTimeseriesProducer.timeSeriesData(0, numSeries) take numSeries
   untypedData.foreach(_.addToBuilder(ingestBuilder))
 
-  val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory)
+  val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.DefaultContainerSize, false)
 
   val converter = new BinaryRegionConsumer {
     def onNext(base: Any, offset: Long): Unit = untyped.comparator.buildPartKeyFromIngest(base, offset, partKeyBuilder)
   }
   // Build part keys from the ingestion records
-  ingestBuilder.allContainers.head.consumeRecords(converter)
+  ingestBuilder.allContainers.foreach(_.consumeRecords(converter))
 
   var partId = 1
   val now = System.currentTimeMillis()
@@ -45,8 +47,20 @@ class PartKeyIndexBenchmark {
       partId += 1
     }
   }
+
+  val start = System.nanoTime()
+  //noinspection ScalaStyle
+  println(s"Indexing started")
   partKeyBuilder.allContainers.foreach(_.consumeRecords(consumer))
   partKeyIndex.refreshReadersBlocking()
+  val end = System.nanoTime()
+  //noinspection ScalaStyle
+  println(s"Indexing finished. Added $partId part keys Took ${(end-start)/1000000000L}s")
+  import scala.collection.JavaConverters._
+
+  //noinspection ScalaStyle
+  println(s"Index Memory Map Size: " +
+    s"${ManagementFactory.getPlatformMXBeans(classOf[BufferPoolMXBean]).asScala.find(_.getName == "mapped").get.getMemoryUsed}")
 
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
@@ -57,7 +71,7 @@ class PartKeyIndexBenchmark {
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
             ColumnFilter("_ws_", Filter.Equals("demo")),
             ColumnFilter("host", Filter.EqualsRegex("H0")),
-            ColumnFilter("__name__", Filter.Equals("heap_usage"))),
+            ColumnFilter("_metric_", Filter.Equals("heap_usage"))),
         now,
         now + 1000)
     }
@@ -66,13 +80,14 @@ class PartKeyIndexBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
   def emptyPartIdsLookupWithEqualsFilters(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       partKeyIndex.partIdsFromFilters(
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-${i + 200}")),
           ColumnFilter("_ws_", Filter.Equals("demo")),
           ColumnFilter("host", Filter.EqualsRegex("H0")),
-          ColumnFilter("__name__", Filter.Equals("heap_usage"))),
+          ColumnFilter("_metric_", Filter.Equals("heap_usage"))),
         now,
         now + 1000)
     }
@@ -81,12 +96,13 @@ class PartKeyIndexBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
   def partIdsLookupWithSuffixRegexFilters(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       partKeyIndex.partIdsFromFilters(
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
           ColumnFilter("_ws_", Filter.Equals("demo")),
-          ColumnFilter("__name__", Filter.Equals("heap_usage")),
+          ColumnFilter("_metric_", Filter.Equals("heap_usage")),
           ColumnFilter("instance", Filter.EqualsRegex("Instance-2.*"))),
         now,
         now + 1000)
@@ -96,12 +112,13 @@ class PartKeyIndexBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
   def partIdsLookupWithPrefixRegexFilters(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       partKeyIndex.partIdsFromFilters(
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
           ColumnFilter("_ws_", Filter.Equals("demo")),
-          ColumnFilter("__name__", Filter.Equals("heap_usage")),
+          ColumnFilter("_metric_", Filter.Equals("heap_usage")),
           ColumnFilter("instance", Filter.EqualsRegex(".*2"))),
         now,
         now + 1000)
@@ -111,11 +128,24 @@ class PartKeyIndexBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
   def startTimeLookupWithPartId(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       val pIds = debox.Buffer.empty[Int]
       cforRange ( i * 1000 to i * 1000 + 1000 ) { j => pIds += j }
       partKeyIndex.startTimeFromPartIds(pIds.iterator())
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
+  def getMetricNames(): Unit = {
+    cforRange ( 0 until 8 ) { i =>
+      val filter = Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
+        ColumnFilter("_ws_", Filter.Equals("demo")))
+      partKeyIndex.shardKeyColValues(filter, now, now + 1000, "_metric_", 10000)
     }
   }
 

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -161,9 +161,9 @@ class PartKeyIndexBenchmark {
       val filter = Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
         ColumnFilter("_ws_", Filter.Equals("demo")))
       val res = mutable.HashSet[ZeroCopyUTF8String]()
-      partKeyIndex.partIdsFromFilters(filter, now, now + 1000).map(partKeyIndex.partKeyFromPartId)
-        .iterator().flatten.takeWhile(_ => res.size < 10000).map { pk =>
-        Schemas.promCounter.partition.binSchema.singleColValues(pk.bytes, UnsafeUtils.arayOffset, "_metric_", res)
+      partKeyIndex.partIdsFromFilters(filter, now, now + 1000).foreach { pId =>
+        val pk = partKeyIndex.partKeyFromPartId(pId)
+        Schemas.promCounter.partition.binSchema.singleColValues(pk.get.bytes, UnsafeUtils.arayOffset, "_metric_", res)
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,6 +72,7 @@ object Dependencies {
     "com.github.rholder.fauxflake" % "fauxflake-core"     % "1.1.0",
     "org.scalactic"                %% "scalactic"         % "3.2.0" withJavadoc(),
     "org.apache.lucene"            % "lucene-core"        % "8.8.2" withJavadoc(),
+    "org.apache.lucene"            % "lucene-facet"       % "8.8.2" withJavadoc(),
     "com.github.alexandrnikitin"   %% "bloom-filter"      % "0.11.0",
     "org.rocksdb"                  % "rocksdbjni"         % "6.11.4",
     "com.esotericsoftware"         % "kryo"               % "4.0.0" excludeAll(excludeMinlog),


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**

For metadata searches that need to enumerate values of fields, we end up iterating through matching documents and build a hash set of field values. This is inefficient. It eats up CPU creating bottlenecks in query execution, especially in high cardinality clusters and reduces overall query throughput.

**New behavior :**

This PR uses Lucene faceting which tremendously improves performance (by 300x) of label-value queries which is a major CPU consumer in the system today.

* Faceting is enabled in raw cluster and disabled in downsample cluster
* Faceting can be disabled in raw cluster via configuration
* If faceting is enabled, label-value queries automatically choose the efficient execution path. Otherwise, they fall back to existing approach.
* Faceting requires 10% more disk space. So raw clusters will need more disk space.
* Faceting increases indexing time by 2x, so node bootstrap will take more time.


## Benchmark of Label-Value Query Performance

### With Synthetic Data 
Benchmarks performed with `PartKeyIndexBenchmark`
Num part keys: 1 mil
Part Keys generated using TestTimeSeriesProducer
All time series have same metric
Query to collect metric names has a ws/ns filter.

#### Prior to this PR, without faceting 
Index Size: 227MB
Time to index: 17s
All time series have about 25 unique metric names
Throughput of getting list of metric names (iterative): 0.281 ops/s

#### With this PR, with faceting all labels
Index Size: 242MB
Time to index: 35s
Throughput of getting list of metric names (facet collector): 113.276 ops/s

### With Production Data 
Data cannot be uploaded to git since it is not sanitized.
Benchmarks performed with `PartKeyIndexBenchmark`
Num part keys: 574k
Query to collect metric names has a ws/ns filter.

#### Prior to this PR, without faceting 
Index Size: 310MB
Time to index: 17s
Throughput of getting list of metric names (iterative): 0.065 ops/s


#### With this PR, with faceting all labels
Index Size: 337MB
Time to index: 39s
Throughput of getting list of metric names (facet collector): 26.4 ops/s

### Summary: 
Index size increased by 6% to 8%
Time to index increased by around 2x
Throughput of label values query increased by 300 to 400 times

