### PR TITLE
feat(downsample): add data export

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -425,11 +425,11 @@ filodb {
       # Describe the sequence of labels to use as a rule key.
       # A time-series should match at most one key.
       key = ["_ws_"]
-      bucket = "file:///Users/alextheimer/Desktop/csv"
+      bucket = "file://<path-to-file>"
       # Map rule-keys to specs.
       rules = [
         {
-          key = ["my_ws"]
+          key = ["unused-by-ds-tests"]
           filters = {
             included = [
               [
@@ -444,11 +444,19 @@ filodb {
           }
         }
       ]
-      # Specifies the path to the file to be exported.
-      # All {{label-name}} strings will be replaced with the label's value.
+      # Specifies how to generate a path to an exported time-series.
+      # The sequence of key-value pairs describe a directory path, where the
+      #   time-series are exported to the final directory.
+      # For example, if the path-spec is:
+      #     path-spec = [
+      #       "key1", "value1",
+      #       "key2", "value2"
+      #     ]
+      # then the exported time-series will be stored at the path:
+      #     ~/key1=value1/key2=value2/<file>
+      # All {{label-name}} strings will be replaced with the time-series label's value.
       # All <<time-spec>> strings will be replaced with the result of formatting
       #   the export window's end time with the time-spec string.
-      # TODO(a_theimer)
       path-spec = [
         "ws",   "{{_ws_}}-suffix1",
         "year", "<<YYYY>>-suffix2",

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -425,6 +425,8 @@ filodb {
 
     data-export {
       enabled = false
+      # See filodb.downsampler.chunk.SparkSessionSetup for details.
+      spark-session-setup-class = ""
       # Describe the sequence of labels that compose a rule's key.
       # A time-series should match at most one key.
       key-labels = ["_ws_"]

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -425,6 +425,10 @@ filodb {
 
     data-export {
       enabled = false
+      save-mode = "error"
+      options = {
+        "header": "true"
+      }
       # See filodb.downsampler.chunk.SparkSessionSetup for details.
       spark-session-setup-class = ""
       # Describe the sequence of labels that compose a rule's key.

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -425,11 +425,11 @@ filodb {
       # Describe the sequence of labels to use as a rule key.
       # A time-series should match at most one key.
       key = ["_ws_"]
+      bucket = "file:///Users/alextheimer/Desktop/csv"
       # Map rule-keys to specs.
       rules = [
         {
           key = ["my_ws"]
-          bucket = "foo.bar.com"
           filters = {
             included = [
               [
@@ -448,11 +448,12 @@ filodb {
       # All {{label-name}} strings will be replaced with the label's value.
       # All <<time-spec>> strings will be replaced with the result of formatting
       #   the export window's end time with the time-spec string.
+      # TODO(a_theimer)
       path-spec = [
-        "{{_ws_}}-suffix1",
-        "<<YYYY>>-suffix2",
-        "v1",
-        "{{_ns_}}-suffix3"
+        "ws",   "{{_ws_}}-suffix1",
+        "year", "<<YYYY>>-suffix2",
+        "api",  "v1",
+        "ns",   "{{_ns_}}-suffix3"
       ]
     }
   }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -342,6 +342,8 @@ filodb {
 
   downsampler {
 
+    chunk-downsampler-enabled = true
+
     # Name of the dataset from which to downsample
     # raw-dataset-name = "prometheus"
 
@@ -422,26 +424,39 @@ filodb {
     ]
 
     data-export {
-      # Describe the sequence of labels to use as a rule key.
+      enabled = false
+      # Describe the sequence of labels that compose a rule's key.
       # A time-series should match at most one key.
-      key = ["_ws_"]
+      key-labels = ["_ws_"]
       bucket = "file://<path-to-file>"
-      # Map rule-keys to specs.
+      # Each row's labels are compared against all rule keys. If a match is found, the rule is applied.
+      #   Otherwise, no rule is applied (i.e. the data will not be exported).
+      # When a rule is applied, data will be exported only if:
+      #     - The labels must not match any group of block-filters, and
+      #     - Either of the following:
+      #         (1) Allow-filters is empty, or
+      #         (2) The labels match any allow-filters group.
+      # This mirrors the logic used by the chunk downsampler.
       rules = [
         {
-          key = ["unused-by-ds-tests"]
-          filters = {
-            included = [
-              [
-                "_ns_=\"my_ns\""
-              ]
-            ]
-            excluded = [
-              [
-                "_metric_=~\".*counter\""
-              ]
-            ]
-          }
+          key = ["ws-foo"]
+          allow-filters = [
+            ["_ns_=\"my_ns\"", "bar!=\"baz\""],
+            ["_ns_=\"my_other_ns\""]
+          ]
+          block-filters = [
+            ["_metric_=~\".*bad_suffix\""]
+          ]
+        },
+        {
+          key = ["ws-bar"]
+          allow-filters = [
+            ["_metric_=\"always_allowed\""]
+          ]
+          block-filters = [
+            ["_ns_=\"some_other_ns\"", "labelA!=\"bad_label\""],
+            ["label1=~\"labels_are_cool\""]
+          ]
         }
       ]
       # Specifies how to generate a path to an exported time-series.

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -420,6 +420,41 @@ filodb {
       #  tagB3 = value3
       #}
     ]
+
+    data-export {
+      # Describe the sequence of labels to use as a rule key.
+      # A time-series should match at most one key.
+      key = ["_ws_"]
+      # Map rule-keys to specs.
+      rules = [
+        {
+          key = ["my_ws"]
+          bucket = "foo.bar.com"
+          filters = {
+            included = [
+              [
+                "_ns_=\"my_ns\""
+              ]
+            ]
+            excluded = [
+              [
+                "_metric_=~\".*counter\""
+              ]
+            ]
+          }
+        }
+      ]
+      # Specifies the path to the file to be exported.
+      # All {{label-name}} strings will be replaced with the label's value.
+      # All <<time-spec>> strings will be replaced with the result of formatting
+      #   the export window's end time with the time-spec string.
+      path-spec = [
+        "{{_ws_}}-suffix1",
+        "<<YYYY>>-suffix2",
+        "v1",
+        "{{_ns_}}-suffix3"
+      ]
+    }
   }
 
   ds-index-job {

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -1,7 +1,8 @@
 package filodb.downsampler
 
-import filodb.core.store.{AllChunkScan, ChunkSetInfoReader, ReadablePartition}
 import kamon.Kamon
+
+import filodb.core.store.{AllChunkScan, ChunkSetInfoReader, ReadablePartition}
 
 object Utils {
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -1,8 +1,12 @@
 package filodb.downsampler
 
 import filodb.core.store.{AllChunkScan, ChunkSetInfoReader, ReadablePartition}
+import kamon.Kamon
 
 object Utils {
+
+  lazy val numRawChunksSkipped = Kamon.counter("num-raw-chunks-skipped").withoutTags()
+
   /**
    * Specifies a range of a chunk's rows.
    */
@@ -39,8 +43,7 @@ object Utils {
       .filter{ chunkRange =>
         val isValidChunk = chunkRange.istartRow <= chunkRange.iendRow
         if (!isValidChunk) {
-          // TODO(a_theimer): numRawChunksSkipped.increment()
-          // TODO(a_theimer): use DsContext?
+          numRawChunksSkipped.increment()
           DownsamplerContext.dsLogger.warn(s"Skipping chunk of partition since startRow lessThan endRow " +
             s"hexPartKey=${readablePart.hexPartKey} " +
             s"startRow=${chunkRange.istartRow} " +

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -11,10 +11,10 @@ object Utils {
                         istartRow: Int,
                         iendRow: Int)
 
-  case class ExportRow(partKeyMap: Map[String, String],
-                       timestamp: Long,
-                       value: Double,
-                       partitionStrings: Iterator[String])
+  case class ExportData(partKeyMap: Map[String, String],
+                        timestamp: Long,
+                        value: Double,
+                        partitionStrings: Iterator[String])
 
   /**
    * Determine, for each chunk, the range of rows with timestamps inside the time-range

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -11,11 +11,6 @@ object Utils {
                         istartRow: Int,
                         iendRow: Int)
 
-  case class ExportData(partKeyMap: Map[String, String],
-                        timestamp: Long,
-                        value: Double,
-                        partitionStrings: Iterator[String])
-
   /**
    * Determine, for each chunk, the range of rows with timestamps inside the time-range
    *   given by userTimeStart and userTimeEndExclusive.

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -1,0 +1,54 @@
+package filodb.downsampler
+
+import filodb.core.store.{AllChunkScan, ChunkSetInfoReader, ReadablePartition}
+
+object Utils {
+  // TODO(a_theimer): would be nice if this could be an iterator
+  /**
+   * Specifies a range of a chunk's rows.
+   */
+  case class ChunkRange(chunkSetInfoReader: ChunkSetInfoReader,
+                        istartRow: Int,
+                        iendRow: Int)
+
+  /**
+   * Determine, for each chunk, the range of rows with timestamps inside the time-range
+   *   given by userTimeStart and userTimeEndExclusive.
+   */
+  def getChunkRangeIter(readablePart: ReadablePartition,
+                                userTimeStart: Long,
+                                userTimeEndExclusive: Long): Iterator[ChunkRange] = {
+    val timestampCol = 0  // FIXME: need a dynamic (but efficient) way to determine this
+    val rawChunksets = readablePart.infos(AllChunkScan)
+
+    val it = new Iterator[ChunkSetInfoReader]() {
+      override def hasNext: Boolean = rawChunksets.hasNext
+      override def next(): ChunkSetInfoReader = rawChunksets.nextInfoReader
+    }
+
+    it.filter(chunkset => chunkset.startTime < userTimeEndExclusive && userTimeStart <= chunkset.endTime)
+      .map { chunkset =>
+        val tsPtr = chunkset.vectorAddress(timestampCol)
+        val tsAcc = chunkset.vectorAccessor(timestampCol)
+        val tsReader = readablePart.chunkReader(timestampCol, tsAcc, tsPtr).asLongReader
+
+        val startRow = tsReader.binarySearch(tsAcc, tsPtr, userTimeStart) & 0x7fffffff
+        // userTimeEndExclusive-1 since ceilingIndex does an inclusive check
+        val endRow = Math.min(tsReader.ceilingIndex(tsAcc, tsPtr, userTimeEndExclusive - 1), chunkset.numRows - 1)
+        ChunkRange(chunkset, startRow, endRow)
+      }
+      .filter{ chunkRange =>
+        val isValidChunk = chunkRange.istartRow <= chunkRange.iendRow
+        if (!isValidChunk) {
+          // TODO(a_theimer): numRawChunksSkipped.increment()
+          // TODO(a_theimer): use DsContext?
+          DownsamplerContext.dsLogger.warn(s"Skipping chunk of partition since startRow lessThan endRow " +
+            s"hexPartKey=${readablePart.hexPartKey} " +
+            s"startRow=${chunkRange.istartRow} " +
+            s"endRow=${chunkRange.iendRow} " +
+            s"chunkset: ${chunkRange.chunkSetInfoReader.debugString}")
+        }
+        isValidChunk
+      }
+  }
+}

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -11,6 +11,9 @@ object Utils {
                         istartRow: Int,
                         iendRow: Int)
 
+  // TODO(a_theimer): should be an interface
+  case class ExportRow(partKeyMap: Map[String, String], timestamp: Long, value: Double)
+
   /**
    * Determine, for each chunk, the range of rows with timestamps inside the time-range
    *   given by userTimeStart and userTimeEndExclusive.

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -3,7 +3,6 @@ package filodb.downsampler
 import filodb.core.store.{AllChunkScan, ChunkSetInfoReader, ReadablePartition}
 
 object Utils {
-  // TODO(a_theimer): would be nice if this could be an iterator
   /**
    * Specifies a range of a chunk's rows.
    */
@@ -16,8 +15,8 @@ object Utils {
    *   given by userTimeStart and userTimeEndExclusive.
    */
   def getChunkRangeIter(readablePart: ReadablePartition,
-                                userTimeStart: Long,
-                                userTimeEndExclusive: Long): Iterator[ChunkRange] = {
+                        userTimeStart: Long,
+                        userTimeEndExclusive: Long): Iterator[ChunkRange] = {
     val timestampCol = 0  // FIXME: need a dynamic (but efficient) way to determine this
     val rawChunksets = readablePart.infos(AllChunkScan)
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/Utils.scala
@@ -11,8 +11,10 @@ object Utils {
                         istartRow: Int,
                         iendRow: Int)
 
-  // TODO(a_theimer): should be an interface
-  case class ExportRow(partKeyMap: Map[String, String], timestamp: Long, value: Double)
+  case class ExportRow(partKeyMap: Map[String, String],
+                       timestamp: Long,
+                       value: Double,
+                       partitionStrings: Iterator[String])
 
   /**
    * Determine, for each chunk, the range of rows with timestamps inside the time-range

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -3,10 +3,12 @@ package filodb.downsampler.chunk
 import scala.collection.mutable.{ArrayBuffer, Map => MMap}
 import scala.concurrent.Await
 import scala.concurrent.duration.FiniteDuration
+
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import monix.reactive.Observable
 import spire.syntax.cfor._
+
 import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.core.{DatasetRef, ErrorResponse, Instance}
 import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -44,7 +44,6 @@ class BatchDownsampler(settings: DownsamplerSettings) extends Instance with Seri
                                                              .withoutTags()
   @transient lazy val numPartitionsFailed = Kamon.counter("num-partitions-failed").withoutTags()
   @transient lazy val numPartitionsSkipped = Kamon.counter("num-partitions-skipped").withoutTags()
-  @transient lazy val numRawChunksSkipped = Kamon.counter("num-raw-chunks-skipped").withoutTags()
   @transient lazy val numRawChunksDownsampled = Kamon.counter("num-raw-chunks-downsampled").withoutTags()
   @transient lazy val numDownsampledChunksWritten = Kamon.counter("num-downsampled-chunks-written").withoutTags()
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -214,11 +214,11 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
                              userStartTime: Long,
                              userEndTime: Long): Iterator[ExportRowData] = {
     val partKeyString = partKeyMap.map(pair => s"${pair._1}=${pair._2}").toSeq.sorted.mkString(",")
-    val partitionByValues = getPartitionByValues(partKeyMap, userStartTime)
     getChunkRangeIter(readablePartition, userStartTime, userEndTime).flatMap{ chunkRow =>
       getTimeValuePairs(partKeyMap, readablePartition,
         chunkRow.chunkSetInfoReader, chunkRow.istartRow, chunkRow.iendRow)
     }.map{ case (timestamp, value) =>
+      val partitionByValues = getPartitionByValues(partKeyMap, userStartTime)
       ExportRowData(partKeyMap, partKeyString, timestamp, value, partitionByValues)
     }
   }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -7,9 +7,9 @@ import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType.DoubleColumn
 import filodb.core.metadata.Schemas
 import filodb.core.query.ColumnFilter
-import filodb.core.store.{AllChunkScan, ChunkSetInfoReader, ReadablePartition}
-import filodb.downsampler.DownsamplerContext
-import filodb.downsampler.chunk.BatchExporter.{DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER, getChunkRangeIter}
+import filodb.core.store.{ChunkSetInfoReader, ReadablePartition}
+import filodb.downsampler.Utils._
+import filodb.downsampler.chunk.BatchExporter.{DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER}
 import filodb.memory.format.{TypedIterator, UnsafeUtils}
 
 case class ExportRule(key: Seq[String],
@@ -20,56 +20,6 @@ case class ExportRule(key: Seq[String],
 object BatchExporter {
   val LABEL_REGEX_MATCHER = """\{\{(.*)\}\}""".r
   val DATE_REGEX_MATCHER = """<<(.*)>>""".r
-
-  // TODO(a_theimer): would be nice if this could be an iterator
-  /**
-   * Specifies a range of a chunk's rows.
-   */
-  case class ChunkRange(chunkSetInfoReader: ChunkSetInfoReader,
-                        istartRow: Int,
-                        iendRow: Int)
-
-  // TODO(a_theimer): move this (and above) to utilities class
-  /**
-   * Determine, for each chunk, the range of rows with timestamps inside the time-range
-   *   given by userTimeStart and userTimeEndExclusive.
-   */
-  private def getChunkRangeIter(readablePart: ReadablePartition,
-                                userTimeStart: Long,
-                                userTimeEndExclusive: Long): Iterator[ChunkRange] = {
-    val timestampCol = 0  // FIXME: need a dynamic (but efficient) way to determine this
-    val rawChunksets = readablePart.infos(AllChunkScan)
-
-    val it = new Iterator[ChunkSetInfoReader]() {
-      override def hasNext: Boolean = rawChunksets.hasNext
-      override def next(): ChunkSetInfoReader = rawChunksets.nextInfoReader
-    }
-
-    it.filter(chunkset => chunkset.startTime < userTimeEndExclusive && userTimeStart <= chunkset.endTime)
-      .map { chunkset =>
-        val tsPtr = chunkset.vectorAddress(timestampCol)
-        val tsAcc = chunkset.vectorAccessor(timestampCol)
-        val tsReader = readablePart.chunkReader(timestampCol, tsAcc, tsPtr).asLongReader
-
-        val startRow = tsReader.binarySearch(tsAcc, tsPtr, userTimeStart) & 0x7fffffff
-        // userTimeEndExclusive-1 since ceilingIndex does an inclusive check
-        val endRow = Math.min(tsReader.ceilingIndex(tsAcc, tsPtr, userTimeEndExclusive - 1), chunkset.numRows - 1)
-        ChunkRange(chunkset, startRow, endRow)
-      }
-      .filter{ chunkRange =>
-        val isValidChunk = chunkRange.istartRow <= chunkRange.iendRow
-        if (!isValidChunk) {
-          // TODO(a_theimer): numRawChunksSkipped.increment()
-          // TODO(a_theimer): use DsContext?
-          DownsamplerContext.dsLogger.warn(s"Skipping chunk of partition since startRow lessThan endRow " +
-            s"hexPartKey=${readablePart.hexPartKey} " +
-            s"startRow=${chunkRange.istartRow} " +
-            s"endRow=${chunkRange.iendRow} " +
-            s"chunkset: ${chunkRange.chunkSetInfoReader.debugString}")
-        }
-        isValidChunk
-      }
-  }
 }
 
 /**

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -1,6 +1,16 @@
 package filodb.downsampler.chunk
 
 import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+
+import scala.collection.mutable
+
+import kamon.Kamon
+import kamon.metric.MeasurementUnit
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
+
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType.DoubleColumn
 import filodb.core.metadata.Schemas
@@ -10,20 +20,14 @@ import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.Utils._
 import filodb.downsampler.chunk.BatchExporter.{DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER}
 import filodb.memory.format.{TypedIterator, UnsafeUtils}
-import kamon.Kamon
-import kamon.metric.MeasurementUnit
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
-
-
-import java.text.SimpleDateFormat
-import java.util.Date
-import scala.collection.mutable
 
 case class ExportRule(key: Seq[String],
                       includeFilterGroups: Seq[Seq[ColumnFilter]],
                       excludeFilterGroups: Seq[Seq[ColumnFilter]])
 
+/**
+ * All info needed to output a result Spark Row.
+ */
 case class ExportRowData(partKeyMap: Map[String, String],
                          partKeyString: String,
                          timestamp: Long,

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -196,7 +196,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
     }
 
     if (shouldExport) {
-      val partKeyString = partKeyMap.toSeq.sortBy(pair => s"${pair._1}=${pair._2}").mkString(",")
+      val partKeyString = partKeyMap.map(pair => s"${pair._1}=${pair._2}").toSeq.sorted.mkString(",")
       val partitionByValues = makePartitionByValues(partKeyMap, userEndTime)
       getChunkRangeIter(readablePartition, userStartTime, userEndTime).flatMap{ chunkRow =>
         getTimeValuePairs(readablePartition, chunkRow.chunkSetInfoReader, chunkRow.istartRow, chunkRow.iendRow)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -172,8 +172,8 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
    * Returns the column values used to partition the data.
    * Value order should match the order of this.partitionByCols.
    */
-  def getPartitionByValues(partKeyMap: Map[String, String], userEndTime: Long): Iterator[String] = {
-    val date = new Date(userEndTime)
+  def getPartitionByValues(partKeyMap: Map[String, String], userStartTime: Long): Iterator[String] = {
+    val date = new Date(userStartTime)
     downsamplerSettings.exportPathSpecPairs.iterator.map(_._2)
       // replace the {{}} strings with labels
       .map{LABEL_REGEX_MATCHER.replaceAllIn(_, matcher => partKeyMap(matcher.group(1)))}
@@ -212,7 +212,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
                              userStartTime: Long,
                              userEndTime: Long): Iterator[ExportRowData] = {
     val partKeyString = partKeyMap.map(pair => s"${pair._1}=${pair._2}").toSeq.sorted.mkString(",")
-    val partitionByValues = getPartitionByValues(partKeyMap, userEndTime)
+    val partitionByValues = getPartitionByValues(partKeyMap, userStartTime)
     getChunkRangeIter(readablePartition, userStartTime, userEndTime).flatMap{ chunkRow =>
       getTimeValuePairs(partKeyMap, readablePartition,
         chunkRow.chunkSetInfoReader, chunkRow.istartRow, chunkRow.iendRow)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -1,0 +1,219 @@
+package filodb.downsampler.chunk
+
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import filodb.core.binaryrecord2.RecordSchema
+import filodb.core.metadata.Column.ColumnType.DoubleColumn
+import filodb.core.metadata.Schemas
+import filodb.core.query.ColumnFilter
+import filodb.core.store.{AllChunkScan, ChunkSetInfoReader, ReadablePartition}
+import filodb.downsampler.DownsamplerContext
+import filodb.downsampler.chunk.BatchExporter.{DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER, getChunkRangeIter}
+import filodb.memory.format.{TypedIterator, UnsafeUtils}
+
+case class ExportRule(key: Seq[String],
+                      bucket: String,
+                      includeFilterGroups: Seq[Seq[ColumnFilter]],
+                      excludeFilterGroups: Seq[Seq[ColumnFilter]])
+
+object BatchExporter {
+  val LABEL_REGEX_MATCHER = """\{\{(.*)\}\}""".r
+  val DATE_REGEX_MATCHER = """<<(.*)>>""".r
+
+  // TODO(a_theimer): would be nice if this could be an iterator
+  /**
+   * Specifies a range of a chunk's rows.
+   */
+  case class ChunkRange(chunkSetInfoReader: ChunkSetInfoReader,
+                        istartRow: Int,
+                        iendRow: Int)
+
+  // TODO(a_theimer): move this (and above) to utilities class
+  /**
+   * Determine, for each chunk, the range of rows with timestamps inside the time-range
+   *   given by userTimeStart and userTimeEndExclusive.
+   */
+  private def getChunkRangeIter(readablePart: ReadablePartition,
+                                userTimeStart: Long,
+                                userTimeEndExclusive: Long): Iterator[ChunkRange] = {
+    val timestampCol = 0  // FIXME: need a dynamic (but efficient) way to determine this
+    val rawChunksets = readablePart.infos(AllChunkScan)
+
+    val it = new Iterator[ChunkSetInfoReader]() {
+      override def hasNext: Boolean = rawChunksets.hasNext
+      override def next(): ChunkSetInfoReader = rawChunksets.nextInfoReader
+    }
+
+    it.filter(chunkset => chunkset.startTime < userTimeEndExclusive && userTimeStart <= chunkset.endTime)
+      .map { chunkset =>
+        val tsPtr = chunkset.vectorAddress(timestampCol)
+        val tsAcc = chunkset.vectorAccessor(timestampCol)
+        val tsReader = readablePart.chunkReader(timestampCol, tsAcc, tsPtr).asLongReader
+
+        val startRow = tsReader.binarySearch(tsAcc, tsPtr, userTimeStart) & 0x7fffffff
+        // userTimeEndExclusive-1 since ceilingIndex does an inclusive check
+        val endRow = Math.min(tsReader.ceilingIndex(tsAcc, tsPtr, userTimeEndExclusive - 1), chunkset.numRows - 1)
+        ChunkRange(chunkset, startRow, endRow)
+      }
+      .filter{ chunkRange =>
+        val isValidChunk = chunkRange.istartRow <= chunkRange.iendRow
+        if (!isValidChunk) {
+          // TODO(a_theimer): numRawChunksSkipped.increment()
+          // TODO(a_theimer): use DsContext?
+          DownsamplerContext.dsLogger.warn(s"Skipping chunk of partition since startRow lessThan endRow " +
+            s"hexPartKey=${readablePart.hexPartKey} " +
+            s"startRow=${chunkRange.istartRow} " +
+            s"endRow=${chunkRange.iendRow} " +
+            s"chunkset: ${chunkRange.chunkSetInfoReader.debugString}")
+        }
+        isValidChunk
+      }
+  }
+}
+
+/**
+ * Exports a window of data to a bucket.
+ */
+case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
+
+  @transient lazy private[downsampler] val schemas = Schemas.fromConfig(downsamplerSettings.filodbConfig).get
+
+  // TODO(a_theimer): probably worth building this into a trie-based structure eventually
+  val rules = downsamplerSettings.exportRules.toSeq
+
+  private def hashToString(bytes: Array[Byte]): String = {
+    MessageDigest.getInstance("SHA-256")
+      .digest(bytes)
+      .map("%02x".format(_))
+      .mkString
+  }
+
+  /**
+   * Returns an iterator of a single column of the argument partition's chunk.
+   * @param iCol the index of the column to iterate.
+   * @param iRowStart the index of the row to begin iteration from.
+   */
+  private def getChunkColIter(partition: ReadablePartition,
+                              chunkReader: ChunkSetInfoReader,
+                              iCol: Int,
+                              iRowStart: Int): TypedIterator = {
+    val tsPtr = chunkReader.vectorAddress(iCol)
+    val tsAcc = chunkReader.vectorAccessor(iCol)
+    partition.chunkReader(iCol, tsAcc, tsPtr).iterate(tsAcc, tsPtr, iRowStart)
+  }
+
+  /**
+   * Extracts and returns an iterator of (timestamp,value) pairs from the argument chunk.
+   * @param irowStart the index of the first row to include in the result.
+   * @param irowEnd the index of the final row to include in the result (exclusive).
+   */
+  private def extractRows(partition: ReadablePartition,
+                          chunkReader: ChunkSetInfoReader,
+                          irowStart: Int,
+                          irowEnd: Int): Iterator[(Long, Double)] = {
+    val timestampCol = 0  // FIXME: need a more dynamic (but efficient) solution
+    val columns = partition.schema.data.columns
+    val valueCol = columns.indexWhere(_.name == partition.schema.data.valueColName)
+    val timestampIter = getChunkColIter(partition, chunkReader, timestampCol, irowStart).asLongIt
+    columns(valueCol).columnType match {
+      case DoubleColumn =>
+        val valueIter = getChunkColIter(partition, chunkReader, valueCol, irowStart).asDoubleIt
+        (irowStart until irowEnd).iterator.map{ _ =>
+          (timestampIter.next, valueIter.next)
+        }
+      case colType =>
+        // TODO(a_theimer): this is commented out so tests pass
+        // throw new IllegalArgumentException(s"unhandled ColumnType: $colType")
+        Iterator.empty
+    }
+  }
+
+  /**
+   * Export the data to a bucket.
+   * @param path the absolute path of the file to write.
+   * @param bucket the export bucket.
+   * @param partKeyPairs label-value pairs of the partition to export.
+   * @param rows sequence of timestamp/value pairs to export.
+   */
+  private def export(path: Seq[String],
+                     bucket: String,
+                     partKeyPairs: Seq[(String, String)],
+                     rows: Iterator[(Long, Double)]): Unit = {
+    // scalastyle:off
+    println(s"======== exporting to $bucket:${path.mkString("/")}")
+    println(s"partKeyPairs: $partKeyPairs")
+    rows.foreach{ case (timestamp, value) =>
+      println(s"-- $timestamp: $value")
+    }
+    // scalastyle:on
+  }
+
+  private def matchAllFilters(filters: Seq[ColumnFilter],
+                              labels: Map[String, String]): Boolean = {
+    filters.forall( filt =>
+      labels.get(filt.column)
+        .exists(value => filt.filter.filterFunc(value))
+    )
+  }
+
+  def exportBatch(readablePartitions: Seq[ReadablePartition],
+                  userStartTime: Long,
+                  userEndTime: Long): Unit = {
+    // TODO(a_theimer): use this space to update metrics / logs
+    readablePartitions.foreach(exportPartition(_, userStartTime, userEndTime))
+  }
+
+  private def exportPartition(readablePartition: ReadablePartition,
+                              userStartTime: Long,
+                              userEndTime: Long): Unit = {
+
+    // get the label-value pairs for this partition
+    val partKeyMap = {
+      val rawSchemaId = RecordSchema.schemaID(readablePartition.partKeyBytes, UnsafeUtils.arayOffset)
+      val schema = schemas(rawSchemaId)
+      schema.partKeySchema.toStringPairs(readablePartition.partKeyBytes, UnsafeUtils.arayOffset).toMap
+    }
+
+    // retrieve the bucket only if this partKey's data should be exported there
+    val bucket = rules.filter{ rule =>
+      downsamplerSettings.exportRuleKey.zipWithIndex.forall{ case (label, i) =>
+        partKeyMap.get(label).contains(rule.key(i))
+      }
+    }.find{ rule =>
+      lazy val matchAnyIncludeGroup = rule.includeFilterGroups.exists{ group =>
+        matchAllFilters(group, partKeyMap)
+      }
+      val matchAnyExcludeGroup = rule.excludeFilterGroups.exists{ group =>
+        matchAllFilters(group, partKeyMap)
+      }
+      !matchAnyExcludeGroup && (rule.includeFilterGroups.isEmpty || matchAnyIncludeGroup)
+    }.map(_.bucket)
+
+    if (bucket.isDefined) {
+      // build the path to export to
+      val directories = {
+        val date = new Date(userEndTime)
+        downsamplerSettings.exportPathSpec
+          // replace the label {{}} strings
+          .map(LABEL_REGEX_MATCHER.replaceAllIn(_, matcher => partKeyMap(matcher.group(1))))
+          // replace the datetime <<>> strings
+          .map{ pathSpecString =>
+            DATE_REGEX_MATCHER.replaceAllIn(pathSpecString, matcher => {
+              val dateFormatter = new SimpleDateFormat(matcher.group(1))
+              dateFormatter.format(date)
+            })}
+      }
+
+      val fileName = hashToString(readablePartition.partKeyBytes)
+
+      val rows = getChunkRangeIter(readablePartition, userStartTime, userEndTime).flatMap{ chunkRow =>
+        extractRows(
+          readablePartition, chunkRow.chunkSetInfoReader, chunkRow.istartRow, chunkRow.iendRow)
+      }
+
+      // TODO(a_theimer): bucket/rows should be interfaces
+      export(directories ++ Seq(fileName), bucket.get, partKeyMap.toSeq, rows)
+    }
+  }
+}

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -85,10 +85,10 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
    * @param irowStart the index of the first row to include in the result.
    * @param irowEnd the index of the final row to include in the result (exclusive).
    */
-  private def extractRows(partition: ReadablePartition,
-                          chunkReader: ChunkSetInfoReader,
-                          irowStart: Int,
-                          irowEnd: Int): Iterator[(Long, Double)] = {
+  private def getTimeValuePairs(partition: ReadablePartition,
+                                chunkReader: ChunkSetInfoReader,
+                                irowStart: Int,
+                                irowEnd: Int): Iterator[(Long, Double)] = {
     val timestampCol = 0  // FIXME: need a more dynamic (but efficient) solution
     val columns = partition.schema.data.columns
     val valueCol = columns.indexWhere(_.name == partition.schema.data.valueColName)
@@ -199,7 +199,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
       val partKeyString = partKeyMap.toSeq.sortBy(pair => s"${pair._1}=${pair._2}").mkString(",")
       val partitionByValues = makePartitionByValues(partKeyMap, userEndTime)
       getChunkRangeIter(readablePartition, userStartTime, userEndTime).flatMap{ chunkRow =>
-        extractRows(readablePartition, chunkRow.chunkSetInfoReader, chunkRow.istartRow, chunkRow.iendRow)
+        getTimeValuePairs(readablePartition, chunkRow.chunkSetInfoReader, chunkRow.istartRow, chunkRow.iendRow)
       }.map{ case (timestamp, value) =>
         ExportRowData(partKeyMap, partKeyString, timestamp, value, partitionByValues.iterator)
       }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -171,14 +171,17 @@ class Downsampler(settings: DownsamplerSettings,
           val rawPartSchema = batchDownsampler.schemas(rawSchemaId)
           new PagedReadablePartition(rawPartSchema, shard = 0, partID = 0, partData = rawPart, minResolutionMs = 1)
         }
+        // Downsample the data (this step does not contribute the the RDD).
         if (settings.chunkDownsamplerIsEnabled) {
           batchDownsampler.downsampleBatch(readablePartsBatch, userTimeStart, userTimeEndExclusive)
         }
+        // Generate the data for the RDD.
         if (settings.exportIsEnabled) {
           batchExporter.getExportRows(readablePartsBatch, userTimeStart, userTimeEndExclusive)
         } else Iterator.empty
       }
 
+    // Export the data produced by "getExportRows" above.
     if (!rdd.isEmpty()) {
       val exportStartMs = System.currentTimeMillis()
       // NOTE: toDF(partitionCols: _*) seems buggy

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -7,7 +7,7 @@ import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
-import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.SparkSession
 
 import filodb.coordinator.KamonShutdownHook
 import filodb.core.binaryrecord2.RecordSchema
@@ -184,8 +184,8 @@ class Downsampler(settings: DownsamplerSettings,
       // NOTE: toDF(partitionCols: _*) seems buggy
       spark.createDataFrame(rdd, batchExporter.exportSchema)
         .write
-        .mode(SaveMode.Overwrite)
-        .option("header", true)
+        .mode(settings.exportSaveMode)
+        .options(settings.exportOptions)
         .partitionBy(batchExporter.partitionByCols: _*)
         .csv(settings.exportBucket)
       val exportEndMs = System.currentTimeMillis()

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -150,8 +150,12 @@ class Downsampler(settings: DownsamplerSettings,
           val rawPartSchema = batchDownsampler.schemas(rawSchemaId)
           new PagedReadablePartition(rawPartSchema, shard = 0, partID = 0, partData = rawPart, minResolutionMs = 1)
         }
-        batchDownsampler.downsampleBatch(readablePartsBatch, userTimeStart, userTimeEndExclusive)
-        batchExporter.getExportRows(readablePartsBatch, userTimeStart, userTimeEndExclusive)
+        if (settings.chunkDownsamplerIsEnabled) {
+          batchDownsampler.downsampleBatch(readablePartsBatch, userTimeStart, userTimeEndExclusive)
+        }
+        if (settings.exportIsEnabled) {
+          batchExporter.getExportRows(readablePartsBatch, userTimeStart, userTimeEndExclusive)
+        } else Iterator.empty
       }
 
     if (!rdd.isEmpty()) {

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -27,6 +27,18 @@ class IdempotentCommitProtocol(jobId: String, path: String,
   extends HadoopMapReduceCommitProtocol(jobId = "data", path, dynamicPartitionOverwrite)
 
 /**
+ * Implement this trait and provide its fully-qualified name as the downsampler config:
+ *     data-export.spark-session-setup-class = "org.fully.qualified.SetupClass"
+ * Any additional code in "setup" will run before the job is created.
+ */
+trait SparkSessionSetup {
+  /**
+   * Additional setup code can be implemented here (to be run before the Spark job is created).
+   */
+  def setup(sparkSession: SparkSession, settings: DownsamplerSettings): Unit
+}
+
+/**
   *
   * Goal: Downsample all real-time data.
   * Goal: Align chunks when this job is run in multiple DCs so that cross-dc repairs can be done.
@@ -88,6 +100,15 @@ class Downsampler(settings: DownsamplerSettings,
               "filodb.downsampler.chunk.IdempotentCommitProtocol")
       .config(sparkConf)
       .getOrCreate()
+
+    // Perform additional session setup if a class is defined in the config.
+    if (settings.sparkSessionSetupClass.isDefined) {
+      Class.forName(settings.sparkSessionSetupClass.get)
+        .getDeclaredConstructor()
+        .newInstance()
+        .asInstanceOf[SparkSessionSetup]
+        .setup(spark, settings)
+    }
 
     DownsamplerContext.dsLogger.info(s"Spark Job Properties: ${spark.sparkContext.getConf.toDebugString}")
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 import kamon.Kamon
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SaveMode, SparkSession}
 import filodb.coordinator.KamonShutdownHook
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore.PagedReadablePartition
@@ -146,10 +146,10 @@ class Downsampler(settings: DownsamplerSettings,
         batchDownsampler.downsampleBatch(readablePartsBatch, userTimeStart, userTimeEndExclusive)
         batchExporter.getExportRows(readablePartsBatch, userTimeStart, userTimeEndExclusive)
       }
-    // TODO(a_theimer): which save mode?
     // NOTE: toDF(partitionCols: _*) seems buggy
     spark.createDataFrame(rdd, batchExporter.exportSchema)
       .write
+      .mode(SaveMode.Overwrite)
       .option("header", true)
       .partitionBy(batchExporter.partitionByCols: _*)
       .csv(settings.exportBucket)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -2,16 +2,18 @@ package filodb.downsampler.chunk
 
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+
 import kamon.Kamon
+import kamon.metric.MeasurementUnit
 import org.apache.spark.SparkConf
+import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 import org.apache.spark.sql.{SaveMode, SparkSession}
+
 import filodb.coordinator.KamonShutdownHook
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore.PagedReadablePartition
 import filodb.downsampler.DownsamplerContext
 import filodb.memory.format.UnsafeUtils
-import kamon.metric.MeasurementUnit
-import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 
 
 /**

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -146,6 +146,7 @@ class Downsampler(settings: DownsamplerSettings,
         batchDownsampler.downsampleBatch(readablePartsBatch, userTimeStart, userTimeEndExclusive)
         batchExporter.getExportRows(readablePartsBatch, userTimeStart, userTimeEndExclusive)
       }
+    // TODO(a_theimer): which save mode?
     // NOTE: toDF(partitionCols: _*) seems buggy
     spark.createDataFrame(rdd, batchExporter.exportSchema)
       .write

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -93,7 +93,8 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
   }
 
   @transient lazy val exportPathSpecPairs =
-    downsamplerConfig.as[Seq[String]]("data-export.path-spec").sliding(2, 2).map(seq => (seq.head, seq.last))
+    downsamplerConfig.as[Seq[String]]("data-export.path-spec")
+      .sliding(2, 2).map(seq => (seq.head, seq.last)).toSeq
 
   /**
    * Two conditions should satisfy for eligibility:

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -92,7 +92,8 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
     }
   }
 
-  @transient lazy val exportPathSpec = downsamplerConfig.as[Seq[String]]("data-export.path-spec")
+  @transient lazy val exportPathSpecPairs =
+    downsamplerConfig.as[Seq[String]]("data-export.path-spec").sliding(2, 2).map(seq => (seq.head, seq.last))
 
   /**
    * Two conditions should satisfy for eligibility:

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -8,12 +8,14 @@ import net.ceedubs.ficus.Ficus._
 import filodb.coordinator.{FilodbSettings, NodeClusterActor}
 import filodb.core.store.{IngestionConfig, StoreConfig}
 import filodb.downsampler.DownsamplerContext
+import filodb.prometheus.ast.InstantExpression
+import filodb.prometheus.parse.Parser
 
 
 /**
-  * DownsamplerSettings is always used in the context of an object so that it need not be serialized to a spark executor
-  * from the spark application driver.
-  */
+ * DownsamplerSettings is always used in the context of an object so that it need not be serialized to a spark executor
+ * from the spark application driver.
+ */
 class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializable {
 
   @transient lazy val filodbSettings = new FilodbSettings(conf)
@@ -70,11 +72,32 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val trace = downsamplerConfig.as[Seq[Map[String, String]]]("trace-filters").map(_.toSeq)
 
+  @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key")
+
+  @transient lazy val exportRules = {
+    downsamplerConfig.as[Seq[Config]]("data-export.rules").map{ config =>
+      val key = config.as[Seq[String]]("key")
+      val bucket = config.getString("bucket")
+      val filters = config.getConfig("filters")
+      val includeFilterGroups = filters.as[Seq[Seq[String]]]("included").map{ group =>
+        Parser.parseQuery(s"{${group.mkString(",")}}")
+          .asInstanceOf[InstantExpression].getUnvalidatedColumnFilters()
+      }
+      val excludeFilterGroups = filters.as[Seq[Seq[String]]]("excluded").map{ group =>
+        Parser.parseQuery(s"{${group.mkString(",")}}")
+          .asInstanceOf[InstantExpression].getUnvalidatedColumnFilters()
+      }
+      ExportRule(key, bucket, includeFilterGroups, excludeFilterGroups)
+    }
+  }
+
+  @transient lazy val exportPathSpec = downsamplerConfig.as[Seq[String]]("data-export.path-spec")
+
   /**
-    * Two conditions should satisfy for eligibility:
-    * (a) If allow list is nonEmpty partKey should match a filter in the allow list.
-    * (b) It should not match any filter in block
-    */
+   * Two conditions should satisfy for eligibility:
+   * (a) If allow list is nonEmpty partKey should match a filter in the allow list.
+   * (b) It should not match any filter in block
+   */
   def isEligibleForDownsample(pkPairs: Seq[(String, String)]): Boolean = {
     if (allow.nonEmpty && !allow.exists(w => w.forall(pkPairs.contains))) {
       false
@@ -86,6 +109,4 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
   def shouldTrace(pkPairs: Seq[(String, String)]): Boolean = {
     trace.exists(w => w.forall(pkPairs.contains))
   }
-
 }
-

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -74,10 +74,11 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key")
 
+  @transient lazy val exportBucket = downsamplerConfig.as[String]("data-export.bucket")
+
   @transient lazy val exportRules = {
     downsamplerConfig.as[Seq[Config]]("data-export.rules").map{ config =>
       val key = config.as[Seq[String]]("key")
-      val bucket = config.getString("bucket")
       val filters = config.getConfig("filters")
       val includeFilterGroups = filters.as[Seq[Seq[String]]]("included").map{ group =>
         Parser.parseQuery(s"{${group.mkString(",")}}")
@@ -87,7 +88,7 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
         Parser.parseQuery(s"{${group.mkString(",")}}")
           .asInstanceOf[InstantExpression].getUnvalidatedColumnFilters()
       }
-      ExportRule(key, bucket, includeFilterGroups, excludeFilterGroups)
+      ExportRule(key, includeFilterGroups, excludeFilterGroups)
     }
   }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -103,6 +103,10 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
     downsamplerConfig.as[Seq[String]]("data-export.path-spec")
       .sliding(2, 2).map(seq => (seq.head, seq.last)).toSeq
 
+  @transient lazy val exportOptions = downsamplerConfig.as[Map[String, String]]("data-export.options")
+
+  @transient lazy val exportSaveMode = downsamplerConfig.getString("data-export.save-mode")
+
   /**
    * Two conditions should satisfy for eligibility:
    * (a) If allow list is nonEmpty partKey should match a filter in the allow list.

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -76,6 +76,10 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportIsEnabled = downsamplerConfig.getBoolean("data-export.enabled")
 
+  @transient lazy val sparkSessionSetupClass =
+    Some(downsamplerConfig.getOrElse("data-export.spark-session-setup-class", ""))
+      .filter(_.nonEmpty)
+
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")
 
   @transient lazy val exportBucket = downsamplerConfig.as[String]("data-export.bucket")

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -25,7 +25,7 @@ import filodb.core.metadata.{Dataset, Schemas}
 import filodb.core.query._
 import filodb.core.query.Filter.Equals
 import filodb.core.store.{AllChunkScan, PartKeyRecord, SinglePartitionScan, StoreConfig, TimeRangeChunkScan}
-import filodb.downsampler.chunk.{BatchDownsampler, Downsampler, DownsamplerSettings}
+import filodb.downsampler.chunk.{BatchDownsampler, BatchExporter, Downsampler, DownsamplerSettings}
 import filodb.downsampler.index.{DSIndexJobSettings, IndexJobDriver}
 import filodb.memory.format.{PrimitiveVectorReader, UnsafeUtils}
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -48,6 +48,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   val queryConfig = QueryConfig(settings.filodbConfig.getConfig("query"))
   val dsIndexJobSettings = new DSIndexJobSettings(settings)
   val batchDownsampler = new BatchDownsampler(settings)
+  val batchExporter = new BatchExporter(settings)
 
   val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8, "_ns_".utf8 -> "my_ns".utf8)
   val seriesTagsNaN = Map("_ws_".utf8 -> "my_ws".utf8, "_ns_".utf8 -> "my_ns".utf8, "nan_support".utf8 -> "yes".utf8)
@@ -419,7 +420,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val sparkConf = new SparkConf(loadDefaults = true)
     sparkConf.setMaster("local[2]")
     sparkConf.set("spark.filodb.downsampler.userTimeOverride", Instant.ofEpochMilli(lastSampleTime).toString)
-    val downsampler = new Downsampler(settings, batchDownsampler)
+    val downsampler = new Downsampler(settings, batchDownsampler, batchExporter)
     downsampler.run(sparkConf).close()
   }
 

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -113,7 +113,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val emptyConf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1"]
+        |      enabled = true
+        |      key-labels = ["l1"]
         |      bucket = "file:///dummy-bucket"
         |      rules = []
         |      path-spec = ["unused"]
@@ -124,15 +125,14 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val onlyKeyConf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1"]
+        |      enabled = true
+        |      key-labels = ["l1"]
         |      bucket = "file:///dummy-bucket"
         |      rules = [
         |        {
         |          key = ["l1a"]
-        |          filters = {
-        |            included = []
-        |            excluded = []
-        |          }
+        |          allow-filters = []
+        |          block-filters = []
         |        }
         |      ]
         |      path-spec = ["unused"]
@@ -143,26 +143,25 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val includeExcludeConf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1"]
+        |      enabled = true
+        |      key-labels = ["l1"]
         |      bucket = "file:///dummy-bucket"
         |      rules = [
         |        {
         |          key = ["l1a"]
-        |          filters = {
-        |            included = [
-        |              [
-        |                "l2=\"l2a\""
-        |              ],
-        |              [
-        |                "l2=~\".*b\""
-        |              ]
+        |          allow-filters = [
+        |            [
+        |              "l2=\"l2a\""
+        |            ],
+        |            [
+        |              "l2=~\".*b\""
         |            ]
-        |            excluded = [
-        |              [
-        |                "l2=\"l2c\""
-        |              ],
-        |            ]
-        |          }
+        |          ]
+        |          block-filters = [
+        |            [
+        |              "l2=\"l2c\""
+        |            ],
+        |          ]
         |        }
         |      ]
         |      path-spec = ["unused"]
@@ -173,24 +172,23 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val multiFilterConf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1"]
+        |      enabled = true
+        |      key-labels = ["l1"]
         |      bucket = "file:///dummy-bucket"
         |      rules = [
         |        {
         |          key = ["l1a"]
-        |          filters = {
-        |            included = [
-        |              [
-        |                "l2=\"l2a\"",
-        |                "l3=~\".*a\""
-        |              ],
-        |              [
-        |                "l2=\"l2a\"",
-        |                "l3=~\".*b\""
-        |              ]
+        |          allow-filters = [
+        |            [
+        |              "l2=\"l2a\"",
+        |              "l3=~\".*a\""
+        |            ],
+        |            [
+        |              "l2=\"l2a\"",
+        |              "l3=~\".*b\""
         |            ]
-        |            excluded = []
-        |          }
+        |          ]
+        |          block-filters = []
         |        }
         |      ]
         |      path-spec = ["unused"]
@@ -201,20 +199,19 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val contradictFilterConf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1"]
+        |      enabled = true
+        |      key-labels = ["l1"]
         |      bucket = "file:///dummy-bucket"
         |      rules = [
         |        {
         |          key = ["l1a"]
-        |          filters = {
-        |            included = [
-        |              [
-        |                "l2=\"l2a\"",
-        |                "l2=~\".*b\""
-        |              ]
+        |          allow-filters = [
+        |            [
+        |              "l2=\"l2a\"",
+        |              "l2=~\".*b\""
         |            ]
-        |            excluded = []
-        |          }
+        |          ]
+        |          block-filters = []
         |        }
         |      ]
         |      path-spec = ["unused"]
@@ -225,15 +222,14 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val multiKeyConf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1", "l2"]
+        |      enabled = true
+        |      key-labels = ["l1", "l2"]
         |      bucket = "file:///dummy-bucket"
         |      rules = [
         |        {
         |          key = ["l1a", "l2a"]
-        |          filters = {
-        |            included = []
-        |            excluded = []
-        |          }
+        |          allow-filters = []
+        |          block-filters = []
         |        }
         |      ]
         |      path-spec = ["unused"]
@@ -244,22 +240,19 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val multiRuleConf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1"]
+        |      enabled = true
+        |      key-labels = ["l1"]
         |      bucket = "file:///dummy-bucket"
         |      rules = [
         |        {
         |          key = ["l1a"]
-        |          filters = {
-        |            included = []
-        |            excluded = []
-        |          }
+        |          allow-filters = []
+        |          block-filters = []
         |        },
         |        {
         |          key = ["l1b"]
-        |          filters = {
-        |            included = []
-        |            excluded = []
-        |          }
+        |          allow-filters = []
+        |          block-filters = []
         |        }
         |      ]
         |      path-spec = ["unused"]
@@ -304,16 +297,17 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val conf = ConfigFactory.parseString(
       """
         |    filodb.downsampler.data-export {
-        |      key = ["l1"]
+        |      enabled = true
+        |      key-labels = ["unused"]
         |      bucket = "file:///dummy-bucket"
         |      rules = []
         |      path-spec = [
-        |        "api",  "v1",
-        |        "l1",   "{{l1}}-foo",
-        |        "year", "bar-<<YYYY>>-baz",
-        |        "month", "hello-<<MM>>"
-        |        "day",   "day-<<dd>>"
-        |        "l2-woah",   "{{l2}}-goodbye"
+        |        "api",     "v1",
+        |        "l1",      "{{l1}}-foo",
+        |        "year",    "bar-<<YYYY>>-baz",
+        |        "month",   "hello-<<MM>>"
+        |        "day",     "day-<<dd>>"
+        |        "l2-woah", "{{l2}}-goodbye"
         |      ]
         |    }
         |""".stripMargin

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -325,7 +325,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       Seq("v1", "l1val-foo", "bar-2022-baz", "hello-09", "day-21", "l2val-goodbye")
 
     val batchExporter = new BatchExporter(new DownsamplerSettings(conf.withFallback(baseConf)))
-    batchExporter.getPartitionByValues(labels, time) shouldEqual expected
+    batchExporter.getPartitionByValues(labels, time).toSeq shouldEqual expected
   }
 
   it ("should write untyped data to cassandra") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Adds an "export" step to the chunk downsampler Spark job.

A time-series is exported to a configured bucket address only if all of the following conditions are met:
- labels match (by equality; without a regex) at least one export rule key
- labels don't match any set of the rule's `exclude` filters
- the `include` filters are empty, or labels match at least one set of the rule's `include` filters

The export path is also configurable:
```
      # Specifies how to generate a path to an exported time-series.
      # The sequence of key-value pairs describe a directory path, where the
      #   time-series are exported to the final directory.
      # For example, if the path-spec is:
      #     path-spec = [
      #       "key1", "value1",
      #       "key2", "value2"
      #     ]
      # then the exported time-series will be stored at the path:
      #     ~/key1=value1/key2=value2/<file>
      # All {{label-name}} strings will be replaced with the time-series label's value.
      # All <<time-spec>> strings will be replaced with the result of formatting
      #   the export window's end time with the time-spec string.
      path-spec = [
        "ws", "{{_ws_}}-foobar",
        "year", "hello-<<YYYY>>",
        "api", "v1",
        "weird-ns-label", "{{_ns_}}"
      ]
```

This PR is a simpler alternative to: https://github.com/filodb/FiloDB/pull/1454