### PR TITLE
update exported label-values

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -218,13 +218,10 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
   }
 
   private def makeLabelString(labels: collection.Map[String, String]): String = {
-    val inner = labels.map {case (k, v) => (k, getExportLabelValueString(v))}.map {case (k, v) =>
-      if (v.contains (",") ) {
-        String.format ("'%s\':\"%s\"", k, v)
-      } else {
-        s"'$k':'$v'"
-      }
-    }.mkString (",")
+    val inner = labels
+      .map {case (k, v) => (k, getExportLabelValueString(v))}
+      .map {case (k, v) => s"'$k':'$v'"}
+      .mkString (",")
     s"{$inner}"
   }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -46,8 +46,8 @@ object BatchExporter {
    */
   def getExportLabelValueString(value: String): String = {
     value
-      // escape all single- and double-quotes if they aren't already escaped
-      .replaceAll("""\\(\"|\')|(\"|\')""", """\\$1$2""")
+      // escape all single-quotes and commas if they aren't already escaped
+      .replaceAll("""\\(\,|\')|(\,|\')""", """\\$1$2""")
   }
 }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -3,11 +3,14 @@ package filodb.downsampler.chunk
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
+
 import scala.collection.mutable
 import scala.util.matching.Regex
+
 import kamon.Kamon
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
+
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn}
 import filodb.core.metadata.Schemas
@@ -15,7 +18,7 @@ import filodb.core.query.ColumnFilter
 import filodb.core.store.{ChunkSetInfoReader, ReadablePartition}
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.Utils._
-import filodb.downsampler.chunk.BatchExporter.{DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER, getExportLabelValueString}
+import filodb.downsampler.chunk.BatchExporter.{getExportLabelValueString, DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER}
 import filodb.memory.format.{TypedIterator, UnsafeUtils}
 import filodb.memory.format.vectors.LongIterator
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -42,7 +42,9 @@ object BatchExporter {
    * Converts a label's value to a value of an exported row's LABELS column.
    */
   def getExportLabelValueString(value: String): String = {
-    value.replaceAll("""\\(\")|(\")""", """\\$1$2""")
+    value
+      // escape all single- and double-quotes if they aren't already escaped
+      .replaceAll("""\\(\"|\')|(\"|\')""", """\\$1$2""")
   }
 }
 

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -377,6 +377,34 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     batchExporter.getPartitionByValues(labels).toSeq shouldEqual expected
   }
 
+  it ("should correctly escape double-quotes in a label's value") {
+    val inputOutputPairs = Map(
+      // empty string
+      "" -> "",
+      // single double-quote
+      """"""" -> """\"""",
+      // double-quote pair
+      """ "" """ -> """ \"\" """,
+      // no quotes
+      """ abc """ -> """ abc """,
+      // escaped quote
+      """ \" """ -> """ \" """,
+      // double-escaped quote
+      """ \\" """ -> """ \\" """,
+      // double-escaped quote pair
+      """ \\"" """ -> """ \\"\" """,
+      // unescaped quote at beginning of string; escaped at end
+      """"foo\"""" -> """\"foo\"""",
+      // escaped quote at beginning of string; unescaped at end
+      """\"foo"""" -> """\"foo\"""",
+      // complex string
+      """ "foo\" " ""\""\ bar "baz" """ -> """ \"foo\" \" \"\"\"\"\ bar \"baz\" """
+    )
+    for ((value, expected) <- inputOutputPairs) {
+      BatchExporter.getExportLabelValueString(value) shouldEqual expected
+    }
+  }
+
   it ("should write untyped data to cassandra") {
 
     val rawDataset = Dataset("prometheus", Schemas.untyped)

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -377,16 +377,17 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     batchExporter.getPartitionByValues(labels).toSeq shouldEqual expected
   }
 
-  it ("should correctly escape double-quotes in a label's value") {
+  it ("should correctly escape quotes in a label's value prior to export") {
     val inputOutputPairs = Map(
       // empty string
       "" -> "",
+      // no quotes
+      """ abc """ -> """ abc """,
+      // ======= DOUBLE QUOTES =======
       // single double-quote
       """"""" -> """\"""",
       // double-quote pair
       """ "" """ -> """ \"\" """,
-      // no quotes
-      """ abc """ -> """ abc """,
       // escaped quote
       """ \" """ -> """ \" """,
       // double-escaped quote
@@ -398,7 +399,26 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       // escaped quote at beginning of string; unescaped at end
       """\"foo"""" -> """\"foo\"""",
       // complex string
-      """ "foo\" " ""\""\ bar "baz" """ -> """ \"foo\" \" \"\"\"\"\ bar \"baz\" """
+      """ "foo\" " ""\""\ bar "baz" """ -> """ \"foo\" \" \"\"\"\"\ bar \"baz\" """,
+      // ======= SINGLE QUOTES =======
+      // single single-quote
+      """'""" -> """\'""",
+      // single-quote pair
+      """ '' """ -> """ \'\' """,
+      // escaped quote
+      """ \' """ -> """ \' """,
+      // double-escaped quote
+      """ \\' """ -> """ \\' """,
+      // double-escaped quote pair
+      """ \\'' """ -> """ \\'\' """,
+      // unescaped quote at beginning of string; escaped at end
+      """'foo\'""" -> """\'foo\'""",
+      // escaped quote at beginning of string; unescaped at end
+      """\'foo'""" -> """\'foo\'""",
+      // complex string
+      """ 'foo\' ' ''\''\ bar 'baz' """ -> """ \'foo\' \' \'\'\'\'\ bar \'baz\' """,
+      // ======= SINGLE AND DOUBLE QUOTES =======
+      """ 'foo\" ' "'\'"\ bar 'baz" """ -> """ \'foo\" \' \"\'\'\"\ bar \'baz\" """
     )
     for ((value, expected) <- inputOutputPairs) {
       BatchExporter.getExportLabelValueString(value) shouldEqual expected

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -385,24 +385,20 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       """ abc """ -> """ abc """,
       // ======= DOUBLE QUOTES =======
       // single double-quote
-      """"""" -> """\"""",
+      """ " """ -> """ " """,
       // double-quote pair
-      """ "" """ -> """ \"\" """,
+      """ "" """ -> """ "" """,
       // escaped quote
       """ \" """ -> """ \" """,
       // double-escaped quote
       """ \\" """ -> """ \\" """,
       // double-escaped quote pair
-      """ \\"" """ -> """ \\"\" """,
-      // unescaped quote at beginning of string; escaped at end
-      """"foo\"""" -> """\"foo\"""",
-      // escaped quote at beginning of string; unescaped at end
-      """\"foo"""" -> """\"foo\"""",
+      """ \\"" """ -> """ \\"" """,
       // complex string
-      """ "foo\" " ""\""\ bar "baz" """ -> """ \"foo\" \" \"\"\"\"\ bar \"baz\" """,
+      """ "foo\" " ""\""\ bar "baz" """ -> """ "foo\" " ""\""\ bar "baz" """,
       // ======= SINGLE QUOTES =======
       // single single-quote
-      """'""" -> """\'""",
+      """ ' """ -> """ \' """,
       // single-quote pair
       """ '' """ -> """ \'\' """,
       // escaped quote
@@ -411,14 +407,26 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       """ \\' """ -> """ \\' """,
       // double-escaped quote pair
       """ \\'' """ -> """ \\'\' """,
-      // unescaped quote at beginning of string; escaped at end
-      """'foo\'""" -> """\'foo\'""",
-      // escaped quote at beginning of string; unescaped at end
-      """\'foo'""" -> """\'foo\'""",
       // complex string
       """ 'foo\' ' ''\''\ bar 'baz' """ -> """ \'foo\' \' \'\'\'\'\ bar \'baz\' """,
-      // ======= SINGLE AND DOUBLE QUOTES =======
-      """ 'foo\" ' "'\'"\ bar 'baz" """ -> """ \'foo\" \' \"\'\'\"\ bar \'baz\" """
+      // ======= COMMAS =======
+      // single single-quote
+      """ , """ -> """ \, """,
+      // single-quote pair
+      """ ,, """ -> """ \,\, """,
+      // escaped quote
+      """ \, """ -> """ \, """,
+      // double-escaped quote
+      """ \\, """ -> """ \\, """,
+      // double-escaped quote pair
+      """ \\,, """ -> """ \\,\, """,
+      // complex string
+      """ 'foo\' ' ''\''\ bar 'baz' """ -> """ \'foo\' \' \'\'\'\'\ bar \'baz\' """,
+      // ======= COMBINATION =======
+      """ 'foo\" ' "'\'"\ bar 'baz" """ -> """ \'foo\" \' "\'\'"\ bar \'baz" """,
+      """ 'foo\" ' ,, "'\'"\ bar 'baz" \, """ -> """ \'foo\" \' \,\, "\'\'"\ bar \'baz" \, """,
+      """ ["foo","ba'r:1234"] """ -> """ ["foo"\,"ba\'r:1234"] """,
+      """ "foo,bar:1234" """ -> """ "foo\,bar:1234" """
     )
     for ((value, expected) <- inputOutputPairs) {
       BatchExporter.getExportLabelValueString(value) shouldEqual expected


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, label-values are exported with unescaped double-quotes, which will prevent them from parsing correctly. This PR makes the following changes:
- Escape all unescaped commas and unescaped single-quotes.
- Always wrap label-values in single-quotes.