### PR TITLE
feat(coord) Stateful shard assignment

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -77,7 +77,8 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
     * All actions are idempotent. It manages the underlying lifecycle of all node actors.
     */
   private[coordinator] lazy val guardian = system.actorOf(NodeGuardian.props(
-    settings, metaStore, memStore, new K8sStatefulSetShardAssignmentStrategy(true)), guardianName)
+    settings, metaStore, memStore, new K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards =
+        settings.config.getBoolean("shard-manager.enable-k8s-stateful-shard-strategy"))), guardianName)
   // TODO: Make parameter driven
 
   def isInitialized: Boolean = _isInitialized.get

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -79,7 +79,7 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
   private[coordinator] lazy val guardian = system.actorOf(NodeGuardian.props(
     settings, metaStore, memStore,
     if (settings.config.getBoolean("shard-manager.enable-k8s-stateful-shard-strategy"))
-      K8sStatefulSetShardAssignmentStrategy else DefaultShardAssignmentStrategy)
+      new K8sStatefulSetShardAssignmentStrategy else DefaultShardAssignmentStrategy)
     , guardianName)
 
   def isInitialized: Boolean = _isInitialized.get

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -79,7 +79,6 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
   private[coordinator] lazy val guardian = system.actorOf(NodeGuardian.props(
     settings, metaStore, memStore, new K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards =
         settings.config.getBoolean("shard-manager.enable-k8s-stateful-shard-strategy"))), guardianName)
-  // TODO: Make parameter driven
 
   def isInitialized: Boolean = _isInitialized.get
 

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -77,7 +77,8 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
     * All actions are idempotent. It manages the underlying lifecycle of all node actors.
     */
   private[coordinator] lazy val guardian = system.actorOf(NodeGuardian.props(
-    settings, metaStore, memStore, DefaultShardAssignmentStrategy), guardianName)
+    settings, metaStore, memStore, new K8sStatefulSetShardAssignmentStrategy(true)), guardianName)
+  // TODO: Make parameter driven
 
   def isInitialized: Boolean = _isInitialized.get
 

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -77,8 +77,10 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
     * All actions are idempotent. It manages the underlying lifecycle of all node actors.
     */
   private[coordinator] lazy val guardian = system.actorOf(NodeGuardian.props(
-    settings, metaStore, memStore, new K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards =
-        settings.config.getBoolean("shard-manager.enable-k8s-stateful-shard-strategy"))), guardianName)
+    settings, metaStore, memStore,
+    if (settings.config.getBoolean("shard-manager.enable-k8s-stateful-shard-strategy"))
+      K8sStatefulSetShardAssignmentStrategy else DefaultShardAssignmentStrategy)
+    , guardianName)
 
   def isInitialized: Boolean = _isInitialized.get
 

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -42,8 +42,7 @@ trait ShardAssignmentStrategy {
  * The implementation assumes the number of shards is a multiple of number of nodes and there are no
  * uneven assignments of shards to nodes
  */
-class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
-  extends ShardAssignmentStrategy with StrictLogging {
+object K8sStatefulSetShardAssignmentStrategy extends ShardAssignmentStrategy with StrictLogging {
 
   private val pat = "-\\d+$".r
 
@@ -61,8 +60,7 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
   override def shardAssignments(coord: ActorRef,
                                 dataset: DatasetRef,
                                 resources: DatasetResourceSpec,
-                                mapper: ShardMapper): Seq[Int] = {
-    if (useHostNameToResolveShards) {
+                                mapper: ShardMapper): Seq[Int] =
       getOrdinalFromActorRef(coord) match {
         case Some((hostName, ordinal)) =>
           val numShardsPerHost = resources.numShards / resources.minNumNodes
@@ -81,15 +79,11 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
               " for coordinator {}", coord.path.address.host.getOrElse(InetAddress.getLocalHost.getHostName))
           DefaultShardAssignmentStrategy.shardAssignments(coord, dataset, resources, mapper)
       }
-    } else
-      DefaultShardAssignmentStrategy.shardAssignments(coord, dataset, resources, mapper)
-  }
 
   override def remainingCapacity(coord: ActorRef,
                                  dataset: DatasetRef,
                                  resources: DatasetResourceSpec,
-                                 mapper: ShardMapper): Int = {
-    if (useHostNameToResolveShards) {
+                                 mapper: ShardMapper): Int =
       getOrdinalFromActorRef(coord) match {
         // Host name has the ordinal at the end, we can thus use the logic we use for stateful sets
         // Difference between fixed number of shards the coordinator can take and those currently assigned
@@ -97,10 +91,6 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
         // Flag to resolve shards using hostname set but hostname does not follow stateful set hostname pattern
         case None     => DefaultShardAssignmentStrategy.remainingCapacity(coord, dataset, resources, mapper)
       }
-    } else {
-      DefaultShardAssignmentStrategy.remainingCapacity(coord, dataset, resources, mapper)
-    }
-  }
 }
 
 

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -74,6 +74,8 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
         case None                      =>
           // Host name does not have the ordinal at the end like a stateful set needs to have, delegate to default
           //strategy
+          logger.debug(
+            "Falling back to DefaultShardAssignmentStrategy as hostname does not match k8s StatefulSet convention")
           DefaultShardAssignmentStrategy.shardAssignments(coord, dataset, resources, mapper)
       }
     } else

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -67,7 +67,7 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
         case Some((hostName, ordinal)) =>
           val numShardsPerHost = resources.numShards / resources.minNumNodes
           // Suppose we have a total of 8 shards and 2 hosts, assuming the hostnames are host-0 and host-1, we will map
-          // host-0 to shard [0,1] and host-1 to shard [2, 3]
+          // host-0 to shard [0,1,2,3] and host-1 to shard [4,5,6,7]
           val firstShard = ordinal * numShardsPerHost
           val shardsMapped = (firstShard until firstShard + numShardsPerHost).toList
           logger.info("Using hostname resolution for shard mapping, mapping host={} to shards={}",

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -47,6 +47,8 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
 
   private val pat = "-\\d+$".r
 
+  logger.info("flag useHostNameToResolveShards is set to {}", useHostNameToResolveShards)
+
   private def getOrdinalFromActorRef(coord: ActorRef): Option[(String, Int)] = {
     // if hostname is None from coordinator actor path, then its a local actor
     // If the host name does not contain an ordinal at the end (e.g filodb-host-0, filodb-host-10), it will match None
@@ -74,8 +76,9 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
         case None                      =>
           // Host name does not have the ordinal at the end like a stateful set needs to have, delegate to default
           //strategy
-          logger.debug(
-            "Falling back to DefaultShardAssignmentStrategy as hostname does not match k8s StatefulSet convention")
+          logger.info(
+            "Falling back to DefaultShardAssignmentStrategy as hostname does not match k8s StatefulSet convention" +
+              " for coordinator {}", coord.path.address.host.getOrElse(InetAddress.getLocalHost.getHostName))
           DefaultShardAssignmentStrategy.shardAssignments(coord, dataset, resources, mapper)
       }
     } else

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -85,8 +85,13 @@ class K8sStatefulSetShardAssignmentStrategy(useHostNameToResolveShards: Boolean)
                                  resources: DatasetResourceSpec,
                                  mapper: ShardMapper): Int = {
     if (useHostNameToResolveShards) {
-      // Remaining capacity
-      ???
+      getOrdinalFromActorRef(coord) match {
+        // Host name has the ordinal at the end, we can thus use the logic we use for stateful sets
+        // Difference between fixed number of shards the coordinator can take and those currently assigned
+        case Some(_)  => (resources.numShards / resources.minNumNodes - mapper.shardsForCoord(coord).size).max(0)
+        // Flag to resolve shards using hostname set but hostname does not follow stateful set hostname pattern
+        case None     => DefaultShardAssignmentStrategy.remainingCapacity(coord, dataset, resources, mapper)
+      }
     } else {
       DefaultShardAssignmentStrategy.remainingCapacity(coord, dataset, resources, mapper)
     }

--- a/coordinator/src/test/scala/filodb.coordinator/ShardAssignmentStrategySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardAssignmentStrategySpec.scala
@@ -25,10 +25,12 @@ class ShardAssignmentStrategySpec extends AkkaSpec {
         Some(("coord1", 0))
       } else if (coord == coord2.ref) {
         Some(("coord2", 1))
-      } else if (coord == coord2.ref) {
+      } else if (coord == coord3.ref) {
         Some(("coord3", 2))
-      } else if (coord == coord2.ref) {
+      } else if (coord == coord4.ref) {
         Some(("coord4", 3))
+      } else if (coord == coord5.ref) {
+        Some(("coord5", 4))
       } else {
         None
       }
@@ -61,24 +63,41 @@ class ShardAssignmentStrategySpec extends AkkaSpec {
 
 
     "K8sShardAssignmentStrategy " must {
-      "delegate to DefaultStrategy if numShards not a multiple of numCoords" in {
+      "Should allocate the extra n shards to first n nodes" in {
         val numShards = 8
-        val numCoords = 3
+        val numCoords = 5
         val resources = DatasetResourceSpec(numShards, numCoords)
         val mapper = new ShardMapper(numShards)
 
         val assignment1 = testK8sStrategy.shardAssignments(coord1.ref, dataset, resources, mapper)
-        assignment1 shouldEqual Seq(0, 1, 2)
+        assignment1 shouldEqual Seq(0, 1)
         mapper.registerNode(assignment1, coord1.ref)
 
         val assignment2 = testK8sStrategy.shardAssignments(coord2.ref, dataset, resources, mapper)
-        assignment2 shouldEqual Seq(3, 4, 5)
+        assignment2 shouldEqual Seq(2, 3)
         mapper.registerNode(assignment2, coord2.ref)
 
         val assignment3 = testK8sStrategy.shardAssignments(coord3.ref, dataset, resources, mapper)
-        assignment3 shouldEqual Seq(6, 7)
+        assignment3 shouldEqual Seq(4, 5)
         mapper.registerNode(assignment3, coord3.ref)
 
+        val assignment4 = testK8sStrategy.shardAssignments(coord4.ref, dataset, resources, mapper)
+        assignment4 shouldEqual Seq(6)
+        mapper.registerNode(assignment4, coord4.ref)
+
+        val assignment5 = testK8sStrategy.shardAssignments(coord5.ref, dataset, resources, mapper)
+        assignment5 shouldEqual Seq(7)
+        mapper.registerNode(assignment5, coord5.ref)
+
+      }
+
+      "Remaining capacity should reflect the appropriate remaining capacity" in {
+        val numShards = 8
+        val numCoords = 5
+        val resources = DatasetResourceSpec(numShards, numCoords)
+        val mapper = new ShardMapper(numShards)
+        List(coord1.ref, coord2.ref, coord3.ref, coord4.ref, coord5.ref)
+          .map(testK8sStrategy.remainingCapacity(_, dataset, resources, mapper)) shouldEqual List(2, 2, 2, 1, 1)
       }
 
       "allocate 4 shards to each coordinator" in {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -205,6 +205,8 @@ filodb {
   shard-manager {
     # Minimum time required between successive automatic shard reassignments done by ShardManager
     reassignment-min-interval = 2 hours
+    # Flag to enable
+    enable-k8s-stateful-shard-strategy = false
   }
 
   cassandra {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -477,7 +477,7 @@ class TimeSeriesShard(val ref: DatasetRef,
       while (intIt.hasNext && nextPart == UnsafeUtils.ZeroPointer) {
         val nextPartID = intIt.next
         nextPart = partitions.get(nextPartID)
-          if (nextPart == UnsafeUtils.ZeroPointer) skippedPartIDs += nextPartID
+        if (nextPart == UnsafeUtils.ZeroPointer) skippedPartIDs += nextPartID
       }
     }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -477,7 +477,7 @@ class TimeSeriesShard(val ref: DatasetRef,
       while (intIt.hasNext && nextPart == UnsafeUtils.ZeroPointer) {
         val nextPartID = intIt.next
         nextPart = partitions.get(nextPartID)
-        if (nextPart == UnsafeUtils.ZeroPointer) skippedPartIDs += nextPartID
+          if (nextPart == UnsafeUtils.ZeroPointer) skippedPartIDs += nextPartID
       }
     }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**

Shard assignment is random, when deployed on Kubernetes  Deployment, when a pod(s) go down, the reassignment to shards to pods is random. This prevents using any state.


**New behavior :**

To use Kubernetes StatefulSets where we need state to be retained across pod restarts, we need a deterministic way to assign shards to pods. In stateful sets, the pod name has an ordinal at the end which can be used to assign shards to pods.


