### PR TITLE
feat(downsample): exclude labels from export

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -431,6 +431,7 @@ filodb {
 
       # Spark SaveMode / options.
       save-mode = "error"
+      format = "csv"
       options = {
         "header": "true"
       }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -432,8 +432,6 @@ filodb {
       options = {
         "header": "true"
       }
-      # See filodb.downsampler.chunk.SparkSessionSetup for details.
-      spark-session-setup-class = ""
       # Describe the sequence of labels that compose a rule's key.
       # A time-series should match at most one key.
       key-labels = ["_ws_"]

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -445,14 +445,12 @@ filodb {
 
       # Each row's labels are compared against all rule-group keys. If a match is found,
       #   the row's labels are compared *sequentially* against each of the group's rules until
-      #   a rule meets both of the following conditions:
-      #       (1) no "block" filter group is matched, and
-      #       (2) an "allow" filter group is matched, or the "allow" filters are empty.
-      # If a rule meets both of these conditions, it is applied. This means that row data is/isn't exported
+      #   a rule meets both of the following criteria:
+      #       (1) No "block" filters are matched.
+      #       (2) The "allow" filters are either matched or empty.
+      # This rule will be applied to the row. This means that row data is/isn't exported
       #   depending on the matched filters, and any other rule effects are also applied (such as dropped labels).
-      # If a matching group is not found, the data will not be exported. Data *will* be exported if
-      #   a matching group was found, but no rule was matched.
-      # Note that this is slightly different than the logic used by the chunk downsampler.
+      # If a matching rule (or group) are not found, the data will not be exported.
       groups = [
         {
           key = ["ws-foo"]

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -428,44 +428,49 @@ filodb {
 
     data-export {
       enabled = false
+
+      # Spark SaveMode / options.
       save-mode = "error"
       options = {
         "header": "true"
       }
-      # Describe the sequence of labels that compose a rule's key.
+
+      # Describe the sequence of labels that compose a rule-group's key.
       # A time-series should match at most one key.
       key-labels = ["_ws_"]
+      # These labels will be dropped from every exported row.
+      drop-labels = ["_ws_", "drop-label1"]
+
       bucket = "file://<path-to-file>"
-      # Each row's labels are compared against all rule keys. If a match is found, the rule is applied.
-      #   Otherwise, no rule is applied (i.e. the data will not be exported).
-      # When a rule is applied, data will be exported only if:
-      #     - The labels must not match any group of block-filters, and
-      #     - Either of the following:
-      #         (1) Allow-filters is empty, or
-      #         (2) The labels match any allow-filters group.
-      # This mirrors the logic used by the chunk downsampler.
-      rules = [
+
+      # Each row's labels are compared against all rule-group keys. If a match is found,
+      #   the row's labels are compared *sequentially* against each of the group's rules until
+      #   a rule meets both of the following conditions:
+      #       (1) no "block" filter group is matched, and
+      #       (2) an "allow" filter group is matched, or the "allow" filters are empty.
+      # If a rule meets both of these conditions, it is applied. This means that row data is/isn't exported
+      #   depending on the matched filters, and any other rule effects are also applied (such as dropped labels).
+      # If a matching group is not found, the data will not be exported. Data *will* be exported if
+      #   a matching group was found, but no rule was matched.
+      # Note that this is slightly different than the logic used by the chunk downsampler.
+      groups = [
         {
           key = ["ws-foo"]
-          allow-filters = [
-            ["_ns_=\"my_ns\"", "bar!=\"baz\""],
-            ["_ns_=\"my_other_ns\""]
-          ]
-          block-filters = [
-            ["_metric_=~\".*bad_suffix\""]
-          ]
-        },
-        {
-          key = ["ws-bar"]
-          allow-filters = [
-            ["_metric_=\"always_allowed\""]
-          ]
-          block-filters = [
-            ["_ns_=\"some_other_ns\"", "labelA!=\"bad_label\""],
-            ["label1=~\"labels_are_cool\""]
+          rules = [
+            {
+              allow-filters = [
+                ["_ns_=\"my_ns\"", "bar!=\"baz\""],
+                ["_ns_=\"my_other_ns\""]
+              ]
+              block-filters = [
+                ["_metric_=~\".*bad_suffix\""]
+              ]
+              drop-labels = ["label1", "other_label"]
+            }
           ]
         }
       ]
+
       # Specifies how to generate a path to an exported time-series.
       # The sequence of key-value pairs describe a directory path, where the
       #   time-series are exported to the final directory.

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -347,6 +347,9 @@ filodb {
 
     chunk-downsampler-enabled = true
 
+    # See filodb.downsampler.chunk.SparkSessionFactory for details.
+    spark-session-factory = "filodb.downsampler.chunk.DefaultSparkSessionFactory"
+
     # Name of the dataset from which to downsample
     # raw-dataset-name = "prometheus"
 
@@ -435,9 +438,6 @@ filodb {
       options = {
         "header": "true"
       }
-
-      # See filodb.downsampler.chunk.SparkSessionFactory for details.
-      spark-session-factory = ""
 
       # Describe the sequence of labels that compose a rule-group's key.
       # A time-series should match at most one key.

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -436,6 +436,9 @@ filodb {
         "header": "true"
       }
 
+      # See filodb.downsampler.chunk.SparkSessionFactory for details.
+      spark-session-factory = ""
+
       # Describe the sequence of labels that compose a rule-group's key.
       # A time-series should match at most one key.
       key-labels = ["_ws_"]

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -3,10 +3,14 @@ package filodb.downsampler.chunk
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
+
 import scala.collection.mutable
+import scala.util.matching.Regex
+
 import kamon.Kamon
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
+
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn}
 import filodb.core.metadata.Schemas
@@ -16,10 +20,8 @@ import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.Utils._
 import filodb.downsampler.chunk.BatchExporter.{DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER}
 import filodb.memory.format.{TypedIterator, UnsafeUtils}
-import filodb.memory.format.vectors.{Histogram, LongIterator}
+import filodb.memory.format.vectors.LongIterator
 
-
-import scala.util.matching.Regex
 
 case class ExportRule(allowFilterGroups: Seq[Seq[ColumnFilter]],
                       blockFilterGroups: Seq[Seq[ColumnFilter]],

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -55,9 +55,9 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings) {
     //   ArrayIndexOutOfBoundsExceptions occur when Spark exports a batch.
     val fields = new mutable.ArrayBuffer[StructField](3 + downsamplerSettings.exportPathSpecPairs.size)
     fields.append(
-      StructField("labels", StringType),
-      StructField("timestamp", LongType),
-      StructField("value", DoubleType)
+      StructField("Labels", StringType),
+      StructField("Timestamp", LongType),
+      StructField("Value", DoubleType)
     )
     // append all partitioning columns as strings
     fields.appendAll(downsamplerSettings.exportPathSpecPairs.map(f => StructField(f._1, StringType)))

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -7,7 +7,6 @@ import java.util.Date
 import scala.collection.mutable
 
 import kamon.Kamon
-import kamon.metric.MeasurementUnit
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -3,11 +3,14 @@ package filodb.downsampler.chunk
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
+
 import scala.collection.mutable
+
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
+
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType.DoubleColumn
 import filodb.core.metadata.Schemas

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -170,8 +170,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     val labelString = {
       val inner = updatedPartKeyMap.map { case (k, v) =>
         if (v.contains(",")) {
-//          String.format("'%s\':\"\"%s\"\"", k, v)  // TODO(a_theimer)
-          s"'$k':'$v'"
+          String.format("'%s\':\"%s\"", k, v)
         } else {
           s"'$k':'$v'"
         }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -163,7 +163,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     val dataSeq = new mutable.ArrayBuffer[Any](3 + downsamplerSettings.exportPathSpecPairs.size)
     dataSeq.append(
       exportData.labelString,
-      exportData.timestamp,
+      exportData.timestamp / 1000,
       exportData.value
     )
     dataSeq.appendAll(exportData.partitionStrings)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -46,6 +46,8 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
 
   @transient lazy private[downsampler] val schemas = Schemas.fromConfig(downsamplerSettings.filodbConfig).get
 
+  @transient lazy val numPartitionsExportPrepped = Kamon.counter("num-partitions-export-prepped").withoutTags()
+
   @transient lazy val exportPrepBatchLatency =
     Kamon.histogram("export-prep-batch-latency", MeasurementUnit.time.milliseconds).withoutTags()
 
@@ -191,6 +193,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
       exportData.value
     )
     dataSeq.appendAll(exportData.partitionStrings)
+    numPartitionsExportPrepped.increment()
     Row.fromSeq(dataSeq)
   }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -16,7 +16,7 @@ import filodb.memory.format.UnsafeUtils
 
 /**
  * Implement this trait and provide its fully-qualified name as the downsampler config:
- *     data-export.spark-session-factory = "org.fully.qualified.FactoryClass"
+ *     spark-session-factory = "org.fully.qualified.FactoryClass"
  */
 trait SparkSessionFactory {
   def make(sparkConf: SparkConf): SparkSession
@@ -82,8 +82,7 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
   // scalastyle:off method.length
   def run(sparkConf: SparkConf): SparkSession = {
 
-    val spark = Class.forName(settings.sparkSessionFactoryClass.getOrElse(
-                              "filodb.downsampler.chunk.DefaultSparkSessionFactory"))
+    val spark = Class.forName(settings.sparkSessionFactoryClass)
         .getDeclaredConstructor()
         .newInstance()
         .asInstanceOf[SparkSessionFactory]

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -164,10 +164,11 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
       // NOTE: toDF(partitionCols: _*) seems buggy
       spark.createDataFrame(rdd, batchExporter.exportSchema)
         .write
+        .format(settings.exportFormat)
         .mode(settings.exportSaveMode)
         .options(settings.exportOptions)
         .partitionBy(batchExporter.partitionByNames: _*)
-        .csv(settings.exportBucket)
+        .save(settings.exportBucket)
       val exportEndMs = System.currentTimeMillis()
       exportLatency.record(exportEndMs - exportStartMs)
     }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -76,9 +76,7 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportIsEnabled = downsamplerConfig.getBoolean("data-export.enabled")
 
-  @transient lazy val sparkSessionFactoryClass =
-    Some(downsamplerConfig.getOrElse("data-export.spark-session-factory", ""))
-      .filter(_.nonEmpty)
+  @transient lazy val sparkSessionFactoryClass = downsamplerConfig.getString("spark-session-factory")
 
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -112,6 +112,8 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportSaveMode = downsamplerConfig.getString("data-export.save-mode")
 
+  @transient lazy val exportFormat = downsamplerConfig.getString("data-export.format")
+
   /**
    * Two conditions should satisfy for eligibility:
    * (a) If allow list is nonEmpty partKey should match a filter in the allow list.

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -76,10 +76,6 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportIsEnabled = downsamplerConfig.getBoolean("data-export.enabled")
 
-  @transient lazy val sparkSessionSetupClass =
-    Some(downsamplerConfig.getOrElse("data-export.spark-session-setup-class", ""))
-      .filter(_.nonEmpty)
-
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")
 
   @transient lazy val exportBucket = downsamplerConfig.as[String]("data-export.bucket")

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -76,6 +76,10 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportIsEnabled = downsamplerConfig.getBoolean("data-export.enabled")
 
+  @transient lazy val sparkSessionFactoryClass =
+    Some(downsamplerConfig.getOrElse("data-export.spark-session-factory", ""))
+      .filter(_.nonEmpty)
+
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")
 
   @transient lazy val exportBucket = downsamplerConfig.as[String]("data-export.bucket")

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -286,7 +286,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       val batchExporter = new BatchExporter(dsSettings)
       // make sure batchExporter correctly decides when to export
       labelConfPairs.foreach { case (partKeyMap, includedConf) =>
-        batchExporter.shouldExport(partKeyMap) shouldEqual includedConf.contains(conf)
+        batchExporter.getRuleIfShouldExport(partKeyMap) shouldEqual includedConf.contains(conf)
       }
     }
   }

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -282,6 +282,36 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
         |""".stripMargin
     )
 
+    val multiRuleSameGroupConf = ConfigFactory.parseString(
+      """
+        |    filodb.downsampler.data-export {
+        |      key-labels = ["l1"]
+        |      groups = [
+        |        {
+        |          key = ["l1a"]
+        |          rules = [
+        |            {
+        |              allow-filters = [["l3=\"l3a\""]]
+        |              block-filters = [["l2=~\"l2(b|d)\""]]
+        |              drop-labels = []
+        |            },
+        |            {
+        |              allow-filters = [["l3=\"l3c\""], ["l2=\"l2c\""]]
+        |              block-filters = [["l2=~\"l2(b|d)\""]]
+        |              drop-labels = []
+        |            },
+        |            {
+        |              allow-filters = [["l3=\"l3c\""], ["l2=\"l2c\""]]
+        |              block-filters = [["l2=~\"l2(b|d)\""]]
+        |              drop-labels = []
+        |            }
+        |          ]
+        |        }
+        |      ]
+        |    }
+        |""".stripMargin
+    )
+
     val allConfs = Seq(
       emptyConf,
       onlyKeyConf,
@@ -289,15 +319,16 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       multiFilterConf,
       contradictFilterConf,
       multiKeyConf,
-      multiRuleConf
+      multiRuleConf,
+      multiRuleSameGroupConf
     )
 
     val labelConfPairs = Seq(
-      (Map("l1" -> "l1a", "l2" -> "l2a", "l3" -> "l3a"), Set[Config](onlyKeyConf,                  includeExcludeConf, multiKeyConf, multiRuleConf,   multiFilterConf)),
+      (Map("l1" -> "l1a", "l2" -> "l2a", "l3" -> "l3a"), Set[Config](onlyKeyConf,                  includeExcludeConf, multiKeyConf, multiRuleConf,   multiFilterConf, multiRuleSameGroupConf)),
       (Map("l1" -> "l1a", "l2" -> "l2a", "l3" -> "l3b"), Set[Config](onlyKeyConf,                  includeExcludeConf, multiKeyConf, multiRuleConf,   multiFilterConf)),
-      (Map("l1" -> "l1a", "l2" -> "l2a", "l3" -> "l3c"), Set[Config](onlyKeyConf,                  includeExcludeConf, multiKeyConf, multiRuleConf)),
+      (Map("l1" -> "l1a", "l2" -> "l2a", "l3" -> "l3c"), Set[Config](onlyKeyConf,                  includeExcludeConf, multiKeyConf, multiRuleConf,                    multiRuleSameGroupConf)),
       (Map("l1" -> "l1a", "l2" -> "l2b", "l3" -> "l3a"), Set[Config](onlyKeyConf,                  includeExcludeConf,               multiRuleConf)),
-      (Map("l1" -> "l1a", "l2" -> "l2c", "l3" -> "l3a"), Set[Config](onlyKeyConf, multiRuleConf)),
+      (Map("l1" -> "l1a", "l2" -> "l2c", "l3" -> "l3a"), Set[Config](onlyKeyConf, multiRuleConf,                                                                       multiRuleSameGroupConf)),
       (Map("l1" -> "l1a", "l2" -> "l2d", "l3" -> "l3a"), Set[Config](onlyKeyConf, multiRuleConf)),
       (Map("l1" -> "l1b", "l2" -> "l2a", "l3" -> "l3a"), Set[Config](             multiRuleConf)),
       (Map("l1" -> "l1c", "l2" -> "l2a", "l3" -> "l3a"), Set[Config]()),


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

## Excluding Labels

Adds a configurable `drop-labels` sequence to export rules. If an export rule is applied to a row, any labels specified in `drop-labels` will be excluded from the exported data.

This PR also changes how rules are defined. Keys now apply to groups of rules; the group is iterated until an applicable rule is found. The benefit of this setup is that rule "modifiers" (i.e. `drop-labels`) can be specified for different sets of time-series.

```
      # Each row's labels are compared against all rule-group keys. If a match is found,
      #   the row's labels are compared *sequentially* against each of the group's rules until
      #   a rule meets both of the following criteria:
      #       (1) No "block" filters are matched.
      #       (2) The "allow" filters are either matched or empty.
      # This rule will be applied to the row. This means that row data is/isn't exported
      #   depending on the matched filters, and any other rule effects are also applied (such as dropped labels).
      # If a matching rule (or group) are not found, the data will not be exported.
      groups = [
        {
          key = ["ws-foo"]
          rules = [
            {
              allow-filters = [
                ["_ns_=\"my_ns\"", "bar!=\"baz\""],
                ["_ns_=\"my_other_ns\""]
              ]
              block-filters = [
                ["_metric_=~\".*bad_suffix\""]
              ]
              drop-labels = ["label1", "other_label"]
            }
          ]
        }
      ]
```

## Other Improvements
- Configurable output file format.
- JSON label-value pairs in the output.
- Various performance optimizations.
- Finds a configured factory class via reflection to make the SparkSession.