### PR TITLE
misc(query): treat untyped as counter for the purpose of rate/increase functions

### DIFF
--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -248,7 +248,7 @@ final case class Schema(partition: PartitionSchema, data: DataSchema, var downsa
   /** Returns ColumnInfos from a set of column IDs.  Throws exception if ID is invalid */
   def infosFromIDs(ids: Seq[ColumnId]): Seq[ColumnInfo] =
     ids.map(columnFromID).map { c => ColumnInfo(c.name, c.columnType,
-      isCumulative = c.params.as[Option[Boolean]]("detectDrops").getOrElse(false)
+      isCumulative = c.params.as[Option[Boolean]]("detectDrops").getOrElse(true)
                         || c.params.as[Option[Boolean]]("counter").getOrElse(false)) }
 
   override final def toString: String = {

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -38,7 +38,9 @@ final case class ColumnInfo(name: String, colType: Column.ColumnType, isCumulati
 object ColumnInfo {
   def apply(col: Column): ColumnInfo = ColumnInfo(col.name, col.columnType, isCumulative(col))
   private def isCumulative(col: Column): Boolean = {
-    // FIXME: hack for supporting rate/increase functions for untyped metrics
+    // untyped metrics are treated as cumulative counters for the sake of rate/increase
+    // functions (backward compatibility).
+    // detectDrops is not set for untyped metrics, so isCumulative is evaluated to true if detectDrops is missing.
     col.params.as[Option[Boolean]]("detectDrops").getOrElse(true) ||
       col.params.as[Option[Boolean]]("counter").getOrElse(false)
   }

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -37,9 +37,11 @@ final case class ColumnInfo(name: String, colType: Column.ColumnType, isCumulati
 
 object ColumnInfo {
   def apply(col: Column): ColumnInfo = ColumnInfo(col.name, col.columnType, isCumulative(col))
-  private def isCumulative(col: Column): Boolean =
-    col.params.as[Option[Boolean]]("detectDrops").getOrElse(false) ||
+  private def isCumulative(col: Column): Boolean = {
+    // FIXME: hack for supporting rate/increase functions for untyped metrics
+    col.params.as[Option[Boolean]]("detectDrops").getOrElse(true) ||
       col.params.as[Option[Boolean]]("counter").getOrElse(false)
+  }
 }
 
 /**


### PR DESCRIPTION
**Pull Request checklist**

- [ x ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

With the support for rate/increase functions for Delta metrics, rate/increase functions' behavior for `untyped` metrics changed. 
This PR is to make sure we preserve the old behavior of rate/increase functions on `untyped`, apply as if they are cumulative.
Only `untyped` schema doesn't have `detectDrops` attribute, this code change uses it to determine if the column is of type `untyped` .