### PR TITLE
fix(misc): make shardKey labels in targetSchema config implicit

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -381,10 +381,10 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   it("should apply the target schema appropriate to the query range") {
 
     val tschemas = Seq(
-      TargetSchemaChange(0L, Seq("foo")),
-      TargetSchemaChange(10000, Seq("bar")),
-      TargetSchemaChange(20000, Seq("foo")),
-      TargetSchemaChange(30000, Seq("bar")),
+      TargetSchemaChange(0L, Seq("foo")),      // + shardKeys (job, __name__)
+      TargetSchemaChange(10000, Seq("bar")),   // + shardKeys (job, __name__)
+      TargetSchemaChange(20000, Seq("foo")),   // + shardKeys (job, __name__)
+      TargetSchemaChange(30000, Seq("bar")),   // + shardKeys (job, __name__)
     )
 
     // Oscillate between "foo" and "bar" as the schema
@@ -418,7 +418,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
           ColumnFilter("foo", Equals("abcdefg")),
           ColumnFilter("bar", Equals("hijklmnop")),
         ), qContext, start, end, useTargetSchemaForShards = true)
-    } should contain theSameElementsAs Seq(22, 15, 22, 15)
+    } should contain theSameElementsAs Seq(1, 26, 1, 26)
   }
 
   it("should create a single plan and not stitch results when target-schema has not changed in query range") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

**Current behavior :**
Right now shardKey labels need to be explicitly defined in target-schema config.

**New behavior :**
With this change, target-schema config implicitly includes shardKey labels. Missing shardKey labels will be included in targetSchema while calculating ingestion/query shards. This simplifies queries to not include shardKey labels in join/group-by queries.