### PR TITLE
fix(query) support regEx for metric in metadata queries

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -51,12 +51,6 @@ object LogicalPlanParser {
       map(f => f._1 + f._2 + f._3).mkString(Comma)}$ClosingCurlyBraces" + window + offsetString
   }
 
-  private def filtersToMetadataQuery(filters: Seq[(String, String, String)]): String = {
-    s"$OpeningCurlyBraces${
-      filters.map(f => f._1 + f._2 + f._3).mkString(Comma)
-    }$ClosingCurlyBraces"
-  }
-
   private def rawSeriesLikeToQuery(lp: RawSeriesLikePlan, addWindow: Boolean): String = {
     lp match {
       case r: RawSeries               => filtersToQuery(getFiltersFromRawSeries(r), r.columns, r.lookbackMs,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -51,6 +51,12 @@ object LogicalPlanParser {
       map(f => f._1 + f._2 + f._3).mkString(Comma)}$ClosingCurlyBraces" + window + offsetString
   }
 
+  private def filtersToMetadataQuery(filters: Seq[(String, String, String)]): String = {
+    s"$OpeningCurlyBraces${
+      filters.map(f => f._1 + f._2 + f._3).mkString(Comma)
+    }$ClosingCurlyBraces"
+  }
+
   private def rawSeriesLikeToQuery(lp: RawSeriesLikePlan, addWindow: Boolean): String = {
     lp match {
       case r: RawSeries               => filtersToQuery(getFiltersFromRawSeries(r), r.columns, r.lookbackMs,
@@ -198,16 +204,10 @@ object LogicalPlanParser {
     s"${periodicSeriesQuery}${sqClause}${offset}"
   }
 
-  def metatadataMatchToQuery(lp: MetadataQueryPlan): String = {
-    lp match {
-      case lp: SeriesKeysByFilters    => filtersToQuery(
-        getFiltersFromColumnFilters(lp.filters), Seq.empty, Option.empty, Option.empty, false)
-      case lp: LabelNames             => filtersToQuery(
-        getFiltersFromColumnFilters(lp.filters), Seq.empty, Option.empty, Option.empty, false)
-      case lp: LabelCardinality       => filtersToQuery(
-        getFiltersFromColumnFilters(lp.filters), Seq.empty, Option.empty, Option.empty, false)
-      case _                          => throw new UnsupportedOperationException(s"$lp can't be converted to Query")
-    }
+  def metadataMatchToQuery(lp: MetadataQueryPlan): String = {
+    s"$OpeningCurlyBraces${
+      getFiltersFromColumnFilters(lp.filters).map(f => f._1 + f._2 + f._3).mkString(Comma)
+    }$ClosingCurlyBraces"
   }
 
   def convertToQuery(logicalPlan: LogicalPlan): String = {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -571,7 +571,7 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
           val params: Map[String, String] = lp match {
             case _: SeriesKeysByFilters |
                  _: LabelNames |
-                 _: LabelCardinality    => Map("match[]" -> LogicalPlanParser.metatadataMatchToQuery(lp))
+                 _: LabelCardinality    => Map("match[]" -> LogicalPlanParser.metadataMatchToQuery(lp))
             case lv: LabelValues        => PlannerUtil.getLabelValuesUrlParams(lv, queryParams)
           }
           createMetadataRemoteExec(qContext, p, params)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -127,15 +127,22 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
   it("should convert metadata series match query1") {
     val query = """http_requests_total{job="app"}"""
     val lp = Parser.metadataQueryToLogicalPlan(query, TimeStepParams(1000, 10, 2000))
-    val res = LogicalPlanParser.metatadataMatchToQuery(lp.asInstanceOf[SeriesKeysByFilters])
-    res shouldEqual "http_requests_total{job=\"app\"}"
+    val res = LogicalPlanParser.metadataMatchToQuery(lp.asInstanceOf[SeriesKeysByFilters])
+    res shouldEqual "{job=\"app\",__name__=\"http_requests_total\"}"
   }
 
   it("should convert metadata series match query2") {
     val query = """{__name__="http_requests_total", job=~"app|job"}"""
     val lp = Parser.metadataQueryToLogicalPlan(query, TimeStepParams(1000, 10, 2000))
-    val res = LogicalPlanParser.metatadataMatchToQuery(lp.asInstanceOf[SeriesKeysByFilters])
-    res shouldEqual "http_requests_total{job=~\"app|job\"}"
+    val res = LogicalPlanParser.metadataMatchToQuery(lp.asInstanceOf[SeriesKeysByFilters])
+    res shouldEqual "{__name__=\"http_requests_total\",job=~\"app|job\"}"
+  }
+
+  it("should convert metadata match query with __name__ regEx") {
+    val query = """{__name__=~".*http_requests.*",job="app"}"""
+    val lp = Parser.metadataQueryToLogicalPlan(query, TimeStepParams(1000, 10, 2000))
+    val res = LogicalPlanParser.metadataMatchToQuery(lp.asInstanceOf[SeriesKeysByFilters])
+    res shouldEqual "{__name__=~\".*http_requests.*\",job=\"app\"}"
   }
 
   it("should convert scalar vector operation query") {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -1211,7 +1211,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val (startSeconds: Int, endSeconds: Int, engine: MultiPartitionPlanner) = getPlannerForMetadataQueryTests
     val lv = SeriesKeysByFilters(ColumnFilter("job", Equals("app"))::ColumnFilter("__name__", Equals("test"))::Nil,
       true, startSeconds * 1000 , endSeconds * 1000)
-    val promQl = """test{job="app"}"""
+    val promQl = """{job="app",__name__="test"}"""
     val promQlQueryParams = PromQlQueryParams(promQl, startSeconds, step, endSeconds)
     val execPlan = engine.materialize(lv, QueryContext(origQueryParams = promQlQueryParams, plannerParams =
       PlannerParams(processMultiPartition = true)))
@@ -1231,7 +1231,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
   it("should materialize LabelNames query correctly") {
     val (startSeconds: Int, endSeconds: Int, engine: MultiPartitionPlanner) = getPlannerForMetadataQueryTests
 
-    val promQl = """test{job="app"}"""
+    val promQl = """{job="app",__name__="test"}"""
     val lv = Parser.labelNamesQueryToLogicalPlan(promQl, TimeStepParams(startSeconds, step, endSeconds))
 
     val promQlQueryParams = PromQlQueryParams(promQl, startSeconds, step, endSeconds, Some("/api/v2/labels/name"))


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Metadata requests with metric regEx in match filter are currently failing with parser error
```
Request: LabelNames with filter match[]={__name__=~".*up.*",foo="bar"}'
Response: 
{
  "status" : "error",
  "data" : null,
  "errorType" : "invalid_query",
  "error" : "Cannot parse [.*up.*{foo =\"bar\"}] because at 1:0 token recognition error at: '.*'"
}
```

**New behavior :**
Should return valid response
```
{
  "status" : "success",
  "data" : [ "__name__", "foo" ..],
  "errorType" : null,
  "error" : null
}

```
