### PR TITLE
bug(core): Address more cases when label is not indexed

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -348,7 +348,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
       } catch {
         case e: IllegalArgumentException =>
           // If this exception is seen, then we have not seen the label. Return empty result.
-          if (!e.getMessage.contains("was not indexed with SortedSetDocValues")) throw e;
+          if (!e.getMessage.contains("was not indexed"))
+            logger.warn(s"Got an exception when doing label-values filters=$colFilters colName=$colName", e)
       }
     }
     labelValuesQueryLatency.record(System.nanoTime() - start)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Looks like there are more error messages seen when label is not indexed such as 'dimension "foo_label" was not indexed'

So we are now catching all IllegalArgumentExceptions to not fail query.
And logging unexpected exceptions so they are not fully swallowed.
