### PR TITLE
maint(coord): update TS cardinality metric names

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
@@ -39,8 +39,8 @@ case class TenantIngestionMetering(settings: FilodbSettings,
 
   private val CLUSTER_TYPE = settings.config.getString("cluster-type")
 
-  private val METRIC_ACTIVE = "active_timeseries_by_tenant"
-  private val METRIC_TOTAL = "total_timeseries_by_tenant"
+  private val METRIC_ACTIVE = "tsdb_metering_active_timeseries"
+  private val METRIC_TOTAL = "tsdb_metering_total_timeseries"
 
   def schedulePeriodicPublishJob() : Unit = {
     // NOTE: the FiniteDuration overload of scheduleWithFixedDelay

--- a/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
@@ -39,8 +39,9 @@ case class TenantIngestionMetering(settings: FilodbSettings,
 
   private val CLUSTER_TYPE = settings.config.getString("cluster-type")
 
-  private val METRIC_ACTIVE = "active_timeseries_by_tenant"
-  private val METRIC_TOTAL = "total_timeseries_by_tenant"
+  private val METRIC_PREFIX = settings.config.getString("metering-metrics-prefix")
+  private val METRIC_ACTIVE = METRIC_PREFIX + "ns_active_timeseries"
+  private val METRIC_TOTAL = METRIC_PREFIX + "ns_total_timeseries"
 
   def schedulePeriodicPublishJob() : Unit = {
     // NOTE: the FiniteDuration overload of scheduleWithFixedDelay

--- a/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
@@ -39,9 +39,8 @@ case class TenantIngestionMetering(settings: FilodbSettings,
 
   private val CLUSTER_TYPE = settings.config.getString("cluster-type")
 
-  private val METRIC_PREFIX = settings.config.getString("metering-metrics-prefix")
-  private val METRIC_ACTIVE = METRIC_PREFIX + "ns_active_timeseries"
-  private val METRIC_TOTAL = METRIC_PREFIX + "ns_total_timeseries"
+  private val METRIC_ACTIVE = "active_timeseries_by_tenant"
+  private val METRIC_TOTAL = "total_timeseries_by_tenant"
 
   def schedulePeriodicPublishJob() : Unit = {
     // NOTE: the FiniteDuration overload of scheduleWithFixedDelay

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -160,8 +160,12 @@ filodb {
   spread-assignment = []
 
   shard-key-level-ingestion-metrics-enabled = true
+
   # Time between each TenantIngestionMetering query/publish job
   metering-query-interval = 15 minutes
+  # Prefixes for TenantIngestionMetering cardinality metrics
+  metering-metrics-prefix = "telemetry_filodb_"
+
   # info config used for metric breakdown
   cluster-type = "raw" // possible values: downsample, raw, recRule, aggregates etc.
   # Name of the deployment partition that this FiloDB cluster belongs to

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -160,12 +160,8 @@ filodb {
   spread-assignment = []
 
   shard-key-level-ingestion-metrics-enabled = true
-
   # Time between each TenantIngestionMetering query/publish job
   metering-query-interval = 15 minutes
-  # Prefixes for TenantIngestionMetering cardinality metrics
-  metering-metrics-prefix = "telemetry_filodb_"
-
   # info config used for metric breakdown
   cluster-type = "raw" // possible values: downsample, raw, recRule, aggregates etc.
   # Name of the deployment partition that this FiloDB cluster belongs to


### PR DESCRIPTION
Changes TS cardinality names from:
```
active_timeseries_by_tenant
total_timeseries_by_tenant
```
to:
```
tsdb_metering_active_timeseries
tsdb_metering_total_timeseries
```