### PR TITLE
fix(core) Fix query on empty labels.

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -819,8 +819,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   private def leafFilter(column: String, filter: Filter): Query = {
     filter match {
       case EqualsRegex(value) =>
-        val term = new Term(column, removeRegexAnchors(value.toString))
-        new RegexpQuery(term, RegExp.NONE)
+        if (value.toString.nonEmpty) new RegexpQuery(new Term(column, removeRegexAnchors(value.toString)), RegExp.NONE)
+        else leafFilter(column, NotEqualsRegex(".+"))
       case NotEqualsRegex(value) =>
         val term = new Term(column, removeRegexAnchors(value.toString))
         val allDocs = new MatchAllDocsQuery
@@ -829,8 +829,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
         booleanQuery.add(new RegexpQuery(term, RegExp.NONE), Occur.MUST_NOT)
         booleanQuery.build()
       case Equals(value) =>
-        val term = new Term(column, value.toString)
-        new TermQuery(term)
+        if (value.toString.nonEmpty) new TermQuery(new Term(column, value.toString))
+        else leafFilter(column, NotEqualsRegex(".+"))
       case NotEquals(value) =>
         val str = value.toString
         val term = new Term(column, str)

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -819,7 +819,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   private def leafFilter(column: String, filter: Filter): Query = {
     filter match {
       case EqualsRegex(value) =>
-        if (value.toString.nonEmpty) new RegexpQuery(new Term(column, removeRegexAnchors(value.toString)), RegExp.NONE)
+        val regex = removeRegexAnchors(value.toString)
+        if (regex.nonEmpty) new RegexpQuery(new Term(column, regex), RegExp.NONE)
         else leafFilter(column, NotEqualsRegex(".+"))
       case NotEqualsRegex(value) =>
         val term = new Term(column, removeRegexAnchors(value.toString))

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -821,7 +821,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
       case EqualsRegex(value) =>
         val regex = removeRegexAnchors(value.toString)
         if (regex.nonEmpty) new RegexpQuery(new Term(column, regex), RegExp.NONE)
-        else leafFilter(column, NotEqualsRegex(".+"))
+        else leafFilter(column, NotEqualsRegex(".+"))  // value="" means the label is absent or has an empty value.
       case NotEqualsRegex(value) =>
         val term = new Term(column, removeRegexAnchors(value.toString))
         val allDocs = new MatchAllDocsQuery
@@ -831,7 +831,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
         booleanQuery.build()
       case Equals(value) =>
         if (value.toString.nonEmpty) new TermQuery(new Term(column, value.toString))
-        else leafFilter(column, NotEqualsRegex(".+"))
+        else leafFilter(column, NotEqualsRegex(".+"))  // value="" means the label is absent or has an empty value.
       case NotEquals(value) =>
         val str = value.toString
         val term = new Term(column, str)

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -807,6 +807,48 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     }
   }
 
+  it("should get a single match for part keys through a field with empty value") {
+    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.slice(95, 96)), Some(partBuilder))
+      .zipWithIndex.map { case (addr, i) =>
+      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+      keyIndex.addPartKey(pk, -1, i, i + 10)(
+        pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
+      PartKeyLuceneIndexRecord(pk, i, i + 10)
+    }
+    keyIndex.refreshReadersBlocking()
+
+    val filter1_found = ColumnFilter("Actor2Code", Equals(""))
+    val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
+    partKeyOpt.isDefined shouldBe true
+    partKeyOpt.get shouldEqual pkrs.head.partKey
+
+    val filter2_found = ColumnFilter("Actor2Code", EqualsRegex(""))
+    val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
+    partKeyOpt2.isDefined shouldBe true
+    partKeyOpt2.get shouldEqual pkrs.head.partKey
+  }
+
+  it("should get a single match for part keys through a non-existing field") {
+    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+      .zipWithIndex.map { case (addr, i) =>
+      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+      keyIndex.addPartKey(pk, -1, i, i + 10)(
+        pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
+      PartKeyLuceneIndexRecord(pk, i, i + 10)
+    }
+    keyIndex.refreshReadersBlocking()
+
+    val filter1_found = ColumnFilter("NonExistingField", Equals(""))
+    val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
+    partKeyOpt.isDefined shouldBe true
+    partKeyOpt.get shouldEqual pkrs.head.partKey
+
+    val filter2_found = ColumnFilter("NonExistingField", EqualsRegex(""))
+    val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
+    partKeyOpt2.isDefined shouldBe true
+    partKeyOpt2.get shouldEqual pkrs.head.partKey
+  }
+
   it("should get a single match for part keys by a regex filter") {
     val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
       .zipWithIndex.map { case (addr, i) =>

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -826,6 +826,11 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
     partKeyOpt2.isDefined shouldBe true
     partKeyOpt2.get shouldEqual pkrs.head.partKey
+
+    val filter3_found = ColumnFilter("Actor2Code", EqualsRegex("^$"))
+    val partKeyOpt3 = keyIndex.singlePartKeyFromFilters(Seq(filter3_found), 4, 10)
+    partKeyOpt3.isDefined shouldBe true
+    partKeyOpt3.get shouldEqual pkrs.head.partKey
   }
 
   it("should get a single match for part keys through a non-existing field") {
@@ -847,6 +852,11 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
     partKeyOpt2.isDefined shouldBe true
     partKeyOpt2.get shouldEqual pkrs.head.partKey
+
+    val filter3_found = ColumnFilter("NonExistingField", EqualsRegex("^$"))
+    val partKeyOpt3 = keyIndex.singlePartKeyFromFilters(Seq(filter3_found), 4, 10)
+    partKeyOpt3.isDefined shouldBe true
+    partKeyOpt3.get shouldEqual pkrs.head.partKey
   }
 
   it("should get a single match for part keys by a regex filter") {


### PR DESCRIPTION
A query like this ts{label=""} should return the data when the label is an empty string or label is not present. Fix this bug by translating Equals("") and EqualsRegex("") to NotEqualsRegex(".+")

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: