### PR TITLE
Fixing remote calls for subqueries

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -111,7 +111,12 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
         } else {
           // Single partition but remote, send the entire plan remotely
           val remotePartitionEndpoint = partitions.head.endPoint
-          val httpEndpoint = remotePartitionEndpoint + params.remoteQueryPath.getOrElse("")
+          val remoteQueryPath = if (params.remoteQueryPath.getOrElse("") == "/api/v1/query") {
+            "/api/v1/query_range"
+          } else {
+            params.remoteQueryPath.getOrElse("")
+          }
+          val httpEndpoint = remotePartitionEndpoint + remoteQueryPath
           val remoteContext = if (logicalPlan.isInstanceOf[PeriodicSeriesPlan]) {
             val psp : PeriodicSeriesPlan = logicalPlan.asInstanceOf[PeriodicSeriesPlan]
             val startSecs = psp.startMs / 1000

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -437,7 +437,7 @@ extends Iterator[ChunkSetInfoReader] {
     // advance window pointers and reset read index
     if (curWindowEnd == -1L) {
       curWindowEnd = start
-      curWindowStart = start - Math.max(window - 1, 0)  // window cannot be below 0, ie start should never be > end
+      curWindowStart = start - Math.max(window, 0)  // window cannot be below 0, ie start should never be > end
     } else {
       curWindowEnd += step
       curWindowStart += step

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -437,7 +437,7 @@ extends Iterator[ChunkSetInfoReader] {
     // advance window pointers and reset read index
     if (curWindowEnd == -1L) {
       curWindowEnd = start
-      curWindowStart = start - Math.max(window, 0)  // window cannot be below 0, ie start should never be > end
+      curWindowStart = start - Math.max(window - 1, 0)  // window cannot be below 0, ie start should never be > end
     } else {
       curWindowEnd += step
       curWindowStart += step


### PR DESCRIPTION
Top level instant subqueries that get redirected to remote partitions are converted to range calls. 
We, however, assume that the remote call should match the original call. Ie if we had an instant query call that came to us, then the remote call should be instant as well. This is not the case with subqueries. Instead of trying to continue to call query or query_range depending on what was the original API called, always call query_range as this API will be able to resolve all cases.
