### PR TITLE
fix(query) Metadata queries with one valid and one invalid tag returns garbled content

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -108,7 +108,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
     // FIXME
     // Single label value query, older version returns Map type where as newer version works with List type
     // so this explicit handling is added for backward compatibility.
-    if(data.nonEmpty && data(0).value.size == 1) {
+    if(data.nonEmpty && urlParams.get("labels").map(_.split(",").size).getOrElse(0) == 1) {
       val iteratorMap = data.flatMap{ r => r.value.map { v => v._2 }}
       import NoCloseCursor._
       val rangeVector = IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**

``MetadataRemoteExec`` as part of optimization  PR https://github.com/filodb/FiloDB/pull/1362, if the data response size is a singleton map, the key name is skipped and the values are returned as a list of strings. However, when a column given is incorrect and does not exist in index, the response has to be a map. 

**New behavior :**

The change checks if the labels given are more than 1 and responds with a string of lists or a singleton map accordingly.
