### PR TITLE
fix(query) Long lookback queries with or vector() operations fail to materialize

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -1530,4 +1530,45 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
     validatePlan(ep, expectedPlan)
 
   }
-}
+
+  it("Materializing Binary join with or vector(0) with long look back should not throw error") {
+      val now = 1634777330123L
+      val start = now / 1000 - 8.days.toSeconds
+      val step = 1.minute.toSeconds
+      val end = now / 1000 - 2.minutes.toSeconds
+
+      val rawRetention = 7.days // 7 days
+      val downsampleRetention = 183.days
+      val earliestRawTime = now - rawRetention.toMillis
+      val earliestDownSampleTime = now - downsampleRetention.toMillis
+      // making sure that the  latestDownsampleTime is not a multiple of 1000
+      val latestDownsampleTime = now - 6.hours.toMillis + 123
+
+      val query = """sum(rate(bar{job= "app"}[30d])) or vector(0)"""
+
+      val logicalPlan = Parser.queryRangeToLogicalPlan(query,
+        TimeStepParams(start, step, end))
+        .asInstanceOf[PeriodicSeriesPlan]
+
+      val rawPlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
+        earliestRetainedTimestampFn = earliestRawTime, queryConfig, "raw")
+      val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
+        earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
+      val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+        earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
+
+      val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
+
+      val expected = """T~InstantVectorFunctionMapper(function=OrVectorDouble)
+                        |-FA1~StaticFuncArgs(0.0,RangeParams(1634086130,60,1634755730))
+                        |-T~AggregatePresenter(aggrOp=Sum, aggrParams=List(), rangeParams=RangeParams(1634086130,60,1634755730))
+                        |--E~LocalPartitionReduceAggregateExec(aggrOp=Sum, aggrParams=List()) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1823110189],downsample)
+                        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+                        |----T~PeriodicSamplesMapper(start=1634086130000, step=60000, end=1634755730000, window=Some(2592000000), functionId=Some(Rate), rawSource=true, offsetMs=None)
+                        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=11, chunkMethod=TimeRangeChunkScan(1631494130000,1634755730000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(bar))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1823110189],downsample)
+                        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+                        |----T~PeriodicSamplesMapper(start=1634086130000, step=60000, end=1634755730000, window=Some(2592000000), functionId=Some(Rate), rawSource=true, offsetMs=None)
+                        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=27, chunkMethod=TimeRangeChunkScan(1631494130000,1634755730000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(bar))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1823110189],downsample)""".stripMargin
+      validatePlan(ep, expected)
+    }
+  }


### PR DESCRIPTION
Queries like `sum(rate(foo{}[long look back])) or vector(0)` fail to materialize. This is a `BinaryJoin` with `rhs`  having  a `ScalarFixedDoublePlan`. Long time range planner for long lookbacks exceeding raw cluster retention get pushed down to downsample cluster and changes the end time. Following code in LongTimeRangePlanner specifically did this update to end time

```
copyLogicalPlanWithUpdatedTimeRange(periodicSeriesPlan,
          TimeRange(periodicSeriesPlan.startMs, latestDownsampleTimestampFn + offsetMillis.min))
```

The issue however comes from the fact that ``ScalarFixedDoublePlan`` uses seconds precision but `lhs` of the `BinaryJoin` stores the milliseconds for end time without truncation which causes the assertion in `BinaryJoin` to check the end date to fail.

Since `latestDownsampleTimestampFn` is the latest downsample time in milliseconds and we support a minimum  granularity between samples to a second, we truncate this time to latest second dropping the 1/1000th seconds .

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
