### PR TITLE
feat(cass): Consolidate to one partkey table instead of table per shard

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -692,7 +692,8 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
   def getOrCreatePartitionKeysV2Table(dataset: DatasetRef): PartitionKeysV2Table = {
     require(partKeysV2TableEnabled) // to make sure we don't trigger table creation unintentionally
     partKeysV2TableCache.getOrElseUpdate(dataset, { dataset: DatasetRef =>
-      new PartitionKeysV2Table(dataset, clusterConnector, ingestionConsistencyLevel)(readEc)
+      new PartitionKeysV2Table(dataset, clusterConnector, ingestionConsistencyLevel,
+        readConsistencyLevel)(readEc)
     })
   }
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -20,6 +20,7 @@ import monix.reactive.Observable
 
 import filodb.cassandra.FiloCassandraConnector
 import filodb.core._
+import filodb.core.metadata.Schemas
 import filodb.core.store._
 import filodb.memory.BinaryRegionLarge
 
@@ -60,10 +61,13 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
 
   logger.info(s"Starting CassandraColumnStore with config ${cassandraConfig.withoutPath("password")}")
 
+  val schemas = Schemas.fromConfig(config).get
+
   private val writeParallelism = cassandraConfig.getInt("write-parallelism")
   private val indexScanParallelismPerShard =
     Math.min(cassandraConfig.getInt("index-scan-parallelism-per-shard"), Runtime.getRuntime.availableProcessors())
   private val pkByUTNumSplits = cassandraConfig.getInt("pk-by-updated-time-table-num-splits")
+  private val pkv2NumBuckets = cassandraConfig.getInt("pk-v2-table-num-buckets")
   private val writeTimeIndexTtlSeconds = cassandraConfig.getDuration("write-time-index-ttl", TimeUnit.SECONDS).toInt
   private val createTablesEnabled = cassandraConfig.getBoolean("create-tables-enabled")
   private val numTokenRangeSplitsForScans = cassandraConfig.getInt("num-token-range-splits-for-scans")
@@ -78,9 +82,9 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
                             MeasurementUnit.time.milliseconds).withoutTags()
 
   def initialize(dataset: DatasetRef, numShards: Int): Future[Response] = {
+    if (createTablesEnabled) {
       val chunkTable = getOrCreateChunkTable(dataset)
       val partitionKeysByUpdateTimeTable = getOrCreatePartitionKeysByUpdateTimeTable(dataset)
-    if (createTablesEnabled) {
       val partKeyTablesInit = Observable.fromIterable(0.until(numShards)).map { s =>
         getOrCreatePartitionKeysTable(dataset, s)
       }.mapEval(t => Task.fromFuture(t.initialize())).toListL
@@ -88,7 +92,16 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       val indexTable = getOrCreateIngestionTimeIndexTable(dataset)
       // Important: make sure nodes are in agreement before any schema changes
       clusterMeta.checkSchemaAgreement()
+
+      def partitionKeysV2TableInit(): Future[Response] = {
+        if (partKeysV2TableEnabled) {
+          val partitionKeysV2Table = getOrCreatePartitionKeysV2Table(dataset)
+          partitionKeysV2Table.initialize()
+        } else Future.successful(Success)
+      }
+
       for {ctResp <- chunkTable.initialize() if ctResp == Success
+           pkv2Resp <- partitionKeysV2TableInit() if pkv2Resp == Success
            ixResp <- indexTable.initialize() if ixResp == Success
            pkutResp <- partitionKeysByUpdateTimeTable.initialize() if pkutResp == Success
            partKeyTablesResp <- partKeyTablesInit.runToFuture if partKeyTablesResp.forall(_ == Success)
@@ -109,7 +122,16 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     }.mapEval(t => Task.fromFuture(t.clearAll())).toListL
     val indexTable = getOrCreateIngestionTimeIndexTable(dataset)
     clusterMeta.checkSchemaAgreement()
+
+    def partitionKeysV2TableTruncate(): Future[Response] = {
+      if (partKeysV2TableEnabled) {
+        val partitionKeysV2Table = getOrCreatePartitionKeysV2Table(dataset)
+        partitionKeysV2Table.clearAll()
+      } else Future.successful(Success)
+    }
+
     for { ctResp    <- chunkTable.clearAll() if ctResp == Success
+          pkv2Resp  <- partitionKeysV2TableTruncate() if pkv2Resp == Success
           ixResp    <- indexTable.clearAll() if ixResp == Success
           pkutResp  <- partitionKeysByUpdateTimeTable.clearAll() if pkutResp == Success
           partKeyTablesResp <- partKeyTablesTrunc.runToFuture if partKeyTablesResp.forall( _ == Success)
@@ -120,17 +142,28 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     val chunkTable = getOrCreateChunkTable(dataset)
     val partitionKeysByUpdateTimeTable = getOrCreatePartitionKeysByUpdateTimeTable(dataset)
     val indexTable = getOrCreateIngestionTimeIndexTable(dataset)
+    val partitionKeysV2Table = getOrCreatePartitionKeysV2Table(dataset)
     val partKeyTablesDrop = Observable.fromIterable(0.until(numShards)).map { s =>
       getOrCreatePartitionKeysTable(dataset, s)
     }.mapEval(t => Task.fromFuture(t.drop())).toListL
     clusterMeta.checkSchemaAgreement()
+
+    def partitionKeysV2TableDrop(): Future[Response] = {
+      if (partKeysV2TableEnabled) {
+        val partitionKeysV2Table = getOrCreatePartitionKeysV2Table(dataset)
+        partitionKeysV2Table.drop()
+      } else Future.successful(Success)
+    }
+
     for {ctResp <- chunkTable.drop() if ctResp == Success
          ixResp <- indexTable.drop() if ixResp == Success
+         pkv2Resp  <- partitionKeysV2TableDrop() if pkv2Resp == Success
          pkutResp  <- partitionKeysByUpdateTimeTable.drop() if pkutResp == Success
          partKeyTablesResp <- partKeyTablesDrop.runToFuture if partKeyTablesResp.forall(_ == Success)
     } yield {
       chunkTableCache.remove(dataset)
       indexTableCache.remove(dataset)
+      partKeysV2TableCache.remove(dataset)
       partitionKeysTableCache.remove(dataset)
       Success
     }
@@ -232,23 +265,21 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
    *
    * @param diskTimeToLiveSeconds ttl
    */
+  // scalastyle:off method.length
   def copyPartitionKeysByTimeRange(datasetRef: DatasetRef,
                                    numOfShards: Int,
                                    splits: Iterator[ScanSplit],
                                    repairStartTime: Long,
                                    repairEndTime: Long,
                                    target: CassandraColumnStore,
-                                   partKeyHashFn: PartKeyRecord => Option[Int],
                                    diskTimeToLiveSeconds: Int): Unit = {
-    def pkRecordWithHash(pkRecord: PartKeyRecord) = {
-      PartKeyRecord(pkRecord.partKey, pkRecord.startTime, pkRecord.endTime, partKeyHashFn(pkRecord))
-    }
 
-    def copyRows(targetPartitionKeysTable: PartitionKeysTable, records: Set[PartKeyRecord], shard: Int) = {
+    def copyRows(targetPartitionKeysTable: PartitionKeysTable, records: Set[PartKeyRecord],
+                 shard: Int) = {
       val partKeys = records.map(partKeyRecord =>
         targetPartitionKeysTable.readPartKey(partKeyRecord.partKey) match {
-          case Some(targetPkr) => pkRecordWithHash(compareAndGet(partKeyRecord, targetPkr))
-          case None => pkRecordWithHash(partKeyRecord)
+          case Some(targetPkr) => compareAndGet(partKeyRecord, targetPkr)
+          case None => partKeyRecord
         }
       )
       val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
@@ -259,28 +290,64 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       )
     }
 
-    // for every split, scan PartitionKeysTable for all the shards.
-    for (split <- splits; shard <- 0 until numOfShards) {
-      val tokens = split.asInstanceOf[CassandraTokenRangeSplit].tokens
-      val srcPartKeysTable = getOrCreatePartitionKeysTable(datasetRef, shard)
-      val targetPartKeysTable = target.getOrCreatePartitionKeysTable(datasetRef, shard)
-      // CQL does not support OR operator. So we need to query separately to get the timeSeries partitionKeys
-      // which were born or died during the data loss period (aka repair window).
-      val rowsByStartTime = srcPartKeysTable.scanRowsByStartTimeRangeNoAsync(tokens, repairStartTime, repairEndTime)
-      val rowsByEndTime = srcPartKeysTable.scanRowsByEndTimeRangeNoAsync(tokens, repairStartTime, repairEndTime)
-      // add to a Set to eliminate duplicate entries.
-      val records = rowsByStartTime.++(rowsByEndTime).map(PartitionKeysTable.rowToPartKeyRecord)
-      if (records.nonEmpty)
-        copyRows(targetPartKeysTable, records, shard)
+    def copyRowsV2(targetPartitionKeysTable: PartitionKeysV2Table, records: Set[PartKeyRecord]) = {
+      val partKeys = records.map(pkr =>
+        targetPartitionKeysTable.readPartKey(pkr.shard,
+                                             PartKeyRecord.getBucket(pkr.partKey, schemas, pkv2NumBuckets),
+                                             pkr.partKey) match {
+          case Some(targetPkr) => compareAndGet(pkr, targetPkr)
+          case None => pkr
+        }
+      )
+      val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
+      Await.result(
+        target.writePartKeys(datasetRef, shard = 0 /* not used */,
+          Observable.fromIterable(partKeys), diskTimeToLiveSeconds, updateHour, !downsampledData),
+        5.minutes // TODO leaving per old code. Need to configure this.
+      )
+    }
+
+    if (partKeysV2TableEnabled) {
+      // for every split, scan PartitionKeysV2Table
+      for (split <- splits) {
+        val tokens = split.asInstanceOf[CassandraTokenRangeSplit].tokens
+        val srcPartKeysTable = getOrCreatePartitionKeysV2Table(datasetRef)
+        val targetPartKeysTable = target.getOrCreatePartitionKeysV2Table(datasetRef)
+        // CQL does not support OR operator. So we need to query separately to get the timeSeries partitionKeys
+        // which were born or died during the data loss period (aka repair window).
+        val rowsByStartTime = srcPartKeysTable.scanRowsByStartTimeRangeNoAsync(tokens, repairStartTime, repairEndTime)
+        val rowsByEndTime = srcPartKeysTable.scanRowsByEndTimeRangeNoAsync(tokens, repairStartTime, repairEndTime)
+        // add to a Set to eliminate duplicate entries.
+        val records = rowsByStartTime.++(rowsByEndTime).map(PartitionKeysV2Table.rowToPartKeyRecord)
+        if (records.nonEmpty)
+          copyRowsV2(targetPartKeysTable, records)
+      }
+    } else {
+      // for every split, scan PartitionKeysTable for all the shards.
+      for (split <- splits; shard <- 0 until numOfShards) {
+        val tokens = split.asInstanceOf[CassandraTokenRangeSplit].tokens
+        val srcPartKeysTable = getOrCreatePartitionKeysTable(datasetRef, shard)
+        val targetPartKeysTable = target.getOrCreatePartitionKeysTable(datasetRef, shard)
+        // CQL does not support OR operator. So we need to query separately to get the timeSeries partitionKeys
+        // which were born or died during the data loss period (aka repair window).
+        val rowsByStartTime = srcPartKeysTable.scanRowsByStartTimeRangeNoAsync(tokens, repairStartTime, repairEndTime)
+        val rowsByEndTime = srcPartKeysTable.scanRowsByEndTimeRangeNoAsync(tokens, repairStartTime, repairEndTime)
+        // add to a Set to eliminate duplicate entries.
+        val records = rowsByStartTime.++(rowsByEndTime).map(r => PartitionKeysTable.rowToPartKeyRecord(r, shard))
+        if (records.nonEmpty)
+          copyRows(targetPartKeysTable, records, shard)
+      }
     }
   }
+  // scalastyle:on method.length
 
   private def compareAndGet(sourceRec: PartKeyRecord, targetRec: PartKeyRecord): PartKeyRecord = {
+
     val startTime = // compare and get the oldest start time
       if (sourceRec.startTime < targetRec.startTime) sourceRec.startTime else targetRec.startTime
     val endTime = // compare and get the latest end time
       if (sourceRec.endTime > targetRec.endTime) sourceRec.endTime else targetRec.endTime
-    PartKeyRecord(sourceRec.partKey, startTime, endTime, None)
+    PartKeyRecord(sourceRec.partKey, startTime, endTime, sourceRec.shard)
   }
 
   /**
@@ -424,24 +491,34 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
     wrappedRanges.flatMap(_.unwrap().asScala.toSeq)
 
   def scanPartKeys(ref: DatasetRef, shard: Int): Observable[PartKeyRecord] = {
-    val table = getOrCreatePartitionKeysTable(ref, shard)
-    Observable.fromIterable(getScanSplits(ref)).flatMap { tokenRange =>
-      table.scanPartKeys(tokenRange.asInstanceOf[CassandraTokenRangeSplit].tokens, indexScanParallelismPerShard)
+
+    if (partKeysV2TableEnabled) {
+      val table = getOrCreatePartitionKeysV2Table(ref)
+      table.scanPartKeys(shard, indexScanParallelismPerShard, pkv2NumBuckets)
+    } else {
+      val table = getOrCreatePartitionKeysTable(ref, shard)
+      Observable.fromIterable(getScanSplits(ref)).flatMap { tokenRange =>
+        table.scanPartKeys(tokenRange.asInstanceOf[CassandraTokenRangeSplit].tokens, indexScanParallelismPerShard)
+      }
     }
   }
 
   // returns the persisted partKey record, or default partKey record (argument) if there is no persisted value.
   def getPartKeyRecordOrDefault(ref: DatasetRef,
                                 shard: Int,
-                                partKeyRecord: PartKeyRecord): PartKeyRecord = {
-    getOrCreatePartitionKeysTable(ref, shard).readPartKey(partKeyRecord.partKey) match {
-      case Some(targetPkr) => targetPkr
-      case None => partKeyRecord // this case is never executed since raw cluster is the source of truth.
+                                pkr: PartKeyRecord): PartKeyRecord = {
+
+    val opt = if (partKeysV2TableEnabled) {
+      val bucket = PartKeyRecord.getBucket(pkr.partKey, schemas, pkv2NumBuckets)
+      getOrCreatePartitionKeysV2Table(ref).readPartKey(shard, bucket, pkr.partKey)
+    } else {
+      getOrCreatePartitionKeysTable(ref, shard).readPartKey(pkr.partKey)
     }
+    opt.getOrElse(pkr)
   }
 
   def writePartKeys(ref: DatasetRef,
-                    shard: Int,
+                    shard: Int, // TODO not used if v2. Remove after migration to v2 tables
                     partKeys: Observable[PartKeyRecord],
                     diskTTLSeconds: Long, updateHour: Long,
                     writeToPkUTTable: Boolean = true): Future[Response] = {
@@ -452,14 +529,21 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
       val ttl = if (pk.endTime == Long.MaxValue) -1 else diskTTLSeconds
       // caller needs to supply hash for partKey - cannot be None
       // Logical & MaxValue needed to make split positive by zeroing sign bit
-      val split = (pk.hash.get & Int.MaxValue) % pkByUTNumSplits
-      val writePkFut = pkTable.writePartKey(pk, ttl).flatMap {
+      val split = PartKeyRecord.getBucket(pk.partKey, schemas, pkByUTNumSplits)
+      val bucket = PartKeyRecord.getBucket(pk.partKey, schemas, pkv2NumBuckets)
+      def writePk() = if (partKeysV2TableEnabled) {
+        val pkv2Table = getOrCreatePartitionKeysV2Table(ref)
+        pkv2Table.writePartKey(bucket, pk, ttl)
+      } else {
+        pkTable.writePartKey(pk, ttl)
+      }
+      val writePkFut = writePk().flatMap {
         case resp if resp == Success && writeToPkUTTable =>
-          pkByUTTable.writePartKey(shard, updateHour, split, pk, writeTimeIndexTtlSeconds)
+          pkByUTTable.writePartKey(pk.shard, updateHour, split, pk, writeTimeIndexTtlSeconds)
         case resp =>
           Future.successful(resp)
       }
-      Task.fromFuture(writePkFut).map{ resp =>
+      Task.fromFuture(writePkFut).map { resp =>
         sinkStats.partKeysWrite(1)
         resp
       }
@@ -471,21 +555,32 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   }
 
   def scanPartKeysByStartEndTimeRangeNoAsync(ref: DatasetRef,
-                                             shard: Int,
+                                             shard: Int, // TODO not used for v2; Remove after migration to v2 tables
                                              split: (String, String),
                                              startTimeGTE: Long,
                                              startTimeLTE: Long,
                                              endTimeGTE: Long,
                                              endTimeLTE: Long): Iterator[PartKeyRecord] = {
-    val pkTable = getOrCreatePartitionKeysTable(ref, shard)
-    pkTable.scanPksByStartEndTimeRangeNoAsync(split, startTimeGTE, startTimeLTE, endTimeGTE, endTimeLTE)
+    if (partKeysV2TableEnabled) {
+      val pkTable = getOrCreatePartitionKeysV2Table(ref)
+      pkTable.scanPksByStartEndTimeRangeNoAsync(split, startTimeGTE, startTimeLTE, endTimeGTE, endTimeLTE)
+    } else {
+      val pkTable = getOrCreatePartitionKeysTable(ref, shard)
+      pkTable.scanPksByStartEndTimeRangeNoAsync(split, startTimeGTE, startTimeLTE, endTimeGTE, endTimeLTE)
+    }
   }
 
   def deletePartKeyNoAsync(ref: DatasetRef,
                            shard: Int,
                            pk: Array[Byte]): Response = {
-    val pkTable = getOrCreatePartitionKeysTable(ref, shard)
-    pkTable.deletePartKeyNoAsync(pk)
+    if (partKeysV2TableEnabled) {
+      val pkTable = getOrCreatePartitionKeysV2Table(ref)
+      val bucket = PartKeyRecord.getBucket(pk, schemas, pkv2NumBuckets)
+      pkTable.deletePartKeyNoAsync(shard, bucket, pk)
+    } else {
+      val pkTable = getOrCreatePartitionKeysTable(ref, shard)
+      pkTable.deletePartKeyNoAsync(pk)
+    }
   }
 
   def getPartKeysByUpdateHour(ref: DatasetRef,
@@ -523,9 +618,11 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
   val cassandraConfig = config.getConfig("cassandra")
   val ingestionConsistencyLevel = ConsistencyLevel.valueOf(cassandraConfig.getString("ingestion-consistency-level"))
   val readConsistencyLevel = ConsistencyLevel.valueOf(cassandraConfig.getString("default-read-consistency-level"))
+  val partKeysV2TableEnabled = cassandraConfig.getBoolean("part-keys-v2-table-enabled")
   val tableCacheSize = config.getInt("columnstore.tablecache-size")
 
   val chunkTableCache = concurrentCache[DatasetRef, TimeSeriesChunksTable](tableCacheSize)
+  val partKeysV2TableCache = concurrentCache[DatasetRef, PartitionKeysV2Table](tableCacheSize)
   val indexTableCache = concurrentCache[DatasetRef, IngestionTimeIndexTable](tableCacheSize)
   val partKeysByUTTableCache = concurrentCache[DatasetRef, PartitionKeysByUpdateTimeTable](tableCacheSize)
   val partitionKeysTableCache = concurrentCache[DatasetRef,
@@ -539,8 +636,6 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
     val keyspace: String = if (!downsampledData) config.getString("keyspace")
                            else config.getString("downsample-keyspace")
 }
-
-  val partParallelism = 4
 
   /**
     * Read chunks from persistent store. Note the following constraints under which query is optimized:
@@ -593,6 +688,13 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
                           new IngestionTimeIndexTable(dataset, clusterConnector, ingestionConsistencyLevel,
                             readConsistencyLevel)(readEc) })
 }
+
+  def getOrCreatePartitionKeysV2Table(dataset: DatasetRef): PartitionKeysV2Table = {
+    require(partKeysV2TableEnabled) // to make sure we don't trigger table creation unintentionally
+    partKeysV2TableCache.getOrElseUpdate(dataset, { dataset: DatasetRef =>
+      new PartitionKeysV2Table(dataset, clusterConnector, ingestionConsistencyLevel)(readEc)
+    })
+  }
 
   def getOrCreatePartitionKeysByUpdateTimeTable(dataset: DatasetRef): PartitionKeysByUpdateTimeTable = {
     partKeysByUTTableCache.getOrElseUpdate(dataset,

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
@@ -55,7 +55,7 @@ sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
   def scanPartKeys(shard: Int, updateHour: Long, split: Int): Observable[PartKeyRecord] = {
     session.executeAsync(readCql.bind(shard: JInt, updateHour: JLong, split: JInt))
       .toObservable.handleObservableErrors
-      .map(PartitionKeysTable.rowToPartKeyRecord)
+      .map(r => PartitionKeysTable.rowToPartKeyRecord(r, shard))
   }
 
 }

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
@@ -75,7 +75,7 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
   private lazy val deleteCql = session.prepare(
     s"DELETE FROM $tableString " +
     s"WHERE partKey = ?"
-  )
+  ).setConsistencyLevel(writeConsistencyLevel)
 
   def writePartKey(pk: PartKeyRecord, diskTimeToLiveSeconds: Long): Future[Response] = {
     if (diskTimeToLiveSeconds <= 0) {

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysV2Table.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysV2Table.scala
@@ -13,86 +13,99 @@ import filodb.cassandra.FiloCassandraConnector
 import filodb.core.{DatasetRef, Response}
 import filodb.core.store.PartKeyRecord
 
-sealed class PartitionKeysTable(val dataset: DatasetRef,
-                                val shard: Int,
+sealed class PartitionKeysV2Table(val dataset: DatasetRef,
                                 val connector: FiloCassandraConnector,
-                                writeConsistencyLevel: ConsistencyLevel,
-                                readConsistencyLevel: ConsistencyLevel)
+                                writeConsistencyLevel: ConsistencyLevel)
                                (implicit ec: ExecutionContext) extends BaseDatasetTable {
 
   import filodb.cassandra.Util._
 
-  val suffix = s"partitionkeys_$shard"
+  val suffix = s"partitionkeysv2"
 
   val createCql =
     s"""CREATE TABLE IF NOT EXISTS $tableString (
+       |    shard int,
+       |    bucket int,
        |    partKey blob,
        |    startTime bigint,
        |    endTime bigint,
-       |    PRIMARY KEY (partKey)
+       |    PRIMARY KEY ((shard, bucket), partKey)
        |) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': '$sstableCompression'}""".stripMargin
 
   private lazy val writePartitionCql = session.prepare(
-      s"INSERT INTO ${tableString} (partKey, startTime, endTime) " +
-      s"VALUES (?, ?, ?) USING TTL ?")
+      s"INSERT INTO ${tableString} (shard, bucket, partKey, startTime, endTime) " +
+      s"VALUES (?, ?, ?, ?, ?) USING TTL ?")
       .setConsistencyLevel(writeConsistencyLevel)
 
   private lazy val writePartitionCqlNoTtl = session.prepare(
-      s"INSERT INTO ${tableString} (partKey, startTime, endTime) " +
-        s"VALUES (?, ?, ?)")
+      s"INSERT INTO ${tableString} (shard, bucket, partKey, startTime, endTime) " +
+        s"VALUES (?, ?, ?, ?, ?)")
       .setConsistencyLevel(writeConsistencyLevel)
 
+  private lazy val selectPkCql = session.prepare(
+    s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
+      s"WHERE shard = ? and bucket = ? and partKey = ?"
+  )
+
   private lazy val scanCql = session.prepare(
-    s"SELECT * FROM $tableString " +
-    s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ?")
-    .setConsistencyLevel(readConsistencyLevel)
+    s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
+      s"WHERE shard = ? and bucket = ?"
+  )
 
   private lazy val scanCqlForStartEndTime = session.prepare(
-    s"SELECT partKey, startTime, endTime FROM $tableString " +
-      s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND " +
+    s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
+      s"WHERE TOKEN(shard, bucket) >= ? AND TOKEN(shard, bucket) < ? AND " +
       s"startTime >= ? AND startTime <= ? AND " +
       s"endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
-    .setConsistencyLevel(readConsistencyLevel)
+    .setConsistencyLevel(ConsistencyLevel.ONE)
 
   private lazy val scanCqlForStartTime = session.prepare(
-    s"SELECT partKey, startTime, endTime FROM $tableString " +
-      s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND startTime >= ? AND startTime <= ? " +
+    s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
+      s"WHERE TOKEN(shard, bucket) >= ? AND TOKEN(shard, bucket) < ? AND startTime >= ? AND startTime <= ? " +
       s"ALLOW FILTERING")
-    .setConsistencyLevel(readConsistencyLevel)
+    .setConsistencyLevel(ConsistencyLevel.ONE)
 
   private lazy val scanCqlForEndTime = session.prepare(
-    s"SELECT partKey, startTime, endTime FROM $tableString " +
-      s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND endTime >= ? AND endTime <= ? " +
+    s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
+      s"WHERE TOKEN(shard, bucket) >= ? AND TOKEN(shard, bucket) < ? AND endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
-    .setConsistencyLevel(readConsistencyLevel)
+    .setConsistencyLevel(ConsistencyLevel.ONE)
 
   private lazy val readCql = session.prepare(
-    s"SELECT partKey, startTime, endTime FROM $tableString " +
-      s"WHERE partKey = ? ")
-    .setConsistencyLevel(readConsistencyLevel)
+    s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
+      s"WHERE shard = ? and bucket = ? and partKey = ?")
+    .setConsistencyLevel(ConsistencyLevel.ONE)
 
   private lazy val deleteCql = session.prepare(
     s"DELETE FROM $tableString " +
-    s"WHERE partKey = ?"
+    s"WHERE shard = ? and bucket = ? and partKey = ?"
   )
 
-  def writePartKey(pk: PartKeyRecord, diskTimeToLiveSeconds: Long): Future[Response] = {
+  def writePartKey(bucket: Int, pk: PartKeyRecord, diskTimeToLiveSeconds: Long): Future[Response] = {
     if (diskTimeToLiveSeconds <= 0) {
-      connector.execStmtWithRetries(writePartitionCqlNoTtl.bind(
+      connector.execStmtWithRetries(writePartitionCqlNoTtl.bind(pk.shard: JInt, bucket: JInt,
         toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong))
     } else {
-      connector.execStmtWithRetries(writePartitionCql.bind(
+      connector.execStmtWithRetries(writePartitionCql.bind(pk.shard: JInt, bucket: JInt,
         toBuffer(pk.partKey), pk.startTime: JLong, pk.endTime: JLong, diskTimeToLiveSeconds.toInt: JInt))
     }
   }
 
-  def scanPartKeys(tokens: Seq[(String, String)], scanParallelism: Int): Observable[PartKeyRecord] = {
-    val res: Observable[Iterator[PartKeyRecord]] = Observable.fromIterable(tokens)
-      .mapParallelUnordered(scanParallelism) { range =>
-        val fut = session.executeAsync(scanCql.bind(range._1.toLong: JLong, range._2.toLong: JLong))
+  def scanPartKeys(shard: Int, scanParallelism: Int, numBuckets: Int): Observable[PartKeyRecord] = {
+
+    /*
+    TODO If this is slow, then another option to evaluate is to do token scan with shard filter.
+    SELECT partKey, startTime, endTime, shard FROM $tableString " +
+      s"WHERE TOKEN(shard, bucket) >= ? AND TOKEN(shard, bucket) < ? AND " +
+      s"shard = ? ALLOW FILTERING")
+     */
+
+    val res: Observable[Iterator[PartKeyRecord]] = Observable.fromIterable(0 until numBuckets)
+      .mapParallelUnordered(scanParallelism) { bucket =>
+        val fut = session.executeAsync(scanCql.bind(shard: JInt, bucket: JInt))
                          .toIterator.handleErrors
-                         .map { rowIt => rowIt.map(r => PartitionKeysTable.rowToPartKeyRecord(r, shard)) }
+                         .map { rowIt => rowIt.map(PartitionKeysV2Table.rowToPartKeyRecord) }
         Task.fromFuture(fut)
       }
     for {
@@ -131,8 +144,8 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
    * Rows consist of partKey, start and end time. Refer the CQL used below.
    */
   def scanRowsByEndTimeRangeNoAsync(tokens: Seq[(String, String)],
-                                      startTime: Long,
-                                      endTime: Long): Set[Row] = {
+                                    startTime: Long,
+                                    endTime: Long): Set[Row] = {
     tokens.iterator.flatMap { case (start, end) =>
       /*
        * FIXME conversion of tokens to Long works only for Murmur3Partitioner because it generates
@@ -167,7 +180,7 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
         startTimeLTE: java.lang.Long,
         endTimeGTE: java.lang.Long,
         endTimeLTE: java.lang.Long)
-    session.execute(stmt).iterator.asScala.map(r => PartitionKeysTable.rowToPartKeyRecord(r, shard))
+    session.execute(stmt).iterator.asScala.map(PartitionKeysV2Table.rowToPartKeyRecord)
   }
 
   /**
@@ -176,10 +189,10 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
    * @param pk partKey bytes
    * @return Option[PartKeyRecord]
    */
-  def readPartKey(pk: Array[Byte]) : Option[PartKeyRecord] = {
-    val iterator = session.execute(readCql.bind().setBytes(0, toBuffer(pk))).iterator()
+  def readPartKey(shard: Int, bucket: Int, pk: Array[Byte]) : Option[PartKeyRecord] = {
+    val iterator = session.execute(readCql.bind(shard: JInt, bucket: JInt, toBuffer(pk))).iterator()
     if (iterator.hasNext) {
-      Some(PartitionKeysTable.rowToPartKeyRecord(iterator.next(), shard))
+      Some(PartitionKeysV2Table.rowToPartKeyRecord(iterator.next()))
     } else {
       None
     }
@@ -191,16 +204,16 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
    * @param pk partKey bytes
    * @return Future[Response]
    */
-  def deletePartKeyNoAsync(pk: Array[Byte]): Response = {
-    val stmt = deleteCql.bind().setBytes(0, toBuffer(pk)).setConsistencyLevel(writeConsistencyLevel)
+  def deletePartKeyNoAsync(shard: Int, bucket: Int, pk: Array[Byte]): Response = {
+    val stmt = deleteCql.bind(shard: JInt, bucket: JInt, toBuffer(pk)).setConsistencyLevel(writeConsistencyLevel)
     connector.execCqlNoAsync(stmt)
   }
 
 }
 
-object PartitionKeysTable {
-  private[columnstore] def rowToPartKeyRecord(row: Row, shard: Int) = {
+object PartitionKeysV2Table {
+  private[columnstore] def rowToPartKeyRecord(row: Row) = {
     PartKeyRecord(row.getBytes("partKey").array(),
-      row.getLong("startTime"), row.getLong("endTime"), shard)
+      row.getLong("startTime"), row.getLong("endTime"), row.getInt("shard"))
   }
 }

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
@@ -88,8 +88,8 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     colStore.write(dataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(gaugePartKeyBytes, firstSampleTime, firstSampleTime + numSamples, Some(150))
-    colStore.writePartKeys(dataset.ref, 0, Observable.now(pk), 259200, 34).futureValue
+    val pk = PartKeyRecord(gaugePartKeyBytes, firstSampleTime, firstSampleTime + numSamples, shard = 0)
+    colStore.writePartKeys(dataset.ref, shard = 0, Observable.now(pk), 259200, 34).futureValue
   }
 
   it ("should be able to do full ODP for non concurrent queries") {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -427,8 +427,14 @@ filodb {
     # Use v2 tables for storing and reading part keys
     part-keys-v2-table-enabled = false
 
-    # Number of buckets used in partKeyv2 cass tables (to control wide rows problem)
-    pk-v2-table-num-buckets = 5000
+    # Number of buckets used in part-key-v2 cass tables
+    # (to control wide rows problem and keep each cass partition under 10mb)
+    # Here is the math:
+    # 6 bil part keys * 2kb per part key = 12 TB
+    # We aim for 10MB per partition, so 12TB  / 10MB per cass-partition = 1.2 million cass-partitions
+    # Since cass-partition is combination of shard+bucket in the schema:
+    # With 256 shards, We need 1.2 mil/256  = 4687 buckets for each shard
+    pk-v2-table-num-buckets = 6000
   }
 
   downsampler {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -420,8 +420,15 @@ filodb {
 
     # Parallel scans per shard. Use this property and num-token-range-splits-for-scans to
     # issue parallel queries to cassandra during index load to index reduce recovery times
+    # Increase this if the number of pk-v2-table-num-buckets is high causing recovery times
+    # to increase
     index-scan-parallelism-per-shard = 2
 
+    # Use v2 tables for storing and reading part keys
+    part-keys-v2-table-enabled = false
+
+    # Number of buckets used in partKeyv2 cass tables (to control wide rows problem)
+    pk-v2-table-num-buckets = 5000
   }
 
   downsampler {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1286,7 +1286,7 @@ class TimeSeriesShard(val ref: DatasetRef,
       val et = p.timestampOfLatestSample  // -1 can be returned if no sample after reboot
       if (et == -1) System.currentTimeMillis() else et
     }
-    PartKeyRecord(p.partKeyBytes, startTime, endTime, Some(p.partKeyHash))
+    PartKeyRecord(p.partKeyBytes, startTime, endTime, shardNum)
   }
 
   // scalastyle:off method.length

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -12,8 +12,17 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core._
+import filodb.core.metadata.Schemas
+import filodb.memory.format.UnsafeUtils
 
-case class PartKeyRecord(partKey: Array[Byte], startTime: Long, endTime: Long, hash: Option[Int])
+case class PartKeyRecord(partKey: Array[Byte], startTime: Long, endTime: Long, shard: Int)
+
+object PartKeyRecord {
+  def getBucket(partKey: Array[Byte], schemas: Schemas, numBuckets: Int): Int = {
+    val hash = schemas.part.binSchema.partitionHash(partKey, UnsafeUtils.arayOffset)
+    (hash & Int.MaxValue) % numBuckets
+  }
+}
 
 /**
  * ChunkSink is the base trait for a sink, or writer to a persistent store, of chunks

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -1,6 +1,31 @@
 filodb {
   dataset-configs = [ ]
 
+  partition-schema {
+    columns = ["_metric_:string", "tags:map"]
+
+    predefined-keys = []
+
+    options {
+      copyTags = {
+        "_ns_" = ["_ns", "exporter", "job"]
+      }
+      ignoreShardKeyColumnSuffixes = {"_metric_" = ["_bucket", "_count", "_sum"]}
+      ignoreTagsOnPartitionKeyHash = ["le"]
+      metricColumn = "_metric_"
+      shardKeyColumns = ["_ws_", "_ns_", "_metric_"]
+      multiColumnFacets = {}
+    }
+  }
+
+  schemas {
+    untyped {
+      columns = ["timestamp:ts", "number:double"]
+      value-column = "number"
+      downsamplers = []
+    }
+  }
+
   cassandra {
     hosts = ["localhost"]
     port = 9042
@@ -21,6 +46,8 @@ filodb {
     create-tables-enabled = true
     num-token-range-splits-for-scans = 2
     index-scan-parallelism-per-shard = 2
+    part-keys-v2-table-enabled = false
+    pk-v2-table-num-buckets = 100
   }
 
   grpc {

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -313,8 +313,8 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val colStore = new NullColumnStore() {
       override def scanPartKeys(ref: DatasetRef, shard: Int): Observable[PartKeyRecord] = {
         val keys = Seq(
-          PartKeyRecord(pks(0), 50, 100, None), // series that has ended ingestion
-          PartKeyRecord(pks(1), 250, Long.MaxValue, None) // series that is currently ingesting
+          PartKeyRecord(pks(0), 50, 100, 0), // series that has ended ingestion
+          PartKeyRecord(pks(1), 250, Long.MaxValue, 0) // series that is currently ingesting
         )
         Observable.fromIterable(keys)
       }

--- a/scripts/schema-create.sh
+++ b/scripts/schema-create.sh
@@ -71,6 +71,17 @@ CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeys_$SHARD (
 EOF
 done
 
+cat << EOF
+CREATE TABLE IF NOT EXISTS ${KEYSP}.${DSET}_partitionkeysv2 (
+    shard int,
+    bucket int,
+    partKey blob,
+    startTime bigint,
+    endTime bigint,
+    PRIMARY KEY ((shard, bucket), partKey)
+) WITH compression = {'chunk_length_in_kb': '16', 'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+EOF
+
 if [[ "${KEYSP}" != "${FILO_DOWNSAMPLE_KEYSPACE}" ]]; then
 cat << EOF
 

--- a/scripts/schema-truncate.sh
+++ b/scripts/schema-truncate.sh
@@ -37,6 +37,10 @@ TRUNCATE ${KEYSP}.${DSET}_partitionkeys_$SHARD;
 EOF
 done
 
+cat << EOF
+TRUNCATE ${KEYSP}.${DSET}_partitionkeysv2;
+EOF
+
 if [[ "${KEYSP}" != "${FILO_DOWNSAMPLE_KEYSPACE}" ]]; then
 cat << EOF
 TRUNCATE ${KEYSP}.${DSET}_pks_by_update_time;

--- a/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/PerShardCardinalityBuster.scala
@@ -107,7 +107,7 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
           if (!isSimulation) {
             val startNs = System.nanoTime()
             try {
-              colStore.deletePartKeyNoAsync(dataset, shard, pk.partKey)
+              colStore.deletePartKeyNoAsync(dataset, pk.shard, pk.partKey)
             } finally {
               cassDeleteLatency.record(System.nanoTime() - startNs)
             }
@@ -125,7 +125,7 @@ class PerShardCardinalityBuster(dsSettings: DownsamplerSettings,
     }.completedL.runToFuture(BusterSchedulers.computeSched)
     import scala.concurrent.duration._
     Await.result(fut, 1.day)
-    BusterContext.log.info(s"Finished deleting keys from a shard split in shard=$shard " +
+    BusterContext.log.info(s"Finished deleting keys from a shard split=$split in shard=$shard " +
       s"numCandidateKeys=${numCandidateKeys.get()} numDeleted=${numDeleted.get()} " +
       s"numCouldNotDelete=${numCouldNotDelete.get()} isSimulation=$isSimulation")
     numDeleted.get()

--- a/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
@@ -117,8 +117,7 @@ class PartitionKeysCopier(conf: SparkConf) {
       copyStartTime.toEpochMilli(),
       copyEndTime.toEpochMilli(),
       targetCassandraColStore,
-      partKeyHashFn,
-      diskTimeToLiveSeconds.toInt)
+      diskTimeToLiveSeconds)
   }
 
   def shutdown(): Unit = {

--- a/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopierValidator.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopierValidator.scala
@@ -105,6 +105,8 @@ class PartitionKeysCopierValidator(sparkConf: SparkConf) extends StrictLogging {
     var allRecords = new ListBuffer[ExpandedPartKeyRecord]()
     for (split <- splits; shard <- 0 until numOfShards) {
       val tokens = split.asInstanceOf[CassandraTokenRangeSplit].tokens
+      // TODO PartKeys V2 Table handling is not done yet. Needs to be tasked.
+      //  Skipping for now since this does not have a unit test, and is not used in prod yet.
       val srcPartKeysTable = cassandraColumnStore.getOrCreatePartitionKeysTable(datasetRef, shard)
       // CQL does not support OR operator. So we need to query separately to get the timeSeries partitionKeys
       // which were born or died during the data loss period (aka repair window).

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -107,6 +107,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   val pkUpdateHour = hour(lastSampleTime)
 
   val metricNames = Seq(gaugeName, gaugeLowFreqName, counterName, deltaCounterName, histName, deltaHistName, histNameNaN, untypedName)
+  val shard = 0
 
   def hour(millis: Long = System.currentTimeMillis()): Long = millis / 1000 / 60 / 60
 
@@ -488,8 +489,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(untypedPartKeyBytes, 74372801000L, currTime, Some(150))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(untypedPartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it ("should write gauge data to cassandra") {
@@ -529,8 +530,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(gaugePartKeyBytes, 74372801000L, currTime, Some(150))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(gaugePartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it ("should write low freq gauge data to cassandra") {
@@ -568,8 +569,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(gaugeLowFreqPartKeyBytes, 74372801000L, currTime, Some(150))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(gaugeLowFreqPartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it ("should write prom counter data to cassandra") {
@@ -613,8 +614,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(counterPartKeyBytes, 74372801000L, currTime, Some(1))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(counterPartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it("should write delta counter data to cassandra") {
@@ -658,8 +659,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(deltaCounterPartKeyBytes, 74372801000L, currTime, Some(1))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(deltaCounterPartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it("should write additional prom counter partitionKeys with start/endtimes overlapping with original partkey - " +
@@ -673,12 +674,12 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val part = new TimeSeriesPartition(0, Schemas.promCounter, partKey, shardInfo, 1)
 
     counterPartKeyBytes = part.partKeyBytes
-    val pk1 = PartKeyRecord(counterPartKeyBytes, startTime - 3600000, currTime, Some(1))
-    val pk2 = PartKeyRecord(counterPartKeyBytes, startTime + 3600000, currTime, Some(1))
-    val pk3 = PartKeyRecord(counterPartKeyBytes, startTime, currTime + 3600000, Some(1))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk1), 259200, pkUpdateHour + 1).futureValue
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk2), 259200, pkUpdateHour + 3).futureValue
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk3), 259200, pkUpdateHour + 2).futureValue
+    val pk1 = PartKeyRecord(counterPartKeyBytes, startTime - 3600000, currTime, shard)
+    val pk2 = PartKeyRecord(counterPartKeyBytes, startTime + 3600000, currTime, shard)
+    val pk3 = PartKeyRecord(counterPartKeyBytes, startTime, currTime + 3600000, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk1), 259200, pkUpdateHour + 1).futureValue
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk2), 259200, pkUpdateHour + 3).futureValue
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk3), 259200, pkUpdateHour + 2).futureValue
   }
 
   it ("should write prom histogram data to cassandra") {
@@ -723,8 +724,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(histPartKeyBytes, 74372801000L, currTime, Some(199))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(histPartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it("should write delta histogram data to cassandra") {
@@ -769,8 +770,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(deltaHistPartKeyBytes, 74372801000L, currTime, Some(199))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(deltaHistPartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   it ("should write prom histogram data with NaNs to cassandra") {
@@ -819,8 +820,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val chunks = part.makeFlushChunks(offheapMem.blockMemFactory)
 
     rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-    val pk = PartKeyRecord(histNaNPartKeyBytes, 74372801000L, currTime, Some(199))
-    rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), 259200, pkUpdateHour).futureValue
+    val pk = PartKeyRecord(histNaNPartKeyBytes, 74372801000L, currTime, shard)
+    rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), 259200, pkUpdateHour).futureValue
   }
 
   val numShards = dsIndexJobSettings.numShards
@@ -832,17 +833,17 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   it("should simulate bulk part key records being written into raw for migration") {
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val schemas = Seq(Schemas.promHistogram, Schemas.gauge, Schemas.promCounter)
-    case class PkToWrite(pkr: PartKeyRecord, shard: Int, updateHour: Long)
+    case class PkToWrite(pkr: PartKeyRecord, updateHour: Long)
     val pks = for { i <- 0 to 10000 } yield {
       val schema = schemas(i % schemas.size)
       val partKey = partBuilder.partKeyFromObjects(schema, s"bulkmetric$i", bulkSeriesTags)
       val bytes = schema.partKeySchema.asByteArray(UnsafeUtils.ZeroPointer, partKey)
-      PkToWrite(PartKeyRecord(bytes, i, i + 500, Some(-i)), i % numShards,
+      PkToWrite(PartKeyRecord(bytes, i, i + 500, i % numShards),
         bulkPkUpdateHours(i % bulkPkUpdateHours.size))
     }
 
     val rawDataset = Dataset("prometheus", Schemas.promHistogram)
-    pks.groupBy(k => (k.shard, k.updateHour)).foreach { case ((shard, updHour), shardPks) =>
+    pks.groupBy(k => (k.pkr.shard, k.updateHour)).foreach { case ((shard, updHour), shardPks) =>
       rawColStore.writePartKeys(rawDataset.ref, shard, Observable.fromIterable(shardPks).map(_.pkr),
         259200, updHour).futureValue
     }
@@ -1638,7 +1639,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
   it("should verify bulk part key records are all present before card busting") {
 
-    val readKeys = (0 until 4).flatMap { shard =>
+    val readKeys = (0 until numShards).flatMap { shard =>
       val partKeys = downsampleColStore.scanPartKeys(batchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
         shard)
       Await.result(partKeys.map(pkMetricName).toListL.runToFuture, 1 minutes)
@@ -1646,7 +1647,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
     readKeys.size shouldEqual 10008
 
-    val readKeys2 = (0 until 4).flatMap { shard =>
+    val readKeys2 = (0 until numShards).flatMap { shard =>
       val partKeys = rawColStore.scanPartKeys(batchDownsampler.rawDatasetRef, shard)
       Await.result(partKeys.map(pkMetricName).toListL.runToFuture, 1 minutes)
     }.toSet
@@ -1681,7 +1682,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
   it("should verify bulk part key records are absent after card busting by time filter in downsample tables") {
 
-    val readKeys = (0 until 4).flatMap { shard =>
+    val readKeys = (0 until numShards).flatMap { shard =>
       val partKeys = downsampleColStore.scanPartKeys(batchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
         shard)
       Await.result(partKeys.map(pkMetricName).toListL.runToFuture, 1 minutes)
@@ -1690,7 +1691,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     // downsample set should not have a few bulk metrics
     readKeys.size shouldEqual 9907
 
-    val readKeys2 = (0 until 4).flatMap { shard =>
+    val readKeys2 = (0 until numShards).flatMap { shard =>
       val partKeys = rawColStore.scanPartKeys(batchDownsampler.rawDatasetRef, shard)
       Await.result(partKeys.map(pkMetricName).toListL.runToFuture, 1 minutes)
     }.toSet
@@ -1729,7 +1730,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
   it("should verify bulk part key records are absent after deletion in both raw and downsample tables") {
 
-    val readKeys = (0 until 4).flatMap { shard =>
+    val readKeys = (0 until numShards).flatMap { shard =>
       val partKeys = downsampleColStore.scanPartKeys(batchDownsampler.downsampleRefsByRes(FiniteDuration(5, "min")),
         shard)
       Await.result(partKeys.map(pkMetricName).toListL.runToFuture, 1 minutes)
@@ -1738,7 +1739,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     // readKeys should not contain bulk PK records
     readKeys shouldEqual (metricNames.toSet - untypedName)
 
-    val readKeys2 = (0 until 4).flatMap { shard =>
+    val readKeys2 = (0 until numShards).flatMap { shard =>
       val partKeys = rawColStore.scanPartKeys(batchDownsampler.rawDatasetRef, shard)
       Await.result(partKeys.map(pkMetricName).toListL.runToFuture, 1 minutes)
     }.toSet
@@ -1938,8 +1939,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       partition.switchBuffers(offheapMem.blockMemFactory, true)
       val chunks = partition.makeFlushChunks(offheapMem.blockMemFactory)
       rawColStore.write(rawDataset.ref, Observable.fromIteratorUnsafe(chunks)).futureValue
-      val pk = PartKeyRecord(partition.partKeyBytes, startMs, endMs, Some(123))
-      rawColStore.writePartKeys(rawDataset.ref, 0, Observable.now(pk), ttl.toSeconds, pkUpdateHour).futureValue
+      val pk = PartKeyRecord(partition.partKeyBytes, startMs, endMs, shard)
+      rawColStore.writePartKeys(rawDataset.ref, shard, Observable.now(pk), ttl.toSeconds, pkUpdateHour).futureValue
     }
 
     // sanity-check

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -140,7 +140,9 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
   def prepareTestData(colStore: CassandraColumnStore, dataset: Dataset): Unit = {
     val shardStats = new TimeSeriesShardStats(dataset.ref, -1)
 
-    def writePartKeys(pk: PartKeyRecord, shard: Int): Unit = {
+    def writePartKeys(pk: PartKeyRecord,
+                      shard: Int // TODO unused in v2; remove when migration to v2 tables is done
+                     ): Unit = {
       colStore.writePartKeys(dataset.ref, shard, Observable.now(pk), 259200, 0L, false).futureValue
     }
 
@@ -172,22 +174,22 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
        */
 
       gauge1PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge1", getSeriesTags(ws + "1", ns + "1")).partKeyBytes
-      writePartKeys(PartKeyRecord(gauge1PartKeyBytes, 1507923801000L, 1510611624000L, Some(150)), shard)
+      writePartKeys(PartKeyRecord(gauge1PartKeyBytes, 1507923801000L, 1510611624000L, shard), shard)
 
       gauge2PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge2", getSeriesTags(ws + "2", ns + "2")).partKeyBytes
-      writePartKeys(PartKeyRecord(gauge2PartKeyBytes, 1510611624000L, 1602561600000L, Some(150)), shard)
+      writePartKeys(PartKeyRecord(gauge2PartKeyBytes, 1510611624000L, 1602561600000L, shard), shard)
 
       gauge3PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge3", getSeriesTags(ws + "3", ns + "3")).partKeyBytes
-      writePartKeys(PartKeyRecord(gauge3PartKeyBytes, 1602554400000L, 1602561600000L, Some(150)), shard)
+      writePartKeys(PartKeyRecord(gauge3PartKeyBytes, 1602554400000L, 1602561600000L, shard), shard)
 
       gauge4PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge4", getSeriesTags(ws + "4", ns + "4")).partKeyBytes
-      writePartKeys(PartKeyRecord(gauge4PartKeyBytes, 1602561600000L, 1609855200000L, Some(150)), shard)
+      writePartKeys(PartKeyRecord(gauge4PartKeyBytes, 1602561600000L, 1609855200000L, shard), shard)
 
       gauge5PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge5", getSeriesTags(ws + "5", ns + "5")).partKeyBytes
-      writePartKeys(PartKeyRecord(gauge5PartKeyBytes, 1609855200000L, 1610028000000L, Some(150)), shard)
+      writePartKeys(PartKeyRecord(gauge5PartKeyBytes, 1609855200000L, 1610028000000L, shard), shard)
 
       gauge6PartKeyBytes = tsPartition(Schemas.gauge, "my_gauge6", getSeriesTags(ws + "6", ns + "6")).partKeyBytes
-      writePartKeys(PartKeyRecord(gauge6PartKeyBytes, 1507923801000L, 1610028000000L, Some(150)), shard)
+      writePartKeys(PartKeyRecord(gauge6PartKeyBytes, 1507923801000L, 1610028000000L, shard), shard)
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Today, we have one table per shard for storing part keys.
This (work-in-progress) PR explores storing all part keys in one table. 
This is to reduce Cassandra compaction cost incurred due to numerous tables.

All features hidden behind feature flag.

These are the read/write path considerations in the design of Cassandra schema
* should be able to load contents of shard efficiently for index bootstrap
* should be able to read/write single part key efficiently for regular ingestion operations
* Should be able to do cardinality busting
* Should be able to do index migration for downsampling
* Should be able to repair across DCs

TODOs for later:
* Performance Testing
* Data migration plan
