### PR TITLE
fix(core) message use histogram_quantile for max(histogram) queries.

### DIFF
--- a/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
@@ -121,22 +121,26 @@ object RowAggregator {
   def apply(aggrOp: AggregationOperator, params: Seq[Any], schema: ResultSchema): RowAggregator = {
     val valColType = ResultSchema.valueColumnType(schema)
     aggrOp match {
-      case Min      => MinRowAggregator
-      case Max      => MaxRowAggregator
+      case Min if valColType == ColumnType.DoubleColumn => MinRowAggregator
+      case Max if valColType == ColumnType.DoubleColumn => MaxRowAggregator
       case Sum if valColType == ColumnType.DoubleColumn => SumRowAggregator
       case Sum if isHistMax(valColType, schema)            => HistMaxSumAggregator
       case Sum if valColType == ColumnType.HistogramColumn => HistSumRowAggregator
       case Count if valColType == ColumnType.DoubleColumn    => CountRowAggregator.double
       case Count if valColType == ColumnType.HistogramColumn => CountRowAggregator.hist
-      case Group    => GroupRowAggregator
-      case Avg      => AvgRowAggregator
-      case TopK     => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, false)
-      case BottomK  => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, true)
-      case Quantile => new QuantileRowAggregator(params(0).asInstanceOf[Double])
-      case Stdvar   => StdvarRowAggregator
-      case Stddev   => StddevRowAggregator
+      case Group if valColType == ColumnType.DoubleColumn   => GroupRowAggregator
+      case Avg if valColType == ColumnType.DoubleColumn  => AvgRowAggregator
+      case TopK if valColType == ColumnType.DoubleColumn
+                  => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, false)
+      case BottomK if valColType == ColumnType.DoubleColumn
+                  => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, true)
+      case Quantile if valColType == ColumnType.DoubleColumn
+          => new QuantileRowAggregator(params(0).asInstanceOf[Double])
+      case Stdvar if valColType == ColumnType.DoubleColumn  => StdvarRowAggregator
+      case Stddev if valColType == ColumnType.DoubleColumn  => StddevRowAggregator
       case CountValues => new CountValuesRowAggregator(params(0).asInstanceOf[String])
-      case _     => ???
+      case _ => throw new IllegalArgumentException(s"This operation ${aggrOp} is not supported for ${valColType}." +
+      s" Because it does not result in a meaningful query. Please contact us if you have a use case.")
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/RowAggregator.scala
@@ -120,27 +120,33 @@ object RowAggregator {
     */
   def apply(aggrOp: AggregationOperator, params: Seq[Any], schema: ResultSchema): RowAggregator = {
     val valColType = ResultSchema.valueColumnType(schema)
-    aggrOp match {
-      case Min if valColType == ColumnType.DoubleColumn => MinRowAggregator
-      case Max if valColType == ColumnType.DoubleColumn => MaxRowAggregator
-      case Sum if valColType == ColumnType.DoubleColumn => SumRowAggregator
-      case Sum if isHistMax(valColType, schema)            => HistMaxSumAggregator
-      case Sum if valColType == ColumnType.HistogramColumn => HistSumRowAggregator
-      case Count if valColType == ColumnType.DoubleColumn    => CountRowAggregator.double
-      case Count if valColType == ColumnType.HistogramColumn => CountRowAggregator.hist
-      case Group if valColType == ColumnType.DoubleColumn   => GroupRowAggregator
-      case Avg if valColType == ColumnType.DoubleColumn  => AvgRowAggregator
-      case TopK if valColType == ColumnType.DoubleColumn
-                  => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, false)
-      case BottomK if valColType == ColumnType.DoubleColumn
-                  => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, true)
-      case Quantile if valColType == ColumnType.DoubleColumn
-          => new QuantileRowAggregator(params(0).asInstanceOf[Double])
-      case Stdvar if valColType == ColumnType.DoubleColumn  => StdvarRowAggregator
-      case Stddev if valColType == ColumnType.DoubleColumn  => StddevRowAggregator
-      case CountValues => new CountValuesRowAggregator(params(0).asInstanceOf[String])
-      case _ => throw new IllegalArgumentException(s"This operation ${aggrOp} is not supported for ${valColType}." +
-      s" Because it does not result in a meaningful query. Please contact us if you have a use case.")
+    if (valColType == ColumnType.HistogramColumn) {
+      aggrOp match {
+        case Sum if isHistMax(valColType, schema) => HistMaxSumAggregator
+        case Sum   => HistSumRowAggregator
+        case Count => CountRowAggregator.hist
+        case _ => throw new IllegalArgumentException(s"The ${aggrOp} operation is not supported directly for histogram"
+          + s" types. Check if you need to resolve to the individual histogram buckets,"
+          + s"or calculate the rate and histogram_quantile before applying the aggregation. "
+          + s"If you have a genuine use case for this query, please get in touch.")
+      }
+    } else if (valColType == ColumnType.DoubleColumn) {
+      aggrOp match {
+        case Min => MinRowAggregator
+        case Max => MaxRowAggregator
+        case Sum => SumRowAggregator
+        case Count => CountRowAggregator.double
+        case Group => GroupRowAggregator
+        case Avg => AvgRowAggregator
+        case TopK => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, false)
+        case BottomK => new TopBottomKRowAggregator(params(0).asInstanceOf[Double].toInt, true)
+        case Quantile => new QuantileRowAggregator(params(0).asInstanceOf[Double])
+        case Stdvar => StdvarRowAggregator
+        case Stddev => StddevRowAggregator
+        case CountValues => new CountValuesRowAggregator(params(0).asInstanceOf[String])
+      }
+    } else {
+      throw new UnsupportedOperationException(s"The ${aggrOp} operation is not supported for ${valColType}");
     }
   }
 }


### PR DESCRIPTION
max(histogram) is not supported histogram_quantile(1, histogram) may be what users want.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: