### PR TITLE
fix(coord) Alternative host lookup strategy to avoid reverse lookup of ip address

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -1,5 +1,6 @@
 package filodb.coordinator
 
+import java.net.InetAddress
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.mutable.HashMap
@@ -18,6 +19,8 @@ import filodb.core.memstore.TimeSeriesStore
 import filodb.core.metadata._
 import filodb.core.store.{IngestionConfig, MetaStore, StoreConfig}
 import filodb.query.QueryCommand
+
+
 
 /**
  * The NodeCoordinatorActor is the common external API entry point for all FiloDB operations.
@@ -211,6 +214,7 @@ private[filodb] final class NodeCoordinatorActor(metaStore: MetaStore,
                                          forward(s, s.ref, sender())
     case Terminated(memstoreCoord)    => terminated(memstoreCoord)
     case MiscCommands.GetClusterActor => sender() ! clusterActor
+    case MiscCommands.GetHostName     => sender() ! InetAddress.getLocalHost.getHostName
     case StatusActor.GetCurrentEvents => statusActor.foreach(_.tell(StatusActor.GetCurrentEvents, sender()))
     case ClearState(ref)              => clearState(ref)
     case NodeProtocol.ResetState      => reset(sender())

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -46,12 +46,28 @@ trait ShardAssignmentStrategy {
  * The implementation assumes the number of shards is a multiple of number of nodes and there are no
  * uneven assignments of shards to nodes
  */
-class K8sStatefulSetShardAssignmentStrategy(val maxAssignmentAttempts: Int = 8)
+class K8sStatefulSetShardAssignmentStrategy(val maxAssignmentAttempts: Int = 8,
+                                            val headlessServiceName: Option[String] = None)
       extends ShardAssignmentStrategy with StrictLogging {
 
   private val pat = "-\\d+$".r
 
-  private[coordinator] def getOrdinalFromActorRef(coord: ActorRef): Option[(String, Int)] =
+  private[coordinator] def getOrdinalFromActorRef(coord: ActorRef): Option[(String, Int)] = {
+    // If a headless service is available that lists all the pod's hostnames and addresses, we use that to lookup
+    // hostname from ip address, this approach avoids reverse lookup using ip address. If headless service is not
+    // defined, the approach falls back to lookup hostname from ipaddress using reverse lookup.
+    headlessServiceName.map(headlessServiceName => {
+      coord.path.address.host
+        .flatMap(host => InetAddress.getAllByName(headlessServiceName)
+          .filter(_.getHostAddress == host).headOption.map(_.getCanonicalHostName))
+        .orElse(Some(InetAddress.getLocalHost.getHostName))
+        .map(name => if (name.contains(".")) name.substring(0, name.indexOf('.')) else name)
+        .flatMap(hostName =>
+          Some((hostName, pat.findFirstIn(hostName).map(ordinal => -Integer.parseInt(ordinal)).getOrElse(-1))))
+    }).getOrElse(getOrdinalFromActorRefUsingReverseLookup(coord))
+  }
+
+  private[coordinator] def getOrdinalFromActorRefUsingReverseLookup(coord: ActorRef): Option[(String, Int)] =
     // if hostname is None from coordinator actor path, then its a local actor
     // If the host name does not contain an ordinal at the end (e.g filodb-host-0, filodb-host-10), it will match None
     coord.path.address.host

--- a/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardAssignmentStrategy.scala
@@ -57,6 +57,8 @@ class K8sStatefulSetShardAssignmentStrategy(val maxAssignmentAttempts: Int = 8)
 
   private[coordinator] def getOrdinalFromActorRef(coord: ActorRef): Option[(String, Int)] =
     Try {
+      // IMP: This is not an ideal solution as this blocks on actor dispatcher thread. Clustering V2 is the preferred
+      // approch but this is acceptable as an interim solution.
       implicit val timeout = Timeout(5.seconds)
       val coordinatorHostName = coord.path.address.host
         .map(_ => Await.result((coord ? MiscCommands.GetHostName).mapTo[String],

--- a/coordinator/src/main/scala/filodb.coordinator/client/NodeCommands.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/NodeCommands.scala
@@ -34,6 +34,8 @@ object MiscCommands {
    * Asks for the NodeClusterActor ActorRef.  Sends back Option[ActorRef].
    */
   case object GetClusterActor extends NodeCommand
+
+  case object GetHostName extends NodeCommand
 }
 
 object IngestionCommands {


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Current strategy of assigning shards to pods is to look at the ordinal of the host name when using stateful sets. The hostname is looked up using reverse IP lookup of the  coordinator Actor. 

**New behavior :**

The strategy will fail when reverse lookup from ip cannot be done reliably. To eliminate this reverse lookup, we add a way to query the coordinator actor to provide its hostname.

