### PR TITLE
fix(query): select correct TargetSchemaChange over time

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -32,7 +32,6 @@ import filodb.memory.format._
 import filodb.prometheus.ast.{InMemoryParam, TimeRangeParams, TimeStepParams, WriteBuffersParam}
 import filodb.prometheus.parse.Parser
 import filodb.query._
-import filodb.query.LogicalPlan.getRawSeriesFilters
 
 // scalastyle:off
 class Arguments(args: Seq[String]) extends ScallopConf(args) {
@@ -309,7 +308,7 @@ object CliMain extends StrictLogging {
         println(FindShardFormatStr.format("Shards", "Query"))
         args.queries().foreach(query => {
           val lp = Parser.queryToLogicalPlan(query, 100, 1)
-          val shardRange = planner.shardsFromFilters(planner.renameMetricFilter(getRawSeriesFilters(lp).head), QueryContext())
+          val shardRange = planner.getShardSpanFromLp(lp, QueryContext())
           println(FindShardFormatStr.format(shardRange.mkString(","), query))
         })
       case _ =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -293,8 +293,7 @@ class SingleClusterPlanner(val dataset: Dataset,
           dsOptions.metricColumn, metric)
         // since target-schema filter is provided in the query, ingestionShard can be used to find the single shard
         // that can answer the query.
-        val ff = Seq(shardMapperFunc.ingestionShard(shardHash, partitionHash, spreadProvToUse.spreadFunc(filters).last.spread))
-        ff
+        Seq(shardMapperFunc.ingestionShard(shardHash, partitionHash, spreadProvToUse.spreadFunc(filters).last.spread))
       } else {
         shardMapperFunc.queryShards(shardHash, spreadProvToUse.spreadFunc(filters).last.spread)
       }
@@ -803,6 +802,7 @@ class SingleClusterPlanner(val dataset: Dataset,
     (newFilters, schemaOpt)
   }
 
+  // scalastyle:off method.length
   private def materializeRawSeries(qContext: QueryContext,
                                    lp: RawSeries,
                                    forceInProcess: Boolean): PlanResult = {
@@ -856,6 +856,7 @@ class SingleClusterPlanner(val dataset: Dataset,
     // when target-schema changes during query window, data might be ingested in different shards after the change.
     PlanResult(execPlans, needsStitch || tsChangeExists)
   }
+  // scalastyle:on method.length
 
   private def materializeLabelValues(qContext: QueryContext,
                                      lp: LabelValues,

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/FindMyShards.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/FindMyShards.scala
@@ -11,7 +11,6 @@ import filodb.core.{MetricsTestData, SpreadChange}
 import filodb.core.metadata.Schemas
 import filodb.core.query.{QueryConfig, QueryContext}
 import filodb.prometheus.parse.Parser
-import filodb.query.LogicalPlan.getRawSeriesFilters
 
 object FindMyShards extends StrictLogging {
 
@@ -27,7 +26,7 @@ object FindMyShards extends StrictLogging {
     val engine = initEngine(numShard, spread)
     queries.foreach(query => {
       val lp = Parser.queryToLogicalPlan(query, 100, 1)
-      val shardRange = engine.shardsFromFilters(engine.renameMetricFilter(getRawSeriesFilters(lp).head), QueryContext())
+      val shardRange = engine.getShardSpanFromLp(lp, QueryContext())
       logger.info(s">>> Shard$shardRange >>> $query")
     })
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, `SingleClusterPlanner::shardsFromFilters` always makes use of the final `TargetSchemaChange` from a sequence of changes. This PR adds logic to select the appropriate `TargetSchemaChange` given a query's range.