### PR TITLE
fix(query): iDelta is applicable only to gauge types

### DIFF
--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -412,10 +412,8 @@ object RangeFunction {
     case Some(Resets)                 => () => new ResetsFunction()
     case Some(Irate) if schema.columns(1).isCumulative
                                       => () => IRateFunction
-    case Some(Idelta) if schema.columns(1).isCumulative
-                                      => () => IDeltaFunction
+    case Some(Idelta)                 => () => IDeltaFunction
     case Some(Irate)                  => () => IRatePeriodicFunction
-    case Some(Idelta)                 => () => LastSampleFunction // Last Delta value
     case Some(Deriv)                  => () => DerivFunction
     case Some(MaxOverTime)            => () => new MinMaxOverTimeFunction(Ordering[Double])
     case Some(MinOverTime)            => () => new MinMaxOverTimeFunction(Ordering[Double].reverse)

--- a/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
@@ -151,14 +151,4 @@ class PeriodicRateFunctionsSpec extends RawDataWindowingSpec {
       new SumOverTimeChunkedFunctionD, querySession)
     it.next.getDouble(1) shouldEqual expectedDelta
   }
-
-  it("idelta over period-counters should work when start and end are outside window") {
-    val startTs = 8071950L
-    val endTs = 8163070L
-    val prevSample = qDelta(qDelta.size - 2)
-    val expected = qDelta.last.value
-    val toEmit = new TransientRow
-    IDeltaPeriodicFunction.apply(startTs, endTs, deltaDCounterWindow, toEmit, queryConfig)
-    Math.abs(toEmit.value - expected) should be < errorOk
-  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

`idelta` function is applicable only to gauge types. This PR reverts the changes made to `idelta` function as part of #1498 