### PR TITLE
fix(query): simplify split-partition logic in MPP

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -1,7 +1,9 @@
 package filodb.coordinator.queryplanner
 
 import scala.collection.mutable.ArrayBuffer
+
 import com.typesafe.scalalogging.StrictLogging
+
 import filodb.core.query.{QueryContext, RangeParams}
 import filodb.prometheus.ast.{Day, Duration, SubqueryUtils, WindowConstants}
 import filodb.prometheus.ast.Vectors.PromMetricLabel

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -385,6 +385,7 @@ object LogicalPlanUtils extends StrictLogging {
       case sp: ScalarPlan =>
         Some(TimeRange(sp.startMs, sp.endMs))
       case _: TsCardinalities =>
+        // past 7 days, since this is the max retention between "active" and "total" counts
         val nowMs = System.currentTimeMillis()
         Some(TimeRange(nowMs - Duration(7, Day).millis(0), nowMs))
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -154,7 +154,7 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
       case lp: ApplyAbsentFunction        => super.materializeAbsentFunction(qContext, lp)
       case lp: ScalarBinaryOperation      => super.materializeScalarBinaryOperation(qContext, lp)
       case lp: ApplyLimitFunction         => super.materializeLimitFunction(qContext, lp)
-      case lp: TsCardinalities            => materializeTsCardinalities(lp, qContext)
+      case lp: TsCardinalities            => throw new IllegalArgumentException("TsCardinalities unexpected here")
       case lp: SubqueryWithWindowing       => super.materializeSubqueryWithWindowing(qContext, lp)
       case lp: TopLevelSubquery            => super.materializeTopLevelSubquery(qContext, lp)
       case _: PeriodicSeries |

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -373,7 +373,7 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
     } else {
       logger.info(s"(ws, ns) pair not provided in prefix=${lp.shardKeyPrefix};" +
                   s"dispatching to all authorized partitions")
-      getMetadataPartitions(lp.filters(), TimeRange(0, Long.MaxValue))
+      getMetadataPartitions(lp.filters(), getRealLeafTimeRange(lp).get)
     }
     val execPlan = if (partitions.isEmpty) {
       logger.warn(s"no partitions found for $lp; defaulting to local planner")

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -311,16 +311,16 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
     val rhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].
       copy(promQl = LogicalPlanParser.convertToQuery(logicalPlan.rhs)))
 
-    val lhsExec = walkLogicalPlanTree(logicalPlan.lhs, lhsQueryContext).plans
-    val rhsExec = walkLogicalPlanTree(logicalPlan.rhs, rhsQueryContext).plans
+    val lhsPlans = walkLogicalPlanTree(logicalPlan.lhs, lhsQueryContext).plans
+    val rhsPlans = walkLogicalPlanTree(logicalPlan.rhs, rhsQueryContext).plans
 
     val execPlan = if (logicalPlan.operator.isInstanceOf[SetOperator])
-      SetOperatorExec(qContext, InProcessPlanDispatcher(queryConfig), lhsExec, rhsExec, logicalPlan.operator,
+      SetOperatorExec(qContext, InProcessPlanDispatcher(queryConfig), lhsPlans, rhsPlans, logicalPlan.operator,
         LogicalPlanUtils.renameLabels(logicalPlan.on, datasetMetricColumn),
         LogicalPlanUtils.renameLabels(logicalPlan.ignoring, datasetMetricColumn), datasetMetricColumn,
         rvRangeFromPlan(logicalPlan))
     else
-      BinaryJoinExec(qContext, inProcessPlanDispatcher, lhsExec, rhsExec, logicalPlan.operator,
+      BinaryJoinExec(qContext, inProcessPlanDispatcher, lhsPlans, rhsPlans, logicalPlan.operator,
         logicalPlan.cardinality, LogicalPlanUtils.renameLabels(logicalPlan.on, datasetMetricColumn),
         LogicalPlanUtils.renameLabels(logicalPlan.ignoring, datasetMetricColumn),
         LogicalPlanUtils.renameLabels(logicalPlan.include, datasetMetricColumn), datasetMetricColumn,

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -108,21 +108,15 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val remoteExec1 = stitchRvsExec.children(0).asInstanceOf[PromQlRemoteExec]
     val queryParams1 = remoteExec1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
     queryParams1.startSecs shouldEqual startSeconds
-    queryParams1.endSecs shouldEqual (localPartitionStart - 1)
+    queryParams1.endSecs shouldEqual (endSeconds)
     queryParams1.stepSecs shouldEqual step
     remoteExec1.queryContext.plannerParams.processFailure shouldEqual true
     remoteExec1.queryContext.plannerParams.processMultiPartition shouldEqual false
     remoteExec1.queryEndpoint shouldEqual "remote-url"
 
-    // expectedStarMs ends up to be 3 400 000, which does not look right to me, it is supposed to be 3 000 000
-    // kpetrov, 12/02/21
-    val expectedStartMs = ((startSeconds*1000) to (endSeconds*1000) by (step*1000)).find { instant =>
-      instant - lookbackMs > (localPartitionStart * 1000)
-    }.get
-
     val remoteExec2 = stitchRvsExec.children(1).asInstanceOf[PromQlRemoteExec]
     val queryParams2 = remoteExec2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
-    queryParams2.startSecs shouldEqual (expectedStartMs / 1000)
+    queryParams2.startSecs shouldEqual startSeconds
     queryParams2.endSecs shouldEqual endSeconds
     queryParams2.stepSecs shouldEqual step
     remoteExec2.queryContext.plannerParams.processFailure shouldEqual true
@@ -836,24 +830,16 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val remoteExec1 = stitchRvsExec.children(0).asInstanceOf[PromQlRemoteExec]
     val queryParams1 = remoteExec1.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
     queryParams1.startSecs shouldEqual startSeconds
-    queryParams1.endSecs shouldEqual 3999
+    queryParams1.endSecs shouldEqual endSeconds
     queryParams1.stepSecs shouldEqual step
     remoteExec1.queryContext.plannerParams.processFailure shouldEqual true
     remoteExec1.queryContext.plannerParams.processMultiPartition shouldEqual false
     remoteExec1.queryEndpoint shouldEqual "remote-url1"
     val remoteExec2 = stitchRvsExec.children(1).asInstanceOf[PromQlRemoteExec]
 
-    val expectedStartMs1 = ((startSeconds*1000) to (endSeconds*1000) by (step*1000)).find { instant =>
-      instant - lookbackMs > (secondPartitionStart * 1000)
-    }.get
-
-    val expectedStartMs2 = ((startSeconds*1000) to (endSeconds*1000) by (step*1000)).find { instant =>
-      instant - lookbackMs > (thirdPartitionStart * 1000)
-    }.get
-
     val queryParams2 = remoteExec2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
-    queryParams2.startSecs shouldEqual expectedStartMs1 / 1000
-    queryParams2.endSecs shouldEqual 6999
+    queryParams2.startSecs shouldEqual startSeconds
+    queryParams2.endSecs shouldEqual endSeconds
     queryParams2.stepSecs shouldEqual step
     remoteExec2.queryContext.plannerParams.processFailure shouldEqual true
     remoteExec2.queryContext.plannerParams.processMultiPartition shouldEqual false
@@ -861,7 +847,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
 
     val remoteExec3 = stitchRvsExec.children(2).asInstanceOf[PromQlRemoteExec]
     val queryParams3 = remoteExec3.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
-    queryParams3.startSecs shouldEqual expectedStartMs2 / 1000
+    queryParams3.startSecs shouldEqual startSeconds
     queryParams3.endSecs shouldEqual endSeconds
     queryParams3.stepSecs shouldEqual step
     remoteExec3.queryContext.plannerParams.processFailure shouldEqual true
@@ -965,7 +951,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val remoteExec = stitchRvsExec.children(0).asInstanceOf[PromQlRemoteExec]
     val queryParams = remoteExec.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
     queryParams.startSecs shouldEqual startSeconds
-    queryParams.endSecs shouldEqual (localPartitionStartMs - 1) / 1000
+    queryParams.endSecs shouldEqual endSeconds
     queryParams.stepSecs shouldEqual step
     remoteExec.queryContext.plannerParams.processFailure shouldEqual true
     remoteExec.queryContext.plannerParams.processMultiPartition shouldEqual false
@@ -973,7 +959,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
 
     val remoteExec2 = stitchRvsExec.children(1).asInstanceOf[PromQlRemoteExec]
     val queryParams2 = remoteExec2.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams]
-    queryParams2.startSecs shouldEqual endSeconds
+    queryParams2.startSecs shouldEqual startSeconds
     queryParams2.endSecs shouldEqual endSeconds
     queryParams2.stepSecs shouldEqual step
     remoteExec2.queryContext.plannerParams.processFailure shouldEqual true

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -1486,7 +1486,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
   }
 
 
-    it("should push multi-namespace portion of query when all of it is in one partition") {
+  it("should push multi-namespace portion of query when all of it is in one partition") {
     def partitions(timeRange: TimeRange): List[PartitionAssignment] = List(PartitionAssignment("remote", "remote-url",
       TimeRange(timeRange.startMs, timeRange.endMs)))
 

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -160,14 +160,14 @@ object Parser extends StrictLogging {
     }
   }
 
-  def queryToLogicalPlan(query: String, queryTimestamp: Long, step: Long, mode: Mode = Shadow): LogicalPlan = {
+  def queryToLogicalPlan(query: String, queryTimestamp: Long, step: Long, mode: Mode = mode): LogicalPlan = {
     // Remember step matters here in instant query, when lookback is provided in step factor
     // notation as in [5i]
     val defaultQueryParams = TimeStepParams(queryTimestamp, step, queryTimestamp)
     queryRangeToLogicalPlan(query, defaultQueryParams, mode)
   }
 
-  def queryRangeToLogicalPlan(query: String, timeParams: TimeRangeParams, mode: Mode = Shadow): LogicalPlan = {
+  def queryRangeToLogicalPlan(query: String, timeParams: TimeRangeParams, mode: Mode = mode): LogicalPlan = {
     val ex = parseQueryWithPrecedence(query, mode)
     ex match {
       case p: PeriodicSeries => p.toSeriesPlan(timeParams)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

High-level idea: if a leaf-level `LogicalPlan` contains data in multiple partitions (i.e. its data has at some point been migrated between partitions), then issue the same query to each and stitch the results. When the results are stitched, timestamps with unequal values will be dropped.

This is an alternative to https://github.com/filodb/FiloDB/pull/1423. It does not accomplish exactly what that PR does (lookbacks between partitions aren't explicitly prevented), but its logic is substantially simpler.