### PR TITLE
*WIP* fix(query): pass ChunkSource to InProcessDispatcher

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -1,12 +1,11 @@
 package filodb.coordinator.queryplanner
 
 import scala.concurrent.duration.FiniteDuration
-
 import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
-
 import filodb.core.query.QueryContext
+import filodb.core.store.ChunkSource
 import filodb.query.{LogicalPlan, QueryResponse}
 import filodb.query.exec.ExecPlan
 
@@ -28,14 +27,15 @@ trait QueryPlanner {
     * Trigger orchestration of the ExecPlan. It sends the ExecPlan to the destination where it will be executed.
     */
   def dispatchExecPlan(execPlan: ExecPlan,
-                       parentSpan: kamon.trace.Span)
+                       parentSpan: kamon.trace.Span,
+                       source: ChunkSource)
                       (implicit sched: Scheduler, timeout: FiniteDuration): Task[QueryResponse] = {
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(parentSpan, false) {
-      execPlan.dispatcher.dispatch(execPlan)
+      execPlan.dispatcher.dispatch(execPlan, source)
     }
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -1212,7 +1212,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val ep4 = planner.materialize(logicalPlan4, QueryContext())
     ep4.isInstanceOf[EmptyResultExec] shouldEqual true
     import GlobalScheduler._
-    val res = ep4.dispatcher.dispatch(ep4).runToFuture.futureValue.asInstanceOf[QueryResult]
+    val res = ep4.dispatcher.dispatch(ep4, UnsupportedChunkSource()).runToFuture.futureValue.asInstanceOf[QueryResult]
     res.result.isEmpty shouldEqual true
   }
 

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -144,7 +144,7 @@ trait ExecPlan extends QueryCommand {
       FiloSchedulers.assertThreadName(QuerySchedName)
       val resultTask = {
         val finalRes = allTransformers.foldLeft((res.rvs, resSchema)) { (acc, transf) =>
-          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult(querySession))
+          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult(querySession, source))
           val resultSchema : ResultSchema = acc._2
           if (resultSchema == ResultSchema.empty && (!transf.canHandleEmptySchemas)) {
             // It is possible a null schema is returned (due to no time series). In that case just skip the
@@ -340,7 +340,8 @@ abstract class LeafExecPlan extends ExecPlan {
   * getResult will get the ScalarRangeVector for the FuncArg
   */
 sealed trait FuncArgs {
-  def getResult(querySession: QuerySession)(implicit sched: Scheduler) : Observable[ScalarRangeVector]
+  def getResult(querySession: QuerySession,
+                source: ChunkSource)(implicit sched: Scheduler) : Observable[ScalarRangeVector]
 }
 
 /**
@@ -348,9 +349,10 @@ sealed trait FuncArgs {
   */
 final case class ExecPlanFuncArgs(execPlan: ExecPlan, timeStepParams: RangeParams) extends FuncArgs {
 
-  override def getResult(querySession: QuerySession)(implicit sched: Scheduler): Observable[ScalarRangeVector] = {
+  override def getResult(querySession: QuerySession,
+                         source: ChunkSource)(implicit sched: Scheduler): Observable[ScalarRangeVector] = {
     Observable.fromTask(
-      execPlan.dispatcher.dispatch(execPlan).onErrorHandle { case ex: Throwable =>
+      execPlan.dispatcher.dispatch(execPlan, source).onErrorHandle { case ex: Throwable =>
         QueryError(execPlan.queryContext.queryId, querySession.queryStats, ex)
       }.map {
         case QueryResult(_, _, result, qStats, isPartialResult, partialResultReason)  =>
@@ -382,7 +384,8 @@ final case class ExecPlanFuncArgs(execPlan: ExecPlan, timeStepParams: RangeParam
   * FuncArgs for scalar parameter
   */
 final case class StaticFuncArgs(scalar: Double, timeStepParams: RangeParams) extends FuncArgs {
-  override def getResult(querySession: QuerySession)(implicit sched: Scheduler): Observable[ScalarRangeVector] = {
+  override def getResult(querySession: QuerySession,
+                         source: ChunkSource)(implicit sched: Scheduler): Observable[ScalarRangeVector] = {
     Observable.now(ScalarFixedDouble(timeStepParams, scalar))
   }
 }
@@ -391,7 +394,8 @@ final case class StaticFuncArgs(scalar: Double, timeStepParams: RangeParams) ext
   * FuncArgs for date and time functions
   */
 final case class TimeFuncArgs(timeStepParams: RangeParams) extends FuncArgs {
-  override def getResult(querySession: QuerySession)(implicit sched: Scheduler): Observable[ScalarRangeVector] = {
+  override def getResult(querySession: QuerySession,
+                         source: ChunkSource)(implicit sched: Scheduler): Observable[ScalarRangeVector] = {
     Observable.now(TimeScalar(timeStepParams))
   }
 }
@@ -409,14 +413,14 @@ abstract class NonLeafExecPlan extends ExecPlan {
   // Use-cases include splitting longer range query into multiple smaller range queries.
   def parallelChildTasks: Boolean = true
 
-  private def dispatchRemotePlan(plan: ExecPlan, qSession: QuerySession, span: kamon.trace.Span)
+  private def dispatchRemotePlan(plan: ExecPlan, qSession: QuerySession, span: kamon.trace.Span, source: ChunkSource)
                                 (implicit sched: Scheduler) = {
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(span, false) {
-      plan.dispatcher.dispatch(plan).onErrorHandle { case ex: Throwable =>
+      plan.dispatcher.dispatch(plan, source).onErrorHandle { case ex: Throwable =>
         QueryError(queryContext.queryId, qSession.queryStats, ex)
       }
     }
@@ -446,7 +450,7 @@ abstract class NonLeafExecPlan extends ExecPlan {
     // NOTE: It's really important to preserve the "index" of the child task, as joins depend on it
     val childTasks = Observable.fromIterable(children.zipWithIndex)
                                .mapParallelUnordered(parallelism) { case (plan, i) =>
-                                 val task = dispatchRemotePlan(plan, querySession, span).map((_, i))
+                                 val task = dispatchRemotePlan(plan, querySession, span, source).map((_, i))
                                  span.mark(s"child-plan-$i-dispatched-${plan.getClass.getSimpleName}")
                                  task
                                }

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -24,10 +24,7 @@ import filodb.query.QueryResponse
   case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatcher {
 
   val clusterName = InetAddress.getLocalHost().getHostName()
-  override def dispatch(plan: ExecPlan)(implicit sched: Scheduler): Task[QueryResponse] = {
-    // unsupported source since its does not apply in case of non-leaf plans
-    val source = UnsupportedChunkSource()
-
+  override def dispatch(plan: ExecPlan, source: ChunkSource)(implicit sched: Scheduler): Task[QueryResponse] = {
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -56,7 +56,8 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       Task {
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
-          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult(querySession))
+          val paramRangeVector: Seq[Observable[ScalarRangeVector]] =
+                    transf.funcParams.map(_.getResult(querySession, source))
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -65,7 +65,8 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
     Kamon.runWithSpan(span, false) {
       Task {
         rangeVectorTransformers.foldLeft((Observable.fromIterable(rangeVectors), resultSchema)) { (acc, transf) =>
-          val paramRangeVector: Seq[Observable[ScalarRangeVector]] = transf.funcParams.map(_.getResult(querySession))
+          val paramRangeVector: Seq[Observable[ScalarRangeVector]] =
+                      transf.funcParams.map(_.getResult(querySession, source))
           (transf.apply(acc._1, querySession, queryContext.plannerParams.sampleLimit, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -1,7 +1,6 @@
 package filodb.query.exec
 
 import scala.util.Random
-
 import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -9,9 +8,9 @@ import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.exceptions.TestFailedException
-
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
+import filodb.core.store.ChunkSource
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
 import org.scalatest.funspec.AnyFunSpec
@@ -33,7 +32,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val tvSchemaTask = Task.eval(tvSchema)
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -1,7 +1,6 @@
 package filodb.query.exec
 
 import scala.util.Random
-
 import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -9,9 +8,9 @@ import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.exceptions.TestFailedException
-
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
+import filodb.core.store.ChunkSource
 import filodb.memory.format.ZeroCopyUTF8String
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
@@ -36,7 +35,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val rand = new Random()
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -1,17 +1,16 @@
 package filodb.query.exec
 
 import scala.util.Random
-
 import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
-
 import filodb.core.MetricsTestData
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
+import filodb.core.store.ChunkSource
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query._
@@ -38,7 +37,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
   val noKey = CustomRangeVectorKey(Map.empty)
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -16,7 +16,7 @@ import filodb.core.binaryrecord2.{RecordBuilder, RecordContainer}
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.{Column, Dataset, Schemas}
 import filodb.core.query.{ColumnFilter, Filter, QueryConfig, QueryContext, QuerySession}
-import filodb.core.store.{AllChunkScan, InMemoryMetaStore, NullColumnStore}
+import filodb.core.store.{AllChunkScan, InMemoryMetaStore, NullColumnStore, ChunkSource}
 import filodb.memory.MemFactory
 import filodb.memory.data.ChunkMap
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
@@ -94,6 +94,8 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
   val histData: Stream[Seq[Any]] = MMD.linearHistSeries().take(100)
   val histMaxData: Stream[Seq[Any]] = MMD.histMax(histData)
 
+  val source = UnsupportedChunkSource()
+
   it ("inprocess dispatcher should execute and return monix task which in turn should return QueryResult") {
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
@@ -108,7 +110,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
       0, filters, AllChunkScan,"_metric_")
 
     val sep = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan1, execPlan2))
-    val result = dispatcher.dispatch(sep).runToFuture.futureValue
+    val result = dispatcher.dispatch(sep, source).runToFuture.futureValue
 
     result match {
       case e: QueryError => throw e.t
@@ -136,7 +138,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
       0, emptyFilters, AllChunkScan, "_metric_")
 
     val sep = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan1, execPlan2))
-    val result = dispatcher.dispatch(sep).runToFuture.futureValue
+    val result = dispatcher.dispatch(sep, source).runToFuture.futureValue
 
     result match {
       case e: QueryError => throw e.t
@@ -148,7 +150,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
     // Switch the order and make sure it's OK if the first result doesn't have any data
     val sep2 = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan2, execPlan1))
-    val result2 = dispatcher.dispatch(sep2).runToFuture.futureValue
+    val result2 = dispatcher.dispatch(sep2, source).runToFuture.futureValue
 
     result2 match {
       case e: QueryError => throw e.t
@@ -160,7 +162,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
     // Two children none of which returns data
     val sep3 = StitchRvsExec(QueryContext(), dispatcher, None, Seq(execPlan2, execPlan2))
-    val result3 = dispatcher.dispatch(sep3).runToFuture.futureValue
+    val result3 = dispatcher.dispatch(sep3, source).runToFuture.futureValue
 
     result3 match {
       case e: QueryError => throw e.t
@@ -173,7 +175,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
 case class DummyDispatcher(memStore: TimeSeriesMemStore, querySession: QuerySession) extends PlanDispatcher {
   // run locally withing any check.
-  override def dispatch(plan: ExecPlan)
+  override def dispatch(plan: ExecPlan, source: ChunkSource)
                        (implicit sched: Scheduler): Task[QueryResponse] = {
     plan.execute(memStore, querySession)
   }

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -15,7 +15,7 @@ import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.Schemas
 import filodb.core.query._
-import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
+import filodb.core.store.{ChunkSource, InMemoryMetaStore, NullColumnStore}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.query._
 import filodb.query.exec.TsCardExec.CardCounts
@@ -97,7 +97,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
   }
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = plan.execute(memStore,
       QuerySession(QueryContext(), queryConfig))(sched)
 
@@ -109,7 +109,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
   val executeDispatcher = new PlanDispatcher {
     override def isLocalCall: Boolean = ???
     override def clusterName: String = ???
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = {
       plan.execute(memStore, querySession)(sched)
     }

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -6,7 +6,7 @@ import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SchemaMismatch, S
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn, LongColumn, TimestampColumn}
 import filodb.core.metadata.Schemas
 import filodb.core.query._
-import filodb.core.store.{AllChunkScan, InMemoryMetaStore, NullColumnStore, TimeRangeChunkScan}
+import filodb.core.store.{AllChunkScan, ChunkSource, InMemoryMetaStore, NullColumnStore, TimeRangeChunkScan}
 import filodb.core.{DatasetRef, QueryTimeoutException, TestData, Types}
 import filodb.memory.MemFactory
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 
 object MultiSchemaPartitionsExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import filodb.core.metadata.{Dataset, DatasetOptions}
 import filodb.core.query.{PromQlQueryParams, QueryContext}
+import filodb.core.store.ChunkSource
 import filodb.memory.format.vectors.MutableHistogram
 import filodb.query
 import filodb.query.{Data, HistSampl, MetadataMapSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, SuccessResponse}
@@ -20,7 +21,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     options = DatasetOptions(Seq("__name__", "job"), "__name__")).get
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -9,7 +9,7 @@ import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSer
 import filodb.core.metadata.Schemas
 import filodb.core.query._
 import filodb.core.query.Filter.Equals
-import filodb.core.store.{InMemoryMetaStore, NullColumnStore}
+import filodb.core.store.{ChunkSource, InMemoryMetaStore, NullColumnStore}
 import filodb.core.TestData
 import filodb.memory.format.SeqRowReader
 import filodb.query._
@@ -105,7 +105,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val executeDispatcher = new PlanDispatcher {
     override def isLocalCall: Boolean = ???
     override def clusterName: String = ???
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = {
       plan.execute(memStore, querySession)(sched)
     }

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -1,7 +1,6 @@
 package filodb.query.exec
 
 import scala.concurrent.duration._
-
 import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -11,11 +10,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.time.{Millis, Seconds, Span}
-
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.Schemas
 import filodb.core.query._
-import filodb.core.store.{AllChunkScan, InMemoryMetaStore, NullColumnStore}
+import filodb.core.store.{AllChunkScan, ChunkSource, InMemoryMetaStore, NullColumnStore}
 import filodb.core.{DatasetRef, TestData}
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
@@ -25,7 +23,7 @@ import filodb.query.{QueryResponse, QueryResult}
 
 object SplitLocalPartitionDistConcatExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlan)
+    override def dispatch(plan: ExecPlan, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Adds a `ChunkSource` param to `PlanDispatcher::dispatch` in order to support `InProcessDispatcher::dispatch` calls. Previously, `InProcessDispatcher` was treated as though its `dispatch` method should never be called by a leaf node (an `UnsupportedChunkSource` was passed to `execute` inside `dispatch`). This constraint is not necessary, and pushdown optimizations are already setup to run entire `ExecPlan` subtrees in-process.