### PR TITLE
feat(core) Persistent index checkpointing

### DIFF
--- a/conf/timeseries-durable-downsample-index-dev-source.conf
+++ b/conf/timeseries-durable-downsample-index-dev-source.conf
@@ -109,7 +109,7 @@
         # Raw schemas from which to downsample
         raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram"]
 
-        index-location = "target/tmp/downsample-index"
+        index-location = "/tmp/downsample-index"
         index-metastore-implementation = "file"
       }
 

--- a/conf/timeseries-filodb-server-ds.conf
+++ b/conf/timeseries-filodb-server-ds.conf
@@ -1,6 +1,8 @@
 include "timeseries-filodb-server.conf"
+dataset-prometheus = { include required("timeseries-durable-downsample-index-dev-source.conf") }
 
 filodb {
+  v2-cluster-enabled = false
   http.bind-port=9080
   store-factory = "filodb.cassandra.DownsampledTSStoreFactory"
 }

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -34,6 +34,8 @@ final case class DownsampleConfig(config: Config) {
                 else Seq.empty
   val indexLocation = config.getOrElse[Option[String]]("index-location", None)
 
+  val maxRefreshHours = config.getOrElse("max-refresh-hours", Long.MaxValue)
+
   val enablePersistentIndexing = indexLocation.isDefined
 
   val indexMetastoreImplementation = if (config.hasPath("index-metastore-implementation")) {

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -59,6 +59,7 @@ class IndexBootstrapper(colStore: ColumnStore) {
                                ref: DatasetRef,
                                ttlMs: Long): Task[Long] = {
 
+    val startCheckpoint = System.currentTimeMillis()
     val recoverIndexLatency = Kamon.gauge("shard-recover-index-latency", MeasurementUnit.time.milliseconds)
       .withTag("dataset", ref.dataset)
       .withTag("shard", shardNum)
@@ -80,7 +81,7 @@ class IndexBootstrapper(colStore: ColumnStore) {
         // Note that we do not set an end time for the Synced here, instead
         // we will do it from DownsampleTimeSeriesShard
         index.refreshReadersBlocking()
-        recoverIndexLatency.update(System.currentTimeMillis() - start)
+        recoverIndexLatency.update(System.currentTimeMillis() - startCheckpoint)
         count
       }
   }

--- a/core/src/main/scala/filodb.core/memstore/IndexMetadataStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexMetadataStore.scala
@@ -164,7 +164,7 @@ class FileSystemBasedIndexMetadataStore(rootDirectory: String, expectedGeneratio
                 (IndexState.TriggerRebuild, None)
               } else if (shouldRebuildIndexForOldSnap(datasetRef, shard, snapFile)) {
                 logger.info("lastSnapTime is more than {} hours from now, " +
-                  "for dataset={} and shard={}triggering index rebuild instead of syncing the delta",
+                  "for dataset={} and shard={}. Triggering index rebuild instead of syncing the delta",
                   maxRefreshHours, datasetRef.toString, shard)
                 (IndexState.TriggerRebuild, None)
               } else

--- a/core/src/main/scala/filodb.core/memstore/IndexMetadataStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexMetadataStore.scala
@@ -1,10 +1,15 @@
 package filodb.core.memstore
 
-import java.io.File
-
+import com.typesafe.scalalogging.StrictLogging
+import java.io.{File, FileInputStream, FileOutputStream}
+import java.nio.ByteBuffer
 import scala.collection.mutable.Map
+import scala.util.{Failure, Success, Try, Using}
 
 import filodb.core.DatasetRef
+import filodb.core.memstore.FileSystemBasedIndexMetadataStore.{genFileV1Magic, snapFileV1Magic}
+
+
 
 
 
@@ -31,7 +36,7 @@ import filodb.core.DatasetRef
  *
  */
 object IndexState extends Enumeration {
-  val Empty, Rebuilding, Refreshing, Synced, TriggerRebuild = Value
+  val Empty, Refreshing, Synced, TriggerRebuild = Value
 }
 
 
@@ -84,6 +89,249 @@ trait IndexMetadataStore {
    */
   def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit
 
+}
+
+object FileSystemBasedIndexMetadataStore {
+  val genFileV1Magic = 0x5b
+  val snapFileV1Magic = 0x5c
+  val expectedGenerationEnv = "INDEX_GENERATION"
+}
+/**
+ * File system based metadata store that uses filesystem for storing the metadata. For rebuilds, current implementation
+ * supports a rebuild of entire DS cluster and not just targeted shards for simplicity.
+ *
+ * @param rootDirectory
+ * @param expectedGeneration: The expected generation of the metadata. If None is found, no rebuild will be triggered
+ *                            The checks for generation will run only when a valid integer generation is passed
+ * @param maxRefreshHours:    Refreshing for a large duration is not efficient and it will be faster to rebuild the
+ *                            index from scratch, if a snapFile and the elapsed time between now and and lastSync
+ *                            time is greater than maxRefreshHours, initState will respond with TriggerRebuild
+ */
+class FileSystemBasedIndexMetadataStore(rootDirectory: String, expectedGeneration: Option[Int],
+                                        maxRefreshHours: Long = Long.MaxValue)
+  extends IndexMetadataStore with StrictLogging {
+
+  val genFilePathFormat = rootDirectory + File.separator + "_%s_%d_rebuild.gen"
+  val snapFilePathFormat = rootDirectory + File.separator + "_%s_%d_snap"
+
+  private def hour(millis: Long = System.currentTimeMillis()): Long = millis / 1000 / 60 / 60
+
+  /**
+   * Init state is only queried when index is instantiated, the filesystem based implementation uses the file
+   * /<rootDirectory>/_<dataset>_<shard>_rebuild.gen file for triggering the rebuild, following cases will decide
+   * if a rebuild is triggered
+   *       a. If no expectedVersion is provided, then simply call currentState
+   *       b. If the file is absent, the state is assumed to be rebuild and the index will be rebuilt.
+   *       c. If the file is present and the contents are garbled, its assumed to be a rebuild of index.
+   *       d. If the file is present and the content returns the current generation (a numeric version),
+   *          the value is compared to an expected environment value and if the environment variable has a generation,
+   *          greater than the one in the file, a rebuild is triggered.
+   *       e. If sync file is present and the time in sync file is is more than maxRefreshHours in the past than now,
+   *          a refresh will be triggered
+   *       f. If none of the above three cases trigger a rebuild, the currentState method is used to determine the state
+   * @param datasetRef The dataset ref
+   * @param shard the shard id of index
+   * @return a tuple of state and the option of time at which the state was recorded
+   */
+  override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) = {
+    val snapFile = new File(snapFilePathFormat.format(datasetRef.dataset, shard))
+    expectedGeneration.map(expectedGen => {
+      val genFile = new File(genFilePathFormat.format(datasetRef.dataset, shard))
+      if (!genFile.exists()) {
+        logger.info("Gen file {} does not exist and expectedGen is {}, triggering rebuild",
+          genFile.toString, expectedGen)
+        (IndexState.TriggerRebuild, None)
+      } else {
+        Using(new FileInputStream(genFile)) { fin =>
+          val magicByte = fin.read()
+          if (magicByte != FileSystemBasedIndexMetadataStore.genFileV1Magic) {
+            // if first byte is not the expected magicByte then the file is not as expected and possibly garbled
+            logger.warn("Gen file {} exist and possibly corrupt, triggering rebuild", genFile.toString)
+            (IndexState.TriggerRebuild, None)
+          } else {
+            // If the first byte is magicByte read just the next 4 bytes. This ensures we just read what we need
+            val bytes = Array[Byte](0, 0, 0, 0)
+            if (fin.read(bytes) != 4) {
+              // Not able to read 4 bytes, the file is truncated and we will trigger a rebuild
+              logger.warn("Gen file {} with right magic bytes but less than 4 bytes for generation," +
+                " triggering rebuild", genFile.toString)
+              (IndexState.TriggerRebuild, None)
+            } else {
+              val generation = ByteBuffer.wrap(bytes).getInt()
+              if (expectedGen > generation) {
+                logger.info("Gen file {} has generation {} and expected generation is {}, triggering rebuild",
+                  genFile.toString, generation, expectedGen)
+                (IndexState.TriggerRebuild, None)
+              } else if (shouldRebuildIndexForOldSnap(datasetRef, shard, snapFile)) {
+                logger.info("lastSnapTime is more than {} hours from now, " +
+                  "for dataset={} and shard={}triggering index rebuild instead of syncing the delta",
+                  maxRefreshHours, datasetRef.toString, shard)
+                (IndexState.TriggerRebuild, None)
+              } else
+                currentState(datasetRef, shard)
+            }
+          }
+        }.get
+      }
+    }).getOrElse(
+      if (shouldRebuildIndexForOldSnap(datasetRef, shard, snapFile))
+        (IndexState.TriggerRebuild, None)
+      else
+        currentState(datasetRef, shard)
+    )
+  }
+
+  /**
+   * Determines if the rebuild of index should be triggered based on how old the snap is in snap file
+   * @param datasetRef
+   * @param shard
+   * @param snapFile
+   * @return
+   */
+  private def shouldRebuildIndexForOldSnap(datasetRef: DatasetRef, shard: Int, snapFile: File): Boolean=
+    if (snapFile.exists()) {
+      Using(new FileInputStream(snapFile)) { fin =>
+        getSnapTime(snapFile.toString, fin) match {
+          case Success(snapTime)    =>  hour() - hour(snapTime) > maxRefreshHours
+          case Failure(_)           =>  true
+        }
+      }.get
+    } else
+      false
+
+/**
+   * The /<rootDirectory>/_<dataset>_<shard>_snap file contains the last time the index for the given dataset and shard
+   * was synched. Current implementation only supports storing Synced state and no state related information is stored
+   * in the snap file. The file contains the magic byte followed by 8 bytes for the long value for the timestamp
+   * starting with most to least significant bytes
+   *
+   * In case the snap file does not exists, magic is not as expected or the file is corrupt, RebuildIndex will be
+   * triggered
+   *
+   * @param datasetRef The dataset ref
+   * @param shard the shard id of index
+   * @return a tuple of state and the option of time at which the state was recorded
+   */
+
+  override def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) = {
+    val snapFile = new File(snapFilePathFormat.format(datasetRef.dataset, shard))
+    if (!snapFile.exists()) {
+      logger.info("Snap file {} does not exist , triggering rebuild", snapFile.toString)
+      (IndexState.Empty, None)
+    } else {
+      Using(new FileInputStream(snapFile)) { fin =>
+        getSnapTime(snapFile.toString, fin) match {
+          case Success(snapTime)    =>
+                                        logger.info("Found lastSyncTime={} for dataset={} and shard={}",
+                                          snapTime, datasetRef.toString, shard)
+                                        (IndexState.Synced, Some(snapTime))
+          case Failure(e)           =>  throw e           // Failure to read the snap file in currentState is fatal
+        }
+      }.get
+    }
+  }
+
+  /**
+   *  Gets the snapTime from the snap file
+   *
+   * @param snapFile   the snapFile
+   * @param fin        The input stream object for the file
+   * @return           Long snap time if file is valid
+   */
+  private def getSnapTime(snapFile: String, fin: FileInputStream): Try[Long] = {
+        val magicByte = fin.read()
+        if (magicByte != FileSystemBasedIndexMetadataStore.snapFileV1Magic) {
+          // if first byte is not the expected magicByte then the file is not as expected and possibly garbled
+          logger.warn(" Snap {} exist and possibly corrupt, this will trigger a rebuild", snapFile.toString)
+          Failure(new IllegalStateException("Invalid magic bytes in snap file"))
+        } else {
+          // If the first byte is magicByte read just the next 8 bytes
+          val bytes = Array[Byte](0, 0, 0, 0, 0, 0, 0, 0)
+          if (fin.read(bytes) != 8) {
+            // Not able to read 8 bytes, the file is truncated and we will trigger a rebuild
+            logger.warn("Snap file {} with right magic bytes but less than 8 for time," +
+              " this will trigger a rebuild of index", snapFile.toString)
+            Failure(new IllegalStateException("Snap file truncated"))
+          } else {
+            val lastSyncTime = ByteBuffer.wrap(bytes).getLong()
+            Success(lastSyncTime)
+          }
+        }
+   }
+  /**
+   *  Updates the state of the index, the snap file will be updated with the correct timestamp in case the state
+   *  is Synced, current implementation of updateState ignores other index states. Also when the index is updated
+   *  and synced, it is important to ensure the gen file is updated with the current generation. This guarantees that
+   *  next time the on bootstrap, the initState should return Synced and not TriggerRebuild
+   *
+   * @param datasetRef The dataset ref
+   * @param shard the shard id of index
+   * @param state One of the IndexState.Values for the index
+   * @param time a time in millis since epoch for when the state was updated
+   */
+  // scalastyle:off method.length
+  override def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {
+    state match {
+      case IndexState.Synced           =>  // Only handle cases where state is Synced
+                                    val snapFile = new File(snapFilePathFormat.format(datasetRef.dataset, shard))
+                                    val genFile = new File(genFilePathFormat.format(datasetRef.dataset, shard))
+                                    Using(new FileOutputStream(snapFile)){
+                                      // First write the last synced time to the snap file
+                                      snapFos =>
+                                        logger.info("Updating state of dataset={}, shard={} with syncTime={}",
+                                          datasetRef.toString, shard, time)
+                                        snapFos.write(snapFileV1Magic)
+                                        val buff = ByteBuffer.allocate(8)
+                                        buff.putLong(time)
+                                        snapFos.write(buff.array())
+                                    }.flatMap { _ =>
+                                      // If writing the snap file is successful, update the generation file so
+                                      // next call to initState does not trigger the rebuild. Note that these
+                                      // two operations are not atomic, we may still have the snap file updated but
+                                      // generation file not, in which case next call to initState will trigger
+                                      // the rebuild.
+                                      expectedGeneration.map{
+                                        generation =>
+                                          Using(new FileOutputStream(genFile)) { genFos =>
+                                            logger.info("Updating genFile " +
+                                              "of dataset={}, shard={} with generation={}",
+                                              datasetRef.toString, shard, generation)
+                                            genFos.write(genFileV1Magic)
+                                            val buff = ByteBuffer.allocate(4)
+                                            buff.putInt(generation)
+                                            genFos.write(buff.array())
+                                          }
+                                      }.getOrElse(Success(()))
+                                    }.get
+      case IndexState.TriggerRebuild   => // Delete gen file so next restart triggers the rebuild
+                                    val genFile = new File(genFilePathFormat.format(datasetRef.toString, shard))
+                                    val deleted = genFile.delete()
+                                    logger.info("genFile={} delete returned {} on TriggerRebuild, " +
+                                      "index will be rebuild on next restart of dataset={} and shard={}",
+                                      genFile, deleted, datasetRef.toString, shard)
+      case IndexState.Empty            => // Empty is invoked denoting the index directory is empty. This also signals
+                                          // metastore to delete the corresponding gen and snap file
+                                          val genFile = new File(genFilePathFormat.format(datasetRef.toString, shard))
+                                          val snapFile = new File(snapFilePathFormat.format(datasetRef.toString, shard))
+                                          val genDeleted = genFile.delete()
+                                          val snapDeleted = snapFile.delete()
+                                          logger.info("genFile={} delete returned {} and " +
+                                            "snapFile={} delete returned {} when empty state was triggered " +
+                                            "for dataset={} and shard={}",
+                                            genFile, genDeleted, snapFile, snapDeleted, datasetRef.toString, shard)
+      case _                           =>  //NOP
+    }
+  }
+  // scalastyle:on method.length
+
+  /**
+   * Updates the state of the index
+   * @param datasetRef The dataset ref
+   * @param shard the shard id of index
+   * @param state One of the IndexState.Values for the index
+   * @param time a time in millis since epoch for when the state was updated
+   */
+  override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = ???
 }
 
 /**

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -141,7 +141,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   // If index rebuild is triggered or the state is Building, simply clean up the index directory and start
   // index rebuild
   if (
-    lifecycleManager.forall(_.shouldTriggerRebuild(ref, shardNum)) || getCurrentIndexState()._1 == IndexState.Rebuilding
+    lifecycleManager.forall(_.shouldTriggerRebuild(ref, shardNum))
   ) {
     logger.info(s"Cleaning up indexDirectory=$indexDiskLocation for  dataset=$ref, shard=$shardNum")
     deleteRecursively(indexDiskLocation.toFile) match {

--- a/core/src/test/scala/filodb.core/memstore/FileSystemBasedIndexMetadataStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/FileSystemBasedIndexMetadataStoreSpec.scala
@@ -331,5 +331,21 @@ class FileSystemBasedIndexMetadataStoreSpec extends AnyFunSpec with Matchers wit
     // as it happens only on start up. Perhaps in future iterations if the refresh overload is high, shard can
     // gracefully shutdown to rebuild the index from scratch
   }
+
+  it("should parse the expectedVersion when a numeric value as String is provided") {
+    FileSystemBasedIndexMetadataStore.expectedVersion("123") shouldEqual Some(123)
+  }
+
+  it("should return None if null string is provided") {
+    FileSystemBasedIndexMetadataStore.expectedVersion(null) shouldEqual None
+  }
+
+  it("should return None if non numeric string is provided") {
+    FileSystemBasedIndexMetadataStore.expectedVersion("test") shouldEqual None
+  }
+
+  it("should return None if overflowing numeric string is provided") {
+    FileSystemBasedIndexMetadataStore.expectedVersion("12345678686774553466 ") shouldEqual None
+  }
 }
 // scalastyle:on

--- a/core/src/test/scala/filodb.core/memstore/FileSystemBasedIndexMetadataStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/FileSystemBasedIndexMetadataStoreSpec.scala
@@ -1,0 +1,335 @@
+package filodb.core.memstore
+
+import filodb.core.GdeltTestData.{datasetOptions, schema}
+import filodb.core.metadata.Dataset
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{FileInputStream, FileOutputStream}
+import java.nio.ByteBuffer
+import scala.util.{Failure, Try}
+
+// scalastyle:off
+class FileSystemBasedIndexMetadataStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
+
+
+  val snap = 1663092567977L
+
+  val dataset = Dataset("gdelt", schema.slice(4, 6), schema.patch(4, Nil, 2), datasetOptions)
+
+  it("initState with no gen file and expected version passed should Trigger rebuild") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+  }
+
+  override def beforeEach(): Unit  = {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val buffer: ByteBuffer = ByteBuffer.allocate(8)
+    buffer.putLong(snap)
+    val fos = new FileOutputStream(snapFile)
+    fos.write(FileSystemBasedIndexMetadataStore.snapFileV1Magic)
+    fos.write(buffer.array())
+    fos.close()
+  }
+
+
+  it("initState with expectedVersion with no magic bytes in gen file should Trigger rebuild") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.createNewFile()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+  }
+
+  it("initState with expectedVersion with invalid magic bytes in gen file should Trigger rebuild") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val os = new FileOutputStream(genFile)
+    os.write(0)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+  }
+
+  it("initState with expectedVersion with valid magic bytes and less than 4 bytes for version should trigger rebuild") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val os = new FileOutputStream(genFile)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    os.write(FileSystemBasedIndexMetadataStore.genFileV1Magic)
+    os.write(Array[Byte](0, 1, 2)) // Length as 3 bytes instead of expected 4
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+  }
+
+  it("initState with expectedVersion, valid magic bytes and 4 bytes for version should invoke currentState") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val os = new FileOutputStream(genFile)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    os.write(FileSystemBasedIndexMetadataStore.genFileV1Magic)
+    os.write(Array[Byte](0, 0, 0, 1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snap)))
+  }
+
+  it("initState with expectedVersion < version in gen file should invoke currentState") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val os = new FileOutputStream(genFile)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    os.write(FileSystemBasedIndexMetadataStore.genFileV1Magic)
+    os.write(Array[Byte](0, 0, 0, 1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snap)))
+  }
+
+
+  it("initState with expectedVersion = version in gen file should invoke currentState") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val os = new FileOutputStream(genFile)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    os.write(FileSystemBasedIndexMetadataStore.genFileV1Magic)
+    os.write(Array[Byte](0, 0, 0, 1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snap)))
+  }
+
+  it("initState with expectedVersion > version in gen file should trigger rebuild") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val os = new FileOutputStream(genFile)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(2))
+    os.write(FileSystemBasedIndexMetadataStore.genFileV1Magic)
+    os.write(Array[Byte](0, 0, 0, 1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+  }
+
+  it("initState with no expected version should invoke currentState") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    genFile.delete()
+    val os = new FileOutputStream(genFile)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    os.write(FileSystemBasedIndexMetadataStore.genFileV1Magic)
+    os.write(Array[Byte](0, 0, 0, 1))
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snap)))
+  }
+
+
+  it("currentState with no snap file should be Empty") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    snapFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Empty, None))
+  }
+
+
+  it("currentState with invalid magic byte should  should Trigger rebuild") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val fos = new FileOutputStream(snapFile)
+    fos.write(0)
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    // invalid magic bytes should trigger rebuild, but currentState should throw exception
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    Try(store.currentState(dataset.ref, 0)) match {
+      case Failure(e: IllegalStateException)  => e.getMessage shouldEqual "Invalid magic bytes in snap file"
+      case _                                  => fail("Expected to see Invalid magic bytes")
+    }
+  }
+
+  it("currentState with truncated length should Trigger rebuild") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    snapFile.delete()
+    val fos = new FileOutputStream(snapFile)
+    fos.write(FileSystemBasedIndexMetadataStore.snapFileV1Magic)
+    fos.write(Array[Byte](0, 0, 0))
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    Try(store.currentState(dataset.ref, 0)) match {
+      case Failure(e: IllegalStateException)  => e.getMessage shouldEqual "Snap file truncated"
+      case _                                  => fail("Expected to see Invalid magic bytes")
+    }
+  }
+
+  it("currentState with valid snap file should return Synced with correct timestamp") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snap)))
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snap)))
+  }
+
+  it("should update snap file but not gen file when updateState with Synced state is invoked with expectedGeneration as None") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    val snapTime = System.currentTimeMillis()
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual false
+    val snapIn = new FileInputStream(snapFile)
+    snapIn.read() shouldEqual FileSystemBasedIndexMetadataStore.snapFileV1Magic
+    val bytes = Array[Byte](0, 0, 0, 0 ,0, 0, 0, 0)
+    snapIn.read(bytes) shouldEqual 8
+    ByteBuffer.wrap(bytes).getLong shouldEqual snapTime
+  }
+
+  it("should update snap file and gen file when updateState with Synced state is invoked with expectedGeneration as Some value") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(10))
+    val snapTime = System.currentTimeMillis()
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual true
+    val snapIn = new FileInputStream(snapFile)
+    snapIn.read() shouldEqual FileSystemBasedIndexMetadataStore.snapFileV1Magic
+    val bytes = Array[Byte](0, 0, 0, 0 ,0, 0, 0, 0)
+    snapIn.read(bytes) shouldEqual 8
+    ByteBuffer.wrap(bytes).getLong shouldEqual snapTime
+
+    val genIn = new FileInputStream(genFile)
+    genIn.read() shouldEqual FileSystemBasedIndexMetadataStore.genFileV1Magic
+    val genBytes = Array[Byte](0, 0, 0, 0)
+    genIn.read(genBytes) shouldEqual 4
+    ByteBuffer.wrap(genBytes).getInt shouldEqual 10
+  }
+
+  it("should not Trigger rebuild where state is synced and expected version is written to gen file") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(10))
+    val snapTime = System.currentTimeMillis()
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual true
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+  }
+
+
+  it("should not Trigger rebuild where state is synced and expected version is None") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    val snapTime = System.currentTimeMillis()
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Empty, None))
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual false
+    // As long as snap file exists, existence of gen file does not matter
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+  }
+
+  it("initState should return TriggerRebuild when state is updated to TriggerRebuild, the currentState should not be affected") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    val snapTime = System.currentTimeMillis()
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual true
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+    // Now update state to TriggerRebuild and the return value should be TriggerRebuild, if snap file exists it
+    // should be unaffected as its still needed for currently running shard to update its state
+    store.updateState(dataset.ref, 0, IndexState.TriggerRebuild, snapTime)
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual false
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+  }
+
+  it("initState should return TriggerRebuild when state is updated to Empty and expectedVersion is not None, the currentState should be Empty") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, Some(1))
+    val snapTime = System.currentTimeMillis()
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual true
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+    // Now update state to TriggerRebuild and the return value should be TriggerRebuild, if snap file exists it
+    // should be unaffected as its still needed for currently running shard to update its state
+    store.updateState(dataset.ref, 0, IndexState.Empty, snapTime)
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    snapFile.exists() shouldEqual false
+    genFile.exists() shouldEqual false
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Empty, None))
+  }
+
+  it("initState should return Empty when state is updated to Empty and expectedVersion is None, the currentState should be Empty") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None)
+    val snapTime = System.currentTimeMillis()
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Empty, None))
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual false
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+    // Now update state to TriggerRebuild and the return value should be TriggerRebuild, if snap file exists it
+    // should be unaffected as its still needed for currently running shard to update its state
+    store.updateState(dataset.ref, 0, IndexState.Empty, snapTime)
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Empty, None))
+    snapFile.exists() shouldEqual false
+    genFile.exists() shouldEqual false
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Empty, None))
+  }
+
+  it("initState should TriggerRebuild if state is older than maxRefreshHours") {
+    val tmpFile = System.getProperty("java.io.tmpdir")
+    val snapFile = new java.io.File(tmpFile, "_gdelt_0_snap")
+    val genFile = new java.io.File(tmpFile, "_gdelt_0_rebuild.gen")
+    snapFile.delete()
+    genFile.delete()
+    val store = new FileSystemBasedIndexMetadataStore(tmpFile, None, 2)
+
+    val snapTime = System.currentTimeMillis() - 4 * 60 * 60 * 1000 // make snapTime 4 hours old
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.Empty, None)) // two hours of max sync time
+    store.updateState(dataset.ref, 0, IndexState.Synced, snapTime)
+    snapFile.exists() shouldEqual true
+    genFile.exists() shouldEqual false
+    store.initState(dataset.ref, 0) shouldEqual ((IndexState.TriggerRebuild, None))
+    store.currentState(dataset.ref, 0) shouldEqual ((IndexState.Synced, Some(snapTime)))
+    // IMPORTANT: Current state is still Synced. If shards are running, it makes no sense to TriggerRebuild
+    // as it happens only on start up. Perhaps in future iterations if the refresh overload is high, shard can
+    // gracefully shutdown to rebuild the index from scratch
+  }
+}
+// scalastyle:on


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Currently on each restart, downsample index is rebuilt from source. This is an issue especially with large downsample stores where index rebuilds can take tens several minutes if not hours. Index is not something we should rebuild from scratch and we can possibly look at updating just the delta from the last sync time. 

**New behavior :**
We introduce a new implementation of ``IndexMetadataStore`` which uses file system for storing the metadata about index sync. Additionally we introduce the concept of ``INDEX_GENERATION`` which is environment variable used to trigger rebuild of index. It is designed to ensure the index is rebuilt only when a new, higher ``INDEX_GENERATION`` is seen and not otherwise.

