### PR TITLE
fix(query): correct MPP partition-split plan time-ranges

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/FailureProvider.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/FailureProvider.scala
@@ -16,6 +16,12 @@ object EmptyFailureProvider extends FailureProvider {
   override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = Nil
 }
 
+object TimeRange {
+  def fromSecs(startSecs: Long, endSecs: Long): TimeRange = {
+    TimeRange(1000 * startSecs, 1000 * endSecs)
+  }
+}
+
 /**
   * Time range.
   *

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -374,4 +374,16 @@ object LogicalPlanUtils extends StrictLogging {
    }
   }
 
+  /**
+   * Snap a timestamp to the next periodic step.
+   * @param timestamp the timestamp to snap.
+   * @param step the size of each periodic step.
+   * @param origin where steps began.
+   */
+  def snapToStep(timestamp: Long, step: Long, origin: Long): Long = {
+    val totalDiff = timestamp - origin
+    val partialStep = totalDiff % step
+    val diffToNextStep = if (partialStep > 0) step - partialStep else 0
+    timestamp + diffToNextStep
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This PR fixes two bugs in `MultiPartitionPlanner`:
- During split-partition queries (i.e. those whose leaf plans span multiple partitions), the partition with the most-recent data will always be queried for data through the end of the `PartitionAssignment` (possibly beyond the end of the query itself).
- Split-partition queries are not aligned to periodic steps.