### PR TITLE
bug(core): Adding facet to find quickly find ALL label names for LabelCardinalityExec

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -48,7 +48,9 @@ object PartKeyLuceneIndex {
   final val START_TIME = "__startTime__"
   final val END_TIME = "__endTime__"
   final val PART_KEY = "__partKey__"
+  final val LABEL_LIST = s"__labelList__"
   final val FACET_FIELD_PREFIX = "$facet_"
+  final val LABEL_LIST_FACET = FACET_FIELD_PREFIX + LABEL_LIST
 
   final val ignoreIndexNames = HashSet(START_TIME, PART_KEY, END_TIME, PART_ID)
 
@@ -204,8 +206,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   //start this thread to flush the segments and refresh the searcher every specific time period
   private var flushThread: ControlledRealTimeReopenThread[IndexSearcher] = _
 
-  private val facetEnabled = facetEnabledAllLabels || facetEnabledSharedKeyLabels
-
   private def facetEnabledForLabel(label: String) = {
     facetEnabledAllLabels || (facetEnabledSharedKeyLabels && schema.options.shardKeyColumns.contains(label))
   }
@@ -253,25 +253,37 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     private val endTimeDv = new NumericDocValuesField(END_TIME, 0L)
     private val otherFields = mutable.WeakHashMap[String, StringField]() // weak so that it is GCed when unused
 
+    private val fieldNames = new ArrayBuffer[String]()
+
     def addField(name: String, value: String): Unit = {
-      addFacet(name, value)
+      addFacet(name, value, false)
       val field = otherFields.getOrElseUpdate(name, new StringField(name, "", Store.NO))
       field.setStringValue(value)
       document.add(field)
+      fieldNames += name
     }
 
-    private[PartKeyLuceneIndex] def addFacet(name: String, value: String) : Unit = {
+    private[PartKeyLuceneIndex] def addFacet(name: String, value: String, always: Boolean) : Unit = {
       // Use PartKeyIndexBenchmark to measure indexing performance before changing this
-      if (name.nonEmpty && value.nonEmpty && facetEnabledForLabel(name) && value.length < FACET_FIELD_MAX_LEN) {
+      if (always ||
+          (name.nonEmpty && value.nonEmpty && facetEnabledForLabel(name) && value.length < FACET_FIELD_MAX_LEN)
+         ) {
         facetsConfig.setRequireDimensionDrillDown(name, false)
         facetsConfig.setIndexFieldName(name, FACET_FIELD_PREFIX + name)
         document.add(new SortedSetDocValuesFacetField(name, value))
       }
     }
 
+    def allFieldsAdded(): Unit = {
+      // this special field is to fetch label names associated with query filter quickly
+      val fieldNamesStr = fieldNames.sorted.mkString(",")
+      addFacet(LABEL_LIST, fieldNamesStr, true)
+    }
+
     def reset(partId: Int, partKey: BytesRef, startTime: Long, endTime: Long): Document = {
-      document.clear();
-      if (facetEnabled) facetsConfig = new FacetsConfig
+      document.clear()
+      fieldNames.clear()
+      facetsConfig = new FacetsConfig
       partIdField.setStringValue(String.valueOf(partId))
       partIdDv.setLongValue(partId)
       partKeyDv.setBytesValue(partKey)
@@ -424,6 +436,15 @@ class PartKeyLuceneIndex(ref: DatasetRef,
         new DefaultSortedSetDocValuesReaderState(key._1, FACET_FIELD_PREFIX + key._2)
       })
 
+  def labelNamesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long): Seq[String] = {
+    val labelSets = labelValuesEfficient(colFilters, startTime, endTime, LABEL_LIST)
+    val labels = mutable.HashSet[String]()
+    labelSets.foreach { labelSet =>
+      labelSet.split(",").foreach(l => labels += l)
+    }
+    labels.toSeq
+  }
+
   def labelValuesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
                            colName: String, limit: Int = 100): Seq[String] = {
     require(facetEnabledForLabel(colName),
@@ -536,7 +557,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     logger.debug(s"Adding document ${partKeyString(partId, partKeyOnHeapBytes, partKeyBytesRefOffset)} " +
       s"with startTime=$startTime endTime=$endTime into dataset=$ref shard=$shardNum")
     val doc = luceneDocument.get()
-    val docToAdd = if (facetEnabled) doc.facetsConfig.build(doc.document) else doc.document
+    val docToAdd = doc.facetsConfig.build(doc.document)
     indexWriter.addDocument(docToAdd)
   }
 
@@ -550,7 +571,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     logger.debug(s"Upserting document ${partKeyString(partId, partKeyOnHeapBytes, partKeyBytesRefOffset)} " +
       s"with startTime=$startTime endTime=$endTime into dataset=$ref shard=$shardNum")
     val doc = luceneDocument.get()
-    val docToAdd = if (facetEnabled) doc.facetsConfig.build(doc.document) else doc.document
+    val docToAdd = doc.facetsConfig.build(doc.document)
     indexWriter.updateDocument(new Term(PART_ID, partId.toString), docToAdd)
   }
 
@@ -579,6 +600,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     cforRange { 0 until numPartColumns } { i =>
       indexers(i).fromPartKey(partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset), partId)
     }
+    luceneDocument.get().allFieldsAdded()
     luceneDocument.get().document
   }
 
@@ -601,7 +623,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
               case _ => emptyStr
             }
           }.mkString("\u03C0")
-          luceneDocument.get().addFacet(name, concatFacetValue)
+          luceneDocument.get().addFacet(name, concatFacetValue, false)
         }
       }
     })
@@ -695,8 +717,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
 
     val doc = luceneDocument.get()
     logger.debug(s"Updating document ${partKeyString(partId, partKeyOnHeapBytes, partKeyBytesRefOffset)} " +
-      s"with startTime=$startTime endTime=$endTime into dataset=$ref shard=$shardNum")
-    val docToAdd = if (facetEnabled) doc.facetsConfig.build(doc.document) else doc.document
+                 s"with startTime=$startTime endTime=$endTime into dataset=$ref shard=$shardNum")
+    val docToAdd = doc.facetsConfig.build(doc.document)
     indexWriter.updateDocument(new Term(PART_ID, partId.toString), docToAdd)
   }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1739,7 +1739,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   def labelNames(filter: Seq[ColumnFilter],
                  endTime: Long,
                  startTime: Long): Seq[String] =
-    labelNamesFromPartKeys(partKeyIndex.labelNamesFromFilters(filter, startTime, endTime))
+    partKeyIndex.labelNamesEfficient(filter, startTime, endTime)
 
   /**
    * Iterator for traversal of partIds, value for the given label will be extracted from the ParitionKey.

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -256,19 +256,17 @@ final case class LabelCardinalityReduceExec(queryContext: QueryContext,
       { case (metadataResult, rv) =>
           val rangeVector = rv.head
           val key = rangeVector.key
-          if (key.keySize > 0) {
-            val sketchMap = metadataResult.getOrElseUpdate(key, MutableMap.empty[ZeroCopyUTF8String, CpcSketch])
-            rangeVector.rows().foreach { rowReader =>
-              val binaryRowReader = rowReader.asInstanceOf[BinaryRecordRowReader]
-              rv.head match {
-                case srv: SerializedRangeVector =>
-                  srv.schema.consumeMapItems(binaryRowReader.recordBase, binaryRowReader.recordOffset, index = 0,
-                    mapConsumer(sketchMap))
-                case _ => throw new UnsupportedOperationException("Metadata query currently needs SRV results")
-              }
+          val sketchMap = metadataResult.getOrElseUpdate(key, MutableMap.empty[ZeroCopyUTF8String, CpcSketch])
+          rangeVector.rows().foreach { rowReader =>
+            val binaryRowReader = rowReader.asInstanceOf[BinaryRecordRowReader]
+            rv.head match {
+              case srv: SerializedRangeVector =>
+                srv.schema.consumeMapItems(binaryRowReader.recordBase, binaryRowReader.recordOffset, index = 0,
+                  mapConsumer(sketchMap))
+              case _ => throw new UnsupportedOperationException("Metadata query currently needs SRV results")
             }
           }
-        metadataResult
+          metadataResult
       }.map (metaDataMutableMap => {
           // metaDataMutableMap is a Map of [RangeVectorKey, MutableMap[ZeroCopyUTF8String, CpcSketch]]
           // Since the key query is specific to one ws/ns/metric, we see no more than one entry in the Map
@@ -403,31 +401,20 @@ final case class LabelCardinalityExec(queryContext: QueryContext,
     source.acquireSharedLock(dataset, shard, querySession)
     val rvs = source match {
       case memstore: TimeSeriesStore =>
-        val shardKeyCols = memstore.schemas(dataset).get.part.options.shardKeyColumns.map(_.utf8)
-
-        // TODO: require presence of shard key in column filters
-        val matches = memstore.partKeysWithFilters(dataset, shard, filters, fetchFirstLastSampleTimes = false,
-          endMs, startMs, limit = 1).toSeq
-        if (matches.nonEmpty) {
+        // first get the list of label names, then fetch each label value and add to CPC sketch
+        val labelNames = memstore.labelNames(dataset, shard, filters, endMs, startMs)
+        if (labelNames.nonEmpty) {
           val sketchMap = scala.collection.mutable.Map[String, CpcSketch]()
-          val firstMatchLVs = matches.head
-          val shardKeyLVs = firstMatchLVs.filterKeys(shardKeyCols.contains)
-          shardKeyLVs.foreach { case (label, value) =>
-            sketchMap.getOrElseUpdate(label.toString, new CpcSketch(logK)).update(value.toString)
-          }
-
-          val nonShardKeyLVs = firstMatchLVs.filterKeys(k => !shardKeyCols.contains(k))
-          nonShardKeyLVs.foreach { case (label, _) =>
-            val labelStr = label.toString
+          labelNames.foreach { case label =>
             // GOTCHA: This approach will not catch cardinality of labels which are disabled for faceting
             // since their value lengths are > 1000. We expect the gateway to reject (or shorten) that data early on.
             memstore.singleLabelValueWithFilters(dataset, shard, filters, label.toString,
               endMs, startMs, querySession, 1000000).foreach { labelValue =>
-              sketchMap.getOrElseUpdate(labelStr, new CpcSketch(logK)).update(labelValue.toString)
+              sketchMap.getOrElseUpdate(label, new CpcSketch(logK)).update(labelValue.toString)
             }
           }
 
-          val rv = IteratorBackedRangeVector(CustomRangeVectorKey(shardKeyLVs.toMap),
+          val rv = IteratorBackedRangeVector(CustomRangeVectorKey.empty,
             UTF8MapIteratorRowReader(
               Seq(sketchMap.map {
                 case (label, cpcSketch) =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Adding facet to identify label names associated with time series quickly.

Earlier we were identifying label names by querying just one time series and extracting label names from them. This does not work well for time series that have dynamic / inconsistent label names. This is not a great design pattern, but Kube State Metrics uses them to add dynamic metadata to time series.

With the facet, we find the label names quickly across all time series.

This is subsequently used by LabelCardinality query.
