### PR TITLE
fix(query): add histogram case to ScalarOperationMapper

### DIFF
--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -2,8 +2,10 @@ package filodb.query.exec
 
 import scala.collection.Iterator
 import scala.collection.mutable.ListBuffer
+
 import monix.reactive.Observable
 import spire.syntax.cfor._
+
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.PartitionSchema
 import filodb.core.query._

--- a/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
@@ -110,7 +110,7 @@ class ExecPlanSpec extends AnyFunSpec with Matchers with ScalaFutures {
     val schema = ResultSchema(
       Seq(ColumnInfo("c0", ColumnType.TimestampColumn),
         ColumnInfo("c1", ColumnType.DoubleColumn)),
-      0 // numRowKeyColumns
+      1 // numRowKeyColumns
     )
 
     val ep = makeFixedLeafExecPlan(Seq(rv), schema)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Previously, histograms were not handled by `ScalarOperationMapper`. Histogram-handler code has now been added.

Example: if `hist_metric` is a histogram, then
```
hist_metric{label="foo"} + 5
```
would throw an exception because `ScalarOperationMapper` would call `getDouble` on a `TransientHistRow`.