### PR TITLE
fix(query): ignore isCumulative field when comparing ResultSchemas

### DIFF
--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -1,5 +1,7 @@
 package filodb.core.query
 
+import java.util.Objects
+
 import scala.reflect.runtime.universe._
 
 import com.typesafe.scalalogging.StrictLogging
@@ -22,9 +24,16 @@ final case class PartitionInfo(schema: RecordSchema, base: Array[Byte], offset: 
 }
 
 /**
- * Describes column/field name and type
+ * Describes column/field name and type.
+ * isCumulative is not considered for equality/Hashcode.
  */
-final case class ColumnInfo(name: String, colType: Column.ColumnType, isCumulative: Boolean = true)
+final case class ColumnInfo(name: String, colType: Column.ColumnType, isCumulative: Boolean = true) {
+  override def equals(obj: Any): Boolean = obj match {
+    case ColumnInfo(n: String, ct: Column.ColumnType, _) => n == name && ct == colType
+    case _ => false
+  }
+  override def hashCode(): Int = Objects.hash(name, colType)
+}
 
 object ColumnInfo {
   def apply(col: Column): ColumnInfo = ColumnInfo(col.name, col.columnType, isCumulative(col))

--- a/query/src/test/scala/filodb/query/ResultTypesSpec.scala
+++ b/query/src/test/scala/filodb/query/ResultTypesSpec.scala
@@ -84,4 +84,23 @@ class ResultTypesSpec extends AnyFunSpec with Matchers with ScalaFutures {
     val queryResult = QueryResult("id:1", resultSchema, Seq(rv1))
     queryResult.resultType shouldEqual(QueryResultType.Scalar)
   }
+
+  it("should ignore isCumulative field when comparing ColumnInfos") {
+    val columns1: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn, true),
+      ColumnInfo("value", ColumnType.DoubleColumn))
+    val resultSchema1 = ResultSchema(columns1, 1)
+
+    val columns2: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn, false),
+      ColumnInfo("value", ColumnType.DoubleColumn))
+    val resultSchema2 = ResultSchema(columns2, 1)
+
+    resultSchema1 shouldEqual resultSchema2
+
+    val columns3: Seq[ColumnInfo] = Seq(ColumnInfo("timestamp1", ColumnType.TimestampColumn, false),
+      ColumnInfo("value", ColumnType.DoubleColumn))
+    val resultSchema3 = ResultSchema(columns3, 1)
+
+    resultSchema2 should not be resultSchema3
+
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

When comparing ResultSchemas, `isCumulative` field will be ignored. This field is used only at the leaf node to pick the right `rate` function depending on whether the ColumnType is cumulative type or not.