### PR TITLE
feat(coord): add JVM shutdown on QueryActor uncaught InternalError

### DIFF
--- a/memory/src/main/scala/filodb.memory/data/Shutdown.scala
+++ b/memory/src/main/scala/filodb.memory/data/Shutdown.scala
@@ -8,8 +8,9 @@ import kamon.Kamon
 object Shutdown extends StrictLogging {
 
   val forcedShutdowns = Kamon.counter("forced-shutdowns").withoutTags()
-  def haltAndCatchFire(e: Exception, unitTest: Boolean = false): Unit = {
+  def haltAndCatchFire(e: Throwable, unitTest: Boolean = false): Unit = {
     forcedShutdowns.increment()
+    Thread.sleep(60000)  // Sleep 1m to make sure counter is published.
     if (unitTest) throw e
     logger.error(s"Shutting down process since it may be in an unstable/corrupt state", e)
     import scala.concurrent.duration._


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Halts the JVM if the QueryActor thread pool catches an InternalError left uncaught by the execution pipeline.