### PR TITLE
fix(coord) Stateful shard assignment strategy should fail if expected hostname resolution fails

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -78,9 +78,10 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
     */
   private[coordinator] lazy val guardian = system.actorOf(NodeGuardian.props(
     settings, metaStore, memStore,
-    if (settings.config.getBoolean("shard-manager.enable-k8s-stateful-shard-strategy"))
-      new K8sStatefulSetShardAssignmentStrategy else DefaultShardAssignmentStrategy)
-    , guardianName)
+    if (settings.config.getBoolean("shard-manager.enable-k8s-stateful-shard-strategy")) {
+      val maxAttempts = settings.config.getInt("shard-manager.k8s-strategy.max-hostname-lookup-attempts")
+      new K8sStatefulSetShardAssignmentStrategy(maxAttempts)
+    } else DefaultShardAssignmentStrategy), guardianName)
 
   def isInitialized: Boolean = _isInitialized.get
 

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -46,7 +46,7 @@ trait ShardAssignmentStrategy {
  * The implementation assumes the number of shards is a multiple of number of nodes and there are no
  * uneven assignments of shards to nodes
  */
-class K8sStatefulSetShardAssignmentStrategy(val maxAssignmentAttempts: Int)
+class K8sStatefulSetShardAssignmentStrategy(val maxAssignmentAttempts: Int = 8)
       extends ShardAssignmentStrategy with StrictLogging {
 
   private val pat = "-\\d+$".r

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -7,6 +7,10 @@ import com.typesafe.scalalogging.StrictLogging
 
 import filodb.coordinator.NodeClusterActor.DatasetResourceSpec
 import filodb.core.DatasetRef
+import filodb.memory.data.Shutdown
+
+
+
 
 trait ShardAssignmentStrategy {
 
@@ -42,7 +46,8 @@ trait ShardAssignmentStrategy {
  * The implementation assumes the number of shards is a multiple of number of nodes and there are no
  * uneven assignments of shards to nodes
  */
-class K8sStatefulSetShardAssignmentStrategy extends ShardAssignmentStrategy with StrictLogging {
+class K8sStatefulSetShardAssignmentStrategy(val maxAssignmentAttempts: Int)
+      extends ShardAssignmentStrategy with StrictLogging {
 
   private val pat = "-\\d+$".r
 
@@ -53,16 +58,26 @@ class K8sStatefulSetShardAssignmentStrategy extends ShardAssignmentStrategy with
       .map(host => InetAddress.getByName(host).getHostName)
       .orElse(Some(InetAddress.getLocalHost.getHostName))
       .map(name => if (name.contains(".")) name.substring(0, name.indexOf('.')) else name)
-      .flatMap(hostName => pat.findFirstIn(hostName).map(ordinal => (hostName, -Integer.parseInt(ordinal))))
-
+      .flatMap(hostName =>
+        Some((hostName, pat.findFirstIn(hostName).map(ordinal => -Integer.parseInt(ordinal)).getOrElse(-1))))
 
 
   override def shardAssignments(coord: ActorRef,
-                                dataset: DatasetRef,
-                                resources: DatasetResourceSpec,
-                                mapper: ShardMapper): Seq[Int] =
-     getOrdinalFromActorRef(coord) match {
-        case Some((hostName, ordinal)) =>
+                       dataset: DatasetRef,
+                       resources: DatasetResourceSpec,
+                       mapper: ShardMapper): Seq[Int] =
+    shardAssignmentsWithRetry(coord, dataset, resources, mapper, currentAttempt = 1, maxAssignmentAttempts)
+
+
+  // scalastyle:off method.length
+  private def shardAssignmentsWithRetry( coord: ActorRef,
+                                         dataset: DatasetRef,
+                                         resources: DatasetResourceSpec,
+                                         mapper: ShardMapper,
+                                         currentAttempt: Int,
+                                         maxAssignmentAttempts: Int): Seq[Int] =
+    getOrdinalFromActorRef(coord) match {
+        case Some((hostName, ordinal)) if ordinal > -1 =>
           val numShardsPerHost = resources.numShards / resources.minNumNodes
           // Suppose we have a total of 8 shards and 2 hosts, assuming the hostnames are host-0 and host-1, we will map
           // host-0 to shard [0,1,2,3] and host-1 to shard [4,5,6,7]
@@ -88,31 +103,55 @@ class K8sStatefulSetShardAssignmentStrategy extends ShardAssignmentStrategy with
           val unassignedShardSet = mapper.unassignedShards.toSet
           val potentialShardsMappedToThisCoordinator =
             (firstShardThisNode until firstShardThisNode + numShardsThisHost).toList.
-              filter(unassignedShardSet.contains(_))
+              filter(unassignedShardSet.contains)
 
           if(potentialShardsMappedToThisCoordinator.nonEmpty) {
             logger.info("Using hostname resolution for shard mapping, mapping host={} to shards={}",
               hostName, potentialShardsMappedToThisCoordinator)
           }
           potentialShardsMappedToThisCoordinator
-        case None                      =>
-          // Host name does not have the ordinal at the end like a stateful set needs to have, delegate to default
-          //strategy
-          logger.info(
-            "Falling back to DefaultShardAssignmentStrategy as hostname does not match k8s StatefulSet convention" +
-              " for coordinator {}", coord.path.address.host.getOrElse(InetAddress.getLocalHost.getHostName))
-          DefaultShardAssignmentStrategy.shardAssignments(coord, dataset, resources, mapper)
-      }
+        case Some((hostName, _))       => retryWithBackoff(coord, dataset, resources, mapper,
+                                            hostName, currentAttempt, maxAssignmentAttempts)(shardAssignmentsWithRetry)
+        case None                      => retryWithBackoff(coord, dataset, resources, mapper, hostName = "",
+                                            currentAttempt, maxAssignmentAttempts)(shardAssignmentsWithRetry)
+  }
+  // scalastyle:on method.length
 
+  private def retryWithBackoff[T](coord: ActorRef, dataset: DatasetRef, resources: DatasetResourceSpec,
+                               mapper: ShardMapper, hostName: String,
+                               currentAttempt: Int, maxAssignmentAttempts: Int)
+                              (f: (ActorRef, DatasetRef, DatasetResourceSpec, ShardMapper, Int, Int) => T): T= {
+    // Host name does not have the ordinal at the end like a stateful set needs to have, retry we we have
+    // retries left
+    if (currentAttempt > maxAssignmentAttempts) {
+      logger.error(s"Unable to resolve host names after $currentAttempt attempts, terminating now")
+      Shutdown.haltAndCatchFire(
+        new Error(s"Unable to resolve host names after $currentAttempt attempts, terminating now"))
+      ???
+    } else {
+      val retryAfter = (1 << currentAttempt).min(60)
+      logger.warn("Hostname resolution did not work after attempt={}, resolved hostName='{}', will retry after {} sec",
+                  currentAttempt, hostName, retryAfter)
+      Thread.sleep(retryAfter * 1000L)
+      f(coord, dataset, resources, mapper, currentAttempt + 1, maxAssignmentAttempts)
+    }
+}
 
   override def remainingCapacity(coord: ActorRef,
                                  dataset: DatasetRef,
                                  resources: DatasetResourceSpec,
                                  mapper: ShardMapper): Int =
+    remainingCapacityWithRetry(coord, dataset, resources, mapper, currentAttempt = 1, maxAssignmentAttempts = 8)
+
+  private def remainingCapacityWithRetry(coord: ActorRef,
+                                 dataset: DatasetRef,
+                                 resources: DatasetResourceSpec,
+                                 mapper: ShardMapper,
+                                 currentAttempt: Int, maxAssignmentAttempts: Int): Int =
     getOrdinalFromActorRef(coord) match {
         // Host name has the ordinal at the end, we can thus use the logic we use for stateful sets
         // Difference between fixed number of shards the coordinator can take and those currently assigned
-        case Some((_, ordinal))  =>
+        case Some((_, ordinal)) if ordinal > -1 =>
           val numShardsPerHost = resources.numShards / resources.minNumNodes
           val numExtraShardsToAssign = resources.numShards % resources.minNumNodes
           val numShardsThisNode = if (numExtraShardsToAssign != 0) {
@@ -123,7 +162,12 @@ class K8sStatefulSetShardAssignmentStrategy extends ShardAssignmentStrategy with
             numShardsPerHost
           (numShardsThisNode - mapper.shardsForCoord(coord).size).max(0)
         // Flag to resolve shards using hostname set but hostname does not follow stateful set hostname pattern
-        case None     => DefaultShardAssignmentStrategy.remainingCapacity(coord, dataset, resources, mapper)
+        case Some((hostName, _))               =>
+                        retryWithBackoff(coord, dataset, resources, mapper, hostName,
+                          currentAttempt, maxAssignmentAttempts)(remainingCapacityWithRetry)
+        case None                              =>
+                        retryWithBackoff(coord, dataset, resources, mapper, hostName = "", currentAttempt,
+                          maxAssignmentAttempts)(remainingCapacityWithRetry)
       }
 }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -274,7 +274,7 @@ filodb {
     # Minimum time required between successive automatic shard reassignments done by ShardManager
     reassignment-min-interval = 2 hours
     # Flag to enable
-    enable-k8s-stateful-shard-strategy = true
+    enable-k8s-stateful-shard-strategy = false
     k8s-strategy {
         max-hostname-lookup-attempts = 8
     }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -274,7 +274,10 @@ filodb {
     # Minimum time required between successive automatic shard reassignments done by ShardManager
     reassignment-min-interval = 2 hours
     # Flag to enable
-    enable-k8s-stateful-shard-strategy = false
+    enable-k8s-stateful-shard-strategy = true
+    k8s-strategy {
+        max-hostname-lookup-attempts = 8
+    }
   }
 
   cassandra {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
 ``K8sStatefulSetShardAssignmentStrategy`` currently falls back to default strategy if the host name resolution does not work. 

**New behavior :**
The current default strategy is not correct and silently will reassign shards to random pods defeating the purpose of having prebuilt index. We need to retry with backoff and see if we can assign shards meant for that pod and fail if its not possible to do so. 


**BREAKING CHANGES**
Previously working  ``K8sStatefulSetShardAssignmentStrategy`` configured with deployment (which isn't the right configuration) will now fail instead of silently falling back to default strategy.

