### PR TITLE
misc(query): treat all double columns except delta as cumulative for rate func

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -144,7 +144,7 @@ filodb {
     }
 
     delta-counter {
-      columns = ["timestamp:ts", "count:double:detectDrops=false"]
+      columns = ["timestamp:ts", "count:double:{detectDrops=false,delta=true}"]
       value-column = "count"
       downsamplers = ["tTime(0)", "dSum(1)"]
       downsample-period-marker = "time(0)"
@@ -165,9 +165,9 @@ filodb {
 
     delta-histogram {
       columns = ["timestamp:ts",
-        "sum:double:detectDrops=false",
-        "count:double:detectDrops=false",
-        "h:hist:counter=false"]
+        "sum:double:{detectDrops=false,delta=true}",
+        "count:double:{detectDrops=false,delta=true}",
+        "h:hist:{counter=false,delta=true}"]
       value-column = "h"
       downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "hSum(3)"]
       downsample-period-marker = "time(0)"

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -247,9 +247,7 @@ final case class Schema(partition: PartitionSchema, data: DataSchema, var downsa
 
   /** Returns ColumnInfos from a set of column IDs.  Throws exception if ID is invalid */
   def infosFromIDs(ids: Seq[ColumnId]): Seq[ColumnInfo] =
-    ids.map(columnFromID).map { c => ColumnInfo(c.name, c.columnType,
-      isCumulative = c.params.as[Option[Boolean]]("detectDrops").getOrElse(true)
-                        || c.params.as[Option[Boolean]]("counter").getOrElse(false)) }
+    ids.map(columnFromID).map(ColumnInfo.apply)
 
   override final def toString: String = {
     s"Schema(partition=$partition, data=$data, downsample=${downsample.map(_.name)})"

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -38,11 +38,9 @@ final case class ColumnInfo(name: String, colType: Column.ColumnType, isCumulati
 object ColumnInfo {
   def apply(col: Column): ColumnInfo = ColumnInfo(col.name, col.columnType, isCumulative(col))
   private def isCumulative(col: Column): Boolean = {
-    // untyped metrics are treated as cumulative counters for the sake of rate/increase
-    // functions (backward compatibility).
-    // detectDrops is not set for untyped metrics, so isCumulative is evaluated to true if detectDrops is missing.
-    col.params.as[Option[Boolean]]("detectDrops").getOrElse(true) ||
-      col.params.as[Option[Boolean]]("counter").getOrElse(false)
+    // only columns with param delta=true are treated as delta/period counters and rate/increase functions are applied
+    // accordingly.
+    !col.params.as[Option[Boolean]]("delta").getOrElse(false)
   }
 }
 

--- a/core/src/test/scala/filodb.core/metadata/ColumnSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/ColumnSpec.scala
@@ -1,7 +1,7 @@
 package filodb.core.metadata
 
 import com.typesafe.config.ConfigFactory
-
+import filodb.core.query.ColumnInfo
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -15,6 +15,8 @@ class ColumnSpec extends AnyFunSpec with Matchers {
                                   ConfigFactory.parseString("counter = true"))
   val histColumn2 = DataColumn(4, "h2", ColumnType.HistogramColumn,
                                ConfigFactory.parseString("counter = true\nsize=20000"))
+  val deltaCountColumn = DataColumn(5, "dc", ColumnType.HistogramColumn,
+    ConfigFactory.parseString("{counter = false, delta = true}"))
 
   describe("Column validations") {
     it("should check that regular column names don't have : in front") {
@@ -42,6 +44,14 @@ class ColumnSpec extends AnyFunSpec with Matchers {
       DataColumn.fromString(ageColumn.toString) should equal (ageColumn)
       DataColumn.fromString(histColumnOpts.toString) should equal (histColumnOpts)
       DataColumn.fromString(histColumn2.toString) should equal (histColumn2)
+      DataColumn.fromString(deltaCountColumn.toString) should equal (deltaCountColumn)
+    }
+    it("check delta param") {
+      ColumnInfo(firstColumn).isCumulative should equal (true)
+      ColumnInfo(ageColumn).isCumulative should equal (true)
+      ColumnInfo(histColumnOpts).isCumulative should equal (true)
+      ColumnInfo(histColumn2).isCumulative should equal (true)
+      ColumnInfo(deltaCountColumn).isCumulative should equal (false)
     }
   }
 }


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

Add param `delta=true` to delta-counter/delta-histogram to denote the columns are periodic/delta temporal metrics. While querying this param is used to determine whether to apply prom-rate/increase function or non-cumulative rate/increase variant.