### PR TITLE
**WIP** fix(maint): add kryo QueryConfig serializer

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/client/FiloKryoSerializers.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/FiloKryoSerializers.scala
@@ -2,8 +2,8 @@ package com.esotericsoftware.kryo.io
 
 import com.esotericsoftware.kryo.{Serializer => KryoSerializer}
 import com.esotericsoftware.kryo.Kryo
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
-
 import filodb.core.binaryrecord2.{RecordSchema => RecordSchema2}
 import filodb.core.query.{ColumnInfo, PartitionInfo, PartitionRangeVectorKey}
 import filodb.memory.format._
@@ -76,5 +76,16 @@ class PartitionInfoSerializer extends KryoSerializer[PartitionInfo] {
     kryo.writeObject(output, info.schema)
     BinaryRegionUtils.writeLargeRegion(info.base, info.offset, output)
     output.writeInt(info.shardNo)
+  }
+}
+
+class ConfigSerializer extends KryoSerializer[Config] {
+  override def write(kryo: Kryo, output: Output, config: Config): Unit = {
+    kryo.writeClassAndObject(output, config.root().render())
+  }
+
+  override def read(kryo: Kryo, input: Input, config: Class[Config]): Config = {
+    val s = kryo.readClassAndObject(input).asInstanceOf[String]
+    ConfigFactory.parseString(s)
   }
 }

--- a/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
@@ -3,10 +3,10 @@ package filodb.coordinator.client
 import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
 import com.esotericsoftware.kryo.io._
 import com.esotericsoftware.minlog.Log
+import com.typesafe.config.Config
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer
 import io.altoo.akka.serialization.kryo.DefaultKryoInitializer
 import io.altoo.akka.serialization.kryo.serializer.scala.ScalaKryo
-
 import filodb.coordinator.FilodbSettings
 import filodb.core._
 import filodb.core.binaryrecord2.{RecordSchema => RecordSchema2}
@@ -39,6 +39,7 @@ class KryoInit extends DefaultKryoInitializer {
 
     kryo.addDefaultSerializer(classOf[RecordSchema2], classOf[RecordSchema2Serializer])
     kryo.addDefaultSerializer(classOf[ZeroCopyUTF8String], classOf[ZeroCopyUTF8StringSerializer])
+    kryo.addDefaultSerializer(classOf[Config], classOf[ConfigSerializer])
     kryo.register(classOf[Schema], new SchemaSerializer)
     kryo.register(classOf[PartitionSchema], new PartSchemaSerializer)
 

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -1,7 +1,6 @@
 package filodb.core.query
 
 import scala.concurrent.duration.FiniteDuration
-
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 
@@ -9,7 +8,7 @@ object QueryConfig {
   val DefaultVectorsLimit = 150
 }
 
-class QueryConfig(queryConfig: Config) {
+class QueryConfig(private val queryConfig: Config) {
   lazy val askTimeout = queryConfig.as[FiniteDuration]("ask-timeout")
   lazy val staleSampleAfterMs = queryConfig.getDuration("stale-sample-after").toMillis
   lazy val minStepMs = queryConfig.getDuration("min-step").toMillis
@@ -22,6 +21,18 @@ class QueryConfig(queryConfig: Config) {
    * Feature flag test: returns true if the config has an entry with "true", "t" etc
    */
   def has(feature: String): Boolean = queryConfig.as[Option[Boolean]](feature).getOrElse(false)
+
+  override def hashCode(): Int = {
+    super.hashCode()
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj.isInstanceOf[QueryConfig] && obj.asInstanceOf[QueryConfig].queryConfig == queryConfig
+  }
+
+  override def toString: String = {
+    s"QueryContext(configHash=${queryConfig.hashCode()})"
+  }
 }
 
 /**

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -23,7 +23,7 @@ class QueryConfig(private val queryConfig: Config) {
   def has(feature: String): Boolean = queryConfig.as[Option[Boolean]](feature).getOrElse(false)
 
   override def hashCode(): Int = {
-    super.hashCode()
+    queryConfig.hashCode()
   }
 
   override def equals(obj: Any): Boolean = {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This is a single commit cherry-picked from an older branch. It fixes `AskTimeoutExceptions` seen sometimes when queries include `Scalar` types (TODO: explicitly `ScalarVectorBinaryJoin`s?).

Prior to this commit, a serialization of a `QueryConfig` would throw an exception because the `kryo` serializer was not properly setup.

Before merging, need to first figure out (a) why this didn't happen before (are `QueryConfig`s not supposed to be serialized?), and (b) if this fixes the root cause.