### PR TITLE
fix(query) routing binary joins in HAPlanner

### DIFF
--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -432,7 +432,7 @@ case class BinaryJoin(lhs: PeriodicSeriesPlan,
   override def startMs: Long = lhs.startMs
   override def stepMs: Long = lhs.stepMs
   override def endMs: Long = lhs.endMs
-  override def isRoutable: Boolean = lhs.isRoutable && rhs.isRoutable
+  override def isRoutable: Boolean = lhs.isRoutable || rhs.isRoutable
   override def replacePeriodicSeriesFilters(filters: Seq[ColumnFilter]): PeriodicSeriesPlan = this.copy(lhs =
     lhs.replacePeriodicSeriesFilters(filters), rhs = rhs.replacePeriodicSeriesFilters(filters))
 }


### PR DESCRIPTION
``HighAvailabilityPlanner`` routes the query to its buddy cluster if the local cluster is unavailable. The field ``isRoutable`` of the ``LogicalPlan`` is used to determine if the query needs to be routed to the buddy cluster or executed locally. Operations like ``vector(0)``, ``1 + 2`` need not be router and does not need local FiloDB shards to be up and running as the query layer can run these operations without FiloDB. If however, we need to run the operation on FiloDB and FiloDB is not available, the query execution will fail with message ``Shard: x is not available``.  

For ``BinaryJoins`` the plan's routablity should be determined by the routablity of lhs or  rhs. That is, if either lhs or rhs needs to FiloDB for execution, it should be routed. The the check should use ``||`` instead of ``&&``.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

BinaryJoins will not be routed when either LHS or RHS is not routable. Thus operations like ``sum(foo{}) or vector(0)``, which should be routed if local partition is unavailable, will not be routed.


**New behavior :**

BinaryJoins will be routed when either LHS or RHS need routing. Thus operations like ``sum(foo{}) or vector(0)``, will be routed if local partition is unavailable


