### PR TITLE
feat(core): Cache lucene DocValuesReaderState since expensive to build

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -436,8 +436,15 @@ filodb {
     # and starving the exclusive access of lock for eviction
     track-queries-holding-eviction-lock = true
 
-    # Whether or not in TimeSeriesShard, faceting is enabled for lucene index
-    index-faceting-enabled = true
+    # Whether or not in TimeSeriesShard, faceting is enabled in lucene index for shard key labels.
+    # If all of the index-faceting-enabled-* properties are false, faceting is fully disabled.
+    # Disable if performance cost of faceting even the shard key label are too high
+    index-faceting-enabled-shard-key-labels = true
+
+    # Whether or not in TimeSeriesShard, faceting is enabled in lucene index for ALL labels.
+    # If all of the index-faceting-enabled-* properties are false, faceting is fully disabled.
+    # Disable if performance cost of faceting all labels is too high
+    index-faceting-enabled-for-all-labels = true
   }
 
   # for standalone worker cluster configuration, see akka-bootstrapper

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -71,7 +71,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   private val stats = new DownsampledTimeSeriesShardStats(rawDatasetRef, shardNum)
 
-  private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, false, shardNum, indexTtlMs)
+  private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, false,
+    false, shardNum, indexTtlMs)
 
   private val indexUpdatedHour = new AtomicLong(0)
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -157,7 +157,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
 
     def addField(name: String, value: String): Unit = {
       // Use PartKeyIndexBenchmark to measure indexing performance before changing this
-      if (facetEnabledForLabel(name) && name.nonEmpty && value.nonEmpty) {
+      if (name.nonEmpty && value.nonEmpty && facetEnabledForLabel(name)) {
         facetsConfig.setRequireDimensionDrillDown(name, false)
         facetsConfig.setIndexFieldName(name, FACET_FIELD_PREFIX + name)
         document.add(new SortedSetDocValuesFacetField(name, value))
@@ -320,8 +320,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
 
   def labelValuesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
                            colName: String, limit: Int = 100): Seq[String] = {
-    require(facetEnabledAllLabels ||
-      facetEnabledSharedKeyLabels && schema.options.shardKeyColumns.contains(colName),
+    require(facetEnabledForLabel(colName),
       s"Faceting not enabled for label $colName; labelValuesEfficient should not have been called")
 
     val readerStateCache = if (schema.options.shardKeyColumns.contains(colName)) readerStateCacheShardKeys
@@ -695,7 +694,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     }
     val collector = new ActionCollector(handleMatch)
     withNewSearcher(s => s.search(query, collector))
-    partIdFromPartKeyLookupLatency.record(Math.max(0, System.nanoTime - startExecute))
+    partIdFromPartKeyLookupLatency.record(System.nanoTime - startExecute)
     chosenPartId
   }
 }

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -19,7 +19,8 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.document._
 import org.apache.lucene.document.Field.Store
 import org.apache.lucene.facet.{FacetsCollector, FacetsConfig}
-import org.apache.lucene.facet.sortedset.{DefaultSortedSetDocValuesReaderState, SortedSetDocValuesFacetCounts, SortedSetDocValuesFacetField}
+import org.apache.lucene.facet.sortedset.{DefaultSortedSetDocValuesReaderState,
+                     SortedSetDocValuesFacetCounts, SortedSetDocValuesFacetField}
 import org.apache.lucene.index._
 import org.apache.lucene.search._
 import org.apache.lucene.search.BooleanClause.Occur

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -56,7 +56,8 @@ filodb {
     max-partitions-on-heap-per-shard = 10000
     ingestion-buffer-mem-size = 80MB
     track-queries-holding-eviction-lock = false
-    index-faceting-enabled = true
+    index-faceting-enabled-shard-key-labels = true
+    index-faceting-enabled-for-all-labels = true
   }
 
   tasks {

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -22,7 +22,7 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   import Filter._
   import GdeltTestData._
 
-  val keyIndex = new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, true, 0, 1.hour.toMillis)
+  val keyIndex = new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis)
   val partBuilder = new RecordBuilder(TestData.nativeMem)
 
   def partKeyOnHeap(partKeySchema: RecordSchema,
@@ -318,7 +318,7 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   }
 
   it("should ignore unsupported columns and return empty filter") {
-    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, true, 0, 1.hour.toMillis)
+    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, true, true, 0, 1.hour.toMillis)
     partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
       index2.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
     }
@@ -369,7 +369,7 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
   it("should be able to fetch label values efficiently using facets") {
     val index3 = new PartKeyLuceneIndex(DatasetRef("prometheus"), Schemas.promCounter.partition,
-      true, 0, 1.hour.toMillis)
+      true, true, 0, 1.hour.toMillis)
     val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
                          "_ns_".utf8 -> "my_ns".utf8)
 
@@ -403,7 +403,7 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
   it("should be able to do regular operations when faceting is disabled") {
     val index3 = new PartKeyLuceneIndex(DatasetRef("prometheus"), Schemas.promCounter.partition,
-      false, 0, 1.hour.toMillis)
+      false, false, 0, 1.hour.toMillis)
     val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
       "_ns_".utf8 -> "my_ns".utf8)
 

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -28,7 +28,7 @@ class PartKeyIndexBenchmark {
 
   println(s"Building Part Keys")
   val ref = DatasetRef("prometheus")
-  val partKeyIndex = new PartKeyLuceneIndex(ref, untyped.partition, true, 0, 1.hour.toMillis)
+  val partKeyIndex = new PartKeyLuceneIndex(ref, untyped.partition, true, true,0, 1.hour.toMillis)
   val numSeries = 1000000
   val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.DefaultContainerSize, false)
   val untypedData = TestTimeseriesProducer.timeSeriesData(0, numSeries) take numSeries

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,8 @@ object Dependencies {
     "com.github.alexandrnikitin"   %% "bloom-filter"      % "0.11.0",
     "org.rocksdb"                  % "rocksdbjni"         % "6.11.4",
     "com.esotericsoftware"         % "kryo"               % "4.0.0" excludeAll(excludeMinlog),
-    "com.dorkbox"            % "MinLog-SLF4J"                 % "1.12"
+    "com.dorkbox"                  % "MinLog-SLF4J"       % "1.12",
+    "com.github.ben-manes.caffeine" % "caffeine"          % "3.0.5"
   )
 
   lazy val sparkJobsDeps = commonDeps ++ Seq(


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* DefaultSortedSetDocValuesReaderState is expensive to build. Using caffeine cache to keep it on the heap
* Add metrics for label-values latency and cache hit rate
* ability to enable faceting only for shard-key-labels