### PR TITLE
feat(query): support rate/increase functions over OTel-style delta metrics

### DIFF
--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -153,8 +153,8 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
     coordinatorActor ! q2
     expectMsgPF(10.seconds.dilated) {
       case QueryResult(_, schema, vectors, _, _, _) =>
-        schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn),
-                                       ColumnInfo("value", ColumnType.DoubleColumn))
+        schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn, false),
+                                       ColumnInfo("value", ColumnType.DoubleColumn, true))
         // query is counting each partition....
         vectors should have length (59 * 2)
         // vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(575.24)

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -117,9 +117,9 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     }
   }
 
-  val timeMinSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("min", DoubleColumn)), 1)
-  val countSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("count", DoubleColumn)), 1)
-  val valueSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn), ColumnInfo("value", DoubleColumn)), 1)
+  val timeMinSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn, false), ColumnInfo("min", DoubleColumn, false)), 1)
+  val countSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn, false), ColumnInfo("count", DoubleColumn)), 1)
+  val valueSchema = ResultSchema(Seq(ColumnInfo("timestamp", TimestampColumn, false), ColumnInfo("value", DoubleColumn)), 1)
   val qOpt = QueryContext(plannerParams = PlannerParams(shardOverrides = Some(Seq(0))), origQueryParams =
     PromQlQueryParams("", 1000, 1, 1000))
 
@@ -381,8 +381,8 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
     probe.send(coordinatorActor, q2)
     probe.expectMsgPF() {
       case QueryResult(_, schema, vectors, _, _, _) =>
-        schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", LongColumn),
-                                       ColumnInfo("value", DoubleColumn))
+        schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", LongColumn, false),
+                                       ColumnInfo("value", DoubleColumn, true))
         vectors should have length (1)
         // vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(575.24)
         // TODO:  verify if the expected results are right.  They are something....

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -246,10 +246,10 @@ class RecordBuilder(memFactory: MemFactory,
   final def addPartKeyRecordFields(base: Any, offset: Long, partKeySchema: RecordSchema): Unit = {
     var id = 0
     partKeySchema.columns.foreach {
-      case ColumnInfo(_, MapColumn) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
-      case ColumnInfo(_, StringColumn) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
-      case ColumnInfo(_, LongColumn) => addLongFromBr(base, offset, id, partKeySchema); id += 1
-      case ColumnInfo(_, DoubleColumn) => addDoubleFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, MapColumn, _) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, StringColumn, _) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, LongColumn, _) => addLongFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, DoubleColumn, _) => addDoubleFromBr(base, offset, id, partKeySchema); id += 1
       case _ => ???
     }
     // finally copy the partition hash over

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -247,7 +247,9 @@ final case class Schema(partition: PartitionSchema, data: DataSchema, var downsa
 
   /** Returns ColumnInfos from a set of column IDs.  Throws exception if ID is invalid */
   def infosFromIDs(ids: Seq[ColumnId]): Seq[ColumnInfo] =
-    ids.map(columnFromID).map { c => ColumnInfo(c.name, c.columnType) }
+    ids.map(columnFromID).map { c => ColumnInfo(c.name, c.columnType,
+      isCumulative = c.params.as[Option[Boolean]]("detectDrops").getOrElse(false)
+                        || c.params.as[Option[Boolean]]("counter").getOrElse(false)) }
 
   override final def toString: String = {
     s"Schema(partition=$partition, data=$data, downsample=${downsample.map(_.name)})"

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -4,6 +4,7 @@ import scala.reflect.runtime.universe._
 
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
+import net.ceedubs.ficus.Ficus._
 import org.joda.time.DateTime
 
 import filodb.core.binaryrecord2.RecordSchema
@@ -23,10 +24,13 @@ final case class PartitionInfo(schema: RecordSchema, base: Array[Byte], offset: 
 /**
  * Describes column/field name and type
  */
-final case class ColumnInfo(name: String, colType: Column.ColumnType)
+final case class ColumnInfo(name: String, colType: Column.ColumnType, isCumulative: Boolean = true)
 
 object ColumnInfo {
-  def apply(col: Column): ColumnInfo = ColumnInfo(col.name, col.columnType)
+  def apply(col: Column): ColumnInfo = ColumnInfo(col.name, col.columnType, isCumulative(col))
+  private def isCumulative(col: Column): Boolean =
+    col.params.as[Option[Boolean]]("detectDrops").getOrElse(false) ||
+      col.params.as[Option[Boolean]]("counter").getOrElse(false)
 }
 
 /**

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -188,10 +188,10 @@ class SchemasSpec extends AnyFunSpec with Matchers {
     it("should return ColumnInfos for colIDs") {
       val sch = largeDataset.schema
       val infos = sch.infosFromIDs(Seq(1, 0))
-      infos shouldEqual Seq(ColumnInfo("first", StringColumn), ColumnInfo("age", LongColumn))
+      infos shouldEqual Seq(ColumnInfo("first", StringColumn, false), ColumnInfo("age", LongColumn, false))
 
       val infos2 = sch.infosFromIDs(Seq(PartColStartIndex, 2))
-      infos2 shouldEqual Seq(ColumnInfo("league", StringColumn), ColumnInfo("last", StringColumn))
+      infos2 shouldEqual Seq(ColumnInfo("league", StringColumn, false), ColumnInfo("last", StringColumn, false))
     }
   }
 

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -32,7 +32,7 @@ class PartKeyIndexBenchmark {
   val numSeries = 1000000
   val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.DefaultContainerSize, false)
   val untypedData = TestTimeseriesProducer.timeSeriesData(0, numSeries,
-           numMetricNames = 1, publishIntervalSec = 10) take numSeries
+           numMetricNames = 1, publishIntervalSec = 10, Schemas.untyped) take numSeries
   untypedData.foreach(_.addToBuilder(ingestBuilder))
 
   val partKeyBuilder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.DefaultContainerSize, false)

--- a/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryAndIngestBenchmark.scala
@@ -17,6 +17,7 @@ import filodb.core.GlobalConfig
 import filodb.core.SpreadChange
 import filodb.core.binaryrecord2.RecordContainer
 import filodb.core.memstore.{SomeData, TimeSeriesMemStore}
+import filodb.core.metadata.Schemas
 import filodb.core.query.{PlannerParams, QueryContext}
 import filodb.core.store.StoreConfig
 import filodb.gateway.GatewayServer
@@ -103,7 +104,8 @@ class QueryAndIngestBenchmark extends StrictLogging {
   val shards = (0 until numShards).map { s => memstore.getShardE(dataset.ref, s) }
 
   private def ingestSamples(noSamples: Int): Future[Unit] = Future {
-    TestTimeseriesProducer.timeSeriesData(startTime, numSeries, numMetricNames = 1, publishIntervalSec = 10)
+    TestTimeseriesProducer.timeSeriesData(startTime, numSeries, numMetricNames = 1,
+                                          publishIntervalSec = 10, Schemas.gauge)
       .take(noSamples * numSeries)
       .foreach { rec =>
         // we shouldn't ingest samples for same timestamps repeatedly. This will also result in out-of-order samples.

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -180,14 +180,14 @@ final case class PeriodicSamplesMapper(startMs: Long,
     } else {
       source.copy(columns = source.columns.zipWithIndex.map {
         // Transform if its not a row key column
-        case (ColumnInfo(name, ColumnType.LongColumn), i) if i >= source.numRowKeyColumns =>
+        case (ColumnInfo(name, ColumnType.LongColumn, _), i) if i >= source.numRowKeyColumns =>
           ColumnInfo("value", ColumnType.DoubleColumn)
-        case (ColumnInfo(name, ColumnType.IntColumn), i) if i >= source.numRowKeyColumns =>
+        case (ColumnInfo(name, ColumnType.IntColumn, _), i) if i >= source.numRowKeyColumns =>
           ColumnInfo(name, ColumnType.DoubleColumn)
         // For double columns, just rename the output so that it's the same no matter source schema.
         // After all after applying a range function, source column doesn't matter anymore
         // NOTE: we only rename if i is 1 or second column.  If its 2 it might be max which cannot be renamed
-        case (ColumnInfo(name, ColumnType.DoubleColumn), i) if i == 1 =>
+        case (ColumnInfo(name, ColumnType.DoubleColumn, _), i) if i == 1 =>
           ColumnInfo("value", ColumnType.DoubleColumn)
         case (c: ColumnInfo, _) => c
       }, fixedVectorLen = if (endMs == startMs) Some(1) else Some(((endMs - startMs) / adjustedStep).toInt + 1))

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -338,9 +338,9 @@ object RangeFunction {
                                   => () => new ChunkedIncreaseFunction
       case Some(Rate) if config.fasterRateEnabled && schema.columns(1).isCumulative
                                   => () => new ChunkedRateFunction
-      case Some(Increase) if config.fasterRateEnabled
+      case Some(Increase) if !schema.columns(1).isCumulative
                                   => () => new SumOverTimeChunkedFunctionD
-      case Some(Rate)     if config.fasterRateEnabled
+      case Some(Rate)     if !schema.columns(1).isCumulative
                                   => () => new RateOverDeltaChunkedFunctionD
 
       case Some(CountOverTime)    => () => new CountOverTimeChunkedFunctionD()

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeInstantFunctions.scala
@@ -69,24 +69,28 @@ object RangeInstantFunctions {
   }
 
   // instant value for a period-counter is the last value in a window.
-  def instantValuePeriodic(startTimestamp: Long,
-                   endTimestamp: Long,
-                   window: Window,
-                   isRate: Boolean): Double = {
-
-    require(window.head.timestamp >= startTimestamp, "Possible internal error, found samples < startTimestamp")
-    require(window.last.timestamp <= endTimestamp, "Possible internal error, found samples > endTimestamp")
-    var resultValue = window.last.value // instant value for a period-counter is the last value in a window.
-    val prevSampleRow = window(window.size - 2)
-    if (isRate) {
-      val sampledInterval = (window.last.timestamp - prevSampleRow.timestamp).toDouble
-      if (sampledInterval == 0) {
-        return Double.NaN // Avoid dividing by 0
+  def instantValueDeltaCounter(startTimestamp: Long,
+                               endTimestamp: Long,
+                               window: Window,
+                               isRate: Boolean): Double = {
+    if (window.size < 2) {
+      Double.NaN // cannot calculate result without 2 samples
+    } else {
+      require(window.head.timestamp >= startTimestamp, "Possible internal error, found samples < startTimestamp")
+      require(window.last.timestamp <= endTimestamp, "Possible internal error, found samples > endTimestamp")
+      var resultValue = window.last.value // instant value for a period-counter is the last value in a window.
+      val prevSampleRow = window(window.size - 2)
+      if (isRate) {
+        val sampledInterval = (window.last.timestamp - prevSampleRow.timestamp).toDouble
+        resultValue = if (sampledInterval == 0) {
+                        Double.NaN // Avoid dividing by 0
+                      } else {
+                        // Convert to per-second.
+                        resultValue / sampledInterval * 1000
+                      }
       }
-      // Convert to per-second.
-      resultValue = resultValue / sampledInterval * 1000
+      resultValue
     }
-    resultValue
   }
 }
 
@@ -135,14 +139,17 @@ object IRatePeriodicFunction extends RangeFunction {
             window: Window,
             sampleToEmit: TransientRow,
             queryConfig: QueryConfig): Unit = {
-    lastFunc.apply(startTimestamp, endTimestamp, window, sampleToEmit, queryConfig)
-    val prevSampleRow = window(window.size - 2)
-    val sampledInterval = (window.last.timestamp - prevSampleRow.timestamp).toDouble
-    if (sampledInterval == 0) {
-      return Double.NaN // Avoid dividing by 0
+    if (window.size < 2) {
+      sampleToEmit.setValues(endTimestamp, Double.NaN) // cannot calculate result without 2 samples
+    } else {
+      lastFunc.apply(startTimestamp, endTimestamp, window, sampleToEmit, queryConfig)
+      val prevSampleRow = window(window.size - 2)
+      val sampledInterval = (window.last.timestamp - prevSampleRow.timestamp).toDouble
+      val result = if (sampledInterval == 0) {
+                    Double.NaN // Avoid dividing by 0
+                   } else sampleToEmit.value / sampledInterval * 1000
+      sampleToEmit.setValues(endTimestamp, result)
     }
-    val result = sampleToEmit.value / sampledInterval * 1000
-    sampleToEmit.setValues(endTimestamp, result) // TODO need to use a NA instead of NaN
   }
 }
 
@@ -156,7 +163,7 @@ object IDeltaPeriodicFunction extends RangeFunction {
             window: Window,
             sampleToEmit: TransientRow,
             queryConfig: QueryConfig): Unit = {
-    val result = RangeInstantFunctions.instantValuePeriodic(startTimestamp,
+    val result = RangeInstantFunctions.instantValueDeltaCounter(startTimestamp,
       endTimestamp, window, false)
     sampleToEmit.setValues(endTimestamp, result)
   }

--- a/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
@@ -3,9 +3,9 @@ package filodb.query.exec.rangefn
 import spire.syntax.cfor._
 
 import filodb.core.query.{QueryConfig, TransientHistRow, TransientRow}
-import filodb.memory.format.{CounterVectorReader, MemoryReader}
-import filodb.memory.format.{vectors => bv}
+import filodb.memory.format.{vectors => bv, CounterVectorReader, MemoryReader, VectorDataReader}
 import filodb.memory.format.BinaryVector.BinaryVectorPtr
+import filodb.memory.format.vectors.HistogramBuckets
 
 object RateFunctions {
 
@@ -27,6 +27,26 @@ object RateFunctions {
                        window.head.timestamp, window.head.value,
                        window.last.timestamp, window.last.value,
                        isCounter, isRate)
+    }
+
+  /**
+   * extrapolate rate for period-counter.
+   * Logic is kept consistent with Prometheus' extrapolatedRate function to extrapolate
+   */
+  def extrapolatedPeriodicRate(startTimestamp: Long,
+                       endTimestamp: Long,
+                       window: Window,
+                       isRate: Boolean): Double =
+    if (window.size < 2) {
+      Double.NaN // cannot calculate result without 2 samples
+    } else {
+      require(window.head.timestamp >= startTimestamp, "Possible internal error, found samples < startTimestamp")
+      require(window.last.timestamp <= endTimestamp, "Possible internal error, found samples > endTimestamp")
+      extrapolatedPeriodicRate(startTimestamp, endTimestamp, window.size,
+        window.head.timestamp,
+        window.last.timestamp,
+        (0 until window.size).map(window(_).value).sum.toLong,
+        isRate)
     }
 
   /**
@@ -72,6 +92,39 @@ object RateFunctions {
     val scaledDelta = delta * (extrapolateToInterval / sampledInterval)
     // for rate, we need rate as a per-second value
     val result = if (isRate) (scaledDelta / (windowEnd - windowStart) * 1000) else scaledDelta
+    result
+  }
+
+  /**
+   * Calculates rate/delta/increase (period-counter) based on window information and between sample1 and sample2
+   *
+   * @param numSamples the number of samples inclusive of start and end
+   */
+  //scalastyle:off parameter.number
+  def extrapolatedPeriodicRate(windowStart: Long,
+                               windowEnd: Long,
+                               numSamples: Int,
+                               sample1Time: Long,
+                               sample2Time: Long,
+                               sum: Double,
+                               isRate: Boolean): Double = {
+    val durationToStart = (sample1Time - windowStart).toDouble / 1000
+    val durationToEnd = (windowEnd - sample2Time).toDouble / 1000
+    val sampledInterval = (sample2Time - sample1Time).toDouble / 1000
+    val averageDurationBetweenSamples = sampledInterval / (numSamples.toDouble - 1)
+
+    // If the first/last samples are close to the boundaries of the range, extrapolate the result. This is as we
+    // expect that another sample will exist given the spacing between samples we've seen thus far, with an
+    // allowance for noise.
+    val extrapolationThreshold = averageDurationBetweenSamples * 1.1
+    var extrapolateToInterval: Double = sampledInterval
+    extrapolateToInterval +=
+      (if (durationToStart < extrapolationThreshold) durationToStart else averageDurationBetweenSamples / 2)
+    extrapolateToInterval +=
+      (if (durationToEnd < extrapolationThreshold) durationToEnd else averageDurationBetweenSamples / 2)
+    val scaledSum = sum * (extrapolateToInterval / sampledInterval)
+    // for rate, we need rate as a per-second value
+    val result = if (isRate) (scaledSum / (windowEnd - windowStart) * 1000) else scaledSum
     result
   }
 }
@@ -125,6 +178,51 @@ object DeltaFunction extends RangeFunction {
       endTimestamp, window, false, false)
     sampleToEmit.setValues(endTimestamp, result)
   }
+}
+
+object PeriodicIncreaseFunction extends RangeFunction {
+
+  override def needsCounterCorrection: Boolean = false
+  def addedToWindow(row: TransientRow, window: Window): Unit = {}
+  def removedFromWindow(row: TransientRow, window: Window): Unit = {}
+  def apply(startTimestamp: Long,
+            endTimestamp: Long,
+            window: Window,
+            sampleToEmit: TransientRow,
+            queryConfig: QueryConfig): Unit = {
+    val result = RateFunctions.extrapolatedPeriodicRate(startTimestamp,
+      endTimestamp, window, false)
+    sampleToEmit.setValues(endTimestamp, result) // TODO need to use a NA instead of NaN
+  }
+}
+
+object PeriodicRateFunction extends RangeFunction {
+
+  override def needsCounterCorrection: Boolean = false
+  def addedToWindow(row: TransientRow, window: Window): Unit = {}
+  def removedFromWindow(row: TransientRow, window: Window): Unit = {}
+
+  def apply(startTimestamp: Long,
+            endTimestamp: Long,
+            window: Window,
+            sampleToEmit: TransientRow,
+            queryConfig: QueryConfig): Unit = {
+    val result = RateFunctions.extrapolatedPeriodicRate(startTimestamp,
+      endTimestamp, window, true)
+    sampleToEmit.setValues(endTimestamp, result) // TODO need to use a NA instead of NaN
+  }
+}
+
+object PeriodicDeltaFunction extends RangeFunction {
+
+  def addedToWindow(row: TransientRow, window: Window): Unit = {}
+  def removedFromWindow(row: TransientRow, window: Window): Unit = {}
+
+  def apply(startTimestamp: Long,
+            endTimestamp: Long,
+            window: Window,
+            sampleToEmit: TransientRow,
+            queryConfig: QueryConfig): Unit = ???
 }
 
 /**
@@ -300,4 +398,155 @@ class HistIncreaseFunction extends HistogramRateFunctionBase {
   def isCounter: Boolean = true
   def isRate: Boolean    = false
 }
+
+/********************** Rate functions for Delta/Periodic counter metrics **********************/
+
+
+/**
+ * A base class for chunked calculation of rate/increase functions - without counter correction.
+ * The algorithm is pretty simple: for each time window, for each chunk, we compare
+ * the timestamps and update the lowest and highest so that we end up with the earliest
+ * and latest first and last samples.  Basically we continually expand the window until
+ * we have the biggest one. And also sum of the values between startRow and endRow is calculated.
+ * Sum of the values gives us `increase` in values from last window. divide `increase` by `time-window` gives us `rate`
+ * It is O(nWindows * nChunks) which is usually << O(nSamples).
+ */
+abstract class ChunkedPeriodicRateFunctionBase extends PeriodCounterChunkedRangeFunction[TransientRow] {
+  var numSamples = 0
+  var lowestTime = Long.MaxValue
+  var lowestValue = Double.NaN
+  var highestTime = 0L
+  var highestValue = Double.NaN
+  var sum = 0d;
+
+  def isRate: Boolean
+
+  override def reset(): Unit = {
+    numSamples = 0
+    lowestTime = Long.MaxValue
+    lowestValue = Double.NaN
+    highestTime = 0L
+    highestValue = Double.NaN
+    sum = 0d;
+    super.reset()
+  }
+
+  def addTimeChunks(acc: MemoryReader, vector: BinaryVectorPtr, reader: VectorDataReader,
+                    startRowNum: Int, endRowNum: Int,
+                    startTime: Long, endTime: Long): Unit = {
+    val dblReader = reader.asDoubleReader
+    if (startTime < lowestTime || endTime > highestTime) {
+      numSamples += endRowNum - startRowNum + 1
+      if (startTime < lowestTime) {
+        lowestTime = startTime
+      }
+      if (endTime > highestTime) {
+        highestTime = endTime
+      }
+      sum += dblReader.sum(acc, vector, start = startRowNum, end = endRowNum) // Sum of the values gives us the increase
+    }
+  }
+
+  override def apply(windowStart: Long, windowEnd: Long, sampleToEmit: TransientRow): Unit = {
+    if (highestTime > lowestTime) {
+      // NOTE: It seems in order to match previous code, we have to adjust the windowStart by -1 so it's "inclusive"
+      val result = RateFunctions.extrapolatedPeriodicRate(
+        windowStart - 1, windowEnd, numSamples,
+        lowestTime,
+        highestTime,
+        sum,
+        isRate)
+      sampleToEmit.setValues(windowEnd, result)
+    } else {
+      sampleToEmit.setValues(windowEnd, Double.NaN)
+    }
+  }
+
+  def apply(endTimestamp: Long, sampleToEmit: TransientRow): Unit = ???
+}
+
+class ChunkedPeriodicRateFunction extends ChunkedPeriodicRateFunctionBase {
+  def isRate: Boolean    = true
+}
+
+class ChunkedPeriodicIncreaseFunction extends ChunkedPeriodicRateFunctionBase {
+  def isRate: Boolean    = false
+}
+
+
+/**
+ * A base class for chunked calculation of rate etc for period-counter-like histograms.
+ * Note that the rate of two histograms is itself a histogram.
+ * Similar algorithm to ChunkedPeriodicRateFunctionBase.
+ * It is O(nWindows * nChunks) which is usually << O(nSamples).
+ */
+abstract class HistogramPeriodicRateFunctionBase extends PeriodCounterChunkedRangeFunction[TransientHistRow] {
+  var numSamples = 0
+  var lowestTime = Long.MaxValue
+  var highestTime = 0L
+  var summedHist: bv.MutableHistogram = bv.MutableHistogram.empty(HistogramBuckets.emptyBuckets)
+
+  def isRate: Boolean
+
+  override def reset(): Unit = {
+    numSamples = 0
+    lowestTime = Long.MaxValue
+    highestTime = 0L
+    summedHist = bv.MutableHistogram.empty(HistogramBuckets.emptyBuckets)
+    super.reset()
+  }
+
+  def addTimeChunks(acc: MemoryReader, vector: BinaryVectorPtr, reader: VectorDataReader,
+                    startRowNum: Int, endRowNum: Int,
+                      startTime: Long, endTime: Long): Unit = reader match {
+    case histReader: bv.RowHistogramReader =>
+      if (startTime < lowestTime || endTime > highestTime) {
+        numSamples += endRowNum - startRowNum + 1
+        if (startTime < lowestTime) {
+          lowestTime = startTime
+        }
+        if (endTime > highestTime) {
+          highestTime = endTime
+        }
+        if (summedHist.isEmpty) {
+          summedHist = histReader.sum(startRowNum, endRowNum)
+        } else {
+          summedHist.addNoCorrection(histReader.sum(startRowNum, endRowNum))
+        }
+      }
+    case _ =>
+  }
+
+  override def apply(windowStart: Long, windowEnd: Long, sampleToEmit: TransientHistRow): Unit = {
+    if (highestTime > lowestTime) {
+      // NOTE: It seems in order to match previous code, we have to adjust the windowStart by -1 so it's "inclusive"
+      // TODO: handle case where schemas are different and we need to interpolate schemas
+
+        val rateArray = new Array[Double](summedHist.numBuckets)
+        cforRange { 0 until rateArray.size } { b =>
+          rateArray(b) = RateFunctions.extrapolatedPeriodicRate(
+            windowStart - 1, windowEnd, numSamples,
+            lowestTime,
+            highestTime,
+            summedHist.bucketValue(b),
+            isRate)
+        }
+        sampleToEmit.setValues(windowEnd, bv.MutableHistogram(summedHist.buckets, rateArray))
+
+    } else {
+      sampleToEmit.setValues(windowEnd, bv.HistogramWithBuckets.empty)
+    }
+  }
+
+  def apply(endTimestamp: Long, sampleToEmit: TransientHistRow): Unit = ???
+}
+
+class HistPeriodicRateFunction extends HistogramPeriodicRateFunctionBase {
+  def isRate: Boolean    = true
+}
+
+class HistPeriodicIncreaseFunction extends HistogramPeriodicRateFunctionBase {
+  def isRate: Boolean    = false
+}
+
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
@@ -1,0 +1,173 @@
+package filodb.query.exec.rangefn
+
+import filodb.core.{MachineMetricsData, TestData}
+import filodb.core.memstore.WriteBufferPool
+import filodb.core.metadata.Dataset
+import filodb.core.query.TransientRow
+import filodb.memory.format.vectors.{LongHistogram, MutableHistogram}
+import filodb.query.exec.{ChunkedWindowIteratorD, ChunkedWindowIteratorH, QueueBasedWindow}
+import filodb.query.util.IndexedArrayQueue
+
+import scala.util.Random
+
+class PeriodicRateFunctionsSpec extends RawDataWindowingSpec {
+  val rand = new Random()
+
+  val deltaCounterSamples = Seq(8072000L->111.0,
+                      8082100L->92.00,
+                      8092196L->103.00,
+                      8102215L->110.00,
+                      8112223L->185.00,
+                      8122388L->39.00,
+                      8132570L->52.00,
+                      8142822L->95.00,
+                      8152858L->7.00,
+                      8162999L->99.00)
+
+  val qDelta = new IndexedArrayQueue[TransientRow]()
+  deltaCounterSamples.foreach { case (t, v) =>
+    val s = new TransientRow(t, v)
+    qDelta.add(s)
+  }
+  val deltaDCounterWindow = new QueueBasedWindow(qDelta)
+  val deltaCounterRV = timeValueRVPk(deltaCounterSamples)
+
+  val errorOk = 0.0000001
+
+  // Basic test cases covered
+  it("rate over period-counter should work when start and end are outside window") {
+    val startTs = 8071950L
+    val endTs =   8163070L
+    val expectedDelta = deltaCounterSamples.map(_._2).sum / (qDelta.last.timestamp - qDelta.head.timestamp) * 1000
+    val toEmitDelta = new TransientRow
+    PeriodicRateFunction.apply(startTs,endTs, deltaDCounterWindow, toEmitDelta, queryConfig)
+    toEmitDelta.value shouldEqual expectedDelta +- errorOk
+
+    // One window, start=end=endTS
+    val it = new ChunkedWindowIteratorD(deltaCounterRV, endTs, 10000, endTs, endTs - startTs,
+                                        new ChunkedPeriodicRateFunction, querySession)
+    it.next.getDouble(1) shouldEqual expectedDelta +- errorOk
+  }
+
+  it("should return NaN for rate over period-counter when window only contains one sample") {
+    val startTs = 8101215L
+    val endTs =   8103215L
+
+    val it = new ChunkedWindowIteratorD(deltaCounterRV, endTs, 10000, endTs, endTs - startTs,
+                                        new ChunkedPeriodicRateFunction, querySession)
+    it.next.getDouble(1).isNaN shouldEqual true
+  }
+
+  it("should not return rate of 0 when delta-counter samples do not increase") {
+    val startTs = 8071950L
+    val endTs =   8163070L
+    val flatSamples = deltaCounterSamples.map { case (t, v) => t -> deltaCounterSamples.head._2 }
+    val flatRV = timeValueRVPk(flatSamples)
+
+    // One window, start=end=endTS
+    val it = new ChunkedWindowIteratorD(flatRV, endTs, 10000, endTs, endTs - startTs,
+                                        new ChunkedPeriodicRateFunction, querySession)
+    it.next.getDouble(1) should not equal 0.0
+  }
+
+  // Also ensures that chunked rate works across chunk boundaries
+  it("rate over period-counter should work for variety of window and step sizes") {
+    val data = (1 to 500).map(_ => rand.nextInt(10)).map(_.toDouble)
+    val tuples = data.zipWithIndex.map { case (d, t) => (defaultStartTS + t * pubFreq, d) }
+    val rv = timeValueRVPk(tuples)  // should be a couple chunks
+
+    (0 until 10).foreach { x =>
+      val windowSize = rand.nextInt(100) + 10
+      val step = rand.nextInt(50) + 5
+      info(s"  iteration $x  windowSize=$windowSize step=$step")
+
+      val slidingRate = slidingWindowIt(data, rv, PeriodicRateFunction, windowSize, step)
+      val slidingResults = slidingRate.map(_.getDouble(1)).toBuffer
+      slidingRate.close()
+
+      val rateChunked = chunkedWindowIt(data, rv, new ChunkedPeriodicRateFunction, windowSize, step)
+      val resultRows = rateChunked.map { r => (r.getLong(0), r.getDouble(1)) }.toBuffer
+      val rates = resultRows.map(_._2)
+
+      // Since the input data and window sizes are randomized, it is not possible to precompute results
+      // beforehand.  Coming up with a formula to figure out the right rate is really hard.
+      // Thus we take an approach of comparing the sliding and chunked results to ensure they are identical.
+
+      // val windowTime = (windowSize.toLong - 1) * pubFreq
+      // val expected = tuples.sliding(windowSize, step).toBuffer
+      //                      .zip(resultRows).map { case (w, (ts, _)) =>
+      //   // For some reason rate is based on window, not timestamps  - so not w.last._1
+      //   (w.sum_of_sample_values) / (windowTime) * 1000
+      //   // (w.sum_of_sample_values) / (w.last._1 - w.head._1) * 1000
+      // }
+      rates shouldEqual slidingResults
+    }
+  }
+
+  val promHistDS = Dataset("histogram", Seq("metric:string", "tags:map"),
+                           Seq("timestamp:ts", "count:long", "sum:long", "h:hist:counter=false"))
+  val histBufferPool = new WriteBufferPool(TestData.nativeMem, promHistDS.schema.data, TestData.storeConf)
+
+  it("should compute rate for DeltaHistogram RVs") {
+    val (data, rv) = MachineMetricsData.histogramRV(100000L, numSamples=10, pool=histBufferPool, ds=promHistDS)
+    val startTs = 99500L
+    val endTs =   161000L // just past 7th sample
+    val lastTime = 160000L
+    val headTime = 100000L
+    val expectedRates = data
+      .slice(0, 7)
+      .map(_(3).asInstanceOf[LongHistogram].values) // buckets
+      .reduce((b1, b2) => b1.zip(b2).map { case (x, y) => x + y }) // sum of respective buckets
+      .map(_.toDouble / (lastTime - headTime) * 1000) // rate
+
+    val expected = MutableHistogram(MachineMetricsData.histBucketScheme, expectedRates.toArray)
+
+    // One window, start=end=endTS
+    val it = new ChunkedWindowIteratorH(rv, endTs, 100000, endTs, endTs - startTs,
+                                        new HistPeriodicRateFunction, querySession)
+    // Scheme should have remained the same
+    val answer = it.next.getHistogram(1)
+    answer.numBuckets shouldEqual expected.numBuckets
+
+    // Have to compare each bucket with floating point error tolerance
+    for { b <- 0 until expected.numBuckets } {
+      answer.bucketTop(b) shouldEqual expected.bucketTop(b)
+      answer.bucketValue(b) shouldEqual expected.bucketValue(b) +- errorOk
+    }
+  }
+
+  it ("irate over period-counters should work when start and end are outside window") {
+    val startTs = 8071950L
+    val endTs =   8163070L
+    val prevSample = qDelta(qDelta.size - 2)
+    val expected = (qDelta.last.value) / (qDelta.last.timestamp - prevSample.timestamp) * 1000
+    val toEmit = new TransientRow
+    IRatePeriodicFunction.apply(startTs, endTs, deltaDCounterWindow, toEmit, queryConfig)
+    Math.abs(toEmit.value - expected) should be < errorOk
+  }
+
+  it ("increase over period-counters should work when start and end are outside window") {
+    val startTs = 8071950L
+    val endTs = 8163070L
+    val expectedDelta =
+      deltaCounterSamples.map(_._2).sum / (qDelta.last.timestamp - qDelta.head.timestamp) * (endTs - startTs)
+    val toEmitDelta = new TransientRow
+    PeriodicIncreaseFunction.apply(startTs, endTs, deltaDCounterWindow, toEmitDelta, queryConfig)
+    toEmitDelta.value shouldEqual expectedDelta +- errorOk
+
+    // One window, start=end=endTS
+    val it = new ChunkedWindowIteratorD(deltaCounterRV, endTs, 10000, endTs, endTs - startTs,
+      new ChunkedPeriodicIncreaseFunction, querySession)
+    it.next.getDouble(1) shouldEqual toEmitDelta.value
+  }
+
+  it("idelta over period-counters should work when start and end are outside window") {
+    val startTs = 8071950L
+    val endTs = 8163070L
+    val prevSample = qDelta(qDelta.size - 2)
+    val expected = qDelta.last.value
+    val toEmit = new TransientRow
+    IDeltaPeriodicFunction.apply(startTs, endTs, deltaDCounterWindow, toEmit, queryConfig)
+    Math.abs(toEmit.value - expected) should be < errorOk
+  }
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

This PR adds support for calculating the rate of change of Otel delta metrics using the rate function.

Previously, the rate function could only be used with counter metrics. With this change, users can now apply the rate function to any Otel delta metric, which will allow them to more easily identify trends.

To use the rate function with Otel delta metrics, simply pass the metric and a time interval to the function as you would with any other time series. The function will return a new time series containing the per-second average rate of change for each time step in the original time series.

Examples:
`rate(otel_delta_metric_name[5m])`

This PR also includes tests to ensure the correct behavior of the rate function with Otel delta metrics.

**CHANGES**
An additional field is added to `ColumnInfo`, to indicate whether a column `isCumulative`. This will be propagated via `ResultSchema` to `PeriodicSamplesMapper` and used during execution to pick the right rate/increate implementation.

> rate_over_delta = (sum_of_values_in_window) / (window_size_in_seconds)



