### PR TITLE
fix(core) Conform to Lucene regex by removing leading ^ and ending $.

### DIFF
--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -786,6 +786,49 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     keyIndex.singlePartKeyFromFilters(Seq(filter2), 4, 10) shouldBe None
   }
 
+  it("should match the regex after anchors stripped") {
+    for ((regex, regexNoAnchors) <- Map(
+      """^.*$""" -> """.*""", // both anchor are stripped.
+      """\$""" -> """\$""", // \$ is not removed.
+      """\\\$""" -> """\\\$""", // \$ is not removed.
+      """\\$""" -> """\\""", // $ is removed.
+      """$""" -> """""", // $ is removed.
+      """\^.*$""" -> """\^.*""", // do not remove \^.
+      """^ ^.*$""" -> """ ^.*""", // only remove the first ^.
+      """^.*\$""" -> """.*\$""",  // do not remove \$
+      """^ $foo""" -> """ $foo""",  // the $ is not at the end, keep it.
+      """.* $ \ $$""" -> """.* $ \ $""",  // only remove the last $
+      """foo.*\\\ $""" -> """foo.*\\\ """, // remove $ for it at the end and not escaped.
+      """foo.*\\\$""" -> """foo.*\\\$""", // keep \$.
+      """foo.*\\$""" -> """foo.*\\""",  // remove $ for it at the end and not escaped.
+      """foo.*$\\\\$""" -> """foo.*$\\\\""",  // keep the first $ since it not at the end.
+    )) {
+      PartKeyLuceneIndex.removeRegexAnchors(regex) shouldEqual regexNoAnchors
+    }
+  }
+
+  it("should get a single match for part keys by a regex filter") {
+    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+      .zipWithIndex.map { case (addr, i) =>
+      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+      keyIndex.addPartKey(pk, -1, i, i + 10)(
+        pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
+      PartKeyLuceneIndexRecord(pk, i, i + 10)
+    }
+    keyIndex.refreshReadersBlocking()
+
+    val filter1_found = ColumnFilter("Actor2Code", EqualsRegex("""^GO.*$"""))
+    val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
+    partKeyOpt.isDefined shouldBe true
+    partKeyOpt.get shouldEqual pkrs(7).partKey
+
+    val filter1_not_found = ColumnFilter("Actor2Code", EqualsRegex("""^GO.*$\$"""))
+    keyIndex.singlePartKeyFromFilters(Seq(filter1_not_found), 4, 10) shouldBe None
+
+    val filter2 = ColumnFilter("Actor2Code", NotEqualsRegex("^.*".utf8))
+    keyIndex.singlePartKeyFromFilters(Seq(filter2), 4, 10) shouldBe None
+  }
+
   it("Should update the state as TriggerRebuild and throw an exception for any error other than CorruptIndexException")
   {
     val events = ArrayBuffer.empty[(IndexState.Value, Long)]


### PR DESCRIPTION
Lucene regex does not support anchor operator such as ^ and $. https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html#regexp-unsupported-operators Remove those characters from users' regex so that Lucene can handle it.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: