### PR TITLE
fix(query): handle empty first schema ID in SelectChunkInfosExec

### DIFF
--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -2,13 +2,13 @@ package filodb.query.exec
 
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 
 import filodb.core.DatasetRef
 import filodb.core.memstore.TimeSeriesShard
 import filodb.core.metadata.Column
 import filodb.core.query._
 import filodb.core.store._
-import monix.reactive.Observable
 
 object SelectChunkInfosExec {
   import Column.ColumnType._

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -2,12 +2,12 @@ package filodb.query.exec
 
 import monix.eval.Task
 import monix.execution.Scheduler
-
 import filodb.core.DatasetRef
 import filodb.core.memstore.TimeSeriesShard
 import filodb.core.metadata.Column
 import filodb.core.query._
 import filodb.core.store._
+import monix.reactive.Observable
 
 object SelectChunkInfosExec {
   import Column.ColumnType._
@@ -47,25 +47,29 @@ final case class SelectChunkInfosExec(queryContext: QueryContext,
     val partMethod = FilteredPartitionScan(ShardSplit(shard), filters)
     val lookupRes = source.lookupPartitions(dataset, partMethod, chunkMethod, querySession)
 
-    val schemas = source.schemas(dataset).get
-    val dataSchema = schema.map { s => schemas.schemas(s) }
-                           .getOrElse(schemas(lookupRes.firstSchemaId.get))
-    val colID = colName.map(n => dataSchema.colIDs(n).get.head).getOrElse(dataSchema.data.valueColumn)
-    val dataColumn = dataSchema.data.columns(colID)
-    val partCols = dataSchema.partitionInfos
-    val numGroups = source.groupsInDataset(dataset)
-    val rvs = source.scanPartitions(dataset, lookupRes, Seq.empty, querySession)
-          .filter(_.hasChunks(chunkMethod))
-          .map { partition =>
-            source.stats.incrReadPartitions(1)
-            val subgroup = TimeSeriesShard.partKeyGroup(dataSchema.partKeySchema, partition.partKeyBase,
-                                                        partition.partKeyOffset, numGroups)
-            val key = PartitionRangeVectorKey(Left(partition),
-                                                  dataSchema.partKeySchema, partCols, shard,
-                                                  subgroup, partition.partID, dataSchema.name)
-            ChunkInfoRangeVector(key, partition, chunkMethod, dataColumn)
-          }
-    ExecResult(rvs, Task.eval(ChunkInfosSchema))
+    if (lookupRes.firstSchemaId.isEmpty) {
+      ExecResult(Observable.empty, Task.eval(ResultSchema.empty))
+    } else {
+      val schemas = source.schemas(dataset).get
+      val dataSchema = schema.map { s => schemas.schemas(s) }
+        .getOrElse(schemas(lookupRes.firstSchemaId.get))
+      val colID = colName.map(n => dataSchema.colIDs(n).get.head).getOrElse(dataSchema.data.valueColumn)
+      val dataColumn = dataSchema.data.columns(colID)
+      val partCols = dataSchema.partitionInfos
+      val numGroups = source.groupsInDataset(dataset)
+      val rvs = source.scanPartitions(dataset, lookupRes, Seq.empty, querySession)
+        .filter(_.hasChunks(chunkMethod))
+        .map { partition =>
+          source.stats.incrReadPartitions(1)
+          val subgroup = TimeSeriesShard.partKeyGroup(dataSchema.partKeySchema, partition.partKeyBase,
+            partition.partKeyOffset, numGroups)
+          val key = PartitionRangeVectorKey(Left(partition),
+            dataSchema.partKeySchema, partCols, shard,
+            subgroup, partition.partID, dataSchema.name)
+          ChunkInfoRangeVector(key, partition, chunkMethod, dataColumn)
+        }
+      ExecResult(rvs, Task.eval(ChunkInfosSchema))
+    }
   }
 
   protected def args: String = s"shard=$shard, chunkMethod=$chunkMethod, filters=$filters, col=$colName"

--- a/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectChunkInfosExec.scala
@@ -2,6 +2,7 @@ package filodb.query.exec
 
 import monix.eval.Task
 import monix.execution.Scheduler
+
 import filodb.core.DatasetRef
 import filodb.core.memstore.TimeSeriesShard
 import filodb.core.metadata.Column


### PR DESCRIPTION
Fixes the broken _filodb_chunkmeta_all cli command

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
_filodb_chunkmeta_all command is broken. It generates the following output when running locally on a 2 node 4 shard setup
when `_type_` is not explicitly defined in the query.

```
 ./filo-cli --host 127.0.0.1 --dataset prometheus --promql '_filodb_chunkmeta_all(heap_usage{_ws_="demo",_ns_="App-0"})' --start 1646523084 
QueryError: NoSuchElementException None.get
QueryStats: TrieMap(List(local, raw, demo, App-0, heap_usage) -> (timeSeriesScanned=0, dataBytesScanned=0, resultBytes=0))
```


Test output of the newly added test without the fix:
```
class filodb.query.QueryError cannot be cast to class filodb.query.QueryResult (filodb.query.QueryError and filodb.query.QueryResult are in unnamed module of loader 'app')
java.lang.ClassCastException: class filodb.query.QueryError cannot be cast to class filodb.query.QueryResult (filodb.query.QueryError and filodb.query.QueryResult are in unnamed module of loader 'app')
	at filodb.query.exec.MultiSchemaPartitionsExecSpec.$anonfun$new$84(MultiSchemaPartitionsExecSpec.scala:459)
....
resp = QueryError id=5cb88e90-6952-4ee9-9fb4-22cbea87e188 java.util.NoSuchElementException None.get

```

**New behavior :**
Output of the command after the fix:

 
 ```
  ./filo-cli --host 127.0.0.1 --dataset prometheus --promql '_filodb_chunkmeta_all(heap_usage{_ws_="demo",_ns_="App-0"})' --start 1646523084 
  
 Number of Range Vectors: 2
/shard:2/b2[schema=untyped  _metric_=heap_usage,tags={_ns_: App-0, _ws_: demo, dc: DC1, host: H0, hostAlias: H0, instance: Instance-1, longTag: AlonglonglonglonglonglonglonglonglonglonglonglonglonglongTag, partition: partition-0, partitionAl: partition-0}] [grp6]
        -73432161-09-07T20:43:59.318-07:52:58 (2317358972492853s ago) -2317357325532182682      363     1646522214728   1646525827699   2912    filodb.memory.format.vectors.DoubleVectorDataReader64$

/shard:0/b2[schema=untyped  _metric_=heap_usage,tags={_ns_: App-0, _ws_: demo, dc: DC0, host: H0, hostAlias: H0, instance: Instance-0, longTag: AlonglonglonglonglonglonglonglonglonglonglonglonglonglongTag, partition: partition-0, partitionAl: partition-0}] [grp6]
        -73432161-09-07T20:43:59.318-07:52:58 (2317358972492853s ago) -2317357325532182682      363     1646522214728   1646525827699   2912    filodb.memory.format.vectors.DoubleVectorDataReader64$

QueryStats: TrieMap(List(local, raw, demo, App-0, heap_usage) -> (timeSeriesScanned=2, dataBytesScanned=0, resultBytes=1028))

```


Test output of the newly added test with the fix:
```
resp = QueryResult(e3c08544-0d66-467d-8576-ab76eee8608e,ResultSchema(List(),1,Map(),None,List()),List(),TrieMap(List(local, raw, multiple, multiple, multiple) -> (timeSeriesScanned=0, dataBytesScanned=0, resultBytes=0)),false,None)


Process finished with exit code 0
```