### PR TITLE
fix(query): absent with sum_over_time result should be consistent

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -125,7 +125,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
       val newQueryParams = queryParams.copy(promQl = LogicalPlanParser.convertToQuery(newLogicalPlan))
       val newQueryContext = qContext.copy(origQueryParams = newQueryParams, plannerParams = qContext.plannerParams.
         copy(skipAggregatePresent = skipAggregatePresentValue))
-      queryPlanner.materialize(logicalPlan.replaceFilters(result), newQueryContext)
+      queryPlanner.materialize(newLogicalPlan, newQueryContext)
     }
   }
 

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -135,7 +135,8 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
                                endMs: Long) extends MetadataQueryPlan
 
 object TsCardinalities {
-  val SHARD_KEY_LABELS = Seq("_ws_", "_ns_", "__name__")
+  val LABEL_WORKSPACE = "_ws_"
+  val SHARD_KEY_LABELS = Seq(LABEL_WORKSPACE, "_ns_", "__name__")
 }
 
 /**
@@ -776,8 +777,12 @@ object LogicalPlan {
    */
   def overrideColumnFilters(base: Seq[ColumnFilter],
                             overrides: Seq[ColumnFilter]): Seq[ColumnFilter] = {
-    val overrideColumns = overrides.map(_.column)
-    base.filterNot(f => overrideColumns.contains(f.column)) ++ overrides
+    if (base.nonEmpty && !base.map(_.column).contains(TsCardinalities.LABEL_WORKSPACE)) {
+      val overrideColumns = overrides.map(_.column)
+      base.filterNot(f => overrideColumns.contains(f.column)) ++ overrides
+    } else {
+      base
+    }
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
```
% curl -i --location -g --request GET 'http://localhost:9900/ws-bar/api/v1/query_range?query=absent(sum_over_time(foo{_ns_="ns-bar"}[5m]))&start=1651815600&end=1651816200&step=60'
HTTP/1.1 200 OK
content-type: application/json; charset=UTF-8
Content-Type: application/json
content-length: 515
Access-Control-Allow-Methods: GET

{
  "status" : "success",
  "data" : {
    "resultType" : "matrix",
    "result" : [ {
      "metric" : {
        "_ns_" : "ns-bar",
        "_ws_" : "ws-bar"
      },
      "values" : [ [ 1651815600, "1.0" ], [ 1651815660, "1.0" ], [ 1651815720, "1.0" ], [ 1651815780, "1.0" ], [ 1651815840, "1.0" ], [ 1651815900, "1.0" ], [ 1651815960, "1.0" ], [ 1651816020, "1.0" ], [ 1651816080, "1.0" ], [ 1651816140, "1.0" ], [ 1651816200, "1.0" ] ]
    } ]
  },
  "errorType" : null,
  "error" : null
}
```

**New behavior :**
```
% curl -i --location -g --request GET 'http://localhost:9900/ws-bar/api/v1/query_range?query=absent(sum_over_time(foo{_ns_="ns-bar"}[5m]))&start=1651815600&end=1651816200&step=60'
HTTP/1.1 200 OK
content-type: application/json; charset=UTF-8
Content-Type: application/json
content-length: 435
Access-Control-Allow-Methods: GET

{
  "status" : "success",
  "data" : {
    "resultType" : "matrix",
    "result" : [ {
      "metric" : { },
      "values" : [ [ 1651815600, "1.0" ], [ 1651815660, "1.0" ], [ 1651815720, "1.0" ], [ 1651815780, "1.0" ], [ 1651815840, "1.0" ], [ 1651815900, "1.0" ], [ 1651815960, "1.0" ], [ 1651816020, "1.0" ], [ 1651816080, "1.0" ], [ 1651816140, "1.0" ], [ 1651816200, "1.0" ] ]
    } ]
  },
  "errorType" : null,
  "error" : null
}
```
