### PR TITLE
fix(query) InprocessDispatcher to use non empty query config

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -256,7 +256,8 @@ trait  DefaultPlanner {
 
    def materializeFixedScalar(qContext: QueryContext,
                                      lp: ScalarFixedDoublePlan): PlanResult = {
-    val scalarFixedDoubleExec = ScalarFixedDoubleExec(qContext, dataset = dataset.ref, lp.timeStepParams, lp.scalar)
+    val scalarFixedDoubleExec = ScalarFixedDoubleExec(qContext, dataset = dataset.ref,
+      lp.timeStepParams, lp.scalar, inProcessPlanDispatcher)
     PlanResult(Seq(scalarFixedDoubleExec))
   }
 
@@ -367,7 +368,8 @@ trait  DefaultPlanner {
 
   def materializeScalarTimeBased(qContext: QueryContext,
                                   lp: ScalarTimeBasedPlan): PlanResult = {
-    val scalarTimeBasedExec = TimeScalarGeneratorExec(qContext, dataset.ref, lp.rangeParams, lp.function)
+    val scalarTimeBasedExec = TimeScalarGeneratorExec(qContext, dataset.ref,
+      lp.rangeParams, lp.function, inProcessPlanDispatcher)
     PlanResult(Seq(scalarTimeBasedExec))
   }
 
@@ -384,7 +386,8 @@ trait  DefaultPlanner {
       Right(rhsExec.plans.map(_.asInstanceOf[ScalarBinaryOperationExec]).head)
     } else Left(lp.rhs.left.get)
 
-    val scalarBinaryExec = ScalarBinaryOperationExec(qContext, dataset.ref, lp.rangeParams, lhs, rhs, lp.operator)
+    val scalarBinaryExec = ScalarBinaryOperationExec(qContext, dataset.ref,
+      lp.rangeParams, lhs, rhs, lp.operator, inProcessPlanDispatcher)
     PlanResult(Seq(scalarBinaryExec))
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
@@ -7,6 +7,7 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.verbs.MustVerb
 
 import filodb.coordinator.ShardMapper
 import filodb.core.MetricsTestData
@@ -20,7 +21,7 @@ import filodb.query.{LabelCardinality, PlanValidationSpec}
 import filodb.query.exec._
 
 // scalastyle:off line.size.limit
-class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationSpec{
+class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationSpec with MustVerb {
   private implicit val system: ActorSystem = ActorSystem()
   private val node = TestProbe().ref
 
@@ -819,5 +820,40 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
     val expectedPlan = "E~PromQlRemoteExec(PromQlQueryParams(bottomk(1.0,((min((foo{_ws_=\"demo\",_ns_=\"remoteNs\"} * on(userID) group_left(userName) bar{_ws_=\"demo\",_ns_=\"remoteNs\"})) by (userName,time) - time()) > 0.0)),1634777330,300,1634777330,None,false), PlannerParams(filodb,None,None,None,None,30000,1000000,100000,100000,false,86400000,86400000,false,true,false,false), queryEndpoint=remotePartition-url, requestTimeoutMs=10000) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@570ba13)"
     validatePlan(execPlan, expectedPlan)
 
+  }
+
+  it(" must have a non empty config plans with scalar operations in") {
+      val query =
+        """min((1000 - foo{_ws_="demo",_ns_="localNs"})
+          |/
+          |(delta(foo{_ws_="demo",_ns_="localNs"}[1h]) > 0 or vector(1)))""".stripMargin
+      val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(endSeconds, step, endSeconds), Antlr)
+      val execPlan = rootPlanner.materialize(lp,
+        QueryContext(origQueryParams = queryParams.copy(promQl = LogicalPlanParser.convertToQuery(lp))))
+    val expectedPlan =
+        """T~AggregatePresenter(aggrOp=Min, aggrParams=List(), rangeParams=RangeParams(1634777330,300,1634777330))
+           |-E~LocalPartitionReduceAggregateExec(aggrOp=Min, aggrParams=List()) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@66e21568)
+           |--T~AggregateMapReduce(aggrOp=Min, aggrParams=List(), without=List(), by=List())
+           |---E~BinaryJoinExec(binaryOp=DIV, on=List(), ignoring=List()) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@66e21568)
+           |----T~ScalarOperationMapper(operator=SUB, scalarOnLhs=true)
+           |-----FA1~StaticFuncArgs(1000.0,RangeParams(1634777330,300,1634777330))
+           |-----T~PeriodicSamplesMapper(start=1634777330000, step=300000, end=1634777330000, window=None, functionId=None, rawSource=true, offsetMs=None)
+           |------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=0, chunkMethod=TimeRangeChunkScan(1634777030000,1634777330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1012526996],raw)
+           |----T~ScalarOperationMapper(operator=SUB, scalarOnLhs=true)
+           |-----FA1~StaticFuncArgs(1000.0,RangeParams(1634777330,300,1634777330))
+           |-----T~PeriodicSamplesMapper(start=1634777330000, step=300000, end=1634777330000, window=None, functionId=None, rawSource=true, offsetMs=None)
+           |------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=1, chunkMethod=TimeRangeChunkScan(1634777030000,1634777330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1012526996],raw)
+           |----E~SetOperatorExec(binaryOp=LOR, on=List(), ignoring=List()) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@66e21568)
+           |-----T~ScalarOperationMapper(operator=GTR, scalarOnLhs=false)
+           |------FA1~StaticFuncArgs(0.0,RangeParams(1634777330,300,1634777330))
+           |------T~PeriodicSamplesMapper(start=1634777330000, step=300000, end=1634777330000, window=Some(3600000), functionId=Some(Delta), rawSource=true, offsetMs=None)
+           |-------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=0, chunkMethod=TimeRangeChunkScan(1634773730000,1634777330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1012526996],raw)
+           |-----T~ScalarOperationMapper(operator=GTR, scalarOnLhs=false)
+           |------FA1~StaticFuncArgs(0.0,RangeParams(1634777330,300,1634777330))
+           |------T~PeriodicSamplesMapper(start=1634777330000, step=300000, end=1634777330000, window=Some(3600000), functionId=Some(Delta), rawSource=true, offsetMs=None)
+           |-------E~MultiSchemaPartitionsExec(dataset=timeseries, shard=1, chunkMethod=TimeRangeChunkScan(1634773730000,1634777330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1012526996],raw)
+           |-----T~VectorFunctionMapper(funcParams=List())
+           |------E~ScalarFixedDoubleExec(params = RangeParams(1634777330,300,1634777330), value = 1.0) on InProcessPlanDispatcher(filodb.core.query.QueryConfig@66e21568)""".stripMargin
+    validatePlan(execPlan, expectedPlan)
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
@@ -7,7 +7,6 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.verbs.MustVerb
 
 import filodb.coordinator.ShardMapper
 import filodb.core.MetricsTestData
@@ -21,7 +20,7 @@ import filodb.query.{LabelCardinality, PlanValidationSpec}
 import filodb.query.exec._
 
 // scalastyle:off line.size.limit
-class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationSpec with MustVerb {
+class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationSpec {
   private implicit val system: ActorSystem = ActorSystem()
   private val node = TestProbe().ref
 

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -24,4 +24,7 @@ class QueryConfig(queryConfig: Config) {
   def has(feature: String): Boolean = queryConfig.as[Option[Boolean]](feature).getOrElse(false)
 }
 
+/**
+ * IMPORTANT: Use this for testing only, using this for anything other than testing may yield undesired behavior
+ */
 object EmptyQueryConfig extends QueryConfig(queryConfig = ConfigFactory.empty())

--- a/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
@@ -19,7 +19,8 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
                                      params: RangeParams,
                                      lhs: Either[Double, ScalarBinaryOperationExec],
                                      rhs: Either[Double, ScalarBinaryOperationExec],
-                                     operator: BinaryOperator) extends LeafExecPlan {
+                                     operator: BinaryOperator,
+                                     dispatcher: InProcessPlanDispatcher) extends LeafExecPlan {
 
   val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
@@ -62,11 +63,4 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
         querySession.partialResultsReason)
     }
   }
-
-  /**
-    * The dispatcher is used to dispatch the ExecPlan
-    * to the node where it will be executed. The Query Engine
-    * will supply this parameter
-    */
-  override final def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 }

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -19,7 +19,8 @@ import filodb.query.{QueryResponse, QueryResult}
 case class ScalarFixedDoubleExec(queryContext: QueryContext,
                                  dataset: DatasetRef,
                                  params: RangeParams,
-                                 value: Double) extends LeafExecPlan {
+                                 value: Double,
+                                 dispatcher: InProcessPlanDispatcher) extends LeafExecPlan {
 
   val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
@@ -65,12 +66,4 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
       }.flatten
     }
   }
-
-  /**
-    * The dispatcher is used to dispatch the ExecPlan
-    * to the node where it will be executed. The Query Engine
-    * will supply this parameter
-    */
-  override def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
-
 }

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -18,7 +18,8 @@ import filodb.query.ScalarFunctionId.{DayOfMonth, DayOfWeek, DaysInMonth, Hour, 
   */
 case class TimeScalarGeneratorExec(queryContext: QueryContext,
                                    dataset: DatasetRef, params: RangeParams,
-                                   function: ScalarFunctionId) extends LeafExecPlan {
+                                   function: ScalarFunctionId,
+                                   dispatcher: InProcessPlanDispatcher) extends LeafExecPlan {
 
   val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
@@ -75,10 +76,4 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
     }
   }
 
-  /**
-    * The dispatcher is used to dispatch the ExecPlan
-    * to the node where it will be executed. The Query Engine
-    * will supply this parameter
-    */
-  override final def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 }

--- a/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
@@ -15,8 +15,8 @@ import filodb.core.metadata.{Dataset, DatasetOptions}
 import filodb.core.query._
 import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
 import filodb.memory.format.ZeroCopyUTF8String
-import filodb.query.{exec, QueryResult, ScalarFunctionId}
-import filodb.query.exec.TimeScalarGeneratorExec
+import filodb.query.{QueryResult, ScalarFunctionId, exec}
+import filodb.query.exec.{InProcessPlanDispatcher, TimeScalarGeneratorExec}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -35,6 +35,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val ignoreKey = CustomRangeVectorKey(
     Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
 
+  val inProcessDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
 
   val testKey1 = CustomRangeVectorKey(
     Map(ZeroCopyUTF8String("src") -> ZeroCopyUTF8String("source-value-10"),
@@ -137,7 +138,8 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
   }
 
   it("should generate time scalar") {
-    val execPlan = TimeScalarGeneratorExec(QueryContext(), timeseriesDataset.ref, RangeParams(10, 10, 100), ScalarFunctionId.Time)
+    val execPlan = TimeScalarGeneratorExec(QueryContext(), timeseriesDataset.ref, RangeParams(10, 10, 100),
+      ScalarFunctionId.Time, inProcessDispatcher)
     implicit val timeout: FiniteDuration = FiniteDuration(5, TimeUnit.SECONDS)
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
@@ -152,7 +154,8 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     }
   }
   it("should generate hour scalar") {
-    val execPlan = TimeScalarGeneratorExec(QueryContext(), timeseriesDataset.ref, RangeParams(1565627710, 10, 1565627790), ScalarFunctionId.Hour)
+    val execPlan = TimeScalarGeneratorExec(QueryContext(), timeseriesDataset.ref,
+      RangeParams(1565627710, 10, 1565627790), ScalarFunctionId.Hour, inProcessDispatcher)
     implicit val timeout: FiniteDuration = FiniteDuration(5, TimeUnit.SECONDS)
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
@@ -168,7 +171,8 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     }
   }
   it("should generate DayOfWeek scalar") {
-    val execPlan = TimeScalarGeneratorExec(QueryContext(), timeseriesDataset.ref, RangeParams(1583682900, 100, 1583683400), ScalarFunctionId.DayOfWeek)
+    val execPlan = TimeScalarGeneratorExec(QueryContext(), timeseriesDataset.ref,
+      RangeParams(1583682900, 100, 1583683400), ScalarFunctionId.DayOfWeek, inProcessDispatcher)
     implicit val timeout: FiniteDuration = FiniteDuration(5, TimeUnit.SECONDS)
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Scalar operations uses dispatcher with empty query config. This causes ``SingleClusterPlanner`` to use same ``InProcessDispatcher`` even for other operations like binary joins yielding undesired failures on query execution. 

**New behavior :**
EmptyConfig should not be used for anything apart from testing and all ``*Exec`` will explicitly be passed with a dispatcher with right config.
