### PR TITLE
fix(spark-jobs): fix a bug to add hours instead of milliseconds to start-time

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -72,7 +72,7 @@ class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSInde
 
     // since we read (for staleness check) before updating index, we don't have to catch up to current time.
     // We can run this job in cadence with Chunk Downsampler job.
-    val toHourExclDefault  = userTimeStart + dsSettings.downsampleChunkDuration
+    val toHourExclDefault  = fromHour + dsSettings.downsampleStoreConfig.flushInterval.toHours + 1
 
     // this override should almost never used by operators - only for unit testing
     val toHourExcl = spark.sparkContext.getConf

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -427,7 +427,6 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val sparkConf = new SparkConf(loadDefaults = true)
     sparkConf.setMaster("local[2]")
     sparkConf.set("spark.filodb.downsampler.index.timeInPeriodOverride", Instant.ofEpochMilli(lastSampleTime).toString)
-    sparkConf.set("spark.filodb.downsampler.index.toHourExclOverride", (pkUpdateHour + 6 + 1).toString)
     val indexUpdater = new IndexJobDriver(settings, dsIndexJobSettings)
     indexUpdater.run(sparkConf).close()
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

fix a bug where in milliseconds were added instead of flush-hours to startHour of the index migration job.