### PR TITLE
*WIP* fix(core): add Lucene post-bootstrap commit

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -41,6 +41,7 @@ class IndexBootstrapper(colStore: ColumnStore) {
       }
       .countL
       .map { count =>
+        index.commit()
         index.refreshReadersBlocking()
         recoverIndexLatency.update(System.currentTimeMillis() - start)
         count


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

# \*\*\*\*\*WIP\*\*\*\*\*\*

Forces a `commit` immediately after the index bootstraps (and before readers are refreshed).

From the Lucene docs ([_IndexWriter::commit_](https://lucene.apache.org/core/7_4_0/core/org/apache/lucene/index/IndexWriter.html#commit--)):
> Commits all pending changes (added and deleted documents, segment merges, added indexes, etc.) to the index, and **syncs all referenced index files, such that a reader will see the changes** and the index updates will survive an OS or machine crash or power loss.

This prevents post-bootstrap query responses from excluding time-series that had not yet been committed to the index.