### PR TITLE
fix(core): Dataset multiColumnFacets configuration to load from config file

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -55,12 +55,10 @@ filodb {
       # lucene facet feature.
       #
       # Note: only "string" column type supported.
-      # multiColumnFacets = [
-      #     {
+      # multiColumnFacets = {
       #       all-hosts-availZone = ["avail_zone", "rack", "host"]
-      #     }
-      #   ]
-      multiColumnFacets = []
+      # }
+      multiColumnFacets = {}
     }
   }
 

--- a/core/src/main/scala/filodb.core/metadata/Dataset.scala
+++ b/core/src/main/scala/filodb.core/metadata/Dataset.scala
@@ -93,7 +93,8 @@ case class DatasetOptions(shardKeyColumns: Seq[String],
       "ignoreShardKeyColumnSuffixes" ->
         ignoreShardKeyColumnSuffixes.mapValues(_.asJava).asJava,
       "ignoreTagsOnPartitionKeyHash" -> ignoreTagsOnPartitionKeyHash.asJava,
-      "copyTags" -> copyTags.groupBy(_._2).map { case (k, v) => (k, v.map(_._1).asJava)}.asJava)
+      "copyTags" -> copyTags.groupBy(_._2).map { case (k, v) => (k, v.map(_._1).asJava)}.asJava,
+      "multiColumnFacets" -> multiColumnFacets.mapValues(_.asJava).asJava)
 
     ConfigFactory.parseMap(map.asJava)
   }
@@ -131,7 +132,8 @@ object DatasetOptions {
                    ignoreShardKeyColumnSuffixes =
                      config.as[Map[String, Seq[String]]]("ignoreShardKeyColumnSuffixes"),
                    ignoreTagsOnPartitionKeyHash = config.as[Seq[String]]("ignoreTagsOnPartitionKeyHash"),
-                   copyTags = copyTagsValue)
+                   copyTags = copyTagsValue,
+                   multiColumnFacets = config.as[Map[String, Seq[String]]]("multiColumnFacets"))
   }
 }
 

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -131,6 +131,7 @@ class SchemasSpec extends AnyFunSpec with Matchers {
                         ignoreTagsOnPartitionKeyHash = ["le"]
                         metricColumn = "__name__"
                         shardKeyColumns = ["__name__", "_ns"]
+                        multiColumnFacets = {}
                       }
                     }"""
 
@@ -204,16 +205,19 @@ class SchemasSpec extends AnyFunSpec with Matchers {
                           columns = ["timestamp:tsa", "code:long", "event:string"]
                           value-column = "event"
                           downsamplers = []
+                          multiColumnFacets = {}
                         }
                         prom2 {
                           columns = ["timestamp:ts", "code:long", "ev. ent:string"]
                           value-column = "foo"
                           downsamplers = []
+                          multiColumnFacets = {}
                         }
                         prom3 {
                           columns = ["timestamp:ts", "code:long", "event:string"]
                           value-column = "event"
                           downsamplers = []
+                          multiColumnFacets = {}
                         }
                       }
                     }""")
@@ -234,11 +238,13 @@ class SchemasSpec extends AnyFunSpec with Matchers {
                           columns = ["timestamp:ts", "value:double"]
                           value-column = "value"
                           downsamplers = []
+                          multiColumnFacets = {}
                         }
                         prom2 {
                           columns = ["timestamp:ts", "value:double"]
                           value-column = "timestamp"
                           downsamplers = []
+                          multiColumnFacets = {}
                         }
                       }
                     }""")
@@ -258,11 +264,13 @@ class SchemasSpec extends AnyFunSpec with Matchers {
                           value-column = "value"
                           downsamplers = ["tTime(0)", "dMin(1)"]
                           downsample-schema = "foo"
+                          multiColumnFacets = {}
                         }
                         prom-ds-gauge {
                           columns = ["timestamp:ts", "min:double"]
                           value-column = "timestamp"
                           downsamplers = []
+                          multiColumnFacets = {}
                         }
                       }
                     }""")
@@ -282,16 +290,19 @@ class SchemasSpec extends AnyFunSpec with Matchers {
                         value-column = "value"
                         downsamplers = ["tTime(0)", "dMin(1)"]
                         downsample-schema = "prom-ds-gauge"
+                        multiColumnFacets = {}
                       }
                       prom-ds-gauge {
                         columns = ["timestamp:ts", "min:double"]
                         value-column = "timestamp"
                         downsamplers = []
+                        multiColumnFacets = {}
                       }
                       hist {
                         columns = ["timestamp:ts", "count:long", "sum:long", "h:hist:counter=true"]
                         value-column = "h"
                         downsamplers = []
+                        multiColumnFacets = {}
                       }
                     }
                   }""")
@@ -323,6 +334,7 @@ class SchemasSpec extends AnyFunSpec with Matchers {
                           ignoreTagsOnPartitionKeyHash = ["le"]
                           metricColumn = "_metric_"
                           shardKeyColumns = ["_metric_", "_ns"]
+                          multiColumnFacets = {}
                         }
                       }"""
 
@@ -346,12 +358,14 @@ class SchemasSpec extends AnyFunSpec with Matchers {
                             value-column = "value"
                             downsamplers = ["tTime(0)", "dMin(1)"]
                             downsample-schema = "prom2"
+                            multiColumnFacets = {}
                           }
                           # Everything exactly the same except for column params, which are different
                           prom2 {
                             columns = ["timestamp:ts", "value:double:detectDrops=true"]
                             value-column = "timestamp"
                             downsamplers = []
+                            multiColumnFacets = {}
                           }
                         }
                       }""")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

earlier changes to DatasetOptions did not have code to set `multiColumnFacets` from config file. This PR fixes this bug.