### PR TITLE
fix(memory) BinaryVector fixes for M1 Mac

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/BinaryVector.scala
@@ -265,6 +265,8 @@ trait BinaryAppendableVector[@specialized(Int, Long, Double, Boolean) A] {
   // Native address of the appendable vector
   def addr: BinaryRegion.NativePointer
 
+  val arch = System.getProperty("os.arch")
+
   /** Max size that current buffer can grow to */
   def maxBytes: Int
 
@@ -343,7 +345,20 @@ trait BinaryAppendableVector[@specialized(Int, Long, Double, Boolean) A] {
   def checkSize(need: Int, have: Int): AddResponse =
     if (!(need <= have)) VectorTooSmall(need, have) else Ack
 
-  @inline final def incNumBytes(inc: Int): Unit = UnsafeUtils.unsafe.getAndAddInt(UnsafeUtils.ZeroPointer, addr, inc)
+  @inline final def incNumBytes(inc: Int): Unit = arch match {
+    case "aarch64"  =>
+      // This is a temporary fix for M1 Mac till the operation
+      // UnsafeUtils.unsafe.getAndAddInt(UnsafeUtils.ZeroPointer, addr, inc) works. Issue with compareAndSet
+      // failing with a SIGBUS when a getAndAddInt is invoked on an address offset that is one of the three
+      // preceding every multiple of 16. For e.g when addrs is 13, 14, 15, 29, 30, 31, 45, 46, 47 byte offset from the
+      // base offset, getAndAddInt fails, however, when we perform get, increment and put in a non atomic operation
+      // it succeeds. This temporary work around for non atomic CAS will only happen on M1 Mac laptops till a fix is
+      // in place and we no longer need to handle these cases separately
+      // Since this code is invoked in ingestion path, ingestion performance needs benchmarking even for non M1 arch
+      val newIncVal = UnsafeUtils.unsafe.getInt(UnsafeUtils.ZeroPointer, addr) + inc
+      UnsafeUtils.unsafe.putInt(UnsafeUtils.ZeroPointer, addr, newIncVal)
+    case _          => UnsafeUtils.unsafe.getAndAddInt(UnsafeUtils.ZeroPointer, addr, inc)
+  }
 
   /**
    * Allocates a new instance of itself growing by factor growFactor.

--- a/memory/src/test/scala/filodb.memory/BlockMemFactorySpec.scala
+++ b/memory/src/test/scala/filodb.memory/BlockMemFactorySpec.scala
@@ -17,14 +17,14 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
     val stats = new MemoryStats(Map("test1" -> "test1"))
     val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1, evictionLock)
     val bmf = new BlockMemFactory(blockManager, 50, Map("test" -> "val"), false)
-
+    val allocationSize = 1000 * PageManager.getInstance().pageSize().toInt / 4096
     // simulate encoding of multiple ts partitions in flush group
 
     for { flushGroup <- 0 to 1 } {
       for {tsParts <- 0 to 5} {
         bmf.startMetaSpan()
         for {chunks <- 0 to 3} {
-          bmf.allocateOffheap(1000)
+          bmf.allocateOffheap(allocationSize)
         }
         bmf.endMetaSpan(d => {}, 45)
       }
@@ -50,7 +50,7 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
   it should "Mark all blocks of BlockMemFactory as reclaimable when used in ODP by DemandPagedChunkStore" in {
     val stats = new MemoryStats(Map("test1" -> "test1"))
     val blockManager = new PageAlignedBlockManager(2048 * 1024, stats, testReclaimer, 1, evictionLock)
-
+    val allocationSize = 1000 * PageManager.getInstance().pageSize().toInt / 4096
     // create block mem factories for different time buckets
     val bmf = new BlockMemFactory(blockManager, 50, Map("test" -> "val"), true)
 
@@ -58,7 +58,7 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
       for {tsParts <- 0 to 10} {
         bmf.startMetaSpan()
         for {chunks <- 0 to 3} {
-          bmf.allocateOffheap(1000)
+          bmf.allocateOffheap(allocationSize)
         }
         bmf.endMetaSpan(d => {}, 45)
       }
@@ -96,13 +96,13 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
 
     // create block mem factories for different time buckets
     val odpFactory = new BlockMemFactory(blockManager, 50, Map("test" -> "val"), true)
-
+    val allocationSize = 1000 * PageManager.getInstance().pageSize().toInt / 4096
     // simulate encoding of multiple ts partitions in flush group
     for { flushGroup <- 0 to 1 } {
       for {tsParts <- 0 to 5} {
         ingestionFactory.startMetaSpan()
         for {chunks <- 0 to 3} {
-          ingestionFactory.allocateOffheap(1000)
+          ingestionFactory.allocateOffheap(allocationSize)
         }
         ingestionFactory.endMetaSpan(d => {}, 45)
       }
@@ -119,7 +119,7 @@ class BlockMemFactorySpec extends AnyFlatSpec with Matchers {
     for {tsParts <- 0 to 10} {
       odpFactory.startMetaSpan()
       for {chunks <- 0 to 3} {
-        odpFactory.allocateOffheap(1000)
+        odpFactory.allocateOffheap(allocationSize)
       }
       odpFactory.endMetaSpan(d => {}, 45)
     }


### PR DESCRIPTION
**Issue**
On Mac M1, ``incNumBytes`` has a quirk. The operation fails with SIGBUS when a ``getAndAddInt`` is invoked on an address offset that is one of the three preceding every multiple of 16. For e.g when addrs is 13, 14, 15, 29, 30, 31, 45, 46, 47 byte offset from the base address, the operation ``UnsafeUtils.unsafe.getAndAddInt(UnsafeUtils.ZeroPointer, addr, inc)`` fails.  However, when we do a get and put non atomically, it works.  The fix is done to currently unblock developers from using M1 Mac. However, the fix is far from ideal as the data written to the block of memory by FiloDB is application specific and the block of memory is opaque to the operating system, in other words, the OS should not be interpreting this data as long as the application is working on the block it is allocated. 

**IMPORTANT**
The PR is built on top of this PR https://github.com/filodb/FiloDB/pull/1428 by @kvpetrov. 

**Next steps**
Once the issue with ``UnsafeUtils.unsafe.getAndAddInt(UnsafeUtils.ZeroPointer, addr, inc)``  is identified, the changes to ``BinaryVector.incNumBytes``  will be reverted. 
