### PR TITLE
fix(exec): mark shard query-ready after index recovery

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -134,9 +134,9 @@ extends TimeSeriesStore with StrictLogging {
   }
 
   def recoverIndex(dataset: DatasetRef, shard: Int): Future[Long] = {
-    val shard = getShardE(dataset, shard)
-    val fut = shard.recoverIndex()
-    fut.onComplete(_ => shard.isReadyForQuery = true)
+    val shardObj = getShardE(dataset, shard)
+    val fut = shardObj.recoverIndex()
+    fut.onComplete(_ => shardObj.isReadyForQuery = true)
     fut
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, a new shard is marked "ready for queries" immediately before initializing an asynchronous index recovery. Until the index is completely built, queries may return partial results.

This PR delays the "ready for queries" mark until after the index has been completely built.