### PR TITLE
fix(query): update more filters from LogicalPlan::replaceFilters

### DIFF
--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -354,8 +354,8 @@ case class PeriodicSeriesWithWindowing(series: RawSeriesLikePlan,
   with NonLeafLogicalPlan {
   override def children: Seq[LogicalPlan] = Seq(series)
 
-  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan = this.copy(series =
-    series.replaceRawSeriesFilters(filters))
+  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan =
+    this.copy(columnFilters = filters, series = series.replaceRawSeriesFilters(filters))
 }
 
 /**
@@ -419,8 +419,9 @@ case class ScalarVectorBinaryOperation(operator: BinaryOperator,
   override def stepMs: Long = vector.stepMs
   override def endMs: Long = vector.endMs
   override def isRoutable: Boolean = vector.isRoutable
-  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan = this.copy(vector =
-    vector.replacePeriodicSeriesFilters(filters))
+  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan =
+    this.copy(vector = vector.replacePeriodicSeriesFilters(filters),
+              scalarArg = scalarArg.replacePeriodicSeriesFilters(filters).asInstanceOf[ScalarPlan])
 }
 
 /**
@@ -582,8 +583,8 @@ case class ApplyAbsentFunction(vectors: PeriodicSeriesPlan,
   override def startMs: Long = vectors.startMs
   override def stepMs: Long = vectors.stepMs
   override def endMs: Long = vectors.endMs
-  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan = this.copy(vectors =
-    vectors.replacePeriodicSeriesFilters(filters))
+  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan =
+    this.copy(columnFilters = filters, vectors = vectors.replacePeriodicSeriesFilters(filters))
 }
 
 /**
@@ -597,8 +598,8 @@ case class ApplyLimitFunction(vectors: PeriodicSeriesPlan,
   override def startMs: Long = vectors.startMs
   override def stepMs: Long = vectors.stepMs
   override def endMs: Long = vectors.endMs
-  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan = this.copy(vectors =
-    vectors.replacePeriodicSeriesFilters(filters))
+  override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan =
+    this.copy(columnFilters = filters, vectors = vectors.replacePeriodicSeriesFilters(filters))
 }
 
 object LogicalPlan {

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -355,7 +355,8 @@ case class PeriodicSeriesWithWindowing(series: RawSeriesLikePlan,
   override def children: Seq[LogicalPlan] = Seq(series)
 
   override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan =
-    this.copy(columnFilters = filters, series = series.replaceRawSeriesFilters(filters))
+    this.copy(columnFilters = LogicalPlan.overrideColumnFilters(columnFilters, filters),
+              series = series.replaceRawSeriesFilters(filters))
 }
 
 /**
@@ -584,7 +585,8 @@ case class ApplyAbsentFunction(vectors: PeriodicSeriesPlan,
   override def stepMs: Long = vectors.stepMs
   override def endMs: Long = vectors.endMs
   override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan =
-    this.copy(columnFilters = filters, vectors = vectors.replacePeriodicSeriesFilters(filters))
+    this.copy(columnFilters = LogicalPlan.overrideColumnFilters(columnFilters, filters),
+              vectors = vectors.replacePeriodicSeriesFilters(filters))
 }
 
 /**
@@ -599,7 +601,8 @@ case class ApplyLimitFunction(vectors: PeriodicSeriesPlan,
   override def stepMs: Long = vectors.stepMs
   override def endMs: Long = vectors.endMs
   override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan =
-    this.copy(columnFilters = filters, vectors = vectors.replacePeriodicSeriesFilters(filters))
+    this.copy(columnFilters = LogicalPlan.overrideColumnFilters(columnFilters, filters),
+              vectors = vectors.replacePeriodicSeriesFilters(filters))
 }
 
 object LogicalPlan {
@@ -732,6 +735,22 @@ object LogicalPlan {
                                                     stepMs = Math.max(p.stepMs, 1)))
       case _                       => None
     }
+  }
+
+  /**
+   * @param base the column filters to override
+   * @param overrides the overriding column filters
+   * @return union of base and override filters except where column names intersect;
+   *         when names intersect, only the overriding filter is included.
+   *         Example:
+   *           base = [(name=a, filter=1), (name=b, filter=2)]
+   *           overrides = [(name=c, filter=3), (name=a, filter=4)]
+   *           result = [(name=a, filter=4), (name=b, filter=2), (name=c, filter=3)]
+   */
+  def overrideColumnFilters(base: Seq[ColumnFilter],
+                            overrides: Seq[ColumnFilter]): Seq[ColumnFilter] = {
+    val overrideColumns = overrides.map(_.column)
+    base.filterNot(f => overrideColumns.contains(f.column)) ++ overrides
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Some `LogicalPlan`s left `ColumnFilter`s un-updated after `replaceFilters` was called. This fix correctly propagates `ColumnFilter` updates to all `LogicalPlan`s in a tree.