### PR TITLE
fix(core) Correctly read env variable value for index generation

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -76,7 +76,9 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       case IndexMetastoreImplementation.NoImp       => None
       case IndexMetastoreImplementation.File        =>
         Some(new FileSystemBasedIndexMetadataStore(downsampleConfig.indexLocation.get,
-          FileSystemBasedIndexMetadataStore.expectedVersion(FileSystemBasedIndexMetadataStore.expectedGenerationEnv),
+          FileSystemBasedIndexMetadataStore.expectedVersion(
+            sys.env.get(FileSystemBasedIndexMetadataStore.expectedGenerationEnv)
+          ),
           downsampleConfig.maxRefreshHours))
       case IndexMetastoreImplementation.Ephemeral   => Some(new EphemeralIndexMetadataStore())
     }

--- a/core/src/main/scala/filodb.core/memstore/IndexMetadataStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexMetadataStore.scala
@@ -96,15 +96,15 @@ object FileSystemBasedIndexMetadataStore extends StrictLogging {
   val snapFileV1Magic = 0x5c
   val expectedGenerationEnv = "INDEX_GENERATION"
 
-  def expectedVersion(expectedVersion: String): Option[Int] = {
-    if (expectedVersion != null) {
+  def expectedVersion(expectedVersion: Option[String]): Option[Int] = {
+    expectedVersion.flatMap(value => {
       logger.info("Expected version for the index from env is {}", expectedVersion)
-      Try(Integer.parseInt(expectedVersion)) match {
-        case Success(parsedVersion)   => Some(parsedVersion)
-        case Failure(e)               => logger.warn("Failed while parsing index generation", e)
+      Try(Integer.parseInt(value)) match {
+        case Success(parsedVersion) => Some(parsedVersion)
+        case Failure(e) => logger.warn("Failed while parsing index generation", e)
           None
       }
-    } else None
+    })
   }
 }
 /**

--- a/core/src/test/scala/filodb.core/memstore/FileSystemBasedIndexMetadataStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/FileSystemBasedIndexMetadataStoreSpec.scala
@@ -333,19 +333,19 @@ class FileSystemBasedIndexMetadataStoreSpec extends AnyFunSpec with Matchers wit
   }
 
   it("should parse the expectedVersion when a numeric value as String is provided") {
-    FileSystemBasedIndexMetadataStore.expectedVersion("123") shouldEqual Some(123)
+    FileSystemBasedIndexMetadataStore.expectedVersion(Some("123")) shouldEqual Some(123)
   }
 
   it("should return None if null string is provided") {
-    FileSystemBasedIndexMetadataStore.expectedVersion(null) shouldEqual None
+    FileSystemBasedIndexMetadataStore.expectedVersion(None) shouldEqual None
   }
 
   it("should return None if non numeric string is provided") {
-    FileSystemBasedIndexMetadataStore.expectedVersion("test") shouldEqual None
+    FileSystemBasedIndexMetadataStore.expectedVersion(Some("test")) shouldEqual None
   }
 
   it("should return None if overflowing numeric string is provided") {
-    FileSystemBasedIndexMetadataStore.expectedVersion("12345678686774553466 ") shouldEqual None
+    FileSystemBasedIndexMetadataStore.expectedVersion(Some("12345678686774553466 ")) shouldEqual None
   }
 }
 // scalastyle:on


### PR DESCRIPTION
``DownsampleTimeseriesShard`` was incorrectly reading the name of the environment variable instead of the value stored in that environment variable to find the generation of the index. The fix now reads the desired value. 
