### PR TITLE
feat(query): QueryStats now includes CPU time used by query

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -147,7 +147,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
         override val key: RangeVectorKey = rvKey
         override def outputRange: Option[RvRange] = None
       }
-      val srv = SerializedRangeVector(rv, cols)
+      val srv = SerializedRangeVector(rv, cols, QueryStats())
       val observedTs = srv.rows.toSeq.map(_.getLong(0))
       val observedVal = srv.rows.toSeq.map(_.getDouble(1))
       observedTs shouldEqual tuples.map(_._1)
@@ -299,7 +299,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val key = CustomRangeVectorKey(keysMap)
     val cols = Seq(ColumnInfo("value", ColumnType.DoubleColumn))
     import filodb.core.query.NoCloseCursor._
-    val ser = SerializedRangeVector(IteratorBackedRangeVector(key, Iterator.empty, None), cols)
+    val ser = SerializedRangeVector(IteratorBackedRangeVector(key, Iterator.empty, None), cols, QueryStats())
 
     val schema = ResultSchema(MachineMetricsData.dataset1.schema.infosFromIDs(0 to 0), 1)
 
@@ -317,7 +317,7 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     val cols = Seq(ColumnInfo("value", ColumnType.MapColumn))
     import filodb.core.query.NoCloseCursor._
     val ser = Seq(SerializedRangeVector(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
-      new UTF8MapIteratorRowReader(input.toIterator), None), cols))
+      new UTF8MapIteratorRowReader(input.toIterator), None), cols, QueryStats()))
 
     val result = QueryResult2("someId", schema, ser)
     val roundTripResult = roundTrip(result).asInstanceOf[QueryResult2]

--- a/core/src/main/scala/filodb.core/Utils.scala
+++ b/core/src/main/scala/filodb.core/Utils.scala
@@ -1,0 +1,16 @@
+package filodb.core
+
+import java.lang.management.ManagementFactory
+
+import com.typesafe.scalalogging.StrictLogging
+
+object Utils extends StrictLogging {
+  private val threadMbean = ManagementFactory.getThreadMXBean
+  private val cpuUserTimeEnabled = threadMbean.isCurrentThreadCpuTimeSupported && threadMbean.isThreadCpuTimeEnabled
+  logger.info(s" CPU User Time Enabled: $cpuUserTimeEnabled")
+
+  def currentCpuUserTimeNanos: Long = {
+    if (cpuUserTimeEnabled) threadMbean.getCurrentThreadCpuTime
+    else System.nanoTime()
+  }
+}

--- a/core/src/main/scala/filodb.core/Utils.scala
+++ b/core/src/main/scala/filodb.core/Utils.scala
@@ -6,11 +6,11 @@ import com.typesafe.scalalogging.StrictLogging
 
 object Utils extends StrictLogging {
   private val threadMbean = ManagementFactory.getThreadMXBean
-  private val cpuUserTimeEnabled = threadMbean.isCurrentThreadCpuTimeSupported && threadMbean.isThreadCpuTimeEnabled
-  logger.info(s" CPU User Time Enabled: $cpuUserTimeEnabled")
+  private val cpuTimeEnabled = threadMbean.isCurrentThreadCpuTimeSupported && threadMbean.isThreadCpuTimeEnabled
+  logger.info(s"Measurement of CPU Time Enabled: $cpuTimeEnabled")
 
-  def currentCpuUserTimeNanos: Long = {
-    if (cpuUserTimeEnabled) threadMbean.getCurrentThreadCpuTime
+  def currentThreadCpuTimeNanos: Long = {
+    if (cpuTimeEnabled) threadMbean.getCurrentThreadCpuTime
     else System.nanoTime()
   }
 }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -442,7 +442,7 @@ object SerializedRangeVector extends StrictLogging {
             schema: RecordSchema,
             execPlan: String,
             queryStats: QueryStats): SerializedRangeVector = {
-    val startNs = Utils.currentCpuUserTimeNanos
+    val startNs = Utils.currentThreadCpuTimeNanos
     var numRows = 0
     try {
       val oldContainerOpt = builder.currentContainer
@@ -478,7 +478,7 @@ object SerializedRangeVector extends StrictLogging {
       queryStats.getResultBytesCounter(Nil).addAndGet(resultSize)
       srv
     } finally {
-      queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentCpuUserTimeNanos - startNs)
+      queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentThreadCpuTimeNanos - startNs)
     }
   }
   // scalastyle:on null

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -442,7 +442,7 @@ object SerializedRangeVector extends StrictLogging {
             schema: RecordSchema,
             execPlan: String,
             queryStats: QueryStats): SerializedRangeVector = {
-    val startNs = System.nanoTime()
+    val startNs = Utils.currentCpuUserTimeNanos
     var numRows = 0
     try {
       val oldContainerOpt = builder.currentContainer
@@ -478,7 +478,7 @@ object SerializedRangeVector extends StrictLogging {
       queryStats.getResultBytesCounter(Nil).addAndGet(resultSize)
       srv
     } finally {
-      queryStats.getCpuNanosCounter(Nil).addAndGet(System.nanoTime() - startNs)
+      queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentCpuUserTimeNanos - startNs)
     }
   }
   // scalastyle:on null

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -12,6 +12,7 @@ class RangeVectorSpec  extends AnyFunSpec with Matchers {
   val numRawSamples = 1000
   val reportingInterval = 10000
   val tuples = (numRawSamples until 0).by(-1).map(n => (now - n * reportingInterval, n.toDouble))
+  val queryStats = QueryStats()
 
   class TuplesRangeVector(inputTuples: Seq[(Long, Double)]) extends RangeVector {
     import NoCloseCursor._
@@ -34,13 +35,13 @@ class RangeVectorSpec  extends AnyFunSpec with Matchers {
 
   it("should be able to create and read from SerializedRangeVector") {
     val rv = new TuplesRangeVector(tuples)
-    val srv = SerializedRangeVector(rv, cols)
+    val srv = SerializedRangeVector(rv, cols, queryStats)
     val observedTs = srv.rows.toSeq.map(_.getLong(0))
     val observedVal = srv.rows.toSeq.map(_.getDouble(1))
     observedTs shouldEqual tuples.map(_._1)
     observedVal shouldEqual tuples.map(_._2)
 
-    val srv2 = SerializedRangeVector(srv, cols)
+    val srv2 = SerializedRangeVector(srv, cols, queryStats)
     val observedTs2 = srv2.rows.toSeq.map(_.getLong(0))
     val observedVal2 = srv2.rows.toSeq.map(_.getDouble(1))
     observedTs2 shouldEqual tuples.map(_._1)
@@ -53,7 +54,7 @@ class RangeVectorSpec  extends AnyFunSpec with Matchers {
     val builder = SerializedRangeVector.newBuilder()
 
     // Sharing one builder across multiple input RangeVectors
-    val srvs = rvs.map(rv => SerializedRangeVector(rv, builder, schema, "RangeVectorSpec"))
+    val srvs = rvs.map(rv => SerializedRangeVector(rv, builder, schema, "RangeVectorSpec", queryStats))
 
     // Now verify each of them
     val observedTs = srvs(0).rows.toSeq.map(_.getLong(0))

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -10,6 +10,8 @@ import filodb.memory.format.vectors.{CustomBuckets, Histogram, HistogramWithBuck
 
 class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
 
+  val queryStats = QueryStats()
+
   private def toRv(samples: Seq[(Long, Double)],
                    rangeVectorKey: RangeVectorKey,
                    rvPeriod: RvRange): RangeVector = {
@@ -48,7 +50,7 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
                       (700, Double.NaN), (800, Double.NaN),
                       (900, Double.NaN), (1000, Double.NaN)), key,
       RvRange(0, 100, 1000))
-    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
+    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 4
     val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
@@ -71,7 +73,7 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
       (700, Double.NaN), (800, Double.NaN),
       (900, Double.NaN), (1000, Double.NaN)), key,
       RvRange(1000, 100, 1000))
-    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
+    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 11
     val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
@@ -96,7 +98,7 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
                           (900, Histogram.empty), (1000, Histogram.empty)), key,
                       RvRange(0, 100, 1000))
 
-    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan")
+    val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 4
     val res = srv.rows.map(r => (r.getLong(0), r.getHistogram(1))).toList

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -10,8 +10,6 @@ import filodb.memory.format.vectors.{CustomBuckets, Histogram, HistogramWithBuck
 
 class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
 
-  val queryStats = QueryStats()
-
   private def toRv(samples: Seq[(Long, Double)],
                    rangeVectorKey: RangeVectorKey,
                    rvPeriod: RvRange): RangeVector = {
@@ -50,7 +48,10 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
                       (700, Double.NaN), (800, Double.NaN),
                       (900, Double.NaN), (1000, Double.NaN)), key,
       RvRange(0, 100, 1000))
+    val queryStats = QueryStats()
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
+    queryStats.getCpuNanosCounter(Nil).get() > 0 shouldEqual true
+    queryStats.getResultBytesCounter(Nil).get() shouldEqual 108
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 4
     val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
@@ -73,7 +74,10 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
       (700, Double.NaN), (800, Double.NaN),
       (900, Double.NaN), (1000, Double.NaN)), key,
       RvRange(1000, 100, 1000))
+    val queryStats = QueryStats()
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
+    queryStats.getCpuNanosCounter(Nil).get() > 0 shouldEqual true
+    queryStats.getResultBytesCounter(Nil).get() shouldEqual 248
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 11
     val res = srv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
@@ -98,7 +102,10 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
                           (900, Histogram.empty), (1000, Histogram.empty)), key,
                       RvRange(0, 100, 1000))
 
+    val queryStats = QueryStats()
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
+    queryStats.getCpuNanosCounter(Nil).get() > 0 shouldEqual true
+    queryStats.getResultBytesCounter(Nil).get() shouldEqual 188
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 4
     val res = srv.rows.map(r => (r.getLong(0), r.getHistogram(1))).toList

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -221,7 +221,7 @@ object PrometheusModel {
 
   def toQueryStatistics(qs: QueryStats): Seq[QueryStatistics] = qs.stat.map(stat =>
     QueryStatistics(stat._1, stat._2.timeSeriesScanned.get(),
-      stat._2.dataBytesScanned.get(), stat._2.resultBytes.get())
+      stat._2.dataBytesScanned.get(), stat._2.resultBytes.get(), stat._2.cpuNanos.get())
   ).toSeq
 
 }

--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -112,13 +112,13 @@ object PromCirceSupport {
   implicit val decodeQueryStatistics: Decoder[QueryStatistics] = new Decoder[QueryStatistics] {
     final def apply(c: HCursor): Decoder.Result[QueryStatistics] = {
       for {
-        group    <- c.downField("group").as[Seq[String]]
+        group             <- c.downField("group").as[Seq[String]]
         timeSeriesScanned <- c.downField("timeSeriesScanned").as[Long]
-        dataBytesScanned     <- c.downField("dataBytesScanned").as[Long]
-        resultBytes     <- c.downField("resultBytes").as[Long]
-        cpuNanos     <- c.downField("cpuNanos").as[Long]
+        dataBytesScanned  <- c.downField("dataBytesScanned").as[Long]
+        resultBytes       <- c.downField("resultBytes").as[Long]
+        cpuNanos          <- c.downField("cpuNanos").as[Option[Long]] // option to be backward compatible
       } yield {
-        QueryStatistics(group, timeSeriesScanned, dataBytesScanned, resultBytes, cpuNanos)
+        QueryStatistics(group, timeSeriesScanned, dataBytesScanned, resultBytes, cpuNanos.getOrElse(0))
       }
     }
   }

--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -116,8 +116,9 @@ object PromCirceSupport {
         timeSeriesScanned <- c.downField("timeSeriesScanned").as[Long]
         dataBytesScanned     <- c.downField("dataBytesScanned").as[Long]
         resultBytes     <- c.downField("resultBytes").as[Long]
+        cpuNanos     <- c.downField("cpuNanos").as[Long]
       } yield {
-        QueryStatistics(group, timeSeriesScanned, dataBytesScanned, resultBytes)
+        QueryStatistics(group, timeSeriesScanned, dataBytesScanned, resultBytes, cpuNanos)
       }
     }
   }

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -17,7 +17,7 @@ final case class ExplainPlanResponse(debugInfo: Seq[String], status: String = "s
                                      message: Option[String]= None) extends PromQueryResponse
 
 final case class QueryStatistics(group: Seq[String], timeSeriesScanned: Long,
-                                 dataBytesScanned: Long, resultBytes: Long)
+                                 dataBytesScanned: Long, resultBytes: Long, cpuNanos: Long)
 
 final case class Data(resultType: String, result: Seq[Result])
 

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -168,7 +168,7 @@ final case class AggregatePresenter(aggrOp: AggregationOperator,
             sourceSchema: ResultSchema,
             paramResponse: Seq[Observable[ScalarRangeVector]]): Observable[RangeVector] = {
     val aggregator = RowAggregator(aggrOp, aggrParams, sourceSchema)
-    RangeVectorAggregator.present(aggregator, source, limit, rangeParams)
+    RangeVectorAggregator.present(aggregator, source, limit, rangeParams, querySession.queryStats)
   }
 
   override def schema(source: ResultSchema): ResultSchema = {
@@ -225,8 +225,9 @@ object RangeVectorAggregator extends StrictLogging {
   def present(aggregator: RowAggregator,
               source: Observable[RangeVector],
               limit: Int,
-              rangeParams: RangeParams): Observable[RangeVector] = {
-    source.flatMap(rv => Observable.fromIterable(aggregator.present(rv, limit, rangeParams)))
+              rangeParams: RangeParams,
+              queryStats: QueryStats): Observable[RangeVector] = {
+    source.flatMap(rv => Observable.fromIterable(aggregator.present(rv, limit, rangeParams, queryStats)))
   }
 
   private def mapReduceInternal(rvs: List[RangeVector],

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -79,7 +79,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
           s" Try applying more filters or reduce time range.")
       case (QueryResult(_, _, result, _, _, _), i) => (result, i)
     }.toListL.map { resp =>
-      val startNs = Utils.currentCpuUserTimeNanos
+      val startNs = Utils.currentThreadCpuTimeNanos
       try {
         span.mark("binary-join-child-results-available")
         Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",
@@ -150,7 +150,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
         Observable.fromIterable(results.values.map(_.resultRv))
       } finally {
         // Adding CPU time here since dealing with metadata join is not insignificant
-        querySession.queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentCpuUserTimeNanos - startNs)
+        querySession.queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentThreadCpuTimeNanos - startNs)
       }
     }
     Observable.fromTask(taskOfResults).flatten

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -78,71 +78,79 @@ final case class BinaryJoinExec(queryContext: QueryContext,
           s" Try applying more filters or reduce time range.")
       case (QueryResult(_, _, result, _, _, _), i) => (result, i)
     }.toListL.map { resp =>
-      span.mark("binary-join-child-results-available")
-      Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",
-        MeasurementUnit.time.milliseconds)
-        .withTag("plan", getClass.getSimpleName)
-        .record(Math.max(0, System.currentTimeMillis - queryContext.submitTime))
-      // NOTE: We can't require this any more, as multischema queries may result in not a QueryResult if the
-      //       filter returns empty results.  The reason is that the schema will be undefined.
-      // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
-      val lhsRvs = resp.filter(_._2 < lhs.size).flatMap(_._1)
-      val rhsRvs = resp.filter(_._2 >= lhs.size).flatMap(_._1)
-      // figure out which side is the "one" side
-      val (oneSide, otherSide, lhsIsOneSide) =
-        if (cardinality == Cardinality.OneToMany) (lhsRvs, rhsRvs, true)
-        else (rhsRvs, lhsRvs, false)
-      val period = oneSide.headOption.flatMap(_.outputRange)
-      // load "one" side keys in a hashmap
-      val oneSideMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
-      oneSide.foreach { rv =>
-        val jk = joinKeys(rv.key)
-        // When spread changes, we need to account for multiple Range Vectors with same key coming from different shards
-        // Each of these range vectors would contain data for different time ranges
-        if (oneSideMap.contains(jk)) {
-          val rvDupe = oneSideMap(jk)
-          if (rv.key.labelValues == rvDupe.key.labelValues) {
-            oneSideMap.put(jk, StitchRvsExec.stitch(rv, rvDupe, outputRvRange))
-          } else {
-            throw new BadQueryException(s"Cardinality $cardinality was used, but many found instead of one for $jk. " +
-              s"${rvDupe.key.labelValues} and ${rv.key.labelValues} were the violating keys on many side")
-          }
-        } else {
-          oneSideMap.put(jk, rv)
-        }
-      }
-      // keep a hashset of result range vector keys to help ensure uniqueness of result range vectors
-      val results = new mutable.HashMap[RangeVectorKey, ResultVal]()
-      case class ResultVal(resultRv: RangeVector, stitchedOtherSide: RangeVector)
-      // iterate across the the "other" side which could be one or many and perform the binary operation
-      otherSide.foreach { rvOther =>
-        val jk = joinKeys(rvOther.key)
-        oneSideMap.get(jk).foreach { rvOne =>
-          val resKey = resultKeys(rvOne.key, rvOther.key)
-          val rvOtherCorrect = if (results.contains(resKey)) {
-            val resVal = results(resKey)
-            if (resVal.stitchedOtherSide.key.labelValues == rvOther.key.labelValues) {
-              StitchRvsExec.stitch(rvOther, resVal.stitchedOtherSide, outputRvRange)
+      val startNs = System.nanoTime()
+      try {
+        span.mark("binary-join-child-results-available")
+        Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",
+          MeasurementUnit.time.milliseconds)
+          .withTag("plan", getClass.getSimpleName)
+          .record(Math.max(0, System.currentTimeMillis - queryContext.submitTime))
+        // NOTE: We can't require this any more, as multischema queries may result in not a QueryResult if the
+        //       filter returns empty results.  The reason is that the schema will be undefined.
+        // require(resp.size == lhs.size + rhs.size, "Did not get sufficient responses for LHS and RHS")
+        val lhsRvs = resp.filter(_._2 < lhs.size).flatMap(_._1)
+        val rhsRvs = resp.filter(_._2 >= lhs.size).flatMap(_._1)
+        // figure out which side is the "one" side
+        val (oneSide, otherSide, lhsIsOneSide) =
+          if (cardinality == Cardinality.OneToMany) (lhsRvs, rhsRvs, true)
+          else (rhsRvs, lhsRvs, false)
+        val period = oneSide.headOption.flatMap(_.outputRange)
+        // load "one" side keys in a hashmap
+        val oneSideMap = new mutable.HashMap[Map[Utf8Str, Utf8Str], RangeVector]()
+        oneSide.foreach { rv =>
+          val jk = joinKeys(rv.key)
+          // When spread changes, we need to account for multiple Range Vectors
+          // with same key coming from different shards
+          // Each of these range vectors would contain data for different time ranges
+          if (oneSideMap.contains(jk)) {
+            val rvDupe = oneSideMap(jk)
+            if (rv.key.labelValues == rvDupe.key.labelValues) {
+              oneSideMap.put(jk, StitchRvsExec.stitch(rv, rvDupe, outputRvRange))
             } else {
-              throw new BadQueryException(s"Non-unique result vectors ${resVal.stitchedOtherSide.key.labelValues} " +
-                s"and ${rvOther.key.labelValues} found for $resKey . Use grouping to create unique matching")
+              throw new BadQueryException(s"Cardinality $cardinality was used, but many found instead of one " +
+                s"for $jk. ${rvDupe.key.labelValues} and ${rv.key.labelValues} were the violating keys on many side")
             }
           } else {
-            rvOther
+            oneSideMap.put(jk, rv)
           }
-
-          // OneToOne cardinality case is already handled. this condition handles OneToMany case
-          if (results.size >= queryContext.plannerParams.joinQueryCardLimit)
-            throw new BadQueryException(s"The result of this join query has cardinality ${results.size} and " +
-              s"has reached the limit of ${queryContext.plannerParams.joinQueryCardLimit}. Try applying more filters.")
-
-          val res = if (lhsIsOneSide) binOp(rvOne.rows, rvOtherCorrect.rows) else binOp(rvOtherCorrect.rows, rvOne.rows)
-          results.put(resKey, ResultVal(IteratorBackedRangeVector(resKey, res, period), rvOtherCorrect))
         }
+        // keep a hashset of result range vector keys to help ensure uniqueness of result range vectors
+        val results = new mutable.HashMap[RangeVectorKey, ResultVal]()
+        case class ResultVal(resultRv: RangeVector, stitchedOtherSide: RangeVector)
+        // iterate across the the "other" side which could be one or many and perform the binary operation
+        otherSide.foreach { rvOther =>
+          val jk = joinKeys(rvOther.key)
+          oneSideMap.get(jk).foreach { rvOne =>
+            val resKey = resultKeys(rvOne.key, rvOther.key)
+            val rvOtherCorrect = if (results.contains(resKey)) {
+              val resVal = results(resKey)
+              if (resVal.stitchedOtherSide.key.labelValues == rvOther.key.labelValues) {
+                StitchRvsExec.stitch(rvOther, resVal.stitchedOtherSide, outputRvRange)
+              } else {
+                throw new BadQueryException(s"Non-unique result vectors ${resVal.stitchedOtherSide.key.labelValues} " +
+                  s"and ${rvOther.key.labelValues} found for $resKey . Use grouping to create unique matching")
+              }
+            } else {
+              rvOther
+            }
+
+            // OneToOne cardinality case is already handled. this condition handles OneToMany case
+            if (results.size >= queryContext.plannerParams.joinQueryCardLimit)
+              throw new BadQueryException(s"The result of this join query has cardinality ${results.size} and has " +
+                s"reached the limit of ${queryContext.plannerParams.joinQueryCardLimit}. Try applying more filters.")
+
+            val res = if (lhsIsOneSide) binOp(rvOne.rows, rvOtherCorrect.rows)
+            else binOp(rvOtherCorrect.rows, rvOne.rows)
+            results.put(resKey, ResultVal(IteratorBackedRangeVector(resKey, res, period), rvOtherCorrect))
+          }
+        }
+        // check for timeout after dealing with metadata, before dealing with numbers
+        querySession.qContext.checkQueryTimeout(this.getClass.getName)
+        Observable.fromIterable(results.values.map(_.resultRv))
+      } finally {
+        // Adding CPU time here since dealing with metadata join is not insignificant
+        querySession.queryStats.getCpuNanosCounter(Nil).addAndGet(System.nanoTime() - startNs)
       }
-      // check for timeout after dealing with metadata, before dealing with numbers
-      querySession.qContext.checkQueryTimeout(this.getClass.getName)
-      Observable.fromIterable(results.values.map(_.resultRv))
     }
     Observable.fromTask(taskOfResults).flatten
   }

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -404,8 +404,6 @@ trait ExecPlan extends QueryCommand {
                   MeasurementUnit.time.milliseconds)
               .withTag("plan", getClass.getSimpleName)
               .record(Math.max(0, System.currentTimeMillis - startExecute))
-            SerializedRangeVector.queryResultBytes.record(resultSize)
-            querySession.queryStats.getResultBytesCounter(Nil).addAndGet(resultSize)
             span.mark(s"resultBytes=$resultSize")
             span.mark(s"resultSamples=$numResultSamples")
             span.mark(s"numSrv=${r.size}")

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -19,6 +19,8 @@ import filodb.memory.format.RowReader
 import filodb.query._
 import filodb.query.Query.qLogger
 
+// scalastyle:off file.size.limit
+
 /**
  * The observable of vectors and the schema that is returned by ExecPlan doExecute
  */

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -131,11 +131,11 @@ trait ExecPlan extends QueryCommand {
       // kamon uses thread-locals.
       // Dont finish span since this code didnt create it
       Kamon.runWithSpan(span, false) {
-        val startNs = Utils.currentCpuUserTimeNanos
+        val startNs = Utils.currentThreadCpuTimeNanos
         val doEx = try {
           doExecute(source, querySession)
         } finally {
-          step1CpuTime = Utils.currentCpuUserTimeNanos - startNs
+          step1CpuTime = Utils.currentThreadCpuTimeNanos - startNs
         }
         Kamon.histogram("query-execute-time-elapsed-step1-done",
           MeasurementUnit.time.milliseconds)
@@ -301,11 +301,11 @@ trait ExecPlan extends QueryCommand {
       // kamon uses thread-locals.
       // Dont finish span since this code didnt create it
       Kamon.runWithSpan(span, false) {
-        val startNs = Utils.currentCpuUserTimeNanos
+        val startNs = Utils.currentThreadCpuTimeNanos
         val doEx = try {
           doExecute(source, querySession)
         } finally {
-          step1CpuTime = Utils.currentCpuUserTimeNanos - startNs
+          step1CpuTime = Utils.currentThreadCpuTimeNanos - startNs
         }
         Kamon.histogram("query-execute-time-elapsed-step1-done",
           MeasurementUnit.time.milliseconds)

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -42,6 +42,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
   private val builder = SerializedRangeVector.newBuilder()
 
   override val urlParams = Map("query" -> promQlQueryParams.promQl)
+  private val dummyQueryStats = QueryStats()
 
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
                               (implicit sched: Scheduler): Future[QueryResponse] = {
@@ -136,8 +137,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
                                                             promQlQueryParams.stepSecs * 1000,
                                                             promQlQueryParams.endSecs * 1000))
       }
+      // dont add this size to queryStats since it was already added by callee use dummy QueryStats()
       SerializedRangeVector(rv, builder, recordSchema.get("default").get,
-        queryWithPlanName(queryContext))
+        queryWithPlanName(queryContext), dummyQueryStats)
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("default").get, rangeVectors, readQueryStats(response.queryStats),
@@ -176,7 +178,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
           promQlQueryParams.endSecs * 1000))
 
       }
-      SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, queryContext.origQueryParams.toString)
+      // dont add this size to queryStats since it was already added by callee use dummy QueryStats()
+      SerializedRangeVector(rv, builder, recordSchema.get("histogram").get, queryContext.origQueryParams.toString,
+        dummyQueryStats)
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(id, resultSchema.get("histogram").get, rangeVectors, readQueryStats(response.queryStats),
@@ -205,8 +209,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
             promQlQueryParams.stepSecs * 1000,
             promQlQueryParams.endSecs * 1000))
       }
+      // dont add this size to queryStats since it was already added by callee use dummy QueryStats()
       SerializedRangeVector(rv, builder, recordSchema.get(Avg.entryName).get,
-        queryWithPlanName(queryContext))
+        queryWithPlanName(queryContext), dummyQueryStats)
     }
 
     // TODO: Handle stitching with verbose flag
@@ -237,8 +242,9 @@ case class PromQlRemoteExec(queryEndpoint: String,
           promQlQueryParams.stepSecs * 1000,
           promQlQueryParams.endSecs * 1000))
       }
+      // dont add this size to queryStats since it was already added by callee use dummy QueryStats()
       SerializedRangeVector(rv, builder, recordSchema.get(QueryFunctionConstants.stdVal).get,
-        queryWithPlanName(queryContext))
+        queryWithPlanName(queryContext), dummyQueryStats)
     }
 
     // TODO: Handle stitching with verbose flag

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -301,7 +301,8 @@ final case class SortFunctionMapper(function: SortFunctionId) extends RangeVecto
 
       // Create SerializedRangeVector so that sorting does not consume rows iterator
       val resultRv = source.toListL.map { rvs =>
-         rvs.map(SerializedRangeVector(_, builder, recSchema, s"SortRangeVectorTransformer: $args")).
+         rvs.map(SerializedRangeVector(_, builder, recSchema,
+           s"SortRangeVectorTransformer: $args", querySession.queryStats)).
            sortBy { rv => if (rv.rows.hasNext) rv.rows.next().getDouble(1) else Double.NaN
         }(ordering)
 

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -90,6 +90,7 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
       queryStats.getTimeSeriesScannedCounter(stat.group).addAndGet(stat.timeSeriesScanned)
       queryStats.getDataBytesScannedCounter(stat.group).addAndGet(stat.dataBytesScanned)
       queryStats.getResultBytesCounter(stat.group).addAndGet(stat.resultBytes)
+      queryStats.getCpuNanosCounter(stat.group).addAndGet(stat.cpuNanos)
     }
     queryStats
   }

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -62,7 +62,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
     val taskOfResults = childResponses.map {
       case (QueryResult(_, schema, result, _, _, _), i) => (schema, result, i)
     }.toListL.map { resp =>
-      val startNs = Utils.currentCpuUserTimeNanos
+      val startNs = Utils.currentThreadCpuTimeNanos
       try {
         span.mark("binary-join-child-results-available")
         Kamon.histogram("query-execute-time-elapsed-step1-child-results-available",
@@ -89,7 +89,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
         Observable.fromIteratorUnsafe(results)
       } finally {
         // Adding CPU time here since dealing with metadata join is not insignificant
-        querySession.queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentCpuUserTimeNanos - startNs)
+        querySession.queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentThreadCpuTimeNanos - startNs)
       }
     }
     Observable.fromTask(taskOfResults).flatten

--- a/query/src/main/scala/filodb/query/exec/aggregator/AvgRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/AvgRowAggregator.scala
@@ -45,7 +45,8 @@ object AvgRowAggregator extends RowAggregator {
     acc
   }
   // ignore last count column. we rely on schema change
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams,
+              queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = {
     source.copy(columns = source.columns :+ ColumnInfo("count", ColumnType.LongColumn))
   }

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountRowAggregator.scala
@@ -40,7 +40,8 @@ abstract class CountRowAggregator extends RowAggregator {
       acc.count += aggRes.getDouble(1)
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = schema
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/CountValuesRowAggregator.scala
@@ -81,7 +81,8 @@ class CountValuesRowAggregator(label: String, limit: Int = 1000) extends RowAggr
     acc
   }
 
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = {
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = {
     val colSchema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
       ColumnInfo("value", ColumnType.DoubleColumn))
     val recSchema = SerializedRangeVector.toSchema(colSchema)

--- a/query/src/main/scala/filodb/query/exec/aggregator/GroupRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/GroupRowAggregator.scala
@@ -27,7 +27,8 @@ object GroupRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/HistMaxSumAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/HistMaxSumAggregator.scala
@@ -1,6 +1,7 @@
 package filodb.query.exec.aggregator
 
-import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema, TransientHistMaxRow}
+import filodb.core.query.{MutableRowReader, QueryStats, RangeParams,
+                          RangeVector, RangeVectorKey, ResultSchema, TransientHistMaxRow}
 import filodb.memory.format.RowReader
 
 object HistMaxSumAggregator extends RowAggregator {
@@ -29,7 +30,8 @@ object HistMaxSumAggregator extends RowAggregator {
     acc.m = if (acc.m.isNaN) aggRes.getDouble(2) else Math.max(acc.m, aggRes.getDouble(2))
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/HistSumRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/HistSumRowAggregator.scala
@@ -1,6 +1,7 @@
 package filodb.query.exec.aggregator
 
-import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema, TransientHistRow}
+import filodb.core.query.{MutableRowReader, QueryStats, RangeParams,
+                          RangeVector, RangeVectorKey, ResultSchema, TransientHistRow}
 import filodb.memory.format.RowReader
 
 object HistSumRowAggregator extends RowAggregator {
@@ -27,7 +28,8 @@ object HistSumRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/MaxRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/MaxRowAggregator.scala
@@ -27,7 +27,8 @@ object MaxRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/MinRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/MinRowAggregator.scala
@@ -28,7 +28,8 @@ object MinRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/QuantileRowAggregator.scala
@@ -63,7 +63,8 @@ class QuantileRowAggregator(q: Double) extends RowAggregator {
     acc
   }
 
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = {
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = {
     val mutRow = new TransientRow()
     val result = aggRangeVector.rows.mapRow { r =>
       val qVal = ArrayDigest.fromBytes(r.getBuffer(1)).quantile(q)

--- a/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
@@ -1,7 +1,7 @@
 package filodb.query.exec.aggregator
 
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema}
+import filodb.core.query.{MutableRowReader, QueryStats, RangeParams, RangeVector, RangeVectorKey, ResultSchema}
 import filodb.memory.format.RowReader
 import filodb.query.AggregationOperator
 import filodb.query.AggregationOperator._
@@ -96,7 +96,8 @@ trait RowAggregator {
     *              Apply limit only on iterators that are NOT lazy and need to be
     *              materialized.
     */
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector]
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector]
 
   /**
     * Schema of the RowReader returned by toRowReader

--- a/query/src/main/scala/filodb/query/exec/aggregator/StddevRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/StddevRowAggregator.scala
@@ -57,7 +57,8 @@ object StddevRowAggregator extends RowAggregator {
     acc
   }
   // ignore last two column. we rely on schema change
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = {
     source.copy(source.columns :+ ColumnInfo("mean", ColumnType.DoubleColumn)
       :+ ColumnInfo("count", ColumnType.LongColumn))

--- a/query/src/main/scala/filodb/query/exec/aggregator/StdvarRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/StdvarRowAggregator.scala
@@ -71,7 +71,8 @@ object StdvarRowAggregator extends RowAggregator {
     acc
   }
   // ignore last two column. we rely on schema change
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = {
     source.copy(source.columns :+ ColumnInfo("mean", ColumnType.DoubleColumn)
       :+ ColumnInfo("count", ColumnType.LongColumn))

--- a/query/src/main/scala/filodb/query/exec/aggregator/SumRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/SumRowAggregator.scala
@@ -1,6 +1,7 @@
 package filodb.query.exec.aggregator
 
-import filodb.core.query.{MutableRowReader, RangeParams, RangeVector, RangeVectorKey, ResultSchema, TransientRow}
+import filodb.core.query.{MutableRowReader, QueryStats, RangeParams,
+                          RangeVector, RangeVectorKey, ResultSchema, TransientRow}
 import filodb.memory.format.RowReader
 /**
   * Map: Every sample is mapped to itself
@@ -26,7 +27,8 @@ object SumRowAggregator extends RowAggregator {
     }
     acc
   }
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = Seq(aggRangeVector)
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = Seq(aggRangeVector)
   def reductionSchema(source: ResultSchema): ResultSchema = source
   def presentationSchema(reductionSchema: ResultSchema): ResultSchema = reductionSchema
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -118,7 +118,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
   // scalastyle:off method.length
   def present(aggRangeVector: RangeVector, limit: Int,
               rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = {
-    val startNs = Utils.currentCpuUserTimeNanos
+    val startNs = Utils.currentThreadCpuTimeNanos
     try {
       val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
       try {
@@ -166,7 +166,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
         srv
       }.toSeq
     } finally {
-      queryStats.getCpuNanosCounter(Nil).getAndAdd(Utils.currentCpuUserTimeNanos - startNs)
+      queryStats.getCpuNanosCounter(Nil).getAndAdd(Utils.currentThreadCpuTimeNanos - startNs)
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable.ListBuffer
 
 import com.typesafe.scalalogging.StrictLogging
 
+import filodb.core.Utils
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.FiloSchedulers
 import filodb.core.memstore.FiloSchedulers.QuerySchedName
@@ -117,7 +118,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
   // scalastyle:off method.length
   def present(aggRangeVector: RangeVector, limit: Int,
               rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = {
-    val startNs = System.nanoTime()
+    val startNs = Utils.currentCpuUserTimeNanos
     try {
       val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
       try {
@@ -165,7 +166,7 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
         srv
       }.toSeq
     } finally {
-      queryStats.getCpuNanosCounter(Nil).getAndAdd(System.nanoTime() - startNs)
+      queryStats.getCpuNanosCounter(Nil).getAndAdd(Utils.currentCpuUserTimeNanos - startNs)
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -114,50 +114,59 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
     builder
   }
 
-  def present(aggRangeVector: RangeVector, limit: Int, rangeParams: RangeParams): Seq[RangeVector] = {
-    val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
+  // scalastyle:off method.length
+  def present(aggRangeVector: RangeVector, limit: Int,
+              rangeParams: RangeParams, queryStats: QueryStats): Seq[RangeVector] = {
+    val startNs = System.nanoTime()
     try {
-      FiloSchedulers.assertThreadName(QuerySchedName)
-      ChunkMap.validateNoSharedLocks(s"TopkQuery-$k-$bottomK")
-      // We limit the results wherever it is materialized first. So it is done here.
-      val rows = aggRangeVector.rows.take(limit)
-      val it = Iterator.from(0, rangeParams.stepSecs.toInt)
-        .takeWhile(_ <= (rangeParams.endSecs - rangeParams.startSecs)).map { t =>
-        val timestamp = t + rangeParams.startSecs
-        val rvkSeen = new ListBuffer[RangeVectorKey]
-        val row = rows.next()
-        var i = 1
-        while (row.notNull(i)) {
-          if (row.filoUTF8String(i) != CustomRangeVectorKey.emptyAsZcUtf8) {
-            val key = row.filoUTF8String(i)
-            logger.debug(s"TopkPresent before decoding key=$key")
-            val rvk = CustomRangeVectorKey.fromZcUtf8(key)
-            logger.debug(s"TopkPresent after decoding key=${rvk.labelValues.mkString(",")}")
-            rvkSeen += rvk
-            val builder = resRvs.getOrElseUpdate(rvk, createBuilder(rangeParams, timestamp))
-            addRecordToBuilder(builder, TimeUnit.SECONDS.toMillis(timestamp), row.getDouble(i + 1))
+      val resRvs = mutable.Map[RangeVectorKey, RecordBuilder]()
+      try {
+        FiloSchedulers.assertThreadName(QuerySchedName)
+        ChunkMap.validateNoSharedLocks(s"TopkQuery-$k-$bottomK")
+        // We limit the results wherever it is materialized first. So it is done here.
+        val rows = aggRangeVector.rows.take(limit)
+        val it = Iterator.from(0, rangeParams.stepSecs.toInt)
+          .takeWhile(_ <= (rangeParams.endSecs - rangeParams.startSecs)).map { t =>
+          val timestamp = t + rangeParams.startSecs
+          val rvkSeen = new ListBuffer[RangeVectorKey]
+          val row = rows.next()
+          var i = 1
+          while (row.notNull(i)) {
+            if (row.filoUTF8String(i) != CustomRangeVectorKey.emptyAsZcUtf8) {
+              val key = row.filoUTF8String(i)
+              logger.debug(s"TopkPresent before decoding key=$key")
+              val rvk = CustomRangeVectorKey.fromZcUtf8(key)
+              logger.debug(s"TopkPresent after decoding key=${rvk.labelValues.mkString(",")}")
+              rvkSeen += rvk
+              val builder = resRvs.getOrElseUpdate(rvk, createBuilder(rangeParams, timestamp))
+              addRecordToBuilder(builder, TimeUnit.SECONDS.toMillis(timestamp), row.getDouble(i + 1))
+            }
+            i += 2
           }
-          i += 2
+          resRvs.keySet.foreach { rvs =>
+            if (!rvkSeen.contains(rvs)) addRecordToBuilder(resRvs(rvs), timestamp * 1000, Double.NaN)
+          }
         }
-        resRvs.keySet.foreach { rvs =>
-          if (!rvkSeen.contains(rvs)) addRecordToBuilder(resRvs(rvs), timestamp * 1000, Double.NaN)
-        }
+        // address step == 0 case
+        if (rangeParams.startSecs == rangeParams.endSecs || rangeParams.stepSecs == 0) it.take(1).toList else it.toList
+      } finally {
+        aggRangeVector.rows().close()
+        ChunkMap.releaseAllSharedLocks()
       }
-      // address step == 0 case
-      if (rangeParams.startSecs == rangeParams.endSecs || rangeParams.stepSecs == 0) it.take(1).toList else it.toList
-    } finally {
-      aggRangeVector.rows().close()
-      ChunkMap.releaseAllSharedLocks()
-    }
 
-    resRvs.map { case (key, builder) =>
-      val numRows = builder.allContainers.map(_.countRecords()).sum
-      logger.debug(s"TopkPresent before creating SRV key = ${key.labelValues.mkString(",")}")
-      new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0,
-                                                    Some(RvRange(rangeParams.startSecs * 1000,
-                                                      rangeParams.stepSecs * 1000,
-                                                      rangeParams.endSecs * 1000)))
-    }.toSeq
+      resRvs.map { case (key, builder) =>
+        val numRows = builder.allContainers.map(_.countRecords()).sum
+        logger.debug(s"TopkPresent before creating SRV key = ${key.labelValues.mkString(",")}")
+        val srv = new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0,
+          Some(RvRange(rangeParams.startSecs * 1000,
+            rangeParams.stepSecs * 1000,
+            rangeParams.endSecs * 1000)))
+        queryStats.getResultBytesCounter(Nil).getAndAdd(srv.estimatedSerializedBytes)
+        srv
+      }.toSeq
+    } finally {
+      queryStats.getCpuNanosCounter(Nil).getAndAdd(System.nanoTime() - startNs)
+    }
   }
 
   def reductionSchema(source: ResultSchema): ResultSchema = {

--- a/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
+++ b/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
@@ -370,7 +370,7 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
                   |            "timeSeriesScanned": 24,
                   |            "dataBytesScanned": 38784,
                   |            "resultBytes": 15492,
-                  |            "cpuNanos"": 434999
+                  |            "cpuNanos": 434999
                   |        }
                   |    ]
                   |}]""".stripMargin

--- a/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
+++ b/query/src/test/scala/filodb/query/PromCirceSupportSpec.scala
@@ -369,11 +369,12 @@ class PromCirceSupportSpec extends AnyFunSpec with Matchers with ScalaFutures {
                   |            ],
                   |            "timeSeriesScanned": 24,
                   |            "dataBytesScanned": 38784,
-                  |            "resultBytes": 15492
+                  |            "resultBytes": 15492,
+                  |            "cpuNanos"": 434999
                   |        }
                   |    ]
                   |}]""".stripMargin
-    val qs = QueryStatistics(Seq("local", "raw", "ws1", "ns1", "metric1"), 24, 38784, 15492)
+    val qs = QueryStatistics(Seq("local", "raw", "ws1", "ns1", "metric1"), 24, 38784, 15492, 434999)
     parser.decode[List[ErrorResponse]](input) match {
       case Right(errorResponse) =>
         errorResponse.head.errorType shouldEqual "query_materialization_failed"

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -24,7 +24,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
   val histMaxSchema = ResultSchema(MMD.histMaxDS.schema.infosFromIDs(Seq(0, 4, 3)), 1, colIDs = Seq(0, 4, 3))
 
   val qc = QueryContext()
-  
+  val queryStats = QueryStats()
+
   it ("should work without grouping") {
     val ignoreKey = CustomRangeVectorKey(
       Map(("ignore").utf8 -> ("ignore").utf8))
@@ -323,7 +324,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val recSchema = SerializedRangeVector.toSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                                                          ColumnInfo("tdig", ColumnType.StringColumn)))
     val builder = SerializedRangeVector.newBuilder()
-    val srv = SerializedRangeVector(result7(0), builder, recSchema, "AggrOverRangeVectorsSpec")
+    val srv = SerializedRangeVector(result7(0), builder, recSchema, "AggrOverRangeVectorsSpec", queryStats)
 
     val resultObs7b = RangeVectorAggregator.present(agg7, Observable.now(srv), 1000, RangeParams(0,1,0))
     val finalResult = resultObs7b.toListL.runToFuture.futureValue

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -115,7 +115,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg7 = RowAggregator(AggregationOperator.Quantile, Seq(0.70), tvSchema)
     val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping, queryContext = qc)
     val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key, queryContext = qc)
-    val resultObs7b = RangeVectorAggregator.present(agg7, resultObs7, 1000, rangeParams)
+    val resultObs7b = RangeVectorAggregator.present(agg7, resultObs7, 1000, rangeParams, queryStats)
     val result7 = resultObs7b.toListL.runToFuture.futureValue
     result7.size shouldEqual 1
     result7(0).key shouldEqual noKey
@@ -235,7 +235,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg5 = RowAggregator(AggregationOperator.BottomK, Seq(2.0), tvSchema)
     val resultObs5a = RangeVectorAggregator.mapReduce(agg5, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
     val resultObs5 = RangeVectorAggregator.mapReduce(agg5,true, resultObs5a, rv=>rv.key,  queryContext = qc)
-    val resultObs5b = RangeVectorAggregator.present(agg5, resultObs5, 1000, rangeParams)
+    val resultObs5b = RangeVectorAggregator.present(agg5, resultObs5, 1000, rangeParams, queryStats)
     val result5 = resultObs5.toListL.runToFuture.futureValue
     result5.size shouldEqual 1
     result5(0).key shouldEqual noKey
@@ -253,7 +253,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(2.0), tvSchema)
     val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
     val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
-    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, rangeParams)
+    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, rangeParams, queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6.size shouldEqual 1
     result6(0).key shouldEqual noKey
@@ -273,7 +273,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg7 = RowAggregator(AggregationOperator.Quantile, Seq(0.5), tvSchema)
     val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
     val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key,  queryContext = qc)
-    val resultObs7b = RangeVectorAggregator.present(agg7, resultObs7, 1000, rangeParams)
+    val resultObs7b = RangeVectorAggregator.present(agg7, resultObs7, 1000, rangeParams, queryStats)
     val result7 = resultObs7b.toListL.runToFuture.futureValue
     result7.size shouldEqual 1
     result7(0).key shouldEqual noKey
@@ -326,7 +326,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val builder = SerializedRangeVector.newBuilder()
     val srv = SerializedRangeVector(result7(0), builder, recSchema, "AggrOverRangeVectorsSpec", queryStats)
 
-    val resultObs7b = RangeVectorAggregator.present(agg7, Observable.now(srv), 1000, RangeParams(0,1,0))
+    val resultObs7b = RangeVectorAggregator.present(agg7, Observable.now(srv), 1000, RangeParams(0,1,0), queryStats)
     val finalResult = resultObs7b.toListL.runToFuture.futureValue
     compareIter(finalResult(0).rows.map(_.getDouble(1)), Seq(3.35d, 5.4d).iterator)
 
@@ -447,7 +447,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     compareIter2(result5(0).rows.map(r=> Set(r.getDouble(2), r.getDouble(4))),
       Seq(Set(1.7976931348623157E308d, 1.7976931348623157E308d), Set(4.4d, 5.4d)).iterator)
     // present
-    val resultObs5b = RangeVectorAggregator.present(agg5, resultObs5, 1000, RangeParams(1,1,2))
+    val resultObs5b = RangeVectorAggregator.present(agg5, resultObs5, 1000, RangeParams(1,1,2), queryStats)
     val result5b = resultObs5b.toListL.runToFuture.futureValue
     result5b.size shouldEqual 2
     result5b(0).key shouldEqual CustomRangeVectorKey(Map("a".utf8 -> "2".utf8))
@@ -460,7 +460,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(2.0), tvSchema)
     val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
     val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
-    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1,1,2))
+    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1,1,2), queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6.size shouldEqual 1
     result6(0).key shouldEqual noKey
@@ -512,7 +512,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(5.0), tvSchema)
     val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
     val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
-    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744,1,1556745))
+    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744,1,1556745), queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6(0).key shouldEqual noKey
     val result6b = resultObs6b.toListL.runToFuture.futureValue
@@ -585,7 +585,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val resultObsa = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(samples),
       noGrouping,  queryContext = qc)
     val resultObsb = RangeVectorAggregator.mapReduce(agg, true, resultObsa, rv=>rv.key,  queryContext = qc)
-    val resultObsc = RangeVectorAggregator.present(agg, resultObsb, 1000, rangeParams)
+    val resultObsc = RangeVectorAggregator.present(agg, resultObsb, 1000, rangeParams, queryStats)
     val result = resultObsc.toListL.runToFuture.futureValue
 
     result.size shouldEqual 2
@@ -644,7 +644,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val resultObs = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
     val resultObs1 = RangeVectorAggregator.mapReduce(agg, true, resultObs,  rv=>rv.key,  queryContext = qc)
 
-    val resultObs2 = RangeVectorAggregator.present(agg, resultObs1, 1000, RangeParams(0,1,0) )
+    val resultObs2 = RangeVectorAggregator.present(agg, resultObs1, 1000, RangeParams(0,1,0), queryStats )
     val result = resultObs2.toListL.runToFuture.futureValue
     result.size.shouldEqual(4)
     result.map(_.key.labelValues).sameElements(expectedLabels) shouldEqual true
@@ -661,7 +661,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(1.0), tvSchema)
     val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
     val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
-    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744, 0, 1556744))
+    val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744, 0, 1556744), queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6(0).key shouldEqual noKey
     val result6b = resultObs6b.toListL.runToFuture.futureValue
@@ -712,7 +712,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val noPresent = (agg: RowAggregator, rv: Observable[RangeVector]) => rv
 
     val withPresent = (agg: RowAggregator, rv: Observable[RangeVector]) => {
-      RangeVectorAggregator.present(agg, rv, 1000, RangeParams(0, 1, 0))
+      RangeVectorAggregator.present(agg, rv, 1000, RangeParams(0, 1, 0), queryStats)
     }
 
     // Tuples of (op, params, presenterFunc, bValExpected).

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -32,6 +32,7 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   val schema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
   val tvSchemaTask = Task.eval(tvSchema)
+  val queryStats = QueryStats()
 
   val dummyDispatcher = new PlanDispatcher {
 
@@ -112,8 +113,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, Nil, Nil, "__name__", Some(RvRange(startMs = 0, endMs =  19, stepMs = 1)))
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     // note below that order of lhs and rhs is reversed, but index is right. Join should take that into account
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
@@ -142,8 +143,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, Nil, Nil, "__name__", Some(RvRange(startMs = 0, endMs = 99, stepMs = 1)))
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((lhs, 0), (rhs, 1))), tvSchemaTask, querySession)
                          .toListL.runToFuture.futureValue
@@ -200,8 +201,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Seq("_step_", "_pi_"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, Seq(rhs1, rhs2).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, Seq(rhs1, rhs2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
@@ -274,8 +275,9 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, ignoring = Seq("tag1"), include = Seq("tag2"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, Seq(rhs1, rhs2, rhs3, rhs4).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, Seq(rhs1, rhs2, rhs3, rhs4)
+      .map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
@@ -309,8 +311,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, Seq("tag1"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     val fut = execPlan.compose(Observable.fromIterable(Seq((lhs, 0), (rhs, 1))), tvSchemaTask, querySession)
@@ -342,8 +344,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, Seq("tag1"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs2.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     val fut = execPlan.compose(Observable.fromIterable(Seq((lhs, 0), (rhs, 1))), tvSchemaTask, querySession)
@@ -363,9 +365,9 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, Seq("tag2"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // val lhs = QueryResult("someId", null, samplesLhs.filter(rv => rv.key.labelValues.get(ZeroCopyUTF8String("tag2")).get.equals("tag1-1")).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     // note below that order of lhs and rhs is reversed, but index is right. Join should take that into account
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
@@ -392,8 +394,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Seq("tag1", "job"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     // note below that order of lhs and rhs is reversed, but index is right. Join should take that into account
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
@@ -444,8 +446,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
     val samplesRhs2 = scala.util.Random.shuffle(samplesRhs.toList) // they may come out of order
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     // note below that order of lhs and rhs is reversed, but index is right. Join should take that into account
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
@@ -496,8 +498,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, Seq("tag2"), Nil, "metric", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector (rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector (rv, schema, queryStats)))
     // scalastyle:on
     // note below that order of lhs and rhs is reversed, but index is right. Join should take that into account
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
@@ -522,9 +524,9 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Nil, Seq("tag2"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // val lhs = QueryResult("someId", null, samplesLhs.filter(rv => rv.key.labelValues.get(ZeroCopyUTF8String("tag2")).get.equals("tag1-1")).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
+    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     // actual query results into 2 rows. since limit is 1, this results in BadQueryException
@@ -547,8 +549,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       Seq("tag1", "job"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, samplesLhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhsGrouping.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     // actual query results into 2 rows. since limit is 1, this results in BadQueryException
@@ -660,8 +662,8 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     }
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, Seq(rhs1, rhs2).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, Seq(lhs1, lhs2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, Seq(rhs1, rhs2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -33,6 +33,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val schema = Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
     ColumnInfo("value", ColumnType.DoubleColumn))
   val tvSchemaTask = Task.eval(tvSchema)
+  val queryStats = QueryStats()
 
   val rand = new Random()
 
@@ -143,8 +144,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Seq("instance"), Nil, Seq("role"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -178,8 +179,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Nil, Seq("role", "mode"), Seq("role"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -219,8 +220,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Seq("instance"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -264,8 +265,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Seq("role"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeRole.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeRole.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -299,8 +300,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Seq("mode"), Seq("dummy"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -385,8 +386,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Seq("instance"), Nil, Seq("role"), "metric", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleLhs.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, sampleRhs.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleLhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, sampleRhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), tvSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -420,8 +421,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Seq("instance"), Nil, Seq("role"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     // actual query results into 2 rows. since limit is 1, this results in BadQueryException
@@ -447,8 +448,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Nil, Seq("role", "mode"), Seq("role"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs2.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     // actual query results into 2 rows. since limit is 1, this results in BadQueryException
@@ -480,8 +481,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
       Seq("instance"), Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", null, sampleNodeCpu.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", null, samplesRhs.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
 
     // actual query results into 4 rows. since limit is 3, this results in BadQueryException

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -37,6 +37,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
   val rand = new Random()
   val error = 0.00000001d
   val noKey = CustomRangeVectorKey(Map.empty)
+  val queryStats = QueryStats()
 
   val dummyDispatcher = new PlanDispatcher {
 
@@ -292,8 +293,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -329,8 +330,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -366,8 +367,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -403,8 +404,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -439,8 +440,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -474,8 +475,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -507,8 +508,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Seq("dummy"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -529,8 +530,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Seq("group", "instance", "job"), "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -551,8 +552,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -581,8 +582,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -641,8 +642,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs1 = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs1 = QueryResult("someId", tvSchema, sampleVectorMatching.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs1 = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs1 = QueryResult("someId", tvSchema, sampleVectorMatching.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result1 = execPlan1.compose(Observable.fromIterable(Seq((rhs1, 1), (lhs1, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -654,8 +655,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Seq("instance"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs2 = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs2 = QueryResult("someId", tvSchema, result1.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs2 = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs2 = QueryResult("someId", tvSchema, result1.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result2 = execPlan2.compose(Observable.fromIterable(Seq((rhs2, 1), (lhs2, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -712,8 +713,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
     val canaryPlusOne = scalarOpMapper(Observable.fromIterable(sampleCanary), querySession, 1000, resultSchema).
       toListL.runToFuture.futureValue
     // scalastyle:off
-    val lhs1 = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs1 = QueryResult("someId", tvSchema, sampleVectorMatching.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs1 = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs1 = QueryResult("someId", tvSchema, sampleVectorMatching.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result1 = execPlan1.compose(Observable.fromIterable(Seq((rhs1, 1), (lhs1, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -725,8 +726,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Seq("l", "group", "job"), "__name__", None)
 
     // scalastyle:off
-    val lhs2 = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs2 = QueryResult("someId", tvSchema, result1.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs2 = QueryResult("someId", tvSchema, canaryPlusOne.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs2 = QueryResult("someId", tvSchema, result1.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result2 = execPlan2.compose(Observable.fromIterable(Seq((rhs2, 1), (lhs2, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -780,8 +781,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -813,8 +814,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Seq("job"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -844,8 +845,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Seq("job", "instance"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -879,8 +880,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Seq("job"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -911,8 +912,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Seq("job", "instance"), Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleCanary.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleRhsShuffled.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -945,8 +946,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleAllNaN.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleAllNaN.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -974,8 +975,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleWithNaN.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleHttpRequests.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleWithNaN.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1000,8 +1001,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Nil, "__name__", None)
 
     // scalastyle:off
-    val lhs = QueryResult("someId", tvSchema, sampleMultipleRows.map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleWithNaN.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, sampleMultipleRows.map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleWithNaN.map(rv => SerializedRangeVector(rv, schema, queryStats)))
     // scalastyle:on
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1056,8 +1057,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def outputRange: Option[RvRange] = None
     }
 
-    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema, queryStats)))
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1104,8 +1105,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def outputRange: Option[RvRange] = None
     }
 
-    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv, rhsRvDupe, rhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv, rhsRvDupe, rhsRvDupe2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1153,8 +1154,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def outputRange: Option[RvRange] = None
     }
 
-    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema, queryStats)))
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1199,8 +1200,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def outputRange: Option[RvRange] = None
     }
 
-    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv, rhsRvDupe, rhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv, rhsRvDupe, rhsRvDupe2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1245,8 +1246,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def outputRange: Option[RvRange] = None
     }
 
-    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv, rhsRvDupe, rhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv, rhsRvDupe, rhsRvDupe2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1292,8 +1293,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       override def outputRange: Option[RvRange] = None
     }
 
-    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, Seq(lhsRv, lhsRvDupe, lhsRvDupe2).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, Seq(rhsRv).map(rv => SerializedRangeVector(rv, schema, queryStats)))
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1360,8 +1361,8 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
       Nil, Nil, "__name__", None)
 
 
-    val lhs = QueryResult("someId", tvSchema, (lhs2 ++ lhs1).map(rv => SerializedRangeVector(rv, schema)))
-    val rhs = QueryResult("someId", tvSchema, sampleNaN.map(rv => SerializedRangeVector(rv, schema)))
+    val lhs = QueryResult("someId", tvSchema, (lhs2 ++ lhs1).map(rv => SerializedRangeVector(rv, schema, queryStats)))
+    val rhs = QueryResult("someId", tvSchema, sampleNaN.map(rv => SerializedRangeVector(rv, schema, queryStats)))
 
     val result = execPlan.compose(Observable.fromIterable(Seq((rhs, 1), (lhs, 0))), resSchemaTask, querySession)
       .toListL.runToFuture.futureValue
@@ -1393,7 +1394,7 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
   }
 
   private def rangeVectors(keyedTs: List[(Map[ZeroCopyUTF8String, ZeroCopyUTF8String], Seq[(Long, Double)])]): List[RangeVector]
-  = keyedTs.map{case (key, value) => SerializedRangeVector(KeyedTupleRangeVector(key, value), resultSchema.columns)}.toList
+  = keyedTs.map{case (key, value) => SerializedRangeVector(KeyedTupleRangeVector(key, value), resultSchema.columns, queryStats)}.toList
 
 
   it("should return true when isEmpty called on emptyRV") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Query Statistics now includes CPU time spent on query. This can be used to do analytics and rate limit on queries.

CPU Time is calculated in these places:

1. Step1 of exec plan execution to construct the monix query pipeline. This is where index lookup happens for leaf plans.
2. Consumption of the pipelined Observables at plan result serialization time. This will cover for all queries including aggregations and pipelined transformations.
3. Binary Join and Set operation compose since they load all data to memory and this operation is not pipelined 
4. Top/BottomK Result serialization

The above list is not comprehensive, hence the number reported is not complete. We do not want delays from execution of other queries to impact CPU time measurement of the current query. The main challenge in achieving completeness is that stream processing of data makes it nasty to accurately calculate CPU time since it would be sum of time for all pipelined lambdas. This will require us to spew instrumentation all over the place. For now, we place it at places where we see significant usage.

