### PR TITLE
feat(query): Query Planning optimization for 'or vector(0)'

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -413,7 +413,7 @@ trait  DefaultPlanner {
    * result in an expensive SetOperatorExec plan into a simple InstantFunctionMapper
    * which is far more efficient.
    */
-  def optimizeOrVectorZero(qContext: QueryContext, logicalPlan: BinaryJoin): Option[PlanResult] = {
+  def optimizeOrVectorDouble(qContext: QueryContext, logicalPlan: BinaryJoin): Option[PlanResult] = {
     if (logicalPlan.operator == BinaryOperator.LOR) {
       logicalPlan.rhs match {
         case VectorPlan(ScalarFixedDoublePlan(value, rangeParams)) =>
@@ -431,7 +431,7 @@ trait  DefaultPlanner {
                             logicalPlan: BinaryJoin,
                             forceInProcess: Boolean = false): PlanResult = {
 
-    optimizeOrVectorZero(qContext, logicalPlan).getOrElse {
+    optimizeOrVectorDouble(qContext, logicalPlan).getOrElse {
       val lhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].
         copy(promQl = LogicalPlanParser.convertToQuery(logicalPlan.lhs)))
       val rhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -412,6 +412,10 @@ trait  DefaultPlanner {
    * Function to optimize and convert `foo or vector(0)` like queries which would normally
    * result in an expensive SetOperatorExec plan into a simple InstantFunctionMapper
    * which is far more efficient.
+   *
+   * Note that vector(0) on left side of operator, example `vector(0) or foo` is not
+   * optimized yet since it is uncommon and almost unseen, and not worth the additional
+   * complexity at the moment.
    */
   def optimizeOrVectorDouble(qContext: QueryContext, logicalPlan: BinaryJoin): Option[PlanResult] = {
     if (logicalPlan.operator == BinaryOperator.LOR) {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -136,7 +136,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
    */
   private def materializeBinaryJoin(logicalPlan: BinaryJoin, qContext: QueryContext): PlanResult = {
 
-    optimizeOrVectorZero(qContext, logicalPlan).getOrElse {
+    optimizeOrVectorDouble(qContext, logicalPlan).getOrElse {
       val lhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].
         copy(promQl = LogicalPlanParser.convertToQuery(logicalPlan.lhs)))
       val rhsQueryContext = qContext.copy(origQueryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams].

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -658,12 +658,16 @@ class SingleClusterPlanner(val dataset: Dataset,
   override def materializeBinaryJoin(qContext: QueryContext,
                                      lp: BinaryJoin,
                                      forceInProcess: Boolean): PlanResult = {
-    // see materializeWithPushdown for details about the pushdown optimization.
-    val pushdownShards = getPushdownShards(qContext, lp)
-    if (pushdownShards.isDefined) {
-      materializeWithPushdown(qContext, lp, pushdownShards.get, forceInProcess)
-    } else {
-      materializeBinaryJoinNoPushdown(qContext, lp, forceInProcess, None)
+
+    optimizeOrVectorZero(qContext, lp).getOrElse {
+
+      // see materializeWithPushdown for details about the pushdown optimization.
+      val pushdownShards = getPushdownShards(qContext, lp)
+      if (pushdownShards.isDefined) {
+        materializeWithPushdown(qContext, lp, pushdownShards.get, forceInProcess)
+      } else {
+        materializeBinaryJoinNoPushdown(qContext, lp, forceInProcess, None)
+      }
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -659,7 +659,7 @@ class SingleClusterPlanner(val dataset: Dataset,
                                      lp: BinaryJoin,
                                      forceInProcess: Boolean): PlanResult = {
 
-    optimizeOrVectorZero(qContext, lp).getOrElse {
+    optimizeOrVectorDouble(qContext, lp).getOrElse {
 
       // see materializeWithPushdown for details about the pushdown optimization.
       val pushdownShards = getPushdownShards(qContext, lp)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -503,6 +503,61 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     binaryJoinNode.asInstanceOf[BinaryJoinExec].rhs.size shouldEqual 4
   }
 
+  it("should optimize or vector(0) queries by using InstantVectorFunctionMapper instead of SetOperatorExec") {
+
+    def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
+      Seq(SpreadChange(0, 2))
+    }
+
+    val queries = Seq(
+      """foo{job="bar", instance="inst1"} or vector(0)""",
+      """sum(foo{job="bar", instance="inst1"}) or vector(0)""",
+    )
+    val expected = Seq(
+      """E~LocalPartitionDistConcatExec() on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-17403230],raw)
+        |-T~InstantVectorFunctionMapper(function=OrVectorDouble)
+        |--FA1~StaticFuncArgs(0.0,RangeParams(20000,100,30000))
+        |--T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |---E~MultiSchemaPartitionsExec(dataset=timeseries, shard=5, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-17403230],raw)
+        |-T~InstantVectorFunctionMapper(function=OrVectorDouble)
+        |--FA1~StaticFuncArgs(0.0,RangeParams(20000,100,30000))
+        |--T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |---E~MultiSchemaPartitionsExec(dataset=timeseries, shard=13, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-17403230],raw)
+        |-T~InstantVectorFunctionMapper(function=OrVectorDouble)
+        |--FA1~StaticFuncArgs(0.0,RangeParams(20000,100,30000))
+        |--T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |---E~MultiSchemaPartitionsExec(dataset=timeseries, shard=21, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-17403230],raw)
+        |-T~InstantVectorFunctionMapper(function=OrVectorDouble)
+        |--FA1~StaticFuncArgs(0.0,RangeParams(20000,100,30000))
+        |--T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |---E~MultiSchemaPartitionsExec(dataset=timeseries, shard=29, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-17403230],raw)""".stripMargin,
+
+      """T~InstantVectorFunctionMapper(function=OrVectorDouble)
+        |-FA1~StaticFuncArgs(0.0,RangeParams(20000,100,30000))
+        |-T~AggregatePresenter(aggrOp=Sum, aggrParams=List(), rangeParams=RangeParams(20000,100,30000))
+        |--E~LocalPartitionReduceAggregateExec(aggrOp=Sum, aggrParams=List()) on ActorPlanDispatcher(Actor[akka://default/system/testActor],raw)
+        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+        |----T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=5, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testActor],raw)
+        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+        |----T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=13, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testActor],raw)
+        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+        |----T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=21, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testActor],raw)
+        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+        |----T~PeriodicSamplesMapper(start=20000000, step=100000, end=30000000, window=None, functionId=None, rawSource=true, offsetMs=None)
+        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=29, chunkMethod=TimeRangeChunkScan(19700000,30000000), filters=List(ColumnFilter(job,Equals(bar)), ColumnFilter(instance,Equals(inst1)), ColumnFilter(__name__,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testActor],raw)""".stripMargin
+    )
+
+    queries.zip(expected).map { case (q, e) =>
+      val lp = Parser.queryRangeToLogicalPlan(q, TimeStepParams(20000, 100, 30000))
+      val execPlan = engine.materialize(lp, QueryContext(promQlQueryParams, plannerParams = PlannerParams
+        (spreadOverride = Some(FunctionalSpreadProvider(spread)), queryTimeoutMillis = 1000000)))
+      validatePlan(execPlan, e)
+    }
+  }
+
   it ("should pushdown BinaryJoins between different shard keys when shards are identical") {
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
       Seq(SpreadChange(0, 5))

--- a/gatling/src/test/scala/filodb/gatling/QueryRangeSimulation.scala
+++ b/gatling/src/test/scala/filodb/gatling/QueryRangeSimulation.scala
@@ -18,19 +18,19 @@ class QueryRangeSimulation extends Simulation {
   object Configuration {
     val baseUrl = "http://localhost:8080"
     val numApps = 1
-    val numUsers = 20
+    val numUsers = 10
     val testDuration = 3.minutes
-    val startSecs = 1670818224L // Before each run, change this to the right timestamp relevant to data stored in server
+    val startSecs = 1678298250L // Before each run, change this to the right timestamp relevant to data stored in server
 
     // Uncomment one query from here:
-    val queryName = "BinaryJoin"
-    val query = """count(heap_usage0{_ns_="App-$appNum",_ws_="demo"} + heap_usage1{_ns_="App-$appNum",_ws_="demo"})"""
+//    val queryName = "BinaryJoin"
+//    val query = """count(heap_usage0{_ns_="App-$appNum",_ws_="demo"} + heap_usage1{_ns_="App-$appNum",_ws_="demo"})"""
 
 //    val queryName = "SumOfSumOverTime"
 //    val query = """sum(sum_over_time(heap_usage0{_ns_="App-$appNum",_ws_="demo"}[5m]))"""
 
-//    val queryName = "GetAllTimeseriesQuery"
-//    val query = """heap_usage0{_ns_="App-$appNum",_ws_="demo"}"""
+    val queryName = "GetAllTimeseriesQuery"
+    val query = """heap_usage0{_ns_="App-$appNum",_ws_="demo", host="H1"} or vector(0)"""
 
   }
 

--- a/gatling/src/test/scala/filodb/gatling/QueryRangeSimulation.scala
+++ b/gatling/src/test/scala/filodb/gatling/QueryRangeSimulation.scala
@@ -18,19 +18,19 @@ class QueryRangeSimulation extends Simulation {
   object Configuration {
     val baseUrl = "http://localhost:8080"
     val numApps = 1
-    val numUsers = 10
+    val numUsers = 20
     val testDuration = 3.minutes
-    val startSecs = 1678298250L // Before each run, change this to the right timestamp relevant to data stored in server
+    val startSecs = 1670818224L // Before each run, change this to the right timestamp relevant to data stored in server
 
     // Uncomment one query from here:
-//    val queryName = "BinaryJoin"
-//    val query = """count(heap_usage0{_ns_="App-$appNum",_ws_="demo"} + heap_usage1{_ns_="App-$appNum",_ws_="demo"})"""
+    val queryName = "BinaryJoin"
+    val query = """count(heap_usage0{_ns_="App-$appNum",_ws_="demo"} + heap_usage1{_ns_="App-$appNum",_ws_="demo"})"""
 
 //    val queryName = "SumOfSumOverTime"
 //    val query = """sum(sum_over_time(heap_usage0{_ns_="App-$appNum",_ws_="demo"}[5m]))"""
 
-    val queryName = "GetAllTimeseriesQuery"
-    val query = """heap_usage0{_ns_="App-$appNum",_ws_="demo", host="H1"} or vector(0)"""
+//    val queryName = "GetAllTimeseriesQuery"
+//    val query = """heap_usage0{_ns_="App-$appNum",_ws_="demo"}"""
 
   }
 

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -30,6 +30,7 @@ object InstantFunctionId extends Enum[InstantFunctionId] {
   case object Minute extends InstantFunctionId("minute")
   case object Month extends InstantFunctionId("month")
   case object Year extends InstantFunctionId("year")
+  case object OrVectorDouble extends InstantFunctionId("or_vector")
 }
 
 

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -98,6 +98,7 @@ object InstantFunction {
       case DayOfWeek          => DayOfWeekImpl()
       case DaysInMonth        => DaysInMonthImpl()
       case DayOfMonth         => DayOfMonthImpl()
+      case OrVectorDouble           => OrVectorImpl()
       case _                  => throw new UnsupportedOperationException(s"$function not supported.")
     }
   }
@@ -139,6 +140,13 @@ final case class ClampMaxImpl() extends DoubleInstantFunction {
     require(scalarParams.size == 1,
       "Cannot use ClampMax without providing a upper limit of max.")
     scala.math.min(value, scalarParams.head)
+  }
+}
+
+final case class OrVectorImpl() extends DoubleInstantFunction {
+  override def apply(value: Double, scalarParams: Seq[Double]): Double = {
+    require(scalarParams.size == 1, "OrVector needs a single double param")
+    if (value.isNaN) scalarParams.head else value
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

`foo or vector(0)` like queries are very common. Current plan materialization results in SetOperatorExec which is expensive since it transmits data over the network and uses more memory. 

A more optimal implementation would be to apply an InstantFunctionMapper to convert the NaNs to 0s. This plan is memory efficient and does not write results to the wire unnecessarily. This is what this PR delivers.

Unit tests cover query planning.

Local performance test shows 25% reduction in average latency. 

Gatling Test Results were run for query `heap_usage0{_ns_="App-0",_ws_="demo", host="H1"} or vector(0)`

1 FiloDB node, 8 shards
2G heap, M1 mac
10 queries per second
Cardinality of result 1250
Time range queried: 3h
Step: 60s


## With optimization

### Run 1
```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       1800 (OK=1800   KO=0     )
> min response time                                    126 (OK=126    KO=-     )
> max response time                                    358 (OK=358    KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                         12 (OK=12     KO=-     )
> response time 50th percentile                        131 (OK=131    KO=-     )
> response time 75th percentile                        135 (OK=135    KO=-     )
> response time 95th percentile                        149 (OK=149    KO=-     )
> response time 99th percentile                        160 (OK=160    KO=-     )
> mean requests/sec                                  9.945 (OK=9.945  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          1800 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
```
### Run 2
```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       1800 (OK=1800   KO=0     )
> min response time                                    125 (OK=125    KO=-     )
> max response time                                    435 (OK=435    KO=-     )
> mean response time                                   134 (OK=134    KO=-     )
> std deviation                                         11 (OK=11     KO=-     )
> response time 50th percentile                        130 (OK=130    KO=-     )
> response time 75th percentile                        134 (OK=134    KO=-     )
> response time 95th percentile                        149 (OK=149    KO=-     )
> response time 99th percentile                        165 (OK=165    KO=-     )
> mean requests/sec                                  9.945 (OK=9.945  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          1800 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
```
### Run 3

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       1800 (OK=1800   KO=0     )
> min response time                                    125 (OK=125    KO=-     )
> max response time                                    334 (OK=334    KO=-     )
> mean response time                                   134 (OK=134    KO=-     )
> std deviation                                         11 (OK=11     KO=-     )
> response time 50th percentile                        130 (OK=130    KO=-     )
> response time 75th percentile                        134 (OK=134    KO=-     )
> response time 95th percentile                        149 (OK=149    KO=-     )
> response time 99th percentile                        168 (OK=168    KO=-     )
> mean requests/sec                                  9.945 (OK=9.945  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          1800 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
```

## Without optimization

### Run 

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       1800 (OK=1800   KO=0     )
> min response time                                      6 (OK=6      KO=-     )
> max response time                                    920 (OK=920    KO=-     )
> mean response time                                   179 (OK=179    KO=-     )
> std deviation                                         48 (OK=48     KO=-     )
> response time 50th percentile                        180 (OK=180    KO=-     )
> response time 75th percentile                        192 (OK=192    KO=-     )
> response time 95th percentile                        217 (OK=217    KO=-     )
> response time 99th percentile                        302 (OK=302    KO=-     )
> mean requests/sec                                  9.945 (OK=9.945  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          1798 (100%)
> 800 ms < t < 1200 ms                                   2 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
```

### Run 2

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       1800 (OK=1800   KO=0     )
> min response time                                    133 (OK=133    KO=-     )
> max response time                                    500 (OK=500    KO=-     )
> mean response time                                   180 (OK=180    KO=-     )
> std deviation                                         29 (OK=29     KO=-     )
> response time 50th percentile                        178 (OK=178    KO=-     )
> response time 75th percentile                        190 (OK=190    KO=-     )
> response time 95th percentile                        210 (OK=210    KO=-     )
> response time 99th percentile                        283 (OK=283    KO=-     )
> mean requests/sec                                  9.945 (OK=9.945  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          1800 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
```

### Run 3

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       1800 (OK=1800   KO=0     )
> min response time                                    134 (OK=134    KO=-     )
> max response time                                    455 (OK=455    KO=-     )
> mean response time                                   181 (OK=181    KO=-     )
> std deviation                                         21 (OK=21     KO=-     )
> response time 50th percentile                        180 (OK=180    KO=-     )
> response time 75th percentile                        192 (OK=192    KO=-     )
> response time 95th percentile                        213 (OK=212    KO=-     )
> response time 99th percentile                        233 (OK=233    KO=-     )
> mean requests/sec                                  9.945 (OK=9.945  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          1800 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
```





