### PR TITLE
feat(query, coord): Part 1 of Query Result Streaming

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
@@ -106,7 +106,7 @@ case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends Pl
              target.tell(plan.execPlan, resultActor)
              qLogger.debug(s"Sent to $target the plan ${plan.execPlan}")
            })
-           .takeWhileInclusive(_.isLast)
+           .takeWhileInclusive(!_.isLast)
            .guarantee(Task.eval {
              qLogger.debug(s"Stopping $resultActor")
              system.stop(resultActor)

--- a/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
@@ -76,8 +76,7 @@ case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends Pl
     if (remainingTime < 1) {
       Observable.raiseError(QueryTimeoutException(queryTimeElapsed, this.getClass.getName))
     } else {
-//      val t = FiniteDuration(remainingTime, TimeUnit.MILLISECONDS)
-      // TODO timeout query
+      // TODO timeout query if response stream not completed in time
 
       // Query Planner sets target as null when shard is down
       if (target == ActorRef.noSender) {

--- a/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
@@ -1,0 +1,112 @@
+package filodb.coordinator
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.pattern.{ask, AskTimeoutException}
+import akka.util.Timeout
+import monix.catnap.ConcurrentQueue
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
+
+import filodb.coordinator.ActorSystemHolder.system
+import filodb.core.QueryTimeoutException
+import filodb.core.query.{QueryStats, ResultSchema}
+import filodb.core.store.ChunkSource
+import filodb.query.{QueryResponse, QueryResult, StrQueryResponse, StrQueryResultFooter}
+import filodb.query.Query.qLogger
+import filodb.query.exec.{ExecPlanWithClientParams, PlanDispatcher}
+
+
+/**
+ * This implementation provides a way to distribute query execution
+ * using Akka Actors.
+ */
+case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends PlanDispatcher {
+
+  def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)(implicit sched: Scheduler): Task[QueryResponse] = {
+    // "source" is unused (the param exists to support InProcessDispatcher).
+    val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
+    val remainingTime = plan.clientParams.deadline - queryTimeElapsed
+    lazy val emptyPartialResult: QueryResult = QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil,
+      QueryStats(), true, Some("Result may be partial since query on some shards timed out"))
+
+    // Don't send if time left is very small
+    if (remainingTime < 1) {
+      Task.raiseError(QueryTimeoutException(queryTimeElapsed, this.getClass.getName))
+    } else {
+      val t = Timeout(FiniteDuration(remainingTime, TimeUnit.MILLISECONDS))
+
+      // Query Planner sets target as null when shard is down
+      if (target == ActorRef.noSender) {
+        Task.eval({
+          qLogger.warn(s"Creating partial result as shard is not available")
+          emptyPartialResult
+        })
+      } else {
+        val fut = (target ? plan.execPlan) (t).map {
+          case resp: QueryResponse => resp
+          case e => throw new IllegalStateException(s"Received bad response $e")
+        }
+          // TODO We can send partial results on timeout. Try later. Need to address QueryTimeoutException too.
+          .recover { // if partial results allowed, then return empty result
+            case e: AskTimeoutException if (plan.execPlan.queryContext.plannerParams.allowPartialResults)
+            =>
+              qLogger.warn(s"Swallowed AskTimeoutException for query id: ${plan.execPlan.queryContext.queryId} " +
+                s"since partial result was enabled: ${e.getMessage}")
+              emptyPartialResult
+          }
+
+        Task.fromFuture(fut)
+      }
+    }
+  }
+
+  def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+                       (implicit sched: Scheduler): Observable[StrQueryResponse] = {
+    // "source" is unused (the param exists to support InProcessDispatcher).
+    val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
+    val remainingTime = plan.clientParams.deadline - queryTimeElapsed
+    lazy val emptyPartialResult = StrQueryResultFooter(plan.execPlan.queryContext.queryId,
+      QueryStats(), true, Some("Result may be partial since query on some shards timed out"))
+
+    // Don't send if time left is very small
+    if (remainingTime < 1) {
+      Observable.raiseError(QueryTimeoutException(queryTimeElapsed, this.getClass.getName))
+    } else {
+      val t = FiniteDuration(remainingTime, TimeUnit.MILLISECONDS)
+
+      // Query Planner sets target as null when shard is down
+      if (target == ActorRef.noSender) {
+        Observable.now({
+          qLogger.warn(s"Creating partial result as shard is not available")
+          emptyPartialResult
+        })
+      } else {
+        Observable.fromTask(ConcurrentQueue.unbounded[Task, StrQueryResponse]()).flatMap { queue =>
+          class ResultActor extends Actor {
+            def receive: Receive = {
+              case q: StrQueryResponse => queue.offer(q)
+            }
+          }
+          // temporary actor to get streaming results
+          val resultActor = system.actorOf(Props.create(classOf[ResultActor]))
+          target.tell(plan, resultActor) // send the query to the target
+          // deal with timeout by sending partial result flag
+          lazy val timeoutPartialResult = StrQueryResultFooter(plan.execPlan.queryContext.queryId,
+            QueryStats(), true, Some("Result may be partial since some shards did not respond in time"))
+          system.scheduler.scheduleOnce(t, resultActor, timeoutPartialResult)(system.dispatcher, Actor.noSender)
+          Observable.repeatEvalF(queue.poll)
+            .takeWhileInclusive(_.isInstanceOf[StrQueryResultFooter])
+            .guarantee(Task.eval(system.stop(resultActor)))
+        }
+      }
+    }
+
+  }
+
+  override def isLocalCall: Boolean = false
+}

--- a/coordinator/src/main/scala/filodb.coordinator/ActorSystemHolder.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ActorSystemHolder.scala
@@ -1,0 +1,18 @@
+package filodb.coordinator
+
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+
+/**
+ * Provides singleton access to the actor system.
+ * Should be called exactly once at JVM startup.
+ */
+object ActorSystemHolder {
+  var system: ActorSystem = _
+
+  def createActorSystem(name: String, config: Config): ActorSystem = {
+    system = ActorSystem("filo-standalone", config)
+    system
+  }
+
+}

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -264,7 +264,7 @@ private[filodb] trait FilodbClusterNode extends KamonInit with NodeConfiguration
       case _ => ConfigFactory.parseString(s"""akka.cluster.roles=["${role.roleName}"]""")
     }).withFallback(systemConfig)
 
-    ActorSystem(role.systemName, allConfig)
+    ActorSystemHolder.createActorSystem(role.systemName, allConfig)
   }
 
   lazy val cluster = FilodbCluster(system)

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -239,7 +239,7 @@ final class QueryActor(memStore: TimeSeriesStore,
   }
 
   def streamToFatQueryResponse(queryContext: QueryContext, resp: Observable[StrQueryResponse]): Task[QueryResponse] = {
-    resp.takeWhileInclusive(_.isLast).toListL.map { r =>
+    resp.takeWhileInclusive(!_.isLast).toListL.map { r =>
       r.collectFirst {
         case StrQueryError(id, stats, t) => QueryError(id, stats, t)
       }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -8,7 +8,7 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.query.QueryContext
-import filodb.query.{LogicalPlan, QueryResponse, StrQueryResponse}
+import filodb.query.{LogicalPlan, QueryResponse, StreamQueryResponse}
 import filodb.query.exec.{ClientParams, ExecPlan, ExecPlanWithClientParams, UnsupportedChunkSource}
 
 /**
@@ -44,7 +44,7 @@ trait QueryPlanner {
 
   def dispatchStreamingExecPlan(execPlan: ExecPlan,
                        parentSpan: kamon.trace.Span)
-                      (implicit sched: Scheduler, timeout: FiniteDuration): Observable[StrQueryResponse] = {
+                      (implicit sched: Scheduler, timeout: FiniteDuration): Observable[StreamQueryResponse] = {
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -5,9 +5,10 @@ import scala.concurrent.duration.FiniteDuration
 import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 
 import filodb.core.query.QueryContext
-import filodb.query.{LogicalPlan, QueryResponse}
+import filodb.query.{LogicalPlan, QueryResponse, StrQueryResponse}
 import filodb.query.exec.{ClientParams, ExecPlan, ExecPlanWithClientParams, UnsupportedChunkSource}
 
 /**
@@ -40,4 +41,19 @@ trait QueryPlanner {
         ClientParams(execPlan.queryContext.plannerParams.queryTimeoutMillis)), UnsupportedChunkSource())
     }
   }
+
+  def dispatchStreamingExecPlan(execPlan: ExecPlan,
+                       parentSpan: kamon.trace.Span)
+                      (implicit sched: Scheduler, timeout: FiniteDuration): Observable[StrQueryResponse] = {
+    // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
+    // across threads. Note that task/observable will not run on the thread where span is present since
+    // kamon uses thread-locals.
+    // Dont finish span since this code didnt create it
+    Kamon.runWithSpan(parentSpan, false) {
+      // UnsupportedChunkSource because leaf plans shouldn't execute in-process from a planner method call.
+      execPlan.dispatcher.dispatchStreaming(ExecPlanWithClientParams(execPlan,
+        ClientParams(execPlan.queryContext.plannerParams.queryTimeoutMillis)), UnsupportedChunkSource())
+    }
+  }
+
 }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorRef
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 
-import filodb.coordinator.ShardMapper
+import filodb.coordinator.{ActorPlanDispatcher, ShardMapper}
 import filodb.coordinator.client.QueryCommands.StaticSpreadProvider
 import filodb.core.{SpreadProvider, StaticTargetSchemaProvider, TargetSchemaChange, TargetSchemaProvider}
 import filodb.core.binaryrecord2.RecordBuilder

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -3,10 +3,12 @@ package filodb.coordinator.queryplanner
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
-import filodb.coordinator.ShardMapper
 
+import filodb.coordinator.{ActorPlanDispatcher, ShardMapper}
 import scala.concurrent.duration._
+
 import monix.execution.Scheduler
+
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
 import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
@@ -27,7 +29,8 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
     override def submitTime: Long = ???
     override def dataset: DatasetRef = ???
     override def dispatcher: PlanDispatcher = ???
-    override def doExecute(source: ChunkSource, querySession: QuerySession)
+    override def doExecute(source: ChunkSource,
+                           querySession: QuerySession)
                           (implicit sched: Scheduler): ExecResult = ???
     override protected def args: String = ???
   }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -6,7 +6,8 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import filodb.coordinator.ShardMapper
+
+import filodb.coordinator.{ActorPlanDispatcher, ShardMapper}
 import filodb.core.MetricsTestData
 import filodb.core.metadata.Schemas
 import filodb.prometheus.ast.TimeStepParams
@@ -17,8 +18,6 @@ import filodb.prometheus.parse.Parser
 import filodb.query.InstantFunctionId.{Exp, HistogramQuantile, Ln}
 import filodb.query.exec._
 import filodb.query.AggregationOperator._
-
-
 import scala.language.postfixOps
 
 class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFutures with PlanValidationSpec {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import monix.execution.Scheduler
 
-import filodb.coordinator.ShardMapper
+import filodb.coordinator.{ActorPlanDispatcher, ShardMapper}
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
 import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext, QuerySession}
@@ -61,7 +61,8 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
     override def submitTime: Long = 1000
     override def dataset: DatasetRef = ???
     override def dispatcher: PlanDispatcher = InProcessPlanDispatcher(queryConfig)
-    override def doExecute(source: ChunkSource, querySession: QuerySession)
+    override def doExecute(source: ChunkSource,
+                           querySession: QuerySession)
                           (implicit sched: Scheduler): ExecResult = ???
     override protected def args: String = "mock-args"
   }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -603,6 +603,10 @@ akka {
       "filodb.coordinator.StatusActor$StatusAck" = kryo
       "filodb.coordinator.CurrentShardSnapshot" = kryo
 
+      "filodb.query.StrQueryError" = kryo
+      "filodb.query.StrQueryResult" = kryo
+      "filodb.query.StrQueryResultHeader" = kryo
+      "filodb.query.StrQueryResultFooter" = kryo
       "filodb.query.QueryResult" = kryo
       "filodb.query.QueryError" = kryo
       "filodb.query.exec.ExecPlan" = kryo

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -603,10 +603,10 @@ akka {
       "filodb.coordinator.StatusActor$StatusAck" = kryo
       "filodb.coordinator.CurrentShardSnapshot" = kryo
 
-      "filodb.query.StrQueryError" = kryo
-      "filodb.query.StrQueryResult" = kryo
-      "filodb.query.StrQueryResultHeader" = kryo
-      "filodb.query.StrQueryResultFooter" = kryo
+      "filodb.query.StreamQueryError" = kryo
+      "filodb.query.StreamQueryResult" = kryo
+      "filodb.query.StreamQueryResultHeader" = kryo
+      "filodb.query.StreamQueryResultFooter" = kryo
       "filodb.query.QueryResult" = kryo
       "filodb.query.QueryError" = kryo
       "filodb.query.exec.ExecPlan" = kryo

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -163,6 +163,7 @@ object QueryContext {
   */
 case class QuerySession(qContext: QueryContext,
                         queryConfig: QueryConfig,
+                        streamingDispatch: Boolean = false, // TODO needs to be removed after streaming becomes stable
                         catchMultipleLockSetErrors: Boolean = false) {
 
   val queryStats: QueryStats = QueryStats()
@@ -245,5 +246,6 @@ case class QueryStats() {
 }
 
 object QuerySession {
-  def makeForTestingOnly(): QuerySession = QuerySession(QueryContext(), QueryConfig.unitTestingQueryConfig)
+  def makeForTestingOnly(): QuerySession = QuerySession(QueryContext(),
+    QueryConfig.unitTestingQueryConfig, streamingDispatch = false)
 }

--- a/query/src/main/scala/filodb/query/Query.scala
+++ b/query/src/main/scala/filodb/query/Query.scala
@@ -9,7 +9,7 @@ import kamon.Kamon
   * in the log message.
   */
 object Query extends StrictLogging {
-  protected[query] val qLogger: Logger = logger
+  val qLogger: Logger = logger
   // TODO refine with dataset tag
   protected[query] val droppedSamples = Kamon.counter("query-dropped-samples").withoutTags
 }

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -65,7 +65,6 @@ final case class QueryResult(id: String,
   }
 }
 
-
 sealed trait StrQueryResponse extends NodeResponse with java.io.Serializable {
   def id: String
   def isLast: Boolean = false
@@ -89,6 +88,6 @@ final case class StrQueryError(id: String,
                             queryStats: QueryStats,
                             t: Throwable) extends StrQueryResponse with filodb.core.ErrorResponse {
   override def isLast: Boolean = true
-  override def toString: String = s"QueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
+  override def toString: String = s"StrQueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
     t.getStackTrace.map(_.toString).mkString("\n")
 }

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -87,6 +87,6 @@ final case class StreamQueryError(id: String,
                                   queryStats: QueryStats,
                                   t: Throwable) extends StreamQueryResponse with filodb.core.ErrorResponse {
   override def isLast: Boolean = true
-  override def toString: String = s"StrQueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
+  override def toString: String = s"StreamQueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
     t.getStackTrace.map(_.toString).mkString("\n")
 }

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -65,3 +65,25 @@ final case class QueryResult(id: String,
   }
 }
 
+
+sealed trait StrQueryResponse extends NodeResponse with java.io.Serializable {
+  def id: String
+}
+
+final case class StrQueryResultHeader(id: String,
+                                resultSchema: ResultSchema) extends StrQueryResponse
+
+final case class StrQueryResult(id: String,
+                                result: RangeVector) extends StrQueryResponse
+
+final case class StrQueryResultFooter(id: String,
+                                      queryStats: QueryStats = QueryStats(),
+                                      mayBePartial: Boolean = false,
+                                      partialResultReason: Option[String] = None) extends StrQueryResponse
+
+final case class StrQueryError(id: String,
+                            queryStats: QueryStats,
+                            t: Throwable) extends StrQueryResponse with filodb.core.ErrorResponse {
+  override def toString: String = s"QueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
+    t.getStackTrace.map(_.toString).mkString("\n")
+}

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -65,28 +65,27 @@ final case class QueryResult(id: String,
   }
 }
 
-sealed trait StrQueryResponse extends NodeResponse with java.io.Serializable {
+sealed trait StreamQueryResponse extends NodeResponse with java.io.Serializable {
   def id: String
   def isLast: Boolean = false
 }
 
-final case class StrQueryResultHeader(id: String,
-                                      resultSchema: ResultSchema) extends StrQueryResponse {
-}
+final case class StreamQueryResultHeader(id: String,
+                                         resultSchema: ResultSchema) extends StreamQueryResponse
 
-final case class StrQueryResult(id: String,
-                                result: RangeVector) extends StrQueryResponse
+final case class StreamQueryResult(id: String,
+                                   result: RangeVector) extends StreamQueryResponse
 
-final case class StrQueryResultFooter(id: String,
-                                      queryStats: QueryStats = QueryStats(),
-                                      mayBePartial: Boolean = false,
-                                      partialResultReason: Option[String] = None) extends StrQueryResponse {
+final case class StreamQueryResultFooter(id: String,
+                                         queryStats: QueryStats = QueryStats(),
+                                         mayBePartial: Boolean = false,
+                                         partialResultReason: Option[String] = None) extends StreamQueryResponse {
   override def isLast: Boolean = true
 }
 
-final case class StrQueryError(id: String,
-                            queryStats: QueryStats,
-                            t: Throwable) extends StrQueryResponse with filodb.core.ErrorResponse {
+final case class StreamQueryError(id: String,
+                                  queryStats: QueryStats,
+                                  t: Throwable) extends StreamQueryResponse with filodb.core.ErrorResponse {
   override def isLast: Boolean = true
   override def toString: String = s"StrQueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
     t.getStackTrace.map(_.toString).mkString("\n")

--- a/query/src/main/scala/filodb/query/ResultTypes.scala
+++ b/query/src/main/scala/filodb/query/ResultTypes.scala
@@ -68,10 +68,12 @@ final case class QueryResult(id: String,
 
 sealed trait StrQueryResponse extends NodeResponse with java.io.Serializable {
   def id: String
+  def isLast: Boolean = false
 }
 
 final case class StrQueryResultHeader(id: String,
-                                resultSchema: ResultSchema) extends StrQueryResponse
+                                      resultSchema: ResultSchema) extends StrQueryResponse {
+}
 
 final case class StrQueryResult(id: String,
                                 result: RangeVector) extends StrQueryResponse
@@ -79,11 +81,14 @@ final case class StrQueryResult(id: String,
 final case class StrQueryResultFooter(id: String,
                                       queryStats: QueryStats = QueryStats(),
                                       mayBePartial: Boolean = false,
-                                      partialResultReason: Option[String] = None) extends StrQueryResponse
+                                      partialResultReason: Option[String] = None) extends StrQueryResponse {
+  override def isLast: Boolean = true
+}
 
 final case class StrQueryError(id: String,
                             queryStats: QueryStats,
                             t: Throwable) extends StrQueryResponse with filodb.core.ErrorResponse {
+  override def isLast: Boolean = true
   override def toString: String = s"QueryError id=$id ${t.getClass.getName} ${t.getMessage}\n" +
     t.getStackTrace.map(_.toString).mkString("\n")
 }

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -65,7 +65,6 @@ trait ReduceAggregateExec extends NonLeafExecPlan {
       }
     Observable.fromTask(task).flatten
   }
-
 }
 
 /**

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -61,6 +61,10 @@ final case class BinaryJoinExec(queryContext: QueryContext,
 
   protected def args: String = s"binaryOp=$binaryOp, on=$on, ignoring=$ignoring"
 
+  protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = ???
+
   //scalastyle:off method.length
   protected[exec] def compose(childResponses: Observable[(QueryResult, Int)],
                               firstSchema: Task[ResultSchema],

--- a/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
+++ b/query/src/main/scala/filodb/query/exec/DistConcatExec.scala
@@ -19,6 +19,12 @@ trait DistConcatExec extends NonLeafExecPlan {
                         querySession: QuerySession): Observable[RangeVector] = {
     childResponses.flatMap(res => Observable.fromIterable(res._1.result))
   }
+
+  protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = {
+    childResponses.flatMap(_._1)
+  }
 }
 
 /**

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -87,7 +87,7 @@ trait ExecPlan extends QueryCommand {
    * This first invokes the doExecute abstract method, then applies
    * the RangeVectorMappers associated with this plan node.
    *
-   * The response is a stream of StrQueryResponse Observable which can
+   * The response is a stream of StreamQueryResponse Observable which can
    * be streamed out to the wire, or processed as optimally appropriate.
    * The advantage of using this over `execute` is that this method uses
    * much less memory than when converted to a fat response object.

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -15,7 +15,7 @@ import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
 import filodb.core.query.{QueryConfig, QuerySession, QueryStats, ResultSchema}
 import filodb.core.store._
-import filodb.query.{QueryResponse, QueryResult, StrQueryResponse}
+import filodb.query.{QueryResponse, QueryResult, StreamQueryResponse}
 import filodb.query.Query.qLogger
 
 /**
@@ -56,7 +56,7 @@ import filodb.query.Query.qLogger
 
   override def dispatchStreaming(plan: ExecPlanWithClientParams,
                                  source: ChunkSource)
-                                (implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                (implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
 }
 
 /**

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -37,7 +37,7 @@ import filodb.query.Query.qLogger
     Kamon.runWithSpan(Kamon.currentSpan(), false) {
       // translate implicit ExecutionContext to monix.Scheduler
       val querySession = QuerySession(plan.execPlan.queryContext, queryConfig,
-                              streamingDispatch = false,
+                              streamingDispatch = PlanDispatcher.streamingResultsEnabled,
                               catchMultipleLockSetErrors = true)
       plan.execPlan.execute(source, querySession)
         .timeout(plan.clientParams.deadline.milliseconds)

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -34,6 +34,10 @@ trait MetadataDistConcatExec extends NonLeafExecPlan {
    */
   override protected def args: String = ""
 
+  protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = ???
+
   /**
     * Compose the sub-query/leaf results here.
     */
@@ -94,6 +98,10 @@ final case class TsCardReduceExec(queryContext: QueryContext,
     }
     acc
   }
+
+  protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = ???
 
   override protected def compose(childResponses: Observable[(QueryResult, Int)],
                                  firstSchema: Task[ResultSchema],
@@ -190,6 +198,11 @@ final class LabelCardinalityPresenter(val funcParams: Seq[FuncArgs]  = Nil) exte
 final case class LabelNamesDistConcatExec(queryContext: QueryContext,
                                            dispatcher: PlanDispatcher,
                                            children: Seq[ExecPlan]) extends MetadataDistConcatExec {
+
+  override protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = ???
+
   /**
    * Pick first non empty result from child.
    */
@@ -211,10 +224,12 @@ trait LabelCardinalityExecPlan {
 }
 final case class LabelCardinalityReduceExec(queryContext: QueryContext,
                                             dispatcher: PlanDispatcher,
-                                            children: Seq[ExecPlan]) extends DistConcatExec
+                                            children: Seq[ExecPlan]) extends NonLeafExecPlan
                                             with LabelCardinalityExecPlan {
 
   import scala.collection.mutable.{Map => MutableMap}
+
+  protected def args: String = ""
 
   private def mapConsumer(sketchMap: MutableMap[ZeroCopyUTF8String, CpcSketch]) = new MapItemConsumer {
     def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
@@ -235,6 +250,10 @@ final case class LabelCardinalityReduceExec(queryContext: QueryContext,
       sketchMap += (key -> newSketch)
     }
   }
+
+  protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = ???
 
   override protected def compose(childResponses: Observable[(QueryResult, Int)],
                                  firstSchema: Task[ResultSchema],

--- a/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
@@ -8,7 +8,7 @@ import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, StrQueryResponse}
 
 object PlanDispatcher {
-  val streamingResultsEnabled = false
+  val streamingResultsEnabled = false // TODO enable when streaming support is complete in all non-leaf plans
 }
 
 /**

--- a/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
@@ -7,6 +7,10 @@ import monix.reactive.Observable
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, StrQueryResponse}
 
+object PlanDispatcher {
+  val streamingResultsEnabled = false
+}
+
 /**
   * This trait externalizes distributed query execution strategy
   * from the ExecPlan.

--- a/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
@@ -1,21 +1,11 @@
 package filodb.query.exec
 
-import java.util.concurrent.TimeUnit
-
-import scala.concurrent.duration.FiniteDuration
-
-import akka.actor.ActorRef
-import akka.pattern.{ask, AskTimeoutException}
-import akka.util.Timeout
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 
-import filodb.core.QueryTimeoutException
-import filodb.core.query.{QueryStats, ResultSchema}
 import filodb.core.store.ChunkSource
-import filodb.query.Query.qLogger
-import filodb.query.QueryResponse
-import filodb.query.QueryResult
+import filodb.query.{QueryResponse, StrQueryResponse}
 
 /**
   * This trait externalizes distributed query execution strategy
@@ -25,52 +15,8 @@ trait PlanDispatcher extends java.io.Serializable {
   def clusterName: String
   def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
               (implicit sched: Scheduler): Task[QueryResponse]
+
+  def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+                        (implicit sched: Scheduler): Observable[StrQueryResponse]
   def isLocalCall: Boolean
-}
-
-/**
-  * This implementation provides a way to distribute query execution
-  * using Akka Actors.
-  */
-case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends PlanDispatcher {
-
-  def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)(implicit sched: Scheduler): Task[QueryResponse] = {
-    // "source" is unused (the param exists to support InProcessDispatcher).
-    val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
-    val remainingTime = plan.clientParams.deadline - queryTimeElapsed
-    lazy val emptyPartialResult: QueryResult = QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil,
-      QueryStats(), true, Some("Result may be partial since query on some shards timed out"))
-
-    // Don't send if time left is very small
-    if (remainingTime < 1) {
-      Task.raiseError(QueryTimeoutException(queryTimeElapsed, this.getClass.getName))
-    } else {
-      val t = Timeout(FiniteDuration(remainingTime, TimeUnit.MILLISECONDS))
-
-      // Query Planner sets target as null when shard is down
-      if (target == ActorRef.noSender) {
-        Task.eval({
-          qLogger.warn(s"Creating partial result as shard is not available")
-          emptyPartialResult
-        })
-      } else {
-        val fut = (target ? plan.execPlan) (t).map {
-          case resp: QueryResponse => resp
-          case e => throw new IllegalStateException(s"Received bad response $e")
-        }
-          // TODO We can send partial results on timeout. Try later. Need to address QueryTimeoutException too.
-          .recover { // if partial results allowed, then return empty result
-            case e: AskTimeoutException if (plan.execPlan.queryContext.plannerParams.allowPartialResults)
-            =>
-              qLogger.warn(s"Swallowed AskTimeoutException for query id: ${plan.execPlan.queryContext.queryId} " +
-                s"since partial result was enabled: ${e.getMessage}")
-              emptyPartialResult
-          }
-
-        Task.fromFuture(fut)
-      }
-    }
-  }
-
-  override def isLocalCall: Boolean = false
 }

--- a/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
@@ -5,7 +5,7 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.store.ChunkSource
-import filodb.query.{QueryResponse, StrQueryResponse}
+import filodb.query.{QueryResponse, StreamQueryResponse}
 
 object PlanDispatcher {
   val streamingResultsEnabled = false // TODO enable when streaming support is complete in all non-leaf plans
@@ -21,6 +21,6 @@ trait PlanDispatcher extends java.io.Serializable {
               (implicit sched: Scheduler): Task[QueryResponse]
 
   def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
-                        (implicit sched: Scheduler): Observable[StrQueryResponse]
+                       (implicit sched: Scheduler): Observable[StreamQueryResponse]
   def isLocalCall: Boolean
 }

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -50,6 +50,10 @@ final case class SetOperatorExec(queryContext: QueryContext,
 
   protected def args: String = s"binaryOp=$binaryOp, on=$on, ignoring=$ignoring"
 
+  protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = ???
+
   protected[exec] def compose(childResponses: Observable[(QueryResult, Int)],
                               firstSchema: Task[ResultSchema],
                               querySession: QuerySession): Observable[RangeVector] = {

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -103,6 +103,10 @@ final case class StitchRvsExec(queryContext: QueryContext,
   }
   protected def args: String = ""
 
+  protected def composeStreaming(childResponses: Observable[(Observable[RangeVector], Int)],
+                                 schemas: Observable[(ResultSchema, Int)],
+                                 querySession: QuerySession): Observable[RangeVector] = ???
+
   protected[exec] def compose(childResponses: Observable[(QueryResult, Int)],
                         firstSchema: Task[ResultSchema],
                         querySession: QuerySession): Observable[RangeVector] = {

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -43,7 +43,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     override def isLocalCall: Boolean = ???
 
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   private def data(i: Int) = Stream.from(0).map(n => new TransientRow(n.toLong, i.toDouble)).take(20)

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -41,6 +41,9 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = ???
+
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
 
   private def data(i: Int) = Stream.from(0).map(n => new TransientRow(n.toLong, i.toDouble)).take(20)

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -44,7 +44,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
 
     override def isLocalCall: Boolean = ???
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   val sampleNodeCpu: Array[RangeVector] = Array(

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -43,6 +43,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = ???
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
 
   val sampleNodeCpu: Array[RangeVector] = Array(

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -46,6 +46,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = ???
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
   val resultSchema = ResultSchema(MetricsTestData.timeseriesSchema.infosFromIDs(0 to 1), 1)
   val resSchemaTask = Task.eval(resultSchema)

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -47,7 +47,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
 
     override def isLocalCall: Boolean = ???
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
   val resultSchema = ResultSchema(MetricsTestData.timeseriesSchema.infosFromIDs(0 to 1), 1)
   val resSchemaTask = Task.eval(resultSchema)

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -221,7 +221,7 @@ case class DummyDispatcher(memStore: TimeSeriesMemStore, querySession: QuerySess
 
   override def isLocalCall: Boolean = ???
   override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                 source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = {
+                                 source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = {
     plan.execPlan.executeStreaming(memStore, querySession)
   }
 }

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -1,15 +1,19 @@
 package filodb.query.exec
 
 import java.util.concurrent.{Executors, TimeUnit}
+
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
+
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
+
 import filodb.core.MetricsTestData.{builder, timeseriesDataset, timeseriesSchema}
 import filodb.core.TestData
 import filodb.core.binaryrecord2.{RecordBuilder, RecordContainer}
@@ -216,4 +220,8 @@ case class DummyDispatcher(memStore: TimeSeriesMemStore, querySession: QuerySess
   override def clusterName: String = ???
 
   override def isLocalCall: Boolean = ???
+  override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                 source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = {
+    plan.execPlan.executeStreaming(memStore, querySession)
+  }
 }

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -2,13 +2,16 @@ package filodb.query.exec
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
+
 import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
+
 import filodb.core.MetricsTestData._
 import filodb.core.TestData
 import filodb.core.binaryrecord2.BinaryRecordRowReader
@@ -104,6 +107,9 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = ???
+
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
 
   val executeDispatcher = new PlanDispatcher {
@@ -113,6 +119,9 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
                          (implicit sched: Scheduler): Task[QueryResponse] = {
       plan.execPlan.execute(memStore, querySession)(sched)
     }
+
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
 
   it ("should read the job names from timeseriesindex matching the columnfilters") {

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -109,7 +109,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     override def isLocalCall: Boolean = ???
 
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   val executeDispatcher = new PlanDispatcher {
@@ -121,7 +121,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     }
 
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   it ("should read the job names from timeseriesindex matching the columnfilters") {

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -1,6 +1,7 @@
 package filodb.query.exec
 
 import com.typesafe.config.ConfigFactory
+
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SchemaMismatch, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn, LongColumn, TimestampColumn}
@@ -19,8 +20,9 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
-
 import scala.concurrent.duration._
+
+import monix.reactive.Observable
 
 object MultiSchemaPartitionsExecSpec {
   val dummyDispatcher = new PlanDispatcher {
@@ -30,6 +32,9 @@ object MultiSchemaPartitionsExecSpec {
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = ???
+
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
 
   val dsRef = DatasetRef("raw-metrics")

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -34,7 +34,7 @@ object MultiSchemaPartitionsExecSpec {
     override def isLocalCall: Boolean = ???
 
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   val dsRef = DatasetRef("raw-metrics")

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -3,15 +3,17 @@ package filodb.query.exec
 import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
 import filodb.core.metadata.{Dataset, DatasetOptions}
 import filodb.core.query.{PromQlQueryParams, QueryContext}
 import filodb.core.store.ChunkSource
 import filodb.memory.format.vectors.MutableHistogram
 import filodb.query
-import filodb.query.{Data, HistSampl, MetadataMapSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, SuccessResponse}
+import filodb.query.{Data, HistSampl, MetadataMapSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, StrQueryResponse, SuccessResponse}
 
 
 class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
@@ -27,6 +29,9 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = ???
+
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
 
   val params = PromQlQueryParams("", 0, 0 , 0)

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -13,7 +13,7 @@ import filodb.core.query.{PromQlQueryParams, QueryContext}
 import filodb.core.store.ChunkSource
 import filodb.memory.format.vectors.MutableHistogram
 import filodb.query
-import filodb.query.{Data, HistSampl, MetadataMapSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, StrQueryResponse, SuccessResponse}
+import filodb.query.{Data, HistSampl, MetadataMapSampl, MetadataSuccessResponse, QueryResponse, QueryResult, Sampl, StreamQueryResponse, SuccessResponse}
 
 
 class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
@@ -31,7 +31,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     override def isLocalCall: Boolean = ???
 
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   val params = PromQlQueryParams("", 0, 0 , 0)

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -3,6 +3,7 @@ package filodb.query.exec
 import com.softwaremill.sttp.{Response, StatusCodes, SttpBackend}
 import com.softwaremill.sttp.testing.SttpBackendStub
 import com.typesafe.config.ConfigFactory
+
 import filodb.core.MetricsTestData._
 import filodb.core.binaryrecord2.BinaryRecordRowReader
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
@@ -22,12 +23,13 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
+
 import filodb.memory.format.ZeroCopyUTF8String._
-
-
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
+import monix.reactive.Observable
 
 class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
 
@@ -108,6 +110,11 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
     override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = {
       plan.execPlan.execute(memStore, querySession)(sched)
+    }
+
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = {
+      plan.execPlan.executeStreaming(memStore, querySession)(sched)
     }
   }
 

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -113,7 +113,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
     }
 
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = {
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = {
       plan.execPlan.executeStreaming(memStore, querySession)(sched)
     }
   }

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.ConfigFactory
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -21,7 +22,7 @@ import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSer
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.memory.MemFactory
-import filodb.query.{QueryResponse, QueryResult}
+import filodb.query.{QueryResponse, QueryResult, StrQueryResponse}
 
 object SplitLocalPartitionDistConcatExecSpec {
   val dummyDispatcher = new PlanDispatcher {
@@ -31,6 +32,9 @@ object SplitLocalPartitionDistConcatExecSpec {
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = ???
+
+    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
   }
 
   val dsRef = DatasetRef("raw-metrics")

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -22,7 +22,7 @@ import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSer
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.memory.MemFactory
-import filodb.query.{QueryResponse, QueryResult, StrQueryResponse}
+import filodb.query.{QueryResponse, QueryResult, StreamQueryResponse}
 
 object SplitLocalPartitionDistConcatExecSpec {
   val dummyDispatcher = new PlanDispatcher {
@@ -34,7 +34,7 @@ object SplitLocalPartitionDistConcatExecSpec {
     override def isLocalCall: Boolean = ???
 
     override def dispatchStreaming(plan: ExecPlanWithClientParams,
-                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StrQueryResponse] = ???
+                                   source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   val dsRef = DatasetRef("raw-metrics")

--- a/standalone/src/main/scala/filodb.standalone/NewFiloServerMain.scala
+++ b/standalone/src/main/scala/filodb.standalone/NewFiloServerMain.scala
@@ -2,7 +2,6 @@ package filodb.standalone
 
 import scala.concurrent.duration.FiniteDuration
 
-import akka.actor.ActorSystem
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import monix.execution.{Scheduler, UncaughtExceptionReporter}
@@ -24,7 +23,7 @@ object NewFiloServerMain extends StrictLogging {
 
       Kamon.init()
 
-      val system = ActorSystem("filo-standalone", allConfig)
+      val system = ActorSystemHolder.createActorSystem("filo-standalone", allConfig)
 
       lazy val ioPool = Scheduler.io(name = FiloSchedulers.IOSchedName,
         reporter = UncaughtExceptionReporter(


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
We send all Query Results as one huge akka message.
The Prometheus Json API is non-streaming. Hence the query-engine was implemented in a non-streaming way as well.
Large akka messages are not good. They use too much heap and create GC issues.

**New behavior :**
Stream query results, one range vector at a time. Also include header and footer to demarcate beginning and end of stream.
True that eventually the translation of result stream to a fat response happens. But it is at the very end and not at every point in the query execution pipeline. Also, the conversion can also be pushed out to a separate query facade process as a deployment option to protect FiloDB from the memory pressure.

**Testing:**

E2E POC test case works for simple data export query with DistConcatExec

**TODO in subsequent iterations:**
* Streaming Support for all non-leaf plans as we do today
* Query Limits
* Query Timeouts in Non-Leaf plans
* Log all errors and exceptions
* Edge cases
* Performance Testing

