### PR TITLE
fix(core): add periodic TSShard index reader refresh

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -100,6 +100,9 @@
 
         # Set to true to enable processing of duplicate samples. Default behavior is to drop duplicates.
         accept-duplicate-samples = false
+
+        # Lucene IndexReader refresh frequency.
+        reader-refresh-interval = 6 hours
       }
       downsample {
         # Resolutions for downsampled data ** in ascending order **

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -465,6 +465,9 @@ filodb {
     # If all of the index-faceting-enabled-* properties are false, faceting is fully disabled.
     # Disable if performance cost of faceting all labels is too high
     index-faceting-enabled-for-all-labels = true
+
+    # Lucene IndexReader refresh frequency.
+    reader-refresh-interval = 6 hours
   }
 
   # for standalone worker cluster configuration, see akka-bootstrapper

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -192,6 +192,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     // records with same part key. This is true since we update part keys only once per flush interval in raw dataset.
     logger.info(s"Starting housekeeping for downsample cluster of dataset=$rawDatasetRef shard=$shardNum " +
       s"every ${rawStoreConfig.flushInterval}")
+    require(!downsampleStoreConfig.readerRefreshInterval.isDefined,
+      "cannot define the reader refresh interval for downsaple config; raw flush interval is used")
     houseKeepingFuture = Observable.intervalWithFixedDelay(rawStoreConfig.flushInterval,
       rawStoreConfig.flushInterval).mapEval { _ =>
       purgeExpiredIndexEntries()

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -192,7 +192,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     // records with same part key. This is true since we update part keys only once per flush interval in raw dataset.
     logger.info(s"Starting housekeeping for downsample cluster of dataset=$rawDatasetRef shard=$shardNum " +
       s"every ${rawStoreConfig.flushInterval}")
-    require(!downsampleStoreConfig.readerRefreshInterval.isDefined,
+    require(downsampleStoreConfig.readerRefreshInterval.isEmpty,
       "cannot define the reader refresh interval for downsaple config; raw flush interval is used")
     houseKeepingFuture = Observable.intervalWithFixedDelay(rawStoreConfig.flushInterval,
       rawStoreConfig.flushInterval).mapEval { _ =>

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -463,11 +463,11 @@ class TimeSeriesShard(val ref: DatasetRef,
 
   private[memstore] val addPartitionsDisabled = AtomicBoolean(false)
 
-  private[memstore] val housekeepingSched = Scheduler.computation(
-    name = "housekeeping",
-    reporter = UncaughtExceptionReporter(logger.error("Uncaught Exception in Housekeeping Scheduler", _)))
+  private[memstore] val readerRefreshSched = Scheduler.computation(
+    name = "reader-refresh",
+    reporter = UncaughtExceptionReporter(logger.error("Uncaught Exception in Reader-Refresh Scheduler", _)))
 
-  private var houseKeepingFuture: CancelableFuture[Unit] = initHousekeeping()
+  private var readerRefreshFuture: CancelableFuture[Unit] = initReaderRefresh()
 
   /////// END MEMBER STATE FIELDS ///////////////////
 
@@ -680,14 +680,14 @@ class TimeSeriesShard(val ref: DatasetRef,
     }
   }
 
-  private def initHousekeeping(): CancelableFuture[Unit] = {
-    logger.info(s"Starting housekeeping for $clusterType cluster of dataset=$ref shard=$shardNum " +
-      s"every ${storeConfig.housekeepingInterval}")
+  private def initReaderRefresh(): CancelableFuture[Unit] = {
+    logger.info(s"Starting reader-refresh for $clusterType cluster of dataset=$ref shard=$shardNum " +
+      s"every ${storeConfig.readerRefreshInterval}")
     Observable.intervalWithFixedDelay(
-      storeConfig.housekeepingInterval,
-      storeConfig.housekeepingInterval).map { _ =>
+      storeConfig.readerRefreshInterval,
+      storeConfig.readerRefreshInterval).map { _ =>
       partKeyIndex.refreshReadersBlocking()
-    }.onErrorRestartUnlimited.completedL.runToFuture(housekeepingSched)
+    }.onErrorRestartUnlimited.completedL.runToFuture(readerRefreshSched)
   }
   /////// END INIT METHODS ///////////////////
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -684,8 +684,8 @@ class TimeSeriesShard(val ref: DatasetRef,
     logger.info(s"Starting reader-refresh for $clusterType cluster of dataset=$ref shard=$shardNum " +
       s"every ${storeConfig.readerRefreshInterval}")
     Observable.intervalWithFixedDelay(
-      storeConfig.readerRefreshInterval,
-      storeConfig.readerRefreshInterval).map { _ =>
+      storeConfig.readerRefreshInterval.get,
+      storeConfig.readerRefreshInterval.get).map { _ =>
       partKeyIndex.refreshReadersBlocking()
     }.onErrorRestartUnlimited.completedL.runToFuture(readerRefreshSched)
   }

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -42,7 +42,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              readerRefreshInterval: Option[FiniteDuration]) {
   import collection.JavaConverters._
   def toConfig: Config =
-    ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
+    ConfigFactory.parseMap((Map("flush-interval" -> (flushInterval.toSeconds + "s"),
                                "time-aligned-chunks-enabled" -> timeAlignedChunksEnabled,
                                "disk-time-to-live" -> (diskTTLSeconds + "s"),
                                "max-chunks-size" -> maxChunksSize,
@@ -63,8 +63,10 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
                                "metering-enabled" -> meteringEnabled,
                                "accept-duplicate-samples" -> acceptDuplicateSamples,
-                               "ingest-resolution-millis" -> estimatedIngestResolutionMillis,
-                               "reader-refresh-interval" -> readerRefreshInterval).asJava)
+                               "ingest-resolution-millis" -> estimatedIngestResolutionMillis) ++
+                               readerRefreshInterval.map(
+                                 _ => Map("reader-refresh-interval" -> (readerRefreshInterval.get.toSeconds + "s"))
+                               ).getOrElse(Map())).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -38,7 +38,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              // approx data resolution, used for estimating the size of data to be scanned for
                              // answering queries, specified in milliseconds
                              estimatedIngestResolutionMillis: Int,
-                             housekeepingInterval: FiniteDuration) {
+                             readerRefreshInterval: FiniteDuration) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -62,7 +62,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
                                "metering-enabled" -> meteringEnabled,
                                "accept-duplicate-samples" -> acceptDuplicateSamples,
-                               "ingest-resolution-millis" -> estimatedIngestResolutionMillis).asJava)
+                               "ingest-resolution-millis" -> estimatedIngestResolutionMillis,
+                               "reader-refresh-interval" -> readerRefreshInterval).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -99,7 +100,6 @@ object StoreConfig {
                                            |accept-duplicate-samples = false
                                            |time-aligned-chunks-enabled = false
                                            |ingest-resolution-millis = 60000
-                                           |housekeeping-interval = 6 hours
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -140,7 +140,7 @@ object StoreConfig {
                 config.getBoolean("metering-enabled"),
                 config.getBoolean("accept-duplicate-samples"),
                 config.getInt("ingest-resolution-millis"),
-                config.as[FiniteDuration]("housekeeping-interval"))
+                config.as[FiniteDuration]("reader-refresh-interval"))
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -37,7 +37,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              acceptDuplicateSamples: Boolean,
                              // approx data resolution, used for estimating the size of data to be scanned for
                              // answering queries, specified in milliseconds
-                             estimatedIngestResolutionMillis: Int) {
+                             estimatedIngestResolutionMillis: Int,
+                             housekeepingInterval: FiniteDuration) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -98,6 +99,7 @@ object StoreConfig {
                                            |accept-duplicate-samples = false
                                            |time-aligned-chunks-enabled = false
                                            |ingest-resolution-millis = 60000
+                                           |housekeeping-interval = 6 hours
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -137,7 +139,8 @@ object StoreConfig {
                 config.getMemorySize("max-data-per-shard-query").toBytes,
                 config.getBoolean("metering-enabled"),
                 config.getBoolean("accept-duplicate-samples"),
-                config.getInt("ingest-resolution-millis"))
+                config.getInt("ingest-resolution-millis"),
+                config.as[FiniteDuration]("housekeeping-interval"))
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -38,7 +38,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              // approx data resolution, used for estimating the size of data to be scanned for
                              // answering queries, specified in milliseconds
                              estimatedIngestResolutionMillis: Int,
-                             readerRefreshInterval: FiniteDuration) {
+                             // must not be defined for downsample config, since it references raw's flush interval
+                             readerRefreshInterval: Option[FiniteDuration]) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -140,7 +141,7 @@ object StoreConfig {
                 config.getBoolean("metering-enabled"),
                 config.getBoolean("accept-duplicate-samples"),
                 config.getInt("ingest-resolution-millis"),
-                config.as[FiniteDuration]("reader-refresh-interval"))
+                config.as[Option[FiniteDuration]]("reader-refresh-interval"))
   }
 }
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -58,6 +58,7 @@ filodb {
     track-queries-holding-eviction-lock = false
     index-faceting-enabled-shard-key-labels = true
     index-faceting-enabled-for-all-labels = true
+    reader-refresh-interval = 6 hours
   }
 
   tasks {

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -49,6 +49,7 @@ object TestData {
       flush-interval = 10 minutes
       part-index-flush-max-delay = 10 seconds
       part-index-flush-min-delay = 2 seconds
+      reader-refresh-interval = 6 hours
     }
   """
   val sourceConf = ConfigFactory.parseString(sourceConfStr)

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -1,7 +1,6 @@
 package filodb.core.memstore
 
 import com.googlecode.javaewah.IntIterator
-
 import filodb.core._
 import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
 import filodb.core.metadata.Schemas
@@ -19,7 +18,6 @@ import java.nio.file.{Files, StandardOpenOption}
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.util.Random
-
 
 class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   import Filter._
@@ -404,72 +402,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
     val labelValues4 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "instance", 1000)
     labelValues4.toSet shouldEqual (0 until 1000).map(c => s"instance$c").toSet
-  }
-
-  it("TODO") {
-
-    val index = new PartKeyLuceneIndex(
-      DatasetRef("prometheus"),
-      Schemas.promCounter.partition,
-      facetEnabledAllLabels = true,
-      facetEnabledSharedKeyLabels = true,
-      shardNum = 0,
-      1.hour.toMillis)
-
-    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
-                         "_ns_".utf8 -> "my_ns".utf8)
-    val partKey = partBuilder.partKeyFromObjects(
-      Schemas.promCounter,
-      parts = s"counter0",
-      seriesTags + ("instance".utf8 -> s"instance0".utf8))
-
-    index.addPartKey(
-      partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), partId = 0, startTime = 5)()
-
-    index.refreshReadersBlocking()
-
-    {
-      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")), ColumnFilter("_ns_", EqualsRegex(".*")))
-      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
-      println(labelValues.toSet == Set("my_ns"))
-    }
-
-    {
-      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")))
-      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
-      println(labelValues.toSet == Set("my_ns"))
-    }
-
-    index.removePartKeys(Buffer(0))
-    // index.refreshReadersBlocking()
-
-    Thread.sleep(5000)
-
-
-    {
-      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")), ColumnFilter("_ns_", EqualsRegex(".*")))
-      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
-      println(labelValues.toSet == Set())
-    }
-
-    {
-      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")))
-      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
-      println(labelValues.toSet == Set())
-    }
-
-
-
-//    val filters2 = Seq(ColumnFilter("_ws_", Equals("NotExist")))
-//    val labelValues2 = index3.labelValuesEfficient(filters2, 0, Long.MaxValue, "_metric_")
-//    labelValues2.size shouldEqual 0
-//
-//    val filters3 = Seq(ColumnFilter("_metric_", Equals("counter1")))
-//    val labelValues3 = index3.labelValuesEfficient(filters3, 0, Long.MaxValue, "_metric_")
-//    labelValues3 shouldEqual Seq("counter1")
-//
-//    val labelValues4 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "instance", 1000)
-//    labelValues4.toSet shouldEqual (0 until 1000).map(c => s"instance$c").toSet
   }
 
   it("should be able to do regular operations when faceting is disabled") {

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -1,6 +1,7 @@
 package filodb.core.memstore
 
 import com.googlecode.javaewah.IntIterator
+
 import filodb.core._
 import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
 import filodb.core.metadata.Schemas
@@ -18,6 +19,7 @@ import java.nio.file.{Files, StandardOpenOption}
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.util.Random
+
 
 class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   import Filter._
@@ -402,6 +404,72 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
     val labelValues4 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "instance", 1000)
     labelValues4.toSet shouldEqual (0 until 1000).map(c => s"instance$c").toSet
+  }
+
+  it("TODO") {
+
+    val index = new PartKeyLuceneIndex(
+      DatasetRef("prometheus"),
+      Schemas.promCounter.partition,
+      facetEnabledAllLabels = true,
+      facetEnabledSharedKeyLabels = true,
+      shardNum = 0,
+      1.hour.toMillis)
+
+    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+                         "_ns_".utf8 -> "my_ns".utf8)
+    val partKey = partBuilder.partKeyFromObjects(
+      Schemas.promCounter,
+      parts = s"counter0",
+      seriesTags + ("instance".utf8 -> s"instance0".utf8))
+
+    index.addPartKey(
+      partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), partId = 0, startTime = 5)()
+
+    index.refreshReadersBlocking()
+
+    {
+      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")), ColumnFilter("_ns_", EqualsRegex(".*")))
+      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
+      println(labelValues.toSet == Set("my_ns"))
+    }
+
+    {
+      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")))
+      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
+      println(labelValues.toSet == Set("my_ns"))
+    }
+
+    index.removePartKeys(Buffer(0))
+    // index.refreshReadersBlocking()
+
+    Thread.sleep(5000)
+
+
+    {
+      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")), ColumnFilter("_ns_", EqualsRegex(".*")))
+      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
+      println(labelValues.toSet == Set())
+    }
+
+    {
+      val filters = Seq(ColumnFilter("_ws_", Equals("my_ws")))
+      val labelValues = index.labelValuesEfficient(filters, 0, Long.MaxValue, "_ns_")
+      println(labelValues.toSet == Set())
+    }
+
+
+
+//    val filters2 = Seq(ColumnFilter("_ws_", Equals("NotExist")))
+//    val labelValues2 = index3.labelValuesEfficient(filters2, 0, Long.MaxValue, "_metric_")
+//    labelValues2.size shouldEqual 0
+//
+//    val filters3 = Seq(ColumnFilter("_metric_", Equals("counter1")))
+//    val labelValues3 = index3.labelValuesEfficient(filters3, 0, Long.MaxValue, "_metric_")
+//    labelValues3 shouldEqual Seq("counter1")
+//
+//    val labelValues4 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "instance", 1000)
+//    labelValues4.toSet shouldEqual (0 until 1000).map(c => s"instance$c").toSet
   }
 
   it("should be able to do regular operations when faceting is disabled") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Adds periodic Lucene `IndexReader` refreshes in `TimeSeriesShard` to prevent faceted label-value queries from including now-deleted labels.