### PR TITLE
fix(query): Avoiding the query scheduler thread assert when InProcessPlanDispatcher is used

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -2,10 +2,12 @@ package filodb.coordinator
 
 import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
+
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
+
 import akka.actor.{ActorRef, Props}
 import akka.pattern.AskTimeoutException
 import kamon.Kamon
@@ -17,6 +19,7 @@ import monix.execution.schedulers.SchedulerService
 import monix.reactive.Observable
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
+
 import filodb.coordinator.queryplanner.SingleClusterPlanner
 import filodb.core._
 import filodb.core.memstore.{FiloSchedulers, TermInfo, TimeSeriesStore}
@@ -168,7 +171,7 @@ final class QueryActor(memStore: TimeSeriesStore,
             .map { res =>
               // below prevents from calling FiloDB directly (without Query Service)
               // UPDATE: 31/10/2022. Avoiding the assert when the InProcessPlanDispatcher is used. As it runs
-              // the query (for example scalar query) on the current/Actor thread instead of the scheduler
+              // the query on the current/Actor thread instead of the scheduler
               if (!q.dispatcher.isInstanceOf[InProcessPlanDispatcher]) {
                 FiloSchedulers.assertThreadName(QuerySchedName)
               }


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

**Current behavior :** IllegalArgumentException when InProcessPlanDispatcher is being used for ExecPlans like EmptyResultExec. Following is an example query and its result.

**Example Query:** http://localhost:8080/promql/prometheus/api/v1/query_range?query=rate(my_counter{_ws_=”aci-telemetry”,_ns_=“Test-data-1667329278_p1”}[2d])&start=1667328078&end=1667329578&step=15

**Result:**
{
  “errorType”: “IllegalArgumentException”,
  “error”: “requirement failed: Current thread expected to startWith query-sched but was filo-standalone-akka.actor.default-dispatcher-3”,
  “status”: “error”,
  “queryStats”: []
}


**New behavior :** Avoiding this assert when InProcessPlanDispatcher is used.