### PR TITLE
misc(query): modify target-schema-mapper to accept list of schema changes over time

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -192,7 +192,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   it("should use target-schema and generate ExecPlan with appropriate shards") {
-    val targetSchema = Map(Map("job" -> "myService") -> Seq("job", "instance"))
+    val targetSchema = Map(Map("job" -> "myService") -> Seq(TargetSchemaChange(schema = Seq("job", "instance"))))
 
     val filodbSpreadMap = new collection.mutable.HashMap[collection.Map[String, String], Int]
     filodbSpreadMap.put(collection.Map(("job" -> "myService")), 2)

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -118,7 +118,7 @@ object QueryContext {
    * @return
    */
   def mapTargetSchemaFunc(shardKeyNames: Seq[String],
-                          targetSchemaMap: Map[Map[String, String], Seq[String]],
+                          targetSchemaMap: Map[Map[String, String], Seq[TargetSchemaChange]],
                           optionalShardKey: String)
           : Seq[ColumnFilter] => Seq[TargetSchemaChange] = {
     filters: Seq[ColumnFilter] =>
@@ -131,19 +131,18 @@ object QueryContext {
       }.toMap
       val defaultSchema = targetSchemaMap.get(nonOptShardKeys)
       val schema = targetSchemaMap.get(shardKeysInQuery)
-      val schemaToUse = schema.orElse(defaultSchema)
-      if (schemaToUse.isDefined) {
-        Seq(TargetSchemaChange(schema = schemaToUse.get))
-      } else {
-        Seq.empty
+      schema.orElse(defaultSchema) match {
+        case Some(targetSchemaChanges) => targetSchemaChanges
+        case None => Seq.empty
       }
   }
 
   def mapTargetSchemaFunc(shardKeyNames: java.util.List[String],
-                          targetSchemaMap: java.util.Map[java.util.Map[String, String], java.util.List[String]],
+                          targetSchemaMap: java.util.Map[java.util.Map[String, String],
+                          java.util.List[TargetSchemaChange]],
                           optionalShardKey: String)
           : Seq[ColumnFilter] => Seq[TargetSchemaChange] = {
-    val targetSchema: Map[Map[String, String], Seq[String]] = targetSchemaMap.asScala.map {
+    val targetSchema: Map[Map[String, String], Seq[TargetSchemaChange]] = targetSchemaMap.asScala.map {
       case (d, v) => d.asScala.toMap -> v.asScala.toSeq
     }.toMap
     mapTargetSchemaFunc(shardKeyNames.asScala, targetSchema, optionalShardKey)


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

`targetSchemaMapper` utility is modified to accept list of `TargetSchemaChange`. This is needed as query planning can fall back to spread-to-all-shards strategy if there is a change in targetSchema config in the query-window.

