### PR TITLE
fix(query): treat empty join key as any other during AND join

### DIFF
--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -93,15 +93,6 @@ final case class SetOperatorExec(queryContext: QueryContext,
     else rvk.labelValues.filterNot(lv => ignoringLabels.contains(lv._1))
   }
 
-  private def joinKeys2(rvk: RangeVectorKey): Option[Map[Utf8Str, Utf8Str]] = {
-    if (onLabels.nonEmpty) {
-      val labels = rvk.labelValues.filter(lv => onLabels.contains(lv._1))
-      Some(labels)
-    } else {
-      Some(rvk.labelValues.filterNot(lv => ignoringLabels.contains(lv._1)))
-    }
-  }
-
   /***
     * Returns true when range vector does not have any values
     */

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -118,7 +118,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
 
     rhsRvs.foreach { rv =>
       val jk = joinKeys(rv.key)
-      // Don't add range vector if it is contains no rows
+      // Don't add range vector if it contains no rows
       if (!isEmpty(rv, rhsSchema)) {
         // When spread changes, we need to account for multiple Range Vectors with same key coming from different shards
         // Each of these range vectors would contain data for different time ranges

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -519,6 +519,19 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       sameElements(result.flatMap(_.rows.map(_.getDouble(1)).toList)) shouldEqual true
   }
 
+  it("should not return LHS when op=LAND and LHS has no labels and RHS is empty") {
+    val execPlan = SetOperatorExec(QueryContext(), dummyDispatcher, Array(dummyPlan),
+                       new Array[ExecPlan](1), BinaryOperator.LAND, Nil, Nil, "__name__", None)
+    val rv = sampleHttpRequests
+      .map(rv => IteratorBackedRangeVector(new CustomRangeVectorKey(Map()), rv.rows(), rv.outputRange))
+      .head
+    val lhs = QueryResult("someId", tvSchema, Seq(rv))
+    val rhs = QueryResult("someId", tvSchema, Nil)
+    val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
+      .toListL.runToFuture.futureValue
+    result.size shouldEqual 0
+  }
+
   it("should return Lhs when LAND is done with vector having no labels and ignoring is used om Lhs labels") {
 
     val sampleRhsShuffled = scala.util.Random.shuffle(sampleNoKey.toList)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, a join such as
```
sum(foo{}) AND bar{}
```
will erroneously return `sum(foo{})` if `bar{}` returns no data.

The logic in `setOpAnd` can be described as two sequential parts:
1. Create a set of all join keys on the RHS.
2. Add a RangeVector from LHS to the result iff its join key appears in the RHS set.

The bug is two-fold:
- At the first step, the logic skips a join key if its vector contains no rows; the key is not added to the RHS set.
- At the second step, we check that the RHS contains each LHS join key. For each key it doesn't contain, the logic falls into an `else if` condition: the LHS vector is added to the result if its join key is empty.

Since the first step won't add the key to the RHS set, the second step will fall into the `else if` and add the LHS vector to the result.

The fix is also two-fold:
- Remove the `else if` condition at the second step. It was setup specifically to handle queries such as `up AND ON (not_a_label) vector(1)`.
- Remove a check during the first step that prevents an empty join key from getting placed into the RHS set. Now, empty join keys are treated like any other (and queries like `up AND ON (not_a_label) vector(1)`) will succeed.