### PR TITLE
fix(parser): add support for zero-duration time range units

### DIFF
--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -6,6 +6,10 @@ import filodb.query.{BinaryJoin, LogicalPlan}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+
+import java.util.concurrent.TimeUnit.{MINUTES, SECONDS, HOURS, DAYS}
+import scala.concurrent.duration.Duration
+
 //noinspection ScalaStyle
 // scalastyle:off
 class ParserSpec extends AnyFunSpec with Matchers {
@@ -754,55 +758,55 @@ class ParserSpec extends AnyFunSpec with Matchers {
   }
 
   it("should correctly parse durations with multiple units") {
-    case class Spec(query: String, windowSec: Int, offsetSec: Int)
+    case class Spec(query: String, windowDuration: Duration, offsetDuration: Duration)
     val specs = Seq(
       Spec(
         """foo{label="bar"}[1m30s] offset 2h15m""",
-            60 + 30,
-            (2 * 60 * 60) + (15 * 60)
+            Duration(1, MINUTES) + Duration(30, SECONDS),
+            Duration(2, HOURS) + Duration(15, MINUTES)
       ),
       Spec(
         """foo{label="bar"}[3d2h25m10s] offset 2d12h15m30s""",
-            (3 * 24 * 60 * 60) + (2 * 60 * 60) + (25 * 60) + 10,
-            (2 * 24 * 60 * 60) + (12 * 60 * 60) + (15 * 60) + 30
+            Duration(3, DAYS) + Duration(2, HOURS) + Duration(25, MINUTES) + Duration(10, SECONDS),
+            Duration(2, DAYS) + Duration(12, HOURS) + Duration(15, MINUTES) + Duration(30, SECONDS),
       ),
       Spec(
         """foo{label="bar"}[3d0h25m0s] offset 0d12h15m30s""",
-            (3 * 24 * 60 * 60) + (25 * 60),
-            (12 * 60 * 60) + (15 * 60) + 30
+            Duration(3, DAYS) + Duration(25, MINUTES),
+            Duration(12, HOURS) + Duration(15, MINUTES) + Duration(30, SECONDS),
       )
     )
     specs.foreach{ spec =>
       Parser.parseQuery(spec.query) match {
         case RangeExpression(_, _, window, offset) =>
-          window.millis(0) shouldEqual 1000 * spec.windowSec
-          offset.get.millis(0) shouldEqual 1000 * spec.offsetSec
+          window.millis(0) shouldEqual spec.windowDuration.toMillis
+          offset.get.millis(0) shouldEqual spec.offsetDuration.toMillis
       }
     }
   }
 
   it("should correctly parse subquery durations with multiple units") {
-    case class Spec(query: String, windowSec: Int, stepSec: Int, offsetSec: Int)
+    case class Spec(query: String, windowDuration: Duration, stepDuration: Duration, offsetDuration: Duration)
     val specs = Seq(
       Spec(
         """foo{label="bar"}[3d2h25m10s:1d4h30m4s] offset 2d12h15m30s""",
-        (3 * 24 * 60 * 60) + (2 * 60 * 60) + (25 * 60) + 10,
-        (1 * 24 * 60 * 60) + (4 * 60 * 60) + (30 * 60) + 4,
-        (2 * 24 * 60 * 60) + (12 * 60 * 60) + (15 * 60) + 30
+            Duration(3, DAYS) + Duration(2, HOURS) + Duration(25, MINUTES) + Duration(10, SECONDS),
+            Duration(1, DAYS) + Duration(4, HOURS) + Duration(30, MINUTES) + Duration(4, SECONDS),
+            Duration(2, DAYS) + Duration(12, HOURS) + Duration(15, MINUTES) + Duration(30, SECONDS)
       ),
       Spec(
         """foo{label="bar"}[3d0h25m0s:1d0h2m] offset 0d12h15m30s""",
-        (3 * 24 * 60 * 60) + (25 * 60),
-        (1 * 24 * 60 * 60) + (2 * 60),
-        (12 * 60 * 60) + (15 * 60) + 30
+            Duration(3, DAYS) + Duration(25, MINUTES),
+            Duration(1, DAYS) + Duration(2, MINUTES),
+            Duration(12, HOURS) + Duration(15, MINUTES) + Duration(30, SECONDS)
       )
     )
     specs.foreach{ spec =>
       Parser.parseQuery(spec.query) match {
         case SubqueryExpression(_, SubqueryClause(window, step), offset, _) =>
-          window.millis(0) shouldEqual 1000 * spec.windowSec
-          step.map(_.millis(0)).getOrElse(0) shouldEqual 1000 * spec.stepSec
-          offset.get.millis(0) shouldEqual 1000 * spec.offsetSec
+          window.millis(0) shouldEqual spec.windowDuration.toMillis
+          step.map(_.millis(0)).getOrElse(0) shouldEqual spec.stepDuration.toMillis
+          offset.get.millis(0) shouldEqual spec.offsetDuration.toMillis
       }
     }
   }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -774,6 +774,16 @@ class ParserSpec extends AnyFunSpec with Matchers {
           offset.get.millis(0) shouldEqual 1000 * offsetSec
       }
     }
+    {
+      val query = """foo{label="bar"}[3d0h25m0s] offset 0d12h15m30s"""
+      val windowSec = (3 * 24 * 60 * 60) + (25 * 60)
+      val offsetSec = (12 * 60 * 60) + (15 * 60) + 30
+      Parser.parseQuery(query) match {
+        case RangeExpression(_, _, window, offset) =>
+          window.millis(0) shouldEqual 1000 * windowSec
+          offset.get.millis(0) shouldEqual 1000 * offsetSec
+      }
+    }
   }
 
   private def printBinaryJoin( lp: LogicalPlan, level: Int = 0) : scala.Unit =  {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, queries with bracket-notation range durations such as:
```
foo{label1="value1"}[2d0h15m]
```
will fail to parse because
- `prometheus.ast.Duration` was used to find the millisecond-duration of each unit-value pair.
- `Duration`s cannot have zero value.

This PR adds logic to skip construction of a `Duration` when a unit's value is zero.