### PR TITLE
fix(query): exclude metric from implicit target-schema labels

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -381,10 +381,10 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   it("should apply the target schema appropriate to the query range") {
 
     val tschemas = Seq(
-      TargetSchemaChange(0L, Seq("foo")),      // + shardKeys (job, __name__)
-      TargetSchemaChange(10000, Seq("bar")),   // + shardKeys (job, __name__)
-      TargetSchemaChange(20000, Seq("foo")),   // + shardKeys (job, __name__)
-      TargetSchemaChange(30000, Seq("bar")),   // + shardKeys (job, __name__)
+      TargetSchemaChange(0L, Seq("foo")),      // + shardKeys (job)
+      TargetSchemaChange(10000, Seq("bar")),   // + shardKeys (job)
+      TargetSchemaChange(20000, Seq("foo")),   // + shardKeys (job)
+      TargetSchemaChange(30000, Seq("bar")),   // + shardKeys (job)
     )
 
     // Oscillate between "foo" and "bar" as the schema
@@ -418,7 +418,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
           ColumnFilter("foo", Equals("abcdefg")),
           ColumnFilter("bar", Equals("hijklmnop")),
         ), qContext, start, end, useTargetSchemaForShards = true)
-    } should contain theSameElementsAs Seq(1, 26, 1, 26)
+    } should contain theSameElementsAs Seq(13, 20, 13, 20)
   }
 
   it("should create a single plan and not stitch results when target-schema has not changed in query range") {

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -703,12 +703,11 @@ object RecordBuilder {
     val tags: Set[String] = labelPairs.keySet
     val nonMetricShardKeys = shardKeyLabelPair - metricShardkey
     val implicitTargetSchema = nonMetricShardKeys.keySet ++ targetSchema
-    val useTargetSchema = implicitTargetSchema.nonEmpty && implicitTargetSchema.diff(tags).isEmpty
+    val useTargetSchema = targetSchema.nonEmpty && implicitTargetSchema.diff(tags).isEmpty
     val shardingLabels = if (useTargetSchema) {
-      labelPairs.filterKeys(implicitTargetSchema.contains)
-    } else nonShardKeyLabelPair
-    // sort by key, then hash each value
-    shardingLabels.toStream.sortBy(pair => pair._1).map(_._2).foreach { v => {
+      implicitTargetSchema.toStream.sorted.map(labelPairs(_))
+    } else nonShardKeyLabelPair.values  // NOTE: avoiding a sort here to preserve legacy logic
+    shardingLabels.foreach { v => {
         hash = RecordBuilder
           .combineHash(hash, BinaryRegion.hash32(v.getBytes(StandardCharsets.UTF_8)))
       }

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -620,12 +620,11 @@ class BinaryRecordSpec extends AnyFunSpec with Matchers with BeforeAndAfter with
     it("should compute partitionKey hash correctly when target schema is provided") {
       val jobHash = BinaryRegion.hash32(labels("job").getBytes(StandardCharsets.UTF_8))
       val instanceHash = BinaryRegion.hash32(labels("instance").getBytes(StandardCharsets.UTF_8))
-      val metricHash = BinaryRegion.hash32(labels("__name__").getBytes(StandardCharsets.UTF_8))
       val nonShardKeyPairs = labels.filter(f => f._1 != "job" && f._1 != "__name__")
       val shardKeyPairs = labels.filter(f => f._1 == "job" || f._1 == "__name__")
       val targetSchema = Seq("job","instance") // job, __name__, instance
 
-      val expectedPartkeyHash = ((7 * 31 + jobHash) * 31 + metricHash) * 31 + instanceHash
+      val expectedPartkeyHash = (7 * 31 + instanceHash) * 31 + jobHash
 
       RecordBuilder.partitionKeyHash(
         nonShardKeyPairs, shardKeyPairs,
@@ -640,7 +639,7 @@ class BinaryRecordSpec extends AnyFunSpec with Matchers with BeforeAndAfter with
       val shardKeyPairs = labels.filter(f => f._1 == "job" || f._1 == "__name__")
       val targetSchema = Seq("instance") // job, __name__, instance
 
-      val expectedPartkeyHash = ((7 * 31 + jobHash) * 31 + metricHash) * 31 + instanceHash
+      val expectedPartkeyHash = (7 * 31 + instanceHash) * 31 + jobHash
 
       RecordBuilder.partitionKeyHash(
         nonShardKeyPairs, shardKeyPairs,
@@ -649,14 +648,13 @@ class BinaryRecordSpec extends AnyFunSpec with Matchers with BeforeAndAfter with
 
     it("should compute partitionKey hash using shardkeys + SORTED targetschema labels") {
       val jobHash = BinaryRegion.hash32(labels("job").getBytes(StandardCharsets.UTF_8))
-      val metricHash = BinaryRegion.hash32(labels("__name__").getBytes(StandardCharsets.UTF_8))
       val instanceHash = BinaryRegion.hash32(labels("instance").getBytes(StandardCharsets.UTF_8))
       val dcHash = BinaryRegion.hash32(labels("dc").getBytes(StandardCharsets.UTF_8))
       val nonShardKeyPairs = labels.filter(f => f._1 != "job" && f._1 != "__name__")
       val shardKeyPairs = labels.filter(f => f._1 == "job" || f._1 == "__name__")
       val targetSchema = Seq("instance", "dc") // // (job, __name__, dc, instance) shardkeys, dc then instance
 
-      val expectedPartkeyHash = (((7 * 31 + jobHash) * 31 + metricHash) * 31 + dcHash) * 31 + instanceHash
+      val expectedPartkeyHash = ((7 * 31 + dcHash) * 31 + instanceHash) * 31 + jobHash
 
       RecordBuilder.partitionKeyHash(
         nonShardKeyPairs, shardKeyPairs,

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -704,4 +704,38 @@ class BinaryRecordSpec extends AnyFunSpec with Matchers with BeforeAndAfter with
     metricName5 shouldEqual "heap_usage_sum"
   }
 
+  it("should correctly ignore metric labels when calculating a target-schema shard hash") {
+    val metricName = "metric"
+    val metricValue = "my-metric"
+    val nonShardKeys = Map("nonShard1" -> "ns1", "nonShard2" -> "ns2")
+    val shardKeys = Map("shard1" -> "s1", "shard2" -> "s2")
+    val targetSchema = Seq("shard1", "shard2", "nonShard1")
+
+    val hashNoMetricShardKey = RecordBuilder.partitionKeyHash(
+      nonShardKeys,
+      shardKeys,
+      targetSchema,
+      metricName,
+      metricValue
+    )
+    val hashWithMetricShardKey = RecordBuilder.partitionKeyHash(
+      nonShardKeys ++ Map(metricName -> metricValue),
+      shardKeys,
+      targetSchema,
+      metricName,
+      metricValue
+    )
+    val otherHash = RecordBuilder.partitionKeyHash(
+      nonShardKeys ++ Map(metricName -> metricValue),
+      shardKeys ++ Map("rando" -> "value"),
+      targetSchema,
+      metricName,
+      metricValue
+    )
+
+    // equal, since the hash should ignore the metric label
+    hashNoMetricShardKey shouldEqual hashWithMetricShardKey
+    // not equal, since some other shard key is different
+    hashNoMetricShardKey should not equal otherHash
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

The current logic incorrectly finds a partition hash when a target-schema is applied; it always includes the metric label in the hash computation. This PR removes the metric label as an implicit target-schema label.