### PR TITLE
fix(downsample): wrap all s3-export row keys/values in double-quotes

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -46,8 +46,8 @@ object BatchExporter {
    */
   def getExportLabelValueString(value: String): String = {
     value
-      // escape all single-quotes and commas if they aren't already escaped
-      .replaceAll("""\\(\,|\')|(\,|\')""", """\\$1$2""")
+      // escape all double-quotes if they aren't already escaped
+      .replaceAll("""\\(\")|(\")""", """\\$1$2""")
   }
 }
 
@@ -220,7 +220,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
   private def makeLabelString(labels: collection.Map[String, String]): String = {
     val inner = labels
       .map {case (k, v) => (k, getExportLabelValueString(v))}
-      .map {case (k, v) => s"'$k':'$v'"}
+      .map {case (k, v) => s""""$k":"$v""""}
       .mkString (",")
     s"{$inner}"
   }

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -377,7 +377,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     batchExporter.getPartitionByValues(labels).toSeq shouldEqual expected
   }
 
-  it ("should correctly escape quotes in a label's value prior to export") {
+  it ("should correctly escape double-quotes in a label's value prior to export") {
     val inputOutputPairs = Map(
       // empty string
       "" -> "",
@@ -385,51 +385,52 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       """ abc """ -> """ abc """,
       // ======= DOUBLE QUOTES =======
       // single double-quote
-      """ " """ -> """ " """,
+      """ " """ -> """ \" """,
       // double-quote pair
-      """ "" """ -> """ "" """,
+      """ "" """ -> """ \"\" """,
       // escaped quote
       """ \" """ -> """ \" """,
       // double-escaped quote
       """ \\" """ -> """ \\" """,
       // double-escaped quote pair
-      """ \\"" """ -> """ \\"" """,
+      """ \\"" """ -> """ \\"\" """,
       // complex string
-      """ "foo\" " ""\""\ bar "baz" """ -> """ "foo\" " ""\""\ bar "baz" """,
+      """ "foo\" " ""\""\ bar "baz" """ -> """ \"foo\" \" \"\"\"\"\ bar \"baz\" """,
       // ======= SINGLE QUOTES =======
       // single single-quote
-      """ ' """ -> """ \' """,
+      """ ' """ -> """ ' """,
       // single-quote pair
-      """ '' """ -> """ \'\' """,
+      """ '' """ -> """ '' """,
       // escaped quote
       """ \' """ -> """ \' """,
       // double-escaped quote
       """ \\' """ -> """ \\' """,
       // double-escaped quote pair
-      """ \\'' """ -> """ \\'\' """,
+      """ \\'' """ -> """ \\'' """,
       // complex string
-      """ 'foo\' ' ''\''\ bar 'baz' """ -> """ \'foo\' \' \'\'\'\'\ bar \'baz\' """,
+      """ 'foo\' ' ''\''\ bar 'baz' """ -> """ 'foo\' ' ''\''\ bar 'baz' """,
       // ======= COMMAS =======
       // single single-quote
-      """ , """ -> """ \, """,
+      """ , """ -> """ , """,
       // single-quote pair
-      """ ,, """ -> """ \,\, """,
+      """ ,, """ -> """ ,, """,
       // escaped quote
       """ \, """ -> """ \, """,
       // double-escaped quote
       """ \\, """ -> """ \\, """,
       // double-escaped quote pair
-      """ \\,, """ -> """ \\,\, """,
+      """ \\,, """ -> """ \\,, """,
       // complex string
-      """ 'foo\' ' ''\''\ bar 'baz' """ -> """ \'foo\' \' \'\'\'\'\ bar \'baz\' """,
+      """ ,foo\, , ,,\,,\ bar ,baz, """ -> """ ,foo\, , ,,\,,\ bar ,baz, """,
       // ======= COMBINATION =======
-      """ 'foo\" ' "'\'"\ bar 'baz" """ -> """ \'foo\" \' "\'\'"\ bar \'baz" """,
-      """ 'foo\" ' ,, "'\'"\ bar 'baz" \, """ -> """ \'foo\" \' \,\, "\'\'"\ bar \'baz" \, """,
-      """ ["foo","ba'r:1234"] """ -> """ ["foo"\,"ba\'r:1234"] """,
-      """ "foo,bar:1234" """ -> """ "foo\,bar:1234" """
+      """ 'foo\" ' "'\'"\ bar 'baz" """ -> """ 'foo\" ' \"'\'\"\ bar 'baz\" """,
+      """ 'foo\" ' ,, "'\'"\ bar 'baz" \, """ -> """ 'foo\" ' ,, \"'\'\"\ bar 'baz\" \, """,
+      """ ["foo","ba'r:1234"] """ -> """ [\"foo\",\"ba'r:1234\"] """,
+      """ "foo,bar:1234" """ -> """ \"foo,bar:1234\" """
     )
     for ((value, expected) <- inputOutputPairs) {
-      BatchExporter.getExportLabelValueString(value) shouldEqual expected
+      val output = BatchExporter.getExportLabelValueString(value)
+      output shouldEqual expected
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, keys/values are wrapped in either single- or double-quotes depending on whether-or-not the string contains any commas. This PR instead wraps _all_ keys/values in double-quotes. Additionally, only unescaped double-quotes are escaped before each string is surrounded by double-quotes.