### PR TITLE
misc(core): add support for multi-field facets to partition-key columns

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -55,7 +55,7 @@ filodb {
       # lucene facet feature.
       #
       # Note: only "string" column type supported.
-      # additionalFacets = [
+      # multiColumnFacets = [
       #     {
       #       all-hosts-availZone = ["avail_zone", "rack", "host"]
       #     }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -40,13 +40,27 @@ filodb {
       # Eg: For copyTags `"_ns_" = [ "exporter", "job" ]`, when an incoming TimeSeries already has both `exporter`
       #     and `job`, then it will pickup only the value from `exporter` for `_ns_`.
       copyTags = {
-        "_ns_" = [ "_ns", "exporter", "job" ]
+        "_ns_" = ["_ns", "exporter", "job"]
       }
-      ignoreShardKeyColumnSuffixes = { "_metric_" = ["_bucket", "_count", "_sum"] }
+      ignoreShardKeyColumnSuffixes = {"_metric_" = ["_bucket", "_count", "_sum"]}
       ignoreTagsOnPartitionKeyHash = ["le"]
       metricColumn = "_metric_"
       # shard key columns should be in hierarchical order
       shardKeyColumns = ["_ws_", "_ns_", "_metric_"]
+
+      # Multi-column facets to be created on "partition-schema" columns.
+      # Eg: below config creates a facet "all-hosts-availZone" by concatenating
+      # the column values ("avail_zone", "rack", "host") "\u03C0" as delimiter
+      # If the data is hierarchical in nature, This feature lets us fetch the metadata very efficiently by using
+      # lucene facet feature.
+      #
+      # Note: only "string" column type supported.
+      # additionalFacets = [
+      #     {
+      #       all-hosts-availZone = ["avail_zone", "rack", "host"]
+      #     }
+      #   ]
+      multiColumnFacets = []
     }
   }
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -251,15 +251,19 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     private val otherFields = mutable.WeakHashMap[String, StringField]() // weak so that it is GCed when unused
 
     def addField(name: String, value: String): Unit = {
+      addFacet(name, value)
+      val field = otherFields.getOrElseUpdate(name, new StringField(name, "", Store.NO))
+      field.setStringValue(value)
+      document.add(field)
+    }
+
+    private[PartKeyLuceneIndex] def addFacet(name: String, value: String) : Unit = {
       // Use PartKeyIndexBenchmark to measure indexing performance before changing this
       if (name.nonEmpty && value.nonEmpty && facetEnabledForLabel(name) && value.length < FACET_FIELD_MAX_LEN) {
         facetsConfig.setRequireDimensionDrillDown(name, false)
         facetsConfig.setIndexFieldName(name, FACET_FIELD_PREFIX + name)
         document.add(new SortedSetDocValuesFacetField(name, value))
       }
-      val field = otherFields.getOrElseUpdate(name, new StringField(name, "", Store.NO))
-      field.setStringValue(value)
-      document.add(field)
     }
 
     def reset(partId: Int, partKey: BytesRef, startTime: Long, endTime: Long): Document = {
@@ -565,10 +569,38 @@ class PartKeyLuceneIndex(ref: DatasetRef,
                            partId: Int, startTime: Long, endTime: Long): Document = {
     val partKeyBytesRef = new BytesRef(partKeyOnHeapBytes, partKeyBytesRefOffset, partKeyNumBytes)
     luceneDocument.get().reset(partId, partKeyBytesRef, startTime, endTime)
+
+    // If configured and enabled, Multi-column facets will be created on "partition-schema" columns
+    createMultiColumnFacets(partKeyOnHeapBytes, partKeyBytesRefOffset)
+
     cforRange { 0 until numPartColumns } { i =>
       indexers(i).fromPartKey(partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset), partId)
     }
     luceneDocument.get().document
+  }
+
+  // Multi-column facets to be created on "partition-schema" columns
+  private def createMultiColumnFacets(partKeyOnHeapBytes: Array[Byte], partKeyBytesRefOffset: Int): Unit = {
+    schema.options.multiColumnFacets.foreach(facetCols => {
+      facetCols match {
+        case (name, cols) => {
+          val concatFacetValue = cols.flatMap { col =>
+            val (columnInfo, pos) = schema.columnIdxLookup(col)
+            if (columnInfo.columnType == StringColumn) {
+              val base = partKeyOnHeapBytes
+              val offset = bytesRefToUnsafeOffset(partKeyBytesRefOffset)
+              val strOffset = schema.binSchema.blobOffset(base, offset, pos)
+              val numBytes = schema.binSchema.blobNumBytes(base, offset, pos)
+              Seq(new String(base, strOffset.toInt - UnsafeUtils.arayOffset,
+                numBytes, StandardCharsets.UTF_8))
+            } else {
+              Seq.empty
+            }
+          }.mkString("\u03C0")
+          luceneDocument.get().addFacet(name, concatFacetValue)
+        }
+      }
+    })
   }
 
   /**

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -78,7 +78,9 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
                           ignoreShardKeyColumnSuffixes: Map[String, Seq[String]] = Map.empty,
                           ignoreTagsOnPartitionKeyHash: Seq[String] = Nil,
                           // For each key, copy the tag to the value if the value is absent
-                          copyTags: Seq[(String, String)] = Seq.empty) {
+                          copyTags: Seq[(String, String)] = Seq.empty,
+                          // Config to create facets for combination of partSchema columns
+                          multiColumnFacets: Map[String, Seq[String]] = Map.empty) {
   override def toString: String = {
     toConfig.root.render(ConfigRenderOptions.concise)
   }

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -58,6 +58,7 @@ final case class DataSchema private(name: String,
 final case class PartitionSchema(columns: Seq[Column],
                                  predefinedKeys: Seq[String],
                                  options: DatasetOptions) {
+  val columnIdxLookup = columns.zipWithIndex.map { case(col, idx) => col.name -> Tuple2(col, idx) }.toMap
   val binSchema = new RecordSchema(columns.map(c => ColumnInfo(c.name, c.columnType)), Some(0), predefinedKeys)
   val hash = Schemas.genHash(columns)
 }

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -202,6 +202,15 @@ object GdeltTestData {
     shardKeyColumns = Seq( "__name__","_ns_","_ws_"))
   val dataset6 = Dataset("gdelt", schema.slice(4, 6), schema.patch(4, Nil, 2), datasetOptions)
 
+
+  // Dataset7: partition Actor2Code,Actor2Name,NumArticles to test additional faceting
+  val datasetOptionsWithFacets = datasetOptions.copy(
+    multiColumnFacets = Map("Actor2Code-Actor2Name" -> Seq("Actor2Code", "Actor2Name"),
+                            "Actor2Name-Actor2Code" -> Seq("Actor2Name", "Actor2Code")))
+  val dataset7 = Dataset("gdelt", schema.slice(4, 7), schema.patch(4, Nil, 2), datasetOptionsWithFacets)
+
+
+
   val datasetOptionConfig = """
     options {
       shardKeyColumns = ["__name__","_ns_","_ws_"]


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

Add support for multi-field facets to partition-key columns. This will optimize the metadata query lookups, If the dataset is hierarchical and there are heavy volume of multi-label value lookups.
- configured/enabled per dataset
- supports only partition-key string type columns