### PR TITLE
fix(misc): fix formatCode for non increasing histogram buckets

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -170,8 +170,9 @@ object BinaryHistogram extends StrictLogging {
   def writeDoubles(buckets: HistogramBuckets, values: Array[Double], buf: MutableDirectBuffer): Int = {
     require(buckets.numBuckets == values.size, s"Values array size of ${values.size} != ${buckets.numBuckets}")
     val formatCode = if (buckets.numBuckets == 0) HistFormat_Null else buckets match {
-      case g: GeometricBuckets               => HistFormat_Geometric_XOR
-      case c: CustomBuckets                  => HistFormat_Custom_XOR
+      case g: GeometricBuckets if g.minusOne => HistFormat_Geometric1_Delta
+      case _: GeometricBuckets               => HistFormat_Geometric_XOR
+      case _: CustomBuckets                  => HistFormat_Custom_XOR
     }
 
     buf.putByte(2, formatCode)

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -283,7 +283,7 @@ class HistogramVectorTest extends NativeVectorTest {
     BinaryHistogram.writeNonIncreasing(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
     appender.addData(buffer) shouldEqual Ack
     val mutableHisto = appender.reader.asHistReader.sum(0,0)
-    BinHistogram(mutHisto.serialize()).formatCode shouldEqual HistFormat_Geometric1_Delta
+    BinHistogram(mutableHisto.serialize()).formatCode shouldEqual HistFormat_Geometric1_Delta
   }
 
   it("should reject initially invalid BinaryHistogram") {

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import org.agrona.concurrent.UnsafeBuffer
 
 import filodb.memory.format._
+import filodb.memory.format.vectors.BinaryHistogram.{BinHistogram, HistFormat_Geometric1_Delta}
 
 class HistogramVectorTest extends NativeVectorTest {
   import HistogramTest._
@@ -274,6 +275,15 @@ class HistogramVectorTest extends NativeVectorTest {
     // A record using a different schema
     BinaryHistogram.writeDelta(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
     appender.addData(buffer) shouldEqual BucketSchemaMismatch
+  }
+  
+   it("histogram should have right formatCode after sum operation is applied") {
+    val appender = HistogramVector.appending(memFactory, 1024)
+    BinaryHistogram.writeDelta(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
+    BinaryHistogram.writeDelta(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
+    appender.addData(buffer) shouldEqual Ack
+    val mutableHisto = appender.reader.asHistReader.sum(0,0)
+    BinHistogram(mutHisto.serialize()).formatCode shouldEqual HistFormat_Geometric1_Delta
   }
 
   it("should reject initially invalid BinaryHistogram") {

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -279,8 +279,8 @@ class HistogramVectorTest extends NativeVectorTest {
   
    it("histogram should have right formatCode after sum operation is applied") {
     val appender = HistogramVector.appending(memFactory, 1024)
-    BinaryHistogram.writeDelta(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
-    BinaryHistogram.writeDelta(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
+    BinaryHistogram.writeNonIncreasing(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
+    BinaryHistogram.writeNonIncreasing(HistogramBuckets.binaryBuckets64, Array.fill(64)(1L), buffer)
     appender.addData(buffer) shouldEqual Ack
     val mutableHisto = appender.reader.asHistReader.sum(0,0)
     BinHistogram(mutHisto.serialize()).formatCode shouldEqual HistFormat_Geometric1_Delta


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

**Issue** 
Downsample job while applying sum based aggregate function on Histogram chunks (of type non-increasing bucket values), `formatCode` is being set to `HistFormat_Geometric_XOR`. To be precise in MutableHistogram.serialize. Later during ingestion these histogram chunks are marked as `InvalidHistogram`, because HistFormat_Geometric_XOR is not in valid format list (`isValidFormatCode`). and these chunks are ignored and never persisted. causing failures during query time.
**Fix**
for non-increasing geometric buckets, format code is set to `HistFormat_Geometric1_Delta` in BinaryHistogram.writeDoubles method.