### PR TITLE
bug(sparkJobs): Dont create new schedulers for each card buster task

### DIFF
--- a/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
@@ -27,6 +27,8 @@ object BusterContext extends StrictLogging {
 /**
  * Requires following typesafe config properties:
  *
+ * filodb.cardbuster.cass-delete-parallelism-per-spark-thread = 1
+ *
  * filodb.cardbuster.delete-pk-filters = [
  *  {
  *     _ns_ = "bulk_ns"

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -3,8 +3,14 @@ package filodb.cardbuster
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
+import scala.concurrent.Await
+
 import kamon.Kamon
+import kamon.metric.MeasurementUnit
+import monix.eval.Task
 import monix.execution.Scheduler
+import monix.execution.atomic.AtomicInt
+import monix.reactive.Observable
 import net.ceedubs.ficus.Ficus._
 
 import filodb.cassandra.columnstore.CassandraColumnStore
@@ -15,16 +21,21 @@ import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.DownsamplerSettings
 import filodb.memory.format.UnsafeUtils
 
+object BusterSchedulers {
+  @transient lazy val readSched = Scheduler.io("cass-read-sched")
+  @transient lazy val writeSched = Scheduler.io("cass-write-sched")
+  @transient lazy val computeSched = Scheduler.computation(name = "buster-compute")
+}
+
 class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
                                 inDownsampleTables: Boolean) extends Serializable {
 
-  @transient lazy protected val readSched = Scheduler.io("cass-read-sched")
-  @transient lazy protected val writeSched = Scheduler.io("cass-write-sched")
   @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(dsSettings.cassandraConfig)
   @transient lazy private val schemas = Schemas.fromConfig(dsSettings.filodbConfig).get
 
   @transient lazy private[cardbuster] val colStore =
-                new CassandraColumnStore(dsSettings.filodbConfig, readSched, session, inDownsampleTables)(writeSched)
+                new CassandraColumnStore(dsSettings.filodbConfig, BusterSchedulers.readSched,
+                  session, inDownsampleTables)(BusterSchedulers.writeSched)
 
   @transient lazy private val downsampleRefsByRes = dsSettings.downsampleResolutions
                                                               .zip(dsSettings.downsampledDatasetRefs).toMap
@@ -34,6 +45,9 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
   @transient lazy private val dsDatasetRef = downsampleRefsByRes(highestDSResolution)
 
   @transient lazy private[cardbuster] val dataset = if (inDownsampleTables) dsDatasetRef else rawDatasetRef
+
+  @transient lazy val numParallelDeletesPerSparkThread = dsSettings.filodbConfig
+                      .as[Option[Int]]("cardbuster.cass-delete-parallelism-per-spark-thread")
 
   @transient lazy val deleteFilter = dsSettings.filodbConfig
     .as[Seq[Map[String, String]]]("cardbuster.delete-pk-filters").map(_.mapValues(_.r.pattern).toSeq)
@@ -50,10 +64,14 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
   @transient lazy val endTimeLTE = Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dsSettings.filodbConfig
     .as[String]("cardbuster.delete-endTimeLTE"))).toEpochMilli
 
+  // scalastyle:off method.length
   def bustIndexRecords(shard: Int, split: (String, String), isSimulation: Boolean): Int = {
     val numPartKeysDeleted = Kamon.counter("num-partkeys-deleted").withTag("dataset", dataset.toString)
         .withTag("shard", shard).withTag("simulation", isSimulation)
     val numPartKeysCouldNotDelete = Kamon.counter("num-partkeys-could-not-delete").withTag("dataset", dataset.toString)
+      .withTag("shard", shard).withTag("simulation", isSimulation)
+    val cassDeleteLatency = Kamon.histogram("pk-delete-latency", MeasurementUnit.time.nanoseconds)
+      .withTag("dataset", dataset.toString)
       .withTag("shard", shard).withTag("simulation", isSimulation)
     require(deleteFilter.nonEmpty, "cardbuster.delete-pk-filters should be non-empty")
     BusterContext.log.info(s"Starting to bust cardinality in shard=$shard with isSimulation=$isSimulation " +
@@ -61,10 +79,10 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
       s"startTimeLTE=$startTimeLTE endTimeGTE=$endTimeGTE  endTimeLTE=$endTimeLTE split=$split")
     val candidateKeys = colStore.scanPartKeysByStartEndTimeRangeNoAsync(dataset, shard,
       split, startTimeGTE, startTimeLTE, endTimeGTE, endTimeLTE)
-    var numDeleted = 0
-    var numCouldNotDelete = 0
-    var numCandidateKeys = 0
-    candidateKeys.filter { pk =>
+    val numDeleted = AtomicInt(0)
+    val numCouldNotDelete = AtomicInt(0)
+    val numCandidateKeys = AtomicInt(0)
+    val keysToDelete = candidateKeys.filter { pk =>
       val rawSchemaId = RecordSchema.schemaID(pk.partKey, UnsafeUtils.arayOffset)
       val schema = schemas(rawSchemaId)
       val pkPairs = schema.partKeySchema.toStringPairs(pk.partKey, UnsafeUtils.arayOffset)
@@ -81,20 +99,35 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
       }
       numCandidateKeys += 1
       willDelete
-    }.foreach { pk =>
-      try {
-        if (!isSimulation) colStore.deletePartKeyNoAsync(dataset, shard, pk.partKey)
-        numPartKeysDeleted.increment()
-        numDeleted += 1
-      } catch { case e: Exception =>
-        BusterContext.log.error(s"Could not delete a part key: ${e.getMessage}")
-        numPartKeysCouldNotDelete.increment()
-        numCouldNotDelete += 1
-      }
-      Unit
     }
-    BusterContext.log.info(s"Finished deleting keys from shard shard=$shard numCandidateKeys=$numCandidateKeys " +
-      s"numDeleted=$numDeleted numCouldNotDelete=$numCouldNotDelete isSimulation=$isSimulation")
-    numDeleted
+    val fut = Observable.fromIteratorUnsafe(keysToDelete)
+                        .mapParallelUnordered(numParallelDeletesPerSparkThread.getOrElse(1)) { pk =>
+      Task.eval {
+        try {
+          if (!isSimulation) {
+            val startNs = System.nanoTime()
+            try {
+              colStore.deletePartKeyNoAsync(dataset, shard, pk.partKey)
+            } finally {
+              cassDeleteLatency.record(System.nanoTime() - startNs)
+            }
+          }
+          numPartKeysDeleted.increment()
+          numDeleted += 1
+        } catch {
+          case e: Exception =>
+            BusterContext.log.error(s"Could not delete a part key: ${e.getMessage}")
+            numPartKeysCouldNotDelete.increment()
+            numCouldNotDelete += 1
+        }
+        Unit
+      }
+    }.completedL.runToFuture(BusterSchedulers.computeSched)
+    import scala.concurrent.duration._
+    Await.result(fut, 1.day)
+    BusterContext.log.info(s"Finished deleting keys from a shard split in shard=$shard " +
+      s"numCandidateKeys=${numCandidateKeys.get()} numDeleted=${numDeleted.get()} " +
+      s"numCouldNotDelete=${numCouldNotDelete.get()} isSimulation=$isSimulation")
+    numDeleted.get()
   }
 }

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -22,9 +22,9 @@ import filodb.downsampler.chunk.DownsamplerSettings
 import filodb.memory.format.UnsafeUtils
 
 object BusterSchedulers {
-  @transient lazy val readSched = Scheduler.io("cass-read-sched")
-  @transient lazy val writeSched = Scheduler.io("cass-write-sched")
-  @transient lazy val computeSched = Scheduler.computation(name = "buster-compute")
+  lazy val readSched = Scheduler.io("cass-read-sched")
+  lazy val writeSched = Scheduler.io("cass-write-sched")
+  lazy val computeSched = Scheduler.computation(name = "buster-compute")
 }
 
 class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

* Dont create new schedulers for each cardinality buster task that is serialized and sent to worker.
* Also include ability to do parallel cassandra writes
* Track cassandra write latency
