### PR TITLE
fix(query): send TsCardinalities directly to child planner from ShardKeyRegexPlanner

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -80,6 +80,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
   def isMetadataQuery(logicalPlan: LogicalPlan): Boolean = {
     logicalPlan match {
       case _: MetadataQueryPlan => true
+      case _: TsCardinalities => true
       case _ => false
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Recent updates redirected the flow of `TsCardinalities` logic in `ShardKeyRegexPlanner` to a matcher it should have never reached. This caused an exception whenever the timeseries cardinalities endpoint was used.

**New behavior :**
`TsCardinalities` is now classified as a metadata query by `ShardKeyRegexPlanner`. Now, it's sent directly to the child planner, and no exception is thrown.