### PR TITLE
fix(query): pushdown joins only if lhs/rhs shard keys are identical

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -365,6 +365,9 @@ class SingleClusterPlanner(val dataset: Dataset,
   }
   // scalastyle:on cyclomatic.complexity
 
+  /**
+   * Return the target-schema labels (if any) that will be used to materialize a RawSeries.
+   */
   private def getTargetSchemaLabelsFromRawSeries(rs: RawSeries, qContext: QueryContext): Option[Seq[String]] = {
     val tsp = targetSchemaProvider(qContext)
     val filters = getColumnFilterGroup(rs).map(_.toSeq)
@@ -443,7 +446,9 @@ class SingleClusterPlanner(val dataset: Dataset,
    */
   private def getPushdownShards(qContext: QueryContext,
                                 lp: LogicalPlan): Option[Set[Int]] = {
-    case class PushdownData(shards: Set[Int], shardKeys: Map[String, String], tschemaLabels: Set[String])
+    case class PushdownData(shards: Set[Int],
+                            shardKeys: Map[String, String],
+                            tschemaLabels: Set[String])
     def helper(lp: LogicalPlan): Option[PushdownData] = lp match {
       // VectorPlans can't currently be pushed down. Consider:
       //     foo{...} or vector(0)
@@ -470,7 +475,7 @@ class SingleClusterPlanner(val dataset: Dataset,
       case aif: ApplyInstantFunction => helper(aif.vectors)
       case bj: BinaryJoin =>
         // lhs/rhs must reside on the same set of shards, and target schema labels for all leaves must be
-        //   discoverable, equal, and preserved by join keys
+        //   discoverable, equal, and preserved by join keys.
         val lhsData = helper(bj.lhs)
         val rhsData = helper(bj.rhs)
         val canPushdown = lhsData.isDefined && rhsData.isDefined && {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -503,8 +503,9 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     binaryJoinNode.asInstanceOf[BinaryJoinExec].rhs.size shouldEqual 4
   }
 
-  it ("should pushdown BinaryJoins between different shard keys when shards are identical") {
+  it ("should not pushdown BinaryJoins between different shard keys") {
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
+      // Spread across all shards.
       Seq(SpreadChange(0, 5))
     }
     def targetSchema(filter: Seq[ColumnFilter]): Seq[TargetSchemaChange] = {
@@ -520,8 +521,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
               spreadOverride = Some(FunctionalSpreadProvider(spread)),
               targetSchemaProviderOverride = Some(FunctionalTargetSchemaProvider(targetSchema)),
               queryTimeoutMillis = 1000000)))
-      execPlan.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual true
-      execPlan.children.forall(c => c.isInstanceOf[BinaryJoinExec])
+      execPlan.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual false
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, queries such as:
```
// target-schema labels:  shard_key, label1
foo{shard_key="aaa"} + on(label1) bar{shard_key="bbb"}
// Note: shard-key labels are implicit in the on() clause.
```
will be pushed down because planner logic only requires that the join operands have target-schemas defined against the same set of labels.

This PR adds logic to also require that shard keys are identical on each side of the join.