### PR TITLE
misc(downsample): merge partkey starttime endtime during index migration

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -107,7 +107,9 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
       val eligible = hasDownsampleSchema && !blocked
       if (eligible) count += 1
       eligible
-    }.map(toDownsamplePkrWithHash)
+    }.map(pkr => dsDatasource.readMergePartkeyStartEndTime(ref = dsDatasetRef, shard = shard.toInt,
+        partKeyRecord = pkr)) // Merge with persisted (if exists) partKey.
+      .map(toDownsamplePkrWithHash)
     val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
     Await.result(dsDatasource.writePartKeys(ref = dsDatasetRef, shard = shard.toInt,
       partKeys = pkRecords,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

**Current behavior :** Currently downsample index migration job reads records from raw cluster's `pks_by_update_time` table and updates PartKeys table in downsample cluster. This approach has limitation that we can not run index migration jobs concurrently for multiple time windows, as we may update the record with stale data depending on the order which jobs are run.

**New behavior :** After this change, we read PartitionKey (if already exists) before writing and merge start/endtimes. Starttime will be the older and Endtime will be the later of the records merged.

**Note** This approach is still susceptible consistency issues, as the read data can become stale due to other writes that can happen. But this is not a big concern since only downsample index migration jobs will be writing to these tables.