### PR TITLE
fix(coord) Stateful set ShardManager bug fix

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/ShardAssignmentStrategySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardAssignmentStrategySpec.scala
@@ -69,25 +69,44 @@ class ShardAssignmentStrategySpec extends AkkaSpec {
         val resources = DatasetResourceSpec(numShards, numCoords)
         val mapper = new ShardMapper(numShards)
 
+        // After assigned to coordinator, the shardAssignment should return empty list and remainingCapacity should
+        // be 0
         val assignment1 = testK8sStrategy.shardAssignments(coord1.ref, dataset, resources, mapper)
         assignment1 shouldEqual Seq(0, 1)
+        testK8sStrategy.remainingCapacity(coord1.ref, dataset, resources, mapper) shouldEqual 2
         mapper.registerNode(assignment1, coord1.ref)
+        val assignment1a = testK8sStrategy.shardAssignments(coord1.ref, dataset, resources, mapper)
+        assignment1a shouldEqual Seq.empty
+        testK8sStrategy.remainingCapacity(coord1.ref, dataset, resources, mapper) shouldEqual 0
+
 
         val assignment2 = testK8sStrategy.shardAssignments(coord2.ref, dataset, resources, mapper)
         assignment2 shouldEqual Seq(2, 3)
         mapper.registerNode(assignment2, coord2.ref)
+        val assignment2a = testK8sStrategy.shardAssignments(coord2.ref, dataset, resources, mapper)
+        assignment2a shouldEqual Seq.empty
+        testK8sStrategy.remainingCapacity(coord2.ref, dataset, resources, mapper) shouldEqual 0
 
         val assignment3 = testK8sStrategy.shardAssignments(coord3.ref, dataset, resources, mapper)
         assignment3 shouldEqual Seq(4, 5)
         mapper.registerNode(assignment3, coord3.ref)
+        val assignment3a = testK8sStrategy.shardAssignments(coord3.ref, dataset, resources, mapper)
+        assignment3a shouldEqual Seq.empty
+        testK8sStrategy.remainingCapacity(coord3.ref, dataset, resources, mapper) shouldEqual 0
 
         val assignment4 = testK8sStrategy.shardAssignments(coord4.ref, dataset, resources, mapper)
         assignment4 shouldEqual Seq(6)
         mapper.registerNode(assignment4, coord4.ref)
+        val assignment4a = testK8sStrategy.shardAssignments(coord4.ref, dataset, resources, mapper)
+        assignment4a shouldEqual Seq.empty
+        testK8sStrategy.remainingCapacity(coord4.ref, dataset, resources, mapper) shouldEqual 0
 
         val assignment5 = testK8sStrategy.shardAssignments(coord5.ref, dataset, resources, mapper)
         assignment5 shouldEqual Seq(7)
         mapper.registerNode(assignment5, coord5.ref)
+        val assignment5a = testK8sStrategy.shardAssignments(coord5.ref, dataset, resources, mapper)
+        assignment5a shouldEqual Seq.empty
+        testK8sStrategy.remainingCapacity(coord5.ref, dataset, resources, mapper) shouldEqual 0
 
       }
 


### PR DESCRIPTION
**Pull Request checklist**
- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Currently ``shardAssignments`` method given a coordinator returns the list of shards the provided coordinator are assigned to. However, the method should just return just the unassigned shards and not a static list. The current implementation returns a static list which works at startup but when nodes go down, all nodes are reported as unassigned despite those nodes serving the data. This the ``num_active_shards`` metrics incorrectly reports the shards as assigned and not active.


**New behavior :**

The ``shardAssignments``'s implementation is now changed to return a subset of the unassigned shards the provide coordinator should serve. If there are none, an empty list if returned. The unit tests are updated accordingly. 

