### PR TITLE
bug(core): Skip facet for long label values

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -50,6 +50,7 @@ object PartKeyLuceneIndex {
 
   val MAX_STR_INTERN_ENTRIES = 10000
   val MAX_TERMS_TO_ITERATE = 10000
+  val FACET_FIELD_MAX_LEN = 1000
 
   val NOT_FOUND = -1
 
@@ -157,7 +158,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
 
     def addField(name: String, value: String): Unit = {
       // Use PartKeyIndexBenchmark to measure indexing performance before changing this
-      if (name.nonEmpty && value.nonEmpty && facetEnabledForLabel(name)) {
+      if (name.nonEmpty && value.nonEmpty && facetEnabledForLabel(name) && value.length < FACET_FIELD_MAX_LEN) {
         facetsConfig.setRequireDimensionDrillDown(name, false)
         facetsConfig.setIndexFieldName(name, FACET_FIELD_PREFIX + name)
         document.add(new SortedSetDocValuesFacetField(name, value))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently we see this faceting exception when encountering long label values:

```
java.lang.IllegalArgumentException: category path exceeds maximum allowed path length: max=8191 len=20098 path=[hosts, xxxxxxxxxxx...
	at org.apache.lucene.facet.taxonomy.FacetLabel.checkComponents(FacetLabel.java:96)
	at org.apache.lucene.facet.taxonomy.FacetLabel.<init>(FacetLabel.java:72)
	at org.apache.lucene.facet.FacetsConfig.processSSDVFacetFields(FacetsConfig.java:383)
	at org.apache.lucene.facet.FacetsConfig.build(FacetsConfig.java:301)
	at org.apache.lucene.facet.FacetsConfig.build(FacetsConfig.java:204)
	at filodb.core.memstore.PartKeyLuceneIndex.addPartKey(PartKeyLuceneIndex.scala:432)
	at filodb.core.memstore.IndexBootstrapper.$anonfun$bootstrapIndexRaw$1(IndexBootstrapper.scala:40)
	at filodb.core.memstore.IndexBootstrapper.$anonfun$bootstrapIndexRaw$1$adapted(IndexBootstrapper.scala:38)
```	

This PR skips faceting for label values > 1000 characters
