### PR TITLE
fix(query) Config to enable requesting a GC after Lucene merge is done

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -613,6 +613,14 @@ filodb {
     # If all of the index-faceting-enabled-* properties are false, faceting is fully disabled.
     # Disable if performance cost of faceting all labels is too high
     index-faceting-enabled-for-all-labels = true
+
+    # IndexWriterPlus intercepts the merge call and if we explicitly wish to request System.gc() to clear
+    # garbage collect any ThreadLocal WeakReferences, we can set this flag to true
+    request-gc-after-index-merge = false
+
+    # If the request-gc-after-index-merge is set to true, the GC after merge will be requested no earlier than the
+    # below mentioned milliseconds since the last time GC was requested
+    min-duration-between-gc = 86400000
   }
 
   # for standalone worker cluster configuration, see akka-bootstrapper

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -276,6 +276,8 @@ class TimeSeriesShard(val ref: DatasetRef,
                            filodbConfig.getBoolean("memstore.index-faceting-enabled-shard-key-labels")
   private val indexFacetingEnabledAllLabels = filodbConfig.getBoolean("memstore.index-faceting-enabled-for-all-labels")
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
+  private val requestGCAfterIndexMerge = filodbConfig.getBoolean("memstore.index-faceting-enabled-for-all-labels")
+  private val minDurationBetweenGC = filodbConfig.getLong("memstore.min-duration-between-gc")
 
   /////// END CONFIGURATION FIELDS ///////////////////
 
@@ -303,7 +305,9 @@ class TimeSeriesShard(val ref: DatasetRef,
     */
   private[memstore] final val partKeyIndex = new PartKeyLuceneIndex(ref, schemas.part,
     indexFacetingEnabledAllLabels, indexFacetingEnabledShardKeyLabels, shardNum,
-    storeConfig.diskTTLSeconds * 1000)
+    storeConfig.diskTTLSeconds * 1000,
+    requestGCAfterMerge = this.requestGCAfterIndexMerge,
+    minDurationBetweenGC = this.minDurationBetweenGC)
 
   private val cardTracker: CardinalityTracker = initCardTracker()
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -276,7 +276,7 @@ class TimeSeriesShard(val ref: DatasetRef,
                            filodbConfig.getBoolean("memstore.index-faceting-enabled-shard-key-labels")
   private val indexFacetingEnabledAllLabels = filodbConfig.getBoolean("memstore.index-faceting-enabled-for-all-labels")
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
-  private val requestGCAfterIndexMerge = filodbConfig.getBoolean("memstore.index-faceting-enabled-for-all-labels")
+  private val requestGCAfterIndexMerge = filodbConfig.getBoolean("memstore.request-gc-after-index-merge")
   private val minDurationBetweenGC = filodbConfig.getLong("memstore.min-duration-between-gc")
 
   /////// END CONFIGURATION FIELDS ///////////////////

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -58,6 +58,8 @@ filodb {
     track-queries-holding-eviction-lock = false
     index-faceting-enabled-shard-key-labels = true
     index-faceting-enabled-for-all-labels = true
+    request-gc-after-index-merge = false
+    min-duration-between-gc = 86400000
   }
 
   tasks {

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -32,6 +32,8 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
                                             |filodb.memstore.ensure-block-memory-headroom-percent = 10
                                             |filodb.memstore.ensure-tsp-count-headroom-percent = 10
                                             |filodb.memstore.ensure-native-memory-headroom-percent = 10
+                                            |filodb.memstore.request-gc-after-index-merge = false
+                                            |filodb.memstore.min-duration-between-gc = 86400000
                                             |  """.stripMargin)
                             .withFallback(ConfigFactory.load("application_test.conf"))
                             .getConfig("filodb")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

For large Lucene index, current version of Lucene is know to build up large number of ``WeakReferences`` with thread locals. We periodically want an option to request a full gc explicitly. The PR lets us drive this with a configuration change.


