### PR TITLE
fix(spark-job): make index job run only for downsample chunk window

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -70,10 +70,9 @@ class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSInde
     val jobIntervalInHours = dsIndexJobSettings.batchLookbackInHours
     val fromHour = hourInMigrationPeriod / jobIntervalInHours * jobIntervalInHours
 
-    // Index migration cannot be rerun just for specific hours, since there could have been
-    // subsequent updates. Perform migration for all hours until last downsample period's hour.
-    val currentHour = hour(System.currentTimeMillis())
-    val toHourExclDefault  = currentHour / jobIntervalInHours * jobIntervalInHours
+    // since we read (for staleness check) before updating index, we don't have to catch up to current time.
+    // We can run this job in cadence with Chunk Downsampler job.
+    val toHourExclDefault  = userTimeStart + dsSettings.downsampleChunkDuration
 
     // this override should almost never used by operators - only for unit testing
     val toHourExcl = spark.sparkContext.getConf


### PR DESCRIPTION


**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

Since we read (for staleness check) before updating index, we don't have to catch up to current time.
Job run is idempotent now.  With this change, job will be run in cadence with Chunk Downsampler job by default.