### PR TITLE
fix(downsample): always merge with persisted raw cluster partkey during migration

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -430,10 +430,10 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     }
   }
 
-  // Merge with latest persisted partkey record. This practically makes index migration job runs idempotent.
-  def readMergePartkeyStartEndTime(ref: DatasetRef,
-                                   shard: Int,
-                                   partKeyRecord: PartKeyRecord): PartKeyRecord = {
+  // returns the persisted partKey record, or default partKey record (argument) if there is no persisted value.
+  def getPartKeyRecordOrDefault(ref: DatasetRef,
+                                shard: Int,
+                                partKeyRecord: PartKeyRecord): PartKeyRecord = {
     getOrCreatePartitionKeysTable(ref, shard).readPartKey(partKeyRecord.partKey) match {
       case Some(targetPkr) => targetPkr
       case None => partKeyRecord // this case is never executed since raw cluster is the source of truth.

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -430,13 +430,13 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     }
   }
 
-  // merges with persisted partkey start/endtime, by picking earliest starttime and latest endtime.
+  // Merge with latest persisted partkey record. This practically makes index migration job runs idempotent.
   def readMergePartkeyStartEndTime(ref: DatasetRef,
                                    shard: Int,
                                    partKeyRecord: PartKeyRecord): PartKeyRecord = {
     getOrCreatePartitionKeysTable(ref, shard).readPartKey(partKeyRecord.partKey) match {
-      case Some(targetPkr) => compareAndGet(partKeyRecord, targetPkr)
-      case None => partKeyRecord
+      case Some(targetPkr) => targetPkr
+      case None => partKeyRecord // this case is never executed since raw cluster is the source of truth.
     }
   }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -108,7 +108,7 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
       val eligible = hasDownsampleSchema && !blocked
       if (eligible) count += 1
       eligible
-    }.map(pkr => rawDataSource.readMergePartkeyStartEndTime(ref = rawDatasetRef, shard = shard.toInt,
+    }.map(pkr => rawDataSource.getPartKeyRecordOrDefault(ref = rawDatasetRef, shard = shard.toInt,
         partKeyRecord = pkr)) // Merge with persisted (if exists) partKey.
       .map(toDownsamplePkrWithHash)
     val updateHour = System.currentTimeMillis() / 1000 / 60 / 60

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -93,6 +93,7 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
 
   def migrateWithDownsamplePartKeys(partKeys: Observable[PartKeyRecord], shard: Int): Int = {
     @volatile var count = 0
+    val rawDataSource = rawCassandraColStore
     val pkRecords = partKeys.filter { pk =>
       val rawSchemaId = RecordSchema.schemaID(pk.partKey, UnsafeUtils.arayOffset)
       val schema = schemas(rawSchemaId)
@@ -107,7 +108,7 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
       val eligible = hasDownsampleSchema && !blocked
       if (eligible) count += 1
       eligible
-    }.map(pkr => dsDatasource.readMergePartkeyStartEndTime(ref = dsDatasetRef, shard = shard.toInt,
+    }.map(pkr => rawDataSource.readMergePartkeyStartEndTime(ref = rawDatasetRef, shard = shard.toInt,
         partKeyRecord = pkr)) // Merge with persisted (if exists) partKey.
       .map(toDownsamplePkrWithHash)
     val updateHour = System.currentTimeMillis() / 1000 / 60 / 60

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -463,7 +463,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       Await.result(partKeys.map(pkMetricName).toListL.runToFuture, 1 minutes)
     }
 
-    // partkey start/endtimes are merged such that starttime and endtime are resolved to oldest latest respectively.
+    // partkey start/endtimes are merged are overridden by the latest partkey record read from raw cluster.
     val startTime = 74372801000L
     val readKeys = readPartKeys.map(_._1).toSet
     val counterPartkey = readPartKeys.filter(_._1 == counterName).head._2

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -467,7 +467,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val startTime = 74372801000L
     val readKeys = readPartKeys.map(_._1).toSet
     val counterPartkey = readPartKeys.filter(_._1 == counterName).head._2
-    counterPartkey.startTime shouldEqual startTime - 3600000
+    counterPartkey.startTime shouldEqual startTime
     counterPartkey.endTime shouldEqual currTime + 3600000
 
     // readKeys should not contain untyped part key - we dont downsample untyped


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This fix is to make sure that Partkey's start and endtimes are overridden with raw cluster persisted values during migration.