### PR TITLE
fix(QueryStats): Using CountingChunkInfoIterator in RawDataRangeVector.rows() to track dataBytesScanned

### DIFF
--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -1,7 +1,7 @@
 dataset-prometheus = { include required("timeseries-dev-source.conf") }
 
 filodb {
-  v2-cluster-enabled = true
+  v2-cluster-enabled = false
   cluster-discovery {
     num-nodes = 2
     failure-detection-interval = 20s

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -1,7 +1,7 @@
 dataset-prometheus = { include required("timeseries-dev-source.conf") }
 
 filodb {
-  v2-cluster-enabled = false
+  v2-cluster-enabled = true
   cluster-discovery {
     num-nodes = 2
     failure-detection-interval = 20s

--- a/core/src/main/scala/filodb.core/store/ReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/store/ReadablePartition.scala
@@ -124,5 +124,10 @@ trait ReadablePartition extends FiloPartition {
   final def timeRangeRows(method: ChunkScanMethod, columnIDs: Array[ColumnId]): RangeVectorCursor =
     new PartitionTimeRangeReader(this, method.startTime, method.endTime, infos(method), columnIDs)
 
+  final def timeRangeRows(method: ChunkScanMethod,
+                          columnIDs: Array[ColumnId],
+                          countInfoIterator: CountingChunkInfoIterator): RangeVectorCursor =
+    new PartitionTimeRangeReader(this, method.startTime, method.endTime, countInfoIterator, columnIDs)
+
   def publishInterval: Option[Long]
 }


### PR DESCRIPTION
- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Raw Queries doesn't track `dataBytesScanned` in QueryStats

**New behavior :** Updated the `RawDataRangeVector.rows()` to use CountingChunkInfoIterator to track dataBytesScanned

**Other information**: