### PR TITLE
feat(coord): Circuit Breaker to protect query engine from overload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
   - openjdk11
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION -sbt-launch-repo https://repo1.maven.org/maven2 test
+  - sbt ++$TRAVIS_SCALA_VERSION -sbt-launch-repo https://repo1.maven.org/maven2 test standalone/assembly gateway/assembly cli/assembly
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -4,7 +4,7 @@ import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
 
 import scala.collection.mutable
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
@@ -13,8 +13,10 @@ import akka.pattern.AskTimeoutException
 import kamon.Kamon
 import kamon.instrumentation.executor.ExecutorInstrumentation
 import kamon.tag.TagSet
+import monix.catnap.CircuitBreaker
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.execution.exceptions.ExecutionRejectedException
 import monix.execution.schedulers.SchedulerService
 import monix.reactive.Observable
 import net.ceedubs.ficus.Ficus._
@@ -83,6 +85,16 @@ final class QueryActor(memStore: TimeSeriesStore,
                                               earliestRawTimestampFn, queryConfig, "raw",
                                               functionalSpreadProvider)
   val queryScheduler = createInstrumentedQueryScheduler()
+
+  private val numRejectedPlans = Kamon.counter("circuit-breaker-rejected-plans").withTags(TagSet.from(tags))
+  private val circuitBreakerNumFailures = config.getInt("circuit-breaker.num-failures")
+  private val circuitBreakerResetTimeout = config.as[FiniteDuration]("circuit-breaker.reset-timeout")
+  private val circuitBreakerExpBackOffFactor = config.getDouble("circuit-breaker.exp-backoff-factor")
+  private val circuitBreakerMaxTimeout = config.as[FiniteDuration]("circuit-breaker.max-reset-timeout")
+  private val circuitBreaker = CircuitBreaker[Task].unsafe(circuitBreakerNumFailures,
+    circuitBreakerResetTimeout, circuitBreakerExpBackOffFactor, circuitBreakerMaxTimeout,
+    onRejected = Task.eval(numRejectedPlans.increment()))
+
 
   private val tags = Map("dataset" -> dsRef.toString)
   private val lpRequests = Kamon.counter("queryactor-logicalPlan-requests").withTags(TagSet.from(tags))
@@ -155,21 +167,27 @@ final class QueryActor(memStore: TimeSeriesStore,
             .onErrorHandle { t =>
               StreamQueryError(q.queryContext.queryId, querySession.queryStats, t)
             }.map { resp =>
-              FiloSchedulers.assertThreadName(QuerySchedName)
+              if (!q.dispatcher.isInstanceOf[InProcessPlanDispatcher]) {
+                FiloSchedulers.assertThreadName(QuerySchedName)
+              }
+              replyTo ! resp
               resp match {
-                case e: StreamQueryError => logQueryErrors(e.t)
+                case e: StreamQueryError =>
+                  logQueryErrors(e.t)
+                  queryErrors.increment()
+                  queryExecuteSpan.fail(e.t.getMessage)
+                  if (e.t.isInstanceOf[QueryTimeoutException] || e.t.isInstanceOf[AskTimeoutException]) throw e.t
                 case _ =>
               }
-              logger.debug(s"Sending response $resp to $replyTo")
-              replyTo ! resp
             }.guarantee(Task.eval {
               querySession.close()
               queryExecuteSpan.finish()
             }).completedL
         } else {
           q.execute(memStore, querySession)(queryScheduler)
-            .map { res =>
-              // below prevents from calling FiloDB directly (without Query Service)
+            .onErrorHandle { t =>
+              QueryError(q.queryContext.queryId, querySession.queryStats, t)
+            }.map { res =>
               // UPDATE: 31/10/2022. Avoiding the assert when the InProcessPlanDispatcher is used. As it runs
               // the query on the current/Actor thread instead of the scheduler
               if (!q.dispatcher.isInstanceOf[InProcessPlanDispatcher]) {
@@ -182,19 +200,24 @@ final class QueryActor(memStore: TimeSeriesStore,
                   logQueryErrors(e.t)
                   queryErrors.increment()
                   queryExecuteSpan.fail(e.t.getMessage)
+                  if (e.t.isInstanceOf[QueryTimeoutException] || e.t.isInstanceOf[AskTimeoutException]) throw e.t
               }
-            }.onErrorHandle { ex =>
-              // Unhandled exception in query, should be rare
-              logger.error(s"queryId ${q.queryContext.queryId} Unhandled Query Error," +
-                s" query was ${q.queryContext.origQueryParams}", ex)
-              replyTo ! QueryError(q.queryContext.queryId, querySession.queryStats, ex)
             }.guarantee(Task.eval {
               queryExecuteSpan.finish()
               querySession.close()
             })
         }
-        logger.debug(s"Will now run query execution pipeline for $q")
-        execTask.runToFuture(queryScheduler)
+        circuitBreaker.protect(execTask)
+          .onErrorHandle {
+            case t: ExecutionRejectedException =>
+              logQueryErrors(t)
+              if (querySession.streamingDispatch)
+                replyTo ! StreamQueryError(q.queryContext.queryId, querySession.queryStats, t)
+              else
+                replyTo ! QueryError(q.queryContext.queryId, querySession.queryStats, t)
+            case _ => // all other errors are already handled
+          }
+          .runToFuture(queryScheduler)
       }
     }
 
@@ -203,11 +226,11 @@ final class QueryActor(memStore: TimeSeriesStore,
       t match {
         case _: BadQueryException => // dont log user errors
         case _: AskTimeoutException => // dont log ask timeouts. useless - let it simply flow up
-        case e: QueryTimeoutException => // log just message, no need for stacktrace
-          logger.error(s"queryId: ${q.queryContext.queryId} QueryTimeoutException: " +
-            s"${q.queryContext.origQueryParams} ${e.getMessage}")
+        case _: QueryTimeoutException | _: ExecutionRejectedException => // log just message, no need for stacktrace
+          logger.error(s"Query Error ${t.getClass.getSimpleName} queryId=${q.queryContext.queryId} " +
+            s"${q.queryContext.origQueryParams} ${t.getMessage}")
         case e: Throwable =>
-          logger.error(s"queryId: ${q.queryContext.queryId} Query Error: " +
+          logger.error(s"Query Error queryId=${q.queryContext.queryId} " +
             s"${q.queryContext.origQueryParams}", e)
       }
       // debug logging

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -268,6 +268,19 @@ filodb {
     # Config values are used when partialResults query parameter is not provided
     allow-partial-results-metadataquery = true
     allow-partial-results-rangequery = false
+
+    circuit-breaker {
+      # query circuit breaker enabled or not
+      enabled = false
+      # open the circuit when number of failures reaches this count
+      open-when-num-failures = 5
+      # move to half-open after this time
+      reset-timeout = 15 seconds
+      # backoff-factor when trying to half-open
+      exp-backoff-factor = 1.5
+      # maximum time in open state
+      max-reset-timeout = 5 minutes
+    }
   }
 
   shard-manager {
@@ -613,7 +626,7 @@ gateway {
 
   # Maximum size of queue for each shard's records.  Must be a power of 2.  When the max queue size is reached
   # then the connection will stop accepting incoming records.
-  max-queue-size = 16384
+  max-queue-size = 262144
 
   # Amount of sleep the ingesting TCP server does when the queue for a given shard is full
   queue-full-wait = 100ms

--- a/gatling/src/test/scala/filodb/gatling/QueryRangeSimulation.scala
+++ b/gatling/src/test/scala/filodb/gatling/QueryRangeSimulation.scala
@@ -18,9 +18,9 @@ class QueryRangeSimulation extends Simulation {
   object Configuration {
     val baseUrl = "http://localhost:8080"
     val numApps = 1
-    val numUsers = 10
+    val numUsers = 20
     val testDuration = 3.minutes
-    val startSecs = 1669662925L // Before each run, change this to the right timestamp relevant to data stored in server
+    val startSecs = 1670818224L // Before each run, change this to the right timestamp relevant to data stored in server
 
     // Uncomment one query from here:
     val queryName = "BinaryJoin"

--- a/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
+++ b/http/src/main/scala/filodb/http/PrometheusApiRoute.scala
@@ -183,9 +183,7 @@ class PrometheusApiRoute(nodeCoord: ActorRef, settings: HttpSettings)(implicit a
         else if (qr.resultSchema.columns.length == 1 && qr.resultSchema.columns(0).colType == MapColumn)
           complete(toMetadataMapResponse(qr, verbose, qr.resultType, Option(qr.mayBePartial)))
         else complete(toPromSuccessResponse(qr, verbose)) // not defined
-      case qr: QueryResult => val translated = if (histMap)
-                                                qr
-                                               else convertHistToPromResult(qr, schemas.part)
+      case qr: QueryResult => val translated = if (histMap) qr else convertHistToPromResult(qr, schemas.part)
                               complete(toPromSuccessResponse(translated, verbose))
       case qr: QueryError => complete(toPromErrorResponse(qr))
       case qr: ExecPlan => complete(toPromExplainPlanResponse(qr))

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -207,6 +207,7 @@ object FiloSettings {
     assemblyMergeStrategy in assembly := {
       case PathList("scala", "collection", "compat", xs @ _*) => MergeStrategy.first
       case PathList("scala", "annotation", "nowarn.class") => MergeStrategy.first
+      case PathList("com", "esotericsoftware", xs @ _*) => MergeStrategy.first
       case m if m.toLowerCase.matches("scala-collection-compat.properties") => MergeStrategy.first
       case m if m.toLowerCase.endsWith("manifest.mf") => MergeStrategy.discard
       case m if m.toLowerCase.matches("meta-inf.*\\.sf$") => MergeStrategy.discard

--- a/scripts/schema-truncate.sh
+++ b/scripts/schema-truncate.sh
@@ -63,4 +63,4 @@ do
     truncate_chunk_tables ${FILO_DOWNSAMPLE_KEYSPACE} "${DATASET}_ds_${RES}"
 done
 
-truncate_partkey_tables ${FILO_DOWNSAMPLE_KEYSPACE} "${DATASET}_ds_${RESOLUTIONS[-1]}"
+truncate_partkey_tables ${FILO_DOWNSAMPLE_KEYSPACE} "${DATASET}_ds_${RESOLUTIONS[@]: -1}"


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

## Motivation
Reject queries before they are accepted into the queue if the system is overloaded thereby reducing latencies for queries that come later, and increasing overall throughput and availability of system. Reduce query timeouts and improve client experience.

## Library used:
https://monix.io/docs/current/catnap/circuit-breaker.html

## Circuit Breaker Configuration

```
    circuit-breaker {
      # query circuit breaker enabled or not
      enabled = false
      # open the circuit when number of failures reaches this count
      open-when-num-failures = 5
      # move to half-open after this time
      reset-timeout = 30 seconds
      # backoff-factor when trying to half-open
      exp-backoff-factor = 1.5
      # maximum time in open state
      max-reset-timeout = 5 minutes
    }
```

## Perf Test Setup

* 1 FiloDB node with 8 shards, 4GB Heap, on M1-Max dev machine
* Ingestion completed. Ingestion not running during query load.
* 5k cardinality 1-to-1 binary join + aggregate query for 3 hours with step of 1min. sum(foo+bar) type query.
* 20 queries per second
* 3 minutes long
* Queries hit FiloDB directly. In a deployment setup where FiloDB is not responsible for serializing results to json, performance will be better.
* Query result streaming not enabled.

## Without Circuit Breaker
![without1](https://user-images.githubusercontent.com/5897052/208315121-4c0fb46d-a93a-4f40-b88d-1b23b772b6e9.jpg)
![without2](https://user-images.githubusercontent.com/5897052/208314991-76a547e4-5c9e-40e5-81bf-f97803f6a6de.jpg)
![without3](https://user-images.githubusercontent.com/5897052/208314993-00893efe-4fdd-4e3e-b5f1-0820a056b3af.jpg)
![without4](https://user-images.githubusercontent.com/5897052/208314998-74a2d75f-4002-4dd3-be90-d5dbaffb4afc.jpg)

## With Circuit Breaker
![with1](https://user-images.githubusercontent.com/5897052/208315046-9f0b86f9-2ce4-46c9-b1ed-48a744122bef.jpg)
![with2](https://user-images.githubusercontent.com/5897052/208315051-207d88be-b046-468a-8009-a0041d1d2440.jpg)
![with3](https://user-images.githubusercontent.com/5897052/208315052-3cc35e3d-188f-4e6e-8379-9e049a480f79.jpg)
![with4](https://user-images.githubusercontent.com/5897052/208315057-b7d8b59a-18d8-49f1-b644-c2d2c2381902.jpg)


## Analysis

* Mean, 50th and 75%ile latencies are much better with circuit breaker since queries dont sit in the queue for long time. Also, clients don’t wait for a long time eventually getting a timeout.
* Total number of OK queries are lesser when Circuit breaker is on (with high latency though). This is because the breaker rejects very early a small percentage of queries that may have OKed with high latency.
* How does FiloDB OK more queries without the circuit breaker - this may be surprising? There is a mechanism to check for query timeout before spending any time on the query, and at regular periods during query execution. This mechanism prevents the engine from spending time on wasteful queries that may have already timed out.
* Without circuit breaker, many requests don’t get a response and timeout. At these times the node is “unavailable”.
* With circuit breaker, we didnt see connection issues on the client. The system was available.

## Conclusion

* If the goal is to reduce latencies at the cost of possibly rejecting/shedding queries (that may have had a small chance of succeeding with high latency) early on, then enabling circuit breaker is a good idea.
* Circuit Breaker is needed for High-Availability. It is also important to protect the system from thundering herd type incessant query workloads. 


