### PR TITLE
feat(preagg): schema types to support ingestion pre-aggregated metrics

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -128,9 +128,7 @@ filodb {
     delta-counter {
       columns = ["timestamp:ts", "count:double:detectDrops=false"]
       value-column = "count"
-      downsamplers = [ "tTime(0)", "dSum(1)" ]
-      downsample-period-marker = "time(0)"
-      downsample-schema = "delta-counter"
+      downsamplers = [] // downsampling is disabled by default
     }
 
     prom-histogram {
@@ -151,9 +149,34 @@ filodb {
         "count:double:detectDrops=false",
         "h:hist:counter=false"]
       value-column = "h"
-      downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "hSum(3)"]
-      downsample-period-marker = "time(0)"
-      downsample-schema = "delta-histogram"
+      downsamplers = [] // downsampling is disabled by default
+    }
+
+    # PreAgg Schema defintions.
+    # preagg-gauge and preagg-delta-counter have same schemas. Defining two different data-schemas to enable
+    # additional features/functionalities at query-time. preaggregated delta-histogram data has same schema
+    # as raw delta-histogram data, so no need to define additional schema for preaggregated data.
+    preagg-gauge {
+      columns = [
+        "timestamp:ts",
+        "value:double:detectDrops=false",
+        "min:double:detectDrops=false",
+        "sum:double:detectDrops=false",
+        "max:double:detectDrops=false",
+      ]
+      value-column = "sum"
+      downsamplers = [] // downsampling is disabled by default
+    }
+    preagg-delta-counter {
+      columns = [
+        "timestamp:ts",
+        "count:double:detectDrops=false",
+        "min:double:detectDrops=false",
+        "sum:double:detectDrops=false",
+        "max:double:detectDrops=false",
+      ]
+      value-column = "count"
+      downsamplers = [] // downsampling is disabled by default
     }
 
     # Used for downsampled gauge data

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -465,4 +465,6 @@ object Schemas extends StrictLogging {
   val promHistogram = global.schemas("prom-histogram")
   val deltaHistogram = global.schemas("delta-histogram")
   val dsGauge = global.schemas("ds-gauge")
+  val preaggGauge = global.schemas("preagg-gauge")
+  val preaggDeltaCounter = global.schemas("preagg-delta-counter")
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

- additional schema types to support ingestion/querying of pre-aggregated metrics - `preagg-gauge` and `preagg-delta-counter`. 
- no additional schema type is needed for `delta-histogram`, as it suffices for both raw and pre-aggregated metrics as they have same data-schema/columns.