### PR TITLE
cherry-pick for 0.9.16 hotfix

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
@@ -186,9 +186,9 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(gaugeName))
     val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams = PlannerParams(sampleLimit = numSamples * 2)),
-      InProcessPlanDispatcher(EmptyQueryConfig), dataset.ref, 0, queryFilters, TimeRangeChunkScan(firstSampleTime, firstSampleTime + 2 *
+      InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), dataset.ref, 0, queryFilters, TimeRangeChunkScan(firstSampleTime, firstSampleTime + 2 *
         numSamples), "_metric_")
-    val queryConfig = new QueryConfig(config.getConfig("query"))
+    val queryConfig = QueryConfig(config.getConfig("query"))
     val querySession = QuerySession(QueryContext(), queryConfig)
     exec.execute(memStore, querySession)(queryScheduler).runToFuture(queryScheduler)
   }

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -293,7 +293,7 @@ object CliMain extends FilodbClusterNode {
     client.getShardMapper(dsRef) match {
       case Some(mapper) =>
         def mapperRef = mapper
-        val queryConfig = new QueryConfig (config.getConfig ("query") )
+        val queryConfig = QueryConfig (config.getConfig ("query") )
         val dataset = new Dataset(dsRef.dataset, Schemas.global.schemas.get(args.schema()).get)
         val planner = new SingleClusterPlanner(dataset, Schemas.global,
           mapperRef, earliestRetainedTimestampFn = 0, queryConfig, "raw",

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -73,7 +73,7 @@ final class QueryActor(memStore: TimeSeriesStore,
   val functionalSpreadProvider = FunctionalSpreadProvider(spreadFunc)
 
   logger.info(s"Starting QueryActor and QueryEngine for ds=$dsRef schemas=$schemas")
-  val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
+  val queryConfig = QueryConfig(config.getConfig("filodb.query"))
   val queryPlanner = new SingleClusterPlanner(dataset, schemas, shardMapFunc,
                                               earliestRawTimestampFn, queryConfig, "raw",
                                               functionalSpreadProvider)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -25,15 +25,14 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
                               remoteExecHttpClient: RemoteExecHttpClient = RemoteHttpClient.defaultClient)
   extends QueryPlanner with StrictLogging {
 
-  import net.ceedubs.ficus.Ficus._
   import LogicalPlanUtils._
   import QueryFailureRoutingStrategy._
   import LogicalPlan._
 
-  val remoteHttpEndpoint: String = queryConfig.routingConfig.getString("remote.http.endpoint")
+  val remoteHttpEndpoint: String = queryConfig.remoteHttpEndpoint
+    .getOrElse(throw new IllegalArgumentException("remoteHttpEndpoint config needed"))
 
-  val remoteHttpTimeoutMs: Long =
-    queryConfig.routingConfig.config.as[Option[Long]]("remote.http.timeout").getOrElse(60000)
+  val remoteHttpTimeoutMs: Long = queryConfig.remoteHttpTimeoutMs.getOrElse(60000)
 
   val inProcessPlanDispatcher = InProcessPlanDispatcher(queryConfig)
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -46,10 +46,7 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
   override val schemas: Schemas = Schemas(dataset.schema)
   override val dsOptions: DatasetOptions = schemas.part.options
 
-  import net.ceedubs.ficus.Ficus._
-
-  val remoteHttpTimeoutMs: Long =
-    queryConfig.routingConfig.config.as[Option[Long]]("remote.http.timeout").getOrElse(60000)
+  val remoteHttpTimeoutMs: Long = queryConfig.remoteHttpTimeoutMs.getOrElse(60000)
 
   val datasetMetricColumn: String = dataset.options.metricColumn
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -93,7 +93,7 @@ class SingleClusterPlanner(val dataset: Dataset,
   def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
     val plannerParams = qContext.plannerParams
     val updatedPlan = updateStartTime(logicalPlan)
-    if (updatedPlan.isEmpty) EmptyResultExec(qContext, dsRef)
+    if (updatedPlan.isEmpty) EmptyResultExec(qContext, dsRef, inProcessPlanDispatcher)
     else {
      val logicalPlan = updatedPlan.get
       val timeSplitConfig = if (plannerParams.timeSplitEnabled)

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -39,7 +39,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
 
   val serialization = SerializationExtension(system)
   val config = ConfigFactory.load("application_test.conf")
-  val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
+  val queryConfig = QueryConfig(config.getConfig("filodb.query"))
 
   private def roundTrip(thing: AnyRef): AnyRef = {
     val serializer = serialization.findSerializerFor(thing)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/FindMyShards.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/FindMyShards.scala
@@ -50,7 +50,7 @@ object FindMyShards extends StrictLogging {
     val schemas = Schemas (dataset.schema)
 
     val config = ConfigFactory.load ("application_test.conf")
-    val queryConfig = new QueryConfig (config.getConfig ("filodb.query") )
+    val queryConfig = QueryConfig (config.getConfig ("filodb.query") )
 
     new SingleClusterPlanner(dataset, schemas, mapperRef, earliestRetainedTimestampFn = 0,
       queryConfig, "raw", StaticSpreadProvider(SpreadChange(0, spread)))

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -38,7 +38,7 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
 
   private val config = ConfigFactory.load("application_test.conf").getConfig("filodb.query").
     withFallback(routingConfig)
-  private val queryConfig = new QueryConfig(config)
+  private val queryConfig = QueryConfig(config)
   /*
   This is the PromQL
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import monix.execution.Scheduler
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
-import filodb.core.query.{EmptyQueryConfig, PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.ChunkSource
 import filodb.prometheus.ast.{TimeStepParams, WindowConstants}
 import filodb.prometheus.parse.Parser
@@ -50,9 +50,9 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
   val latestDownsampleTime = now - 4.minutes.toMillis // say it takes 4 minutes to downsample
 
   private val config = ConfigFactory.load("application_test.conf")
-  private val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
+  private val queryConfig = QueryConfig(config.getConfig("filodb.query"))
 
-  private def disp = InProcessPlanDispatcher(EmptyQueryConfig)
+  private def disp = InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig)
   val dataset = MetricsTestData.timeseriesDataset
   val datasetMetricColumn = dataset.options.metricColumn
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -35,7 +35,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
 
   private val config = ConfigFactory.load("application_test.conf")
     .getConfig("filodb.query").withFallback(routingConfig)
-  private val queryConfig = new QueryConfig(config)
+  private val queryConfig = QueryConfig(config)
 
   val localPlanner = new SingleClusterPlanner(dataset, schemas, mapperRef, earliestRetainedTimestampFn = 0,
     queryConfig, "raw", StaticSpreadProvider(SpreadChange(0, 1)))

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
@@ -36,7 +36,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
   private val routingConfig = ConfigFactory.parseString(routingConfigString)
 
   private val config = ConfigFactory.load("application_test.conf").getConfig("filodb.query").withFallback(routingConfig)
-  private val queryConfig = new QueryConfig(config)
+  private val queryConfig = QueryConfig(config)
 
   private val now = 1634777330000L
 
@@ -48,7 +48,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
   val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
     earliestRetainedTimestampFn = now - downsampleRetention, queryConfig, "downsample")
 
-  private def inProcessDispatcher =  InProcessPlanDispatcher(EmptyQueryConfig)
+  private def inProcessDispatcher =  InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig)
 
   private val timeToDownsample = 6.hours.toMillis
   private val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ScalarQueriesSpec.scala
@@ -30,7 +30,7 @@ class ScalarQueriesSpec extends AnyFunSpec with Matchers {
   val schemas = Schemas(dataset.schema)
 
   val config = ConfigFactory.load("application_test.conf")
-  val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
+  val queryConfig = QueryConfig(config.getConfig("filodb.query"))
 
   val engine = new SingleClusterPlanner(dataset, schemas, mapperRef, earliestRetainedTimestampFn = 0,
     queryConfig, "raw")

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -32,7 +32,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   private val routingConfig = ConfigFactory.parseString(routingConfigString)
   private val config = ConfigFactory.load("application_test.conf").getConfig("filodb.query").
     withFallback(routingConfig)
-  private val queryConfig = new QueryConfig(config)
+  private val queryConfig = QueryConfig(config)
 
   private val promQlQueryParams = PromQlQueryParams("sum(heap_usage)", 100, 1, 1000)
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -38,7 +38,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   private val schemas = Schemas(dataset.schema)
 
   private val config = ConfigFactory.load("application_test.conf")
-  private val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
+  private val queryConfig = QueryConfig(config.getConfig("filodb.query"))
 
   private val engine = new SingleClusterPlanner(dataset, schemas, mapperRef, earliestRetainedTimestampFn = 0,
     queryConfig, "raw")

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
@@ -36,7 +36,7 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
   private val schemas = Schemas(dataset.schema)
 
   private val config = ConfigFactory.load("application_test.conf")
-  private val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
+  private val queryConfig = QueryConfig(config.getConfig("filodb.query"))
 
   private val splitThresholdMs = 20000
   private val splitSizeMs = 10000

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -37,7 +37,7 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
   private val routingConfig = ConfigFactory.parseString(routingConfigString)
   private val config = ConfigFactory.load("application_test.conf").getConfig("filodb.query").
     withFallback(routingConfig)
-  private val queryConfig = new QueryConfig(config)
+  private val queryConfig = QueryConfig(config)
 
   private val promQlQueryParams = PromQlQueryParams("sum(heap_usage)", 100, 1, 1000)
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -200,6 +200,10 @@ filodb {
 
     # Choices are "legacy", "antlr", and "shadow". Shadow mode uses legacy but also checks antlr for errors.
     parser = "shadow"
+
+    routing {
+      # not currently used
+    }
   }
 
   shard-manager {

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -217,5 +217,5 @@ case class QueryStats() {
 }
 
 object QuerySession {
-  def makeForTestingOnly(): QuerySession = QuerySession(QueryContext(), EmptyQueryConfig)
+  def makeForTestingOnly(): QuerySession = QuerySession(QueryContext(), QueryConfig.unitTestingQueryConfig)
 }

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -78,6 +78,9 @@ filodb {
     fastreduce-max-windows = 50
     translate-prom-to-filodb-histogram = true
     parser = "antlr"
+    routing {
+      # not currently used
+    }
   }
 
   spread-default = 1

--- a/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
@@ -41,7 +41,7 @@ class HistogramQueryBenchmark {
   import monix.execution.Scheduler.Implicits.global
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val policy = new FixedMaxPartitionsEvictionPolicy(1000)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
   val ingestConf = TestData.storeConf.copy(shardMemSize = 512 * 1024 * 1024, maxChunksSize = 200)

--- a/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryHiCardInMemoryBenchmark.scala
@@ -45,7 +45,7 @@ class QueryHiCardInMemoryBenchmark extends StrictLogging {
   val spread = 0
   val config = ConfigFactory.load("filodb-defaults.conf")
     .withValue("filodb.memstore.ingestion-buffer-mem-size", ConfigValueFactory.fromAnyRef("1GB"))
-  val queryConfig = new QueryConfig(config.getConfig("filodb.query"))
+  val queryConfig = QueryConfig(config.getConfig("filodb.query"))
   implicit val _ = queryConfig.askTimeout
 
   // TODO: move setup and ingestion to another trait

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -88,7 +88,7 @@ class QueryInMemoryBenchmark extends StrictLogging {
   actorAsk(clusterActor, command) { case DatasetVerified => println(s"dataset setup") }
   coordinator ! command
 
-  val queryConfig = new QueryConfig(cluster.settings.allConfig.getConfig("filodb.query"))
+  val queryConfig = QueryConfig(cluster.settings.allConfig.getConfig("filodb.query"))
 
   import monix.execution.Scheduler.Implicits.global
 

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -21,7 +21,7 @@ object Parser extends StrictLogging {
 
   val mode: Mode = {
     val conf = GlobalConfig.systemConfig
-    val queryConfig = new QueryConfig(conf.getConfig("filodb.query"))
+    val queryConfig = QueryConfig(conf.getConfig("filodb.query"))
     val parser = queryConfig.parser
     logger.info(s"Query parser mode: $parser")
     parser match {

--- a/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
+++ b/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
@@ -5,13 +5,13 @@ import monix.execution.Scheduler
 
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{ColumnInfo, EmptyQueryConfig, QueryContext, QuerySession, QueryStats, ResultSchema}
+import filodb.core.query.{ColumnInfo, QueryContext, QuerySession, QueryStats, ResultSchema}
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, QueryResult}
 
 case class EmptyResultExec(queryContext: QueryContext,
-                           dataset: DatasetRef) extends LeafExecPlan {
-  override def dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
+                           dataset: DatasetRef,
+                           dispatcher: InProcessPlanDispatcher) extends LeafExecPlan {
 
   override def execute(source: ChunkSource,
                        querySession: QuerySession)

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -71,23 +71,21 @@ case class MetadataRemoteExec(queryEndpoint: String,
   }
 
   private def mapTsCardinalitiesResponse(response: MetadataSuccessResponse, id: String): QueryResponse = {
-
     import NoCloseCursor._
     import TsCardinalities._
     import TsCardExec._
 
     val RECORD_SCHEMA = SerializedRangeVector.toSchema(RESULT_SCHEMA.columns)
 
-    val data = response.data.asInstanceOf[Seq[TsCardinalitiesSampl]]
+    val rows = response.data.asInstanceOf[Seq[TsCardinalitiesSampl]]
       .map { ts =>
-        val key = CustomRangeVectorKey(ts.group.map { case (k, v) => (k.utf8, v.utf8) })
         val prefix = SHARD_KEY_LABELS.take(ts.group.size).map(l => ts.group(l))
         val counts = CardCounts(ts.cardinality("active"), ts.cardinality("total"))
-        val row = CardRowReader(prefixToGroup(prefix), counts)
-        val rv = IteratorBackedRangeVector(key, NoCloseCursor(Seq(row).iterator), None)
-        SerializedRangeVector(rv, builder, RECORD_SCHEMA, queryWithPlanName(queryContext))
+        CardRowReader(prefixToGroup(prefix), counts)
       }
-    QueryResult(id, RESULT_SCHEMA, data)
+    val rv = IteratorBackedRangeVector(CustomRangeVectorKey.empty, NoCloseCursor(rows.iterator), None)
+    val srv = SerializedRangeVector(rv, builder, RECORD_SCHEMA, queryWithPlanName(queryContext))
+    QueryResult(id, RESULT_SCHEMA, Seq(srv))
   }
 
   private def mapLabelCardinalityResponse(response: MetadataSuccessResponse, id: String): QueryResponse = {

--- a/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
@@ -25,7 +25,7 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
   val columns: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
   val resultSchema = ResultSchema(columns, 1)
-  val operatorFunction = BinaryOperatorFunction.factoryMethod(operator)
+  @transient lazy val operatorFunction = BinaryOperatorFunction.factoryMethod(operator)
 
   def evaluate: Double = {
     if (lhs.isRight  && rhs.isRight) operatorFunction.calculate(lhs.right.get.evaluate, rhs.right.get.evaluate)

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -334,9 +334,9 @@ object RangeFunction {
     func match {
       case None                   => () => new LastSampleChunkedFunctionD
       case Some(Last)             => () => new LastSampleChunkedFunctionD
-      case Some(Rate)     if config.has("faster-rate") => () => new ChunkedRateFunction
-      case Some(Increase) if config.has("faster-rate") => () => new ChunkedIncreaseFunction
-      case Some(Delta)    if config.has("faster-rate") => () => new ChunkedDeltaFunction
+      case Some(Rate)     if config.fasterRateEnabled => () => new ChunkedRateFunction
+      case Some(Increase) if config.fasterRateEnabled => () => new ChunkedIncreaseFunction
+      case Some(Delta)    if config.fasterRateEnabled => () => new ChunkedDeltaFunction
       case Some(CountOverTime)    => () => new CountOverTimeChunkedFunctionD()
       case Some(SumOverTime)      => () => new SumOverTimeChunkedFunctionD
       case Some(AvgWithSumAndCountOverTime) => require(schema.columns(2).name == "count")

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -21,7 +21,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   import MultiSchemaPartitionsExecSpec._
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val rand = new Random()
   val error = 0.00000001d

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -24,7 +24,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
   import MultiSchemaPartitionsExecSpec._
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -25,7 +25,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
   import MultiSchemaPartitionsExecSpec._
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   val tvSchema = ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),

--- a/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
@@ -24,7 +24,7 @@ import ZeroCopyUTF8String._
 class ExecPlanSpec extends AnyFunSpec with Matchers with ScalaFutures {
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))

--- a/query/src/test/scala/filodb/query/exec/HistToPromSeriesMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistToPromSeriesMapperSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 
 class HistToPromSeriesMapperSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   import monix.execution.Scheduler.Implicits.global

--- a/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
@@ -16,7 +16,7 @@ import org.scalatest.matchers.should.Matchers
 class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   val rangeParams =  RangeParams(100, 20, 200)

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -15,7 +15,7 @@ import filodb.core.TestData
 import filodb.core.binaryrecord2.{RecordBuilder, RecordContainer}
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.{Column, Dataset, Schemas}
-import filodb.core.query.{ColumnFilter, EmptyQueryConfig, Filter, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query.{ColumnFilter, Filter, QueryConfig, QueryContext, QuerySession}
 import filodb.core.store.{AllChunkScan, InMemoryMetaStore, NullColumnStore}
 import filodb.memory.MemFactory
 import filodb.memory.data.ChunkMap
@@ -66,7 +66,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
   val dataset: Dataset = timeseriesDataset
 
   val config: Config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
@@ -98,7 +98,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
-    val dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
+    val dispatcher: PlanDispatcher = InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig)
 
     val dummyDispatcher = DummyDispatcher(memStore, querySession)
 
@@ -126,7 +126,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
     val emptyFilters = Seq (ColumnFilter("__name__", Filter.Equals("nonsense".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
 
-    val dispatcher: PlanDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
+    val dispatcher: PlanDispatcher = InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig)
 
     val dummyDispatcher = DummyDispatcher(memStore, querySession)
 

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -29,7 +29,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   val policy = new FixedMaxPartitionsEvictionPolicy(20)

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -47,7 +47,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
 import filodb.memory.format.ZeroCopyUTF8String._
 
+
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -239,5 +240,44 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
     result.toArray shouldEqual jobQueryResult3
   }
 
+  it ("timeseries cardinality remote exec") {
+    import TsCardExec._
+    import TsCardinalities._
+
+    val samples = Seq(
+      TsCardinalitiesSampl(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "baz"), Map("active" -> 123, "total" -> 234)),
+      TsCardinalitiesSampl(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "bat"), Map("active" -> 345, "total" -> 456)),
+      TsCardinalitiesSampl(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "bak"), Map("active" -> 567, "total" -> 678)),
+    )
+
+    val testingBackendTsCard: SttpBackend[Future, Nothing] = SttpBackendStub.asynchronousFuture
+      .whenRequestMatches(_.uri.path.startsWith(List("api","v1","metering","cardinality","timeseries"))
+      )
+      .thenRespondWrapped(Future {
+        Response(Right(Right(MetadataSuccessResponse(samples, "success", Option.empty, Option.empty))), StatusCodes.PartialContent, "", Nil, Nil)
+      })
+
+    val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/metering/cardinality/timeseries", 10000L,
+      Map("match[]" -> """{_ws_="foo", _ns_="bar"}""", "numGroupByFields" -> "3"),
+      QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/metering/cardinality/timeseries"))),
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackendTsCard))
+
+    val resp = exec.execute(memStore, querySession).runToFuture.futureValue
+    val result = (resp: @unchecked) match {
+      case QueryResult(id, _, response, _, _, _) =>
+        // should only contain a single RV where each row describes a single group's cardinalities
+        response.size shouldEqual 1
+        val rows = response.head.rows().map{ rr =>
+          RowData.fromRowReader(rr)
+        }.toSet
+        val expRows = samples.map{ s =>
+          // order the shard keys according to precedence
+          val prefix = SHARD_KEY_LABELS.map(s.group(_))
+          val counts = CardCounts(s.cardinality("active"), s.cardinality("total"))
+          RowData(prefixToGroup(prefix), counts)
+        }.toSet
+        rows shouldEqual expRows
+    }
+  }
 }
 

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -33,7 +33,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   val policy = new FixedMaxPartitionsEvictionPolicy(20)

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -48,7 +48,7 @@ class SplitLocalPartitionDistConcatExecSpec extends AnyFunSpec with Matchers wit
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -184,7 +184,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     // Output range is from 0 to 150, o/p must have data starting from 0 to 150 with a step of 10. If data is
     // missing in the input Rvs, it should be NaN
     // null needed below since there is a require in code that prevents empty children
-    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig), Some(RvRange(0, 10, 150)),
+    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), Some(RvRange(0, 10, 150)),
       Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
     val rs = ResultSchema(List(ColumnInfo("timestamp",
       TimestampColumn), ColumnInfo("value", DoubleColumn)), 1)
@@ -236,7 +236,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
               )
 
     // rvRange is None, this is the case when stitch is called on raw series
-    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig), None,
+    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), None,
             Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
     val rs = ResultSchema(List(ColumnInfo("timestamp",
         TimestampColumn), ColumnInfo("value", DoubleColumn)), 1)
@@ -255,7 +255,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   it ("should reduce result schemas with different fixedVecLengths without error") {
 
     // null needed below since there is a require in code that prevents empty children
-    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig),
+    val exec = StitchRvsExec(QueryContext(), InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig),
       Some(RvRange(0, 10, 100)), Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
 
     val rs1 = ResultSchema(List(ColumnInfo("timestamp",
@@ -426,7 +426,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
   it("should fail if step is non positive number") {
     val caught = intercept[IllegalArgumentException] {
-      StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig),
+      StitchRvsExec(QueryContext(), InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig),
         Some(RvRange(startMs = 0, endMs = 100, stepMs = 0)),
         Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
     }
@@ -436,7 +436,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
   it("should fail if start > end is non positive number") {
     val caught = intercept[IllegalArgumentException] {
-      StitchRvsExec(QueryContext(), InProcessPlanDispatcher(EmptyQueryConfig),
+      StitchRvsExec(QueryContext(), InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig),
         Some(RvRange(startMs = 110, endMs = 100, stepMs = 1)),
         Seq(UnsafeUtils.ZeroPointer.asInstanceOf[ExecPlan]))
     }

--- a/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AbsentFunctionSpec.scala
@@ -23,7 +23,7 @@ class AbsentFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures with
 
   val config: Config = ConfigFactory.load("application_test.conf").getConfig("filodb")
   val resultSchema = ResultSchema(MetricsTestData.timeseriesSchema.infosFromIDs(0 to 1), 1)
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   val testKey1 = CustomRangeVectorKey(

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -146,7 +146,7 @@ trait RawDataWindowingSpec extends AnyFunSpec with Matchers with BeforeAndAfter 
   val pubFreq = 10000L
 
   val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   // windowSize and step are in number of elements of the data

--- a/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/BinaryOperatorSpec.scala
@@ -38,7 +38,7 @@ class BinaryOperatorSpec extends AnyFunSpec with Matchers with ScalaFutures {
         new TransientRow(4L, 94935.1523d)).iterator
       override def outputRange: Option[RvRange] = None
     })
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   val rand = new Random()

--- a/query/src/test/scala/filodb/query/exec/rangefn/LabelReplaceSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/LabelReplaceSpec.scala
@@ -47,7 +47,7 @@ class LabelReplaceSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def outputRange: Option[RvRange] = None
     })
 
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   it("should replace label only when match is found in label replace") {

--- a/query/src/test/scala/filodb/query/exec/rangefn/LableJoinSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/LableJoinSpec.scala
@@ -92,7 +92,7 @@ class LableJoinSpec extends AnyFunSpec with Matchers with ScalaFutures {
       override def outputRange: Option[RvRange] = None
     })
 
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
 
   it("label_join joins all src values in order") {

--- a/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
@@ -27,7 +27,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     options = DatasetOptions(Seq("__name__", "job"), "__name__")).get
 
   val config: Config = ConfigFactory.load("application_test.conf").getConfig("filodb")
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val policy = new FixedMaxPartitionsEvictionPolicy(20)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
@@ -35,7 +35,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val ignoreKey = CustomRangeVectorKey(
     Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
 
-  val inProcessDispatcher = InProcessPlanDispatcher(EmptyQueryConfig)
+  val inProcessDispatcher = InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig)
 
   val testKey1 = CustomRangeVectorKey(
     Map(ZeroCopyUTF8String("src") -> ZeroCopyUTF8String("source-value-10"),

--- a/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest.matchers.should.Matchers
 class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val config: Config = ConfigFactory.load("application_test.conf").getConfig("filodb")
   val resultSchema = ResultSchema(MetricsTestData.timeseriesSchema.infosFromIDs(0 to 1), 1)
-  val queryConfig = new QueryConfig(config.getConfig("query"))
+  val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val ignoreKey = CustomRangeVectorKey(
     Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -47,7 +47,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   val conf = ConfigFactory.parseFile(new File("conf/timeseries-filodb-server.conf")).resolve()
 
   val settings = new DownsamplerSettings(conf)
-  val queryConfig = new QueryConfig(settings.filodbConfig.getConfig("query"))
+  val queryConfig = QueryConfig(settings.filodbConfig.getConfig("query"))
   val dsIndexJobSettings = new DSIndexJobSettings(settings)
   val batchDownsampler = new BatchDownsampler(settings)
 
@@ -843,7 +843,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       val colFltrs = if (metricName == histNameNaN) colFiltersNaN else colFilters
       val queryFilters = colFltrs :+ ColumnFilter("_metric_", Equals(metricName))
       val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams = PlannerParams(sampleLimit = 1000)),
-        InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
+        InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
         TimeRangeChunkScan(74372801000L, 74373042000L), "_metric_")
 
       val querySession = QuerySession(QueryContext(), queryConfig)
@@ -875,7 +875,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(counterName))
     val qc = QueryContext(plannerParams = PlannerParams(sampleLimit = 1000))
     val exec = MultiSchemaPartitionsExec(qc,
-      InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
+      InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
       AllChunkScan, "_metric_")
     exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(310000),
       Some(InternalRangeFunction.Rate), qc))
@@ -908,7 +908,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(counterName))
     val qc = QueryContext(plannerParams = PlannerParams(sampleLimit = 1000))
     val exec = MultiSchemaPartitionsExec(qc,
-      InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
+      InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
       AllChunkScan, "_metric_")
     exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(290000),
       Some(InternalRangeFunction.Rate), qc))
@@ -939,7 +939,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
       val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(untypedName))
       val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams
-        = PlannerParams(sampleLimit = 1000)), InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0,
+        = PlannerParams(sampleLimit = 1000)), InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig),
+        batchDownsampler.rawDatasetRef, 0,
         queryFilters, AllChunkScan, "_metric_")
 
       val querySession = QuerySession(QueryContext(), queryConfig)
@@ -964,8 +965,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(gaugeName))
     val exec = MultiSchemaPartitionsExec(QueryContext(plannerParams = PlannerParams(sampleLimit = 1000)),
-      InProcessPlanDispatcher(EmptyQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters, AllChunkScan,
-      "_metric_", colName = Option("sum"))
+      InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), batchDownsampler.rawDatasetRef, 0,
+      queryFilters, AllChunkScan, "_metric_", colName = Option("sum"))
     val querySession = QuerySession(QueryContext(), queryConfig)
     val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName", 3)
     val res = exec.execute(downsampleTSStore, querySession)(queryScheduler)


### PR DESCRIPTION
Need to confirm TS-card fix behaves as-expected before merge.

Not included, but maybe should be:
df92944a459c2d2bd294e25652ba4cc5ed23e0b5 fix(query): absent with sum_over_time result should be consistent (#1380)