### PR TITLE
fix(core): during serialization use delta encoding for Geometric1_Delta histograms

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -191,7 +191,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
   final def serialize(intoBuf: Option[MutableDirectBuffer] = None): MutableDirectBuffer = {
     val buf = intoBuf.getOrElse(BinaryHistogram.histBuf)
     buckets match {
-      case g: GeometricBuckets => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
+      case g: GeometricBuckets if g.minusOne => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
       case _ => BinaryHistogram.writeDoubles(buckets, values, buf)
     }
     buf

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -191,7 +191,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
   final def serialize(intoBuf: Option[MutableDirectBuffer] = None): MutableDirectBuffer = {
     val buf = intoBuf.getOrElse(BinaryHistogram.histBuf)
     buckets match {
-      case g: GeometricBuckets if g.minusOne => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
+      case g: GeometricBuckets => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
       case _ => BinaryHistogram.writeDoubles(buckets, values, buf)
     }
     buf

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -190,7 +190,10 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
   final def bucketValue(no: Int): Double = values(no)
   final def serialize(intoBuf: Option[MutableDirectBuffer] = None): MutableDirectBuffer = {
     val buf = intoBuf.getOrElse(BinaryHistogram.histBuf)
-    BinaryHistogram.writeDoubles(buckets, values, buf)
+    buckets match {
+      case g: GeometricBuckets if g.minusOne => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
+      case _ => BinaryHistogram.writeDoubles(buckets, values, buf)
+    }
     buf
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -170,9 +170,8 @@ object BinaryHistogram extends StrictLogging {
   def writeDoubles(buckets: HistogramBuckets, values: Array[Double], buf: MutableDirectBuffer): Int = {
     require(buckets.numBuckets == values.size, s"Values array size of ${values.size} != ${buckets.numBuckets}")
     val formatCode = if (buckets.numBuckets == 0) HistFormat_Null else buckets match {
-      case g: GeometricBuckets if g.minusOne => HistFormat_Geometric1_Delta
-      case _: GeometricBuckets               => HistFormat_Geometric_XOR
-      case _: CustomBuckets                  => HistFormat_Custom_XOR
+      case g: GeometricBuckets               => HistFormat_Geometric_XOR
+      case c: CustomBuckets                  => HistFormat_Custom_XOR
     }
 
     buf.putByte(2, formatCode)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

MutableHistogram serialize method is using xor encoding (writeDoubles) for Geometric1_Delta. This results in faulty encoding during downsampling of Geometric histograms. With this change, serialize method will use delta encoding (writeDelta) for Geometric histograms.