### PR TITLE
feat(query):  partialResult flag and remote query suppport in partial results

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -41,7 +41,7 @@ object QueryConfig {
                                            remoteHttpEndpoint = None,
                                            enforceResultByteLimit = false,
                                            allowPartialResultsRangeQuery = false,
-                                           allowPartialResultsMetadataQuery = false)
+                                           allowPartialResultsMetadataQuery = true)
 }
 
 case class QueryConfig(askTimeout: FiniteDuration,
@@ -55,4 +55,4 @@ case class QueryConfig(askTimeout: FiniteDuration,
                        remoteHttpEndpoint: Option[String],
                        enforceResultByteLimit: Boolean = false,
                        allowPartialResultsRangeQuery: Boolean = false,
-                       allowPartialResultsMetadataQuery: Boolean = false)
+                       allowPartialResultsMetadataQuery: Boolean = true)

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -59,7 +59,7 @@ object QueryContext {
 
   def apply(queryParams: TsdbQueryParams, constSpread: Option[SpreadProvider],
             allowPartialResults: Boolean): QueryContext =
-    QueryContext(origQueryParams = queryParams, plannerParams = PlannerParams( constSpread, allowPartialResults))
+    QueryContext(origQueryParams = queryParams, plannerParams = PlannerParams(constSpread, allowPartialResults))
 
   /**
     * Creates a spreadFunc that looks for a particular filter with keyName Equals a value, and then maps values

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -38,7 +38,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
     import PromCirceSupport._
     import io.circe.parser
     remoteExecHttpClient.httpMetadataPost(queryEndpoint, httpTimeoutMs,
-      queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
+      queryContext.submitTime, getUrlParams(queryContext.plannerParams.allowPartialResults), queryContext.traceInfo)
       .map { response =>
         // Error response from remote partition is a nested json present in response.body
         // as response status code is not 2xx

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -49,7 +49,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
     import PromCirceSupport._
     import io.circe.parser
     remoteExecHttpClient.httpPost(queryEndpoint, requestTimeoutMs,
-      queryContext.submitTime, getUrlParams(), queryContext.traceInfo)
+      queryContext.submitTime, getUrlParams(queryContext.plannerParams.allowPartialResults), queryContext.traceInfo)
       .map { response =>
         // Error response from remote partition is a nested json present in response.body
         // as response status code is not 2xx


### PR DESCRIPTION
-If `partialResult` query parameter is specified in the query it will be used to determine whether partial result should be provided. If it is not specified `allow-partial-results-metadataquery` or a`allow-partial-results-rangequery` value from config will be used
-Partial result support for multipartition remote queries