### PR TITLE
feat(query): support implicit workspace

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -58,12 +58,23 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
     val nonMetricShardKeyFilters =
       LogicalPlan.getNonMetricShardKeyFilters(logicalPlan, dataset.options.nonMetricShardColumns)
     if (isMetadataQuery(logicalPlan)
-      || LogicalPlan.hasShardKeyEqualsOnly(logicalPlan, dataset.options.nonMetricShardColumns)) {
+      || (hasRequiredShardKeysPresent(nonMetricShardKeyFilters, dataset.options.nonMetricShardColumns) &&
+      LogicalPlan.hasShardKeyEqualsOnly(logicalPlan, dataset.options.nonMetricShardColumns))) {
       queryPlanner.materialize(logicalPlan, qContext)
     } else if (hasSingleShardKeyMatch(nonMetricShardKeyFilters)) {
       // For queries like topk(2, test{_ws_ = "demo", _ns_ =~ "App-1"}) which have just one matching value
       generateExecWithoutRegex(logicalPlan, nonMetricShardKeyFilters.head, qContext).head
     } else walkLogicalPlanTree(logicalPlan, qContext).plans.head
+  }
+
+  def hasRequiredShardKeysPresent(nonMetricShardKeyFilters: Seq[Seq[ColumnFilter]],
+                                  nonMetricShardColumns: Seq[String]): Boolean = {
+    nonMetricShardKeyFilters
+      .foreach(filterGroup => {
+        val columnNames = filterGroup.map(_.column)
+        if (!nonMetricShardColumns.toSet.subsetOf(columnNames.toSet)) return false
+      })
+    true
   }
 
   def isMetadataQuery(logicalPlan: LogicalPlan): Boolean = {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -69,11 +69,11 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
 
   def hasRequiredShardKeysPresent(nonMetricShardKeyFilters: Seq[Seq[ColumnFilter]],
                                   nonMetricShardColumns: Seq[String]): Boolean = {
-    nonMetricShardKeyFilters
-      .foreach(filterGroup => {
-        val columnNames = filterGroup.map(_.column)
-        if (!nonMetricShardColumns.toSet.subsetOf(columnNames.toSet)) return false
-      })
+    val nonMetricShardColumnsSet = nonMetricShardColumns.toSet
+    nonMetricShardKeyFilters.foreach(filterGroup => {
+      val columnNames = filterGroup.map(_.column)
+      if (!nonMetricShardColumnsSet.subsetOf(columnNames.toSet)) return false
+    })
     true
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -58,6 +58,26 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       contains(ColumnFilter("_ns_", Equals("App-2"))) shouldEqual(true)
   }
 
+  it("should generate Exec plan for implicit ws query") {
+    val lp = Parser.queryToLogicalPlan("test{_ns_ =~ \"App.*\", instance = \"Inst-1\" }", 1000, 1000)
+    val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
+      ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
+      ColumnFilter("_ns_", Equals("App-2"))))}
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, queryConfig)
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = PromQlQueryParams(
+      """test{_ns_ =~ "App.*", instance = "Inst-1" }""", 100, 1, 1000)))
+    execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual(true)
+    execPlan.children(0).children.head.isInstanceOf[MultiSchemaPartitionsExec]
+    execPlan.children(1).children.head.asInstanceOf[MultiSchemaPartitionsExec].filters.
+      contains(ColumnFilter("_ns_", Equals("App-1"))) shouldEqual(true)
+    execPlan.children(0).children.head.asInstanceOf[MultiSchemaPartitionsExec].filters.
+      contains(ColumnFilter("_ns_", Equals("App-2"))) shouldEqual(true)
+    execPlan.children(0).children.head.asInstanceOf[MultiSchemaPartitionsExec].filters.
+      contains(ColumnFilter("_ws_", Equals("demo"))) shouldEqual(true)
+    execPlan.children(1).children.head.asInstanceOf[MultiSchemaPartitionsExec].filters.
+      contains(ColumnFilter("_ws_", Equals("demo"))) shouldEqual(true)
+  }
+
   it("should generate Exec plan for subquery with windowing") {
     val lp = Parser.queryToLogicalPlan(
       """avg_over_time(test{_ws_ = "demo", _ns_ =~ "App.*", instance = "Inst-1" }[5m:1m])""",


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Queries without `_ws_` key fails while creating exec plan

`foo{_ns_="foo"}` fails with bad request

**New behavior :** Enable ShardKeyRegexPlanner to utilize shardKeyMatcher columnFilters to derive the missing `_ws_` key

`foo{_ns_="foo"}` passes if `_ws_` info is available in shardKeyMatcher.
