### PR TITLE
misc(core): populateRawChunks log/shutdown on caught throwable

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -80,7 +80,7 @@ extends RawToPartitionMaker with StrictLogging {
                 case t: Throwable =>
                   // Failure above may indicate data corruption. At the very least,
                   //   something has gone remarkably wrong.
-                  logger.error(s"Unexpected error; shutting down. $t")
+                  logger.error(s"Unexpected error when doing on-demand paging; shutting down.", t)
                   Shutdown.haltAndCatchFire(t)
               }
               metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),

--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -11,6 +11,7 @@ import spire.syntax.cfor._
 
 import filodb.core.store._
 import filodb.memory.{BlockManager, BlockMemFactory}
+import filodb.memory.data.Shutdown
 import filodb.memory.format.BinaryVector.BinaryVectorPtr
 import filodb.memory.format.UnsafeUtils
 
@@ -47,6 +48,7 @@ extends RawToPartitionMaker with StrictLogging {
     tsShard.maxMetaSize, baseContext ++ Map("odp" -> "true"),
     markFullBlocksAsReclaimable = true)
 
+  // scalastyle:off method.length
   /**
    * Stores raw chunks into offheap memory and populates chunks into partition
    */
@@ -67,7 +69,6 @@ extends RawToPartitionMaker with StrictLogging {
         // to allocate a block just for storing an unnecessary metadata entry.
         if (!rawVectors.isEmpty) {
           val chunkID = ChunkSetInfo.getChunkID(infoBytes)
-
           if (!tsPart.chunkmapContains(chunkID)) {
             val chunkPtrs = new ArrayBuffer[BinaryVectorPtr](rawVectors.length)
             var metaAddr: Long = 0
@@ -75,10 +76,15 @@ extends RawToPartitionMaker with StrictLogging {
               memFactory.startMetaSpan()
               try {
                 copyToOffHeap(rawVectors, memFactory, chunkPtrs)
-              } finally {
-                metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),
-                  tsPart.schema.data.blockMetaSize.toShort)
+              } catch {
+                case t: Throwable =>
+                  // Failure above may indicate data corruption. At the very least,
+                  //   something has gone remarkably wrong.
+                  logger.error(s"Unexpected error; shutting down. $t")
+                  Shutdown.haltAndCatchFire(t)
               }
+              metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),
+                tsPart.schema.data.blockMetaSize.toShort)
             }
             require(metaAddr != 0)
             val infoAddr = metaAddr + 4 // Important: don't point at partID
@@ -101,6 +107,7 @@ extends RawToPartitionMaker with StrictLogging {
         s"not found, this is bad")
     }
   }
+  // scalastyle:on method.length
 
   /**
     * Copies the onHeap contents read from ColStore into off-heap using the given memFactory.

--- a/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/DemandPagedChunkStore.scala
@@ -47,7 +47,6 @@ extends RawToPartitionMaker with StrictLogging {
     tsShard.maxMetaSize, baseContext ++ Map("odp" -> "true"),
     markFullBlocksAsReclaimable = true)
 
-  //scalastyle:off method.length
   /**
    * Stores raw chunks into offheap memory and populates chunks into partition
    */
@@ -68,21 +67,17 @@ extends RawToPartitionMaker with StrictLogging {
         // to allocate a block just for storing an unnecessary metadata entry.
         if (!rawVectors.isEmpty) {
           val chunkID = ChunkSetInfo.getChunkID(infoBytes)
+
           if (!tsPart.chunkmapContains(chunkID)) {
             val chunkPtrs = new ArrayBuffer[BinaryVectorPtr](rawVectors.length)
             var metaAddr: Long = 0
-            var somethingThrown = false
             memFactory.synchronized {
               memFactory.startMetaSpan()
               try {
                 copyToOffHeap(rawVectors, memFactory, chunkPtrs)
-              } catch {
-                case _ => somethingThrown = true
               } finally {
-                // Require a metadata allocation/write only if nothing was thrown during copyToOffHeap,
-                //   since something might have been thrown before anything was written to off-heap memory.
                 metaAddr = memFactory.endMetaSpan(writeMeta(_, tsPart.partID, infoBytes, chunkPtrs),
-                  tsPart.schema.data.blockMetaSize.toShort, requireMetaWrite = !somethingThrown)
+                  tsPart.schema.data.blockMetaSize.toShort)
               }
             }
             require(metaAddr != 0)
@@ -106,7 +101,6 @@ extends RawToPartitionMaker with StrictLogging {
         s"not found, this is bad")
     }
   }
-  //scalastyle:on method.length
 
   /**
     * Copies the onHeap contents read from ColStore into off-heap using the given memFactory.

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -277,11 +277,12 @@ class BlockMemFactory(blockStore: BlockManager,
     *
     * @param metadataWriter the function to write metadata to each block.  Param is the long metadata address.
     * @param metaSize the number of bytes the piece of metadata takes
+    * @param requireMetaWrite true iff at least one allocation/write of medatata info is required
     * @return the Long native address of the last metadata block written
     * throws IllegalStateException if startMetaSpan wasn't called, or if metaSize is larger
     * than max allowed, or if nothing was allocated
     */
-  def endMetaSpan(metadataWriter: Long => Unit, metaSize: Short): Long = {
+  def endMetaSpan(metadataWriter: Long => Unit, metaSize: Short, requireMetaWrite: Boolean = true): Long = {
     if (!metadataSpanActive) {
       throw new IllegalStateException("Not in a metadata span")
     }
@@ -309,7 +310,7 @@ class BlockMemFactory(blockStore: BlockManager,
     metadataSpan.clear()
     metadataSpanActive = false
 
-    if (metaAddr == 0) {
+    if (requireMetaWrite && metaAddr == 0) {
       throw new IllegalStateException("Nothing was allocated")
     }
 

--- a/memory/src/main/scala/filodb.memory/MemFactory.scala
+++ b/memory/src/main/scala/filodb.memory/MemFactory.scala
@@ -277,12 +277,11 @@ class BlockMemFactory(blockStore: BlockManager,
     *
     * @param metadataWriter the function to write metadata to each block.  Param is the long metadata address.
     * @param metaSize the number of bytes the piece of metadata takes
-    * @param requireMetaWrite true iff at least one allocation/write of medatata info is required
     * @return the Long native address of the last metadata block written
     * throws IllegalStateException if startMetaSpan wasn't called, or if metaSize is larger
     * than max allowed, or if nothing was allocated
     */
-  def endMetaSpan(metadataWriter: Long => Unit, metaSize: Short, requireMetaWrite: Boolean = true): Long = {
+  def endMetaSpan(metadataWriter: Long => Unit, metaSize: Short): Long = {
     if (!metadataSpanActive) {
       throw new IllegalStateException("Not in a metadata span")
     }
@@ -310,7 +309,7 @@ class BlockMemFactory(blockStore: BlockManager,
     metadataSpan.clear()
     metadataSpanActive = false
 
-    if (requireMetaWrite && metaAddr == 0) {
+    if (metaAddr == 0) {
       throw new IllegalStateException("Nothing was allocated")
     }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

If something is thrown during `DemandPagedChunkStore::copyToOffHeap` before anything was copied, then `endMetaSpan` will fail its requirement that metadata is written at least once. Since `endMetaSpan` exists in a `finally` clause, the requirement's `IllegalArgumentException` will "override" whatever was initially thrown.

This PR just logs the original `Throwable` and shuts down the JVM.

