### PR TITLE
perf(coord): Improve performance of result streaming

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -1,8 +1,5 @@
 package filodb.coordinator
 
-import java.lang.Thread.UncaughtExceptionHandler
-import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
-
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.{Failure, Success}
@@ -11,13 +8,10 @@ import scala.util.control.NonFatal
 import akka.actor.{ActorRef, Props}
 import akka.pattern.AskTimeoutException
 import kamon.Kamon
-import kamon.instrumentation.executor.ExecutorInstrumentation
 import kamon.tag.TagSet
 import monix.catnap.CircuitBreaker
 import monix.eval.Task
-import monix.execution.Scheduler
 import monix.execution.exceptions.ExecutionRejectedException
-import monix.execution.schedulers.SchedulerService
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 
@@ -33,7 +27,6 @@ import filodb.core.query.QuerySession
 import filodb.core.query.QueryStats
 import filodb.core.query.SerializedRangeVector
 import filodb.core.store.CorruptVectorException
-import filodb.memory.data.Shutdown
 import filodb.query._
 import filodb.query.exec.{ExecPlan, InProcessPlanDispatcher, PlanDispatcher}
 
@@ -88,7 +81,7 @@ final class QueryActor(memStore: TimeSeriesStore,
   val queryPlanner = new SingleClusterPlanner(dataset, schemas, shardMapFunc,
                                               earliestRawTimestampFn, queryConfig, "raw",
                                               functionalSpreadProvider)
-  val queryScheduler = createInstrumentedQueryScheduler()
+  val queryScheduler = QueryScheduler.queryScheduler
 
   private val tags = Map("dataset" -> dsRef.toString)
   private val lpRequests = Kamon.counter("queryactor-logicalPlan-requests").withTags(TagSet.from(tags))
@@ -109,47 +102,6 @@ final class QueryActor(memStore: TimeSeriesStore,
     onHalfOpen = Task.eval(logger.info("Query CircuitBreaker is now half-open")),
     onOpen = Task.eval(logger.info("Query CircuitBreaker is now open"))
   )
-
-  /**
-    * Instrumentation adds following metrics on the Query Scheduler
-    *
-    * # Counter
-    * executor_tasks_submitted_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
-    * # Counter
-    * executor_tasks_completed_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
-    * # Histogram
-    * executor_threads_active{type="ThreadPoolExecutor",name="query-sched-prometheus"}
-    * # Histogram
-    * executor_queue_size_count{type="ThreadPoolExecutor",name="query-sched-prometheus"}
-    *
-    */
-  private def createInstrumentedQueryScheduler(): SchedulerService = {
-    val numSchedThreads = Math.ceil(config.getDouble("filodb.query.threads-factor")
-                                      * sys.runtime.availableProcessors).toInt
-    val schedName = s"$QuerySchedName-$dsRef"
-    val exceptionHandler = new UncaughtExceptionHandler {
-      override def uncaughtException(t: Thread, e: Throwable): Unit = {
-        logger.error("Uncaught Exception in Query Scheduler", e)
-        uncaughtExceptions.increment()
-        e match {
-          case ie: InternalError => Shutdown.haltAndCatchFire(ie)
-          case _ => { /* Do nothing. */ }
-        }
-      }
-    }
-    val threadFactory = new ForkJoinPool.ForkJoinWorkerThreadFactory {
-      def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
-        val thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
-        thread.setDaemon(true)
-        thread.setUncaughtExceptionHandler(exceptionHandler)
-        thread.setName(s"$schedName-${thread.getPoolIndex}")
-        thread
-      }
-    }
-    val executor = new ForkJoinPool( numSchedThreads, threadFactory, exceptionHandler, true)
-
-    Scheduler.apply(ExecutorInstrumentation.instrument(executor, schedName))
-  }
 
   // scalastyle:off method.length
   def execPhysicalPlan2(q: ExecPlan, replyTo: ActorRef): Unit = {
@@ -172,7 +124,7 @@ final class QueryActor(memStore: TimeSeriesStore,
         val execTask = if (querySession.streamingDispatch) {
           q.executeStreaming(memStore, querySession)(queryScheduler)
             .onErrorHandle { t =>
-              StreamQueryError(q.queryContext.queryId, querySession.queryStats, t)
+              StreamQueryError(q.queryContext.queryId, q.planId, querySession.queryStats, t)
             }.map { resp =>
               // Avoiding the assert when the InProcessPlanDispatcher is used. As it runs
               // the query on the current/Actor thread instead of the scheduler
@@ -227,7 +179,7 @@ final class QueryActor(memStore: TimeSeriesStore,
               case t: ExecutionRejectedException =>
                 logQueryErrors(t)
                 if (querySession.streamingDispatch)
-                  replyTo ! StreamQueryError(q.queryContext.queryId, querySession.queryStats, t)
+                  replyTo ! StreamQueryError(q.queryContext.queryId, q.planId, querySession.queryStats, t)
                 else
                   replyTo ! QueryError(q.queryContext.queryId, querySession.queryStats, t)
               case _ => // all other errors are already handled

--- a/coordinator/src/main/scala/filodb.coordinator/QueryScheduler.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryScheduler.scala
@@ -1,0 +1,63 @@
+package filodb.coordinator
+
+
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
+
+import com.typesafe.scalalogging.StrictLogging
+import kamon.instrumentation.executor.ExecutorInstrumentation
+import monix.execution.Scheduler
+import monix.execution.schedulers.SchedulerService
+
+import filodb.core.GlobalConfig
+import filodb.core.memstore.FiloSchedulers.QuerySchedName
+import filodb.memory.data.Shutdown
+
+object QueryScheduler extends StrictLogging {
+
+
+  val queryScheduler = createInstrumentedQueryScheduler()
+
+  /**
+   * Instrumentation adds following metrics on the Query Scheduler
+   *
+   * # Counter
+   * executor_tasks_submitted_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+   * # Counter
+   * executor_tasks_completed_total{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+   * # Histogram
+   * executor_threads_active{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+   * # Histogram
+   * executor_queue_size_count{type="ThreadPoolExecutor",name="query-sched-prometheus"}
+   *
+   */
+  private def createInstrumentedQueryScheduler(): SchedulerService = {
+    val numSchedThreads = Math.ceil(GlobalConfig.systemConfig.getDouble("filodb.query.threads-factor")
+      * sys.runtime.availableProcessors).toInt
+    val schedName = s"$QuerySchedName"
+    val exceptionHandler = new UncaughtExceptionHandler {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = {
+        logger.error("Uncaught Exception in Query Scheduler", e)
+        e match {
+          case ie: InternalError => Shutdown.haltAndCatchFire(ie)
+          case _ => {
+            /* Do nothing. */
+          }
+        }
+      }
+    }
+    val threadFactory = new ForkJoinPool.ForkJoinWorkerThreadFactory {
+      def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
+        val thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
+        thread.setDaemon(true)
+        thread.setUncaughtExceptionHandler(exceptionHandler)
+        thread.setName(s"$schedName-${thread.getPoolIndex}")
+        thread
+      }
+    }
+    val executor = new ForkJoinPool(numSchedThreads, threadFactory, exceptionHandler, true)
+
+    Scheduler.apply(ExecutorInstrumentation.instrument(executor, schedName))
+  }
+
+}

--- a/coordinator/src/main/scala/filodb.coordinator/ResultActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ResultActor.scala
@@ -1,0 +1,33 @@
+package filodb.coordinator
+
+import akka.actor.Props
+import monix.reactive.MulticastStrategy
+import monix.reactive.subjects.ConcurrentSubject
+
+import filodb.coordinator.ActorSystemHolder.system
+import filodb.query.Query.qLogger
+import filodb.query.StreamQueryResponse
+
+
+object ResultActor {
+  def props(subject: ConcurrentSubject[StreamQueryResponse, StreamQueryResponse]): Props =
+    Props(classOf[ResultActor], subject)
+  lazy val subject = ConcurrentSubject[StreamQueryResponse](MulticastStrategy.Publish)(QueryScheduler.queryScheduler)
+  lazy val resultActor = system.actorOf(Props(new ResultActor(subject)))
+}
+
+class ResultActor(subject: ConcurrentSubject[StreamQueryResponse, StreamQueryResponse]) extends BaseActor {
+
+  def receive: Receive = {
+    case q: StreamQueryResponse =>
+      try {
+        subject.onNext(q)
+        qLogger.debug(s"Result Actor got ${q.getClass} as response from ${sender()}")
+      } catch {
+        case e: Throwable =>
+          qLogger.error(s"Exception when processing $q", e)
+      }
+    case msg =>
+      qLogger.error(s"Unexpected message $msg in ResultActor from sender ${sender()}")
+  }
+}

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -283,6 +283,10 @@ filodb {
     # feature flag for query result streaming
     streaming-query-results-enabled = false
 
+    # Number of result RVs per streaming result message
+    # Applies when streaming is enabled
+    num-rvs-per-result-message = 250
+
     translate-prom-to-filodb-histogram = true
     # Timeout for query engine subtree/ExecPlans for requests to sub nodes
     # Higher default until we have a way to really timeout query execution at leaves

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -22,12 +22,13 @@ object QueryConfig {
     val allowPartialResultsRangeQuery = queryConfig.getBoolean("allow-partial-results-rangequery")
     val grpcDenyList = queryConfig.getString("grpc.partitions-deny-list")
     val containerOverrides = queryConfig.as[Map[String, Int]]("container-size-overrides")
+    val numRvsPerResultMessage = queryConfig.getInt("num-rvs-per-result-message")
     QueryConfig(askTimeout, staleSampleAfterMs, minStepMs, fastReduceMaxWindows, parser, translatePromToFilodbHistogram,
       fasterRateEnabled, routingConfig.as[Option[String]]("partition_name"),
       routingConfig.as[Option[Long]]("remote.http.timeout"),
       routingConfig.as[Option[String]]("remote.http.endpoint"),
       routingConfig.as[Option[String]]("remote.grpc.endpoint"),
-      enforceResultByteLimit,
+      numRvsPerResultMessage, enforceResultByteLimit,
       allowPartialResultsRangeQuery, allowPartialResultsMetadataQuery,
       grpcDenyList.split(",").map(_.trim.toLowerCase).toSet,
       None,
@@ -68,6 +69,7 @@ case class QueryConfig(askTimeout: FiniteDuration,
                        remoteHttpTimeoutMs: Option[Long],
                        remoteHttpEndpoint: Option[String],
                        remoteGrpcEndpoint: Option[String],
+                       numRvsPerResultMessage: Int = 100,
                        enforceResultByteLimit: Boolean = false,
                        allowPartialResultsRangeQuery: Boolean = false,
                        allowPartialResultsMetadataQuery: Boolean = true,

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -110,6 +110,7 @@ filodb {
   }
   query {
     streaming-query-results-enabled = false
+    num-rvs-per-result-message = 25
     ask-timeout = 10 seconds
     stale-sample-after = 5 minutes
     sample-limit = 1000000

--- a/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
+++ b/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
@@ -131,6 +131,7 @@ class PromQLGrpcServer(queryPlannerSelector: String => QueryPlanner,
                         SerializedRangeVector.apply(irv, rb,
                           SerializedRangeVector.toSchema(qres.resultSchema.columns, qres.resultSchema.brSchemas),
                           "GrpcServer", qres.queryStats)
+                      case result => result
                     })
                     span.mark("onNext of the streaming result called")
                     responseObserver.onNext(strQueryResult.toProto)

--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -107,7 +107,7 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
 
             val newPlan = SelectRawPartitionsExec(queryContext, dispatcher, dataset,
                                                   Some(sch), Some(lookupRes),
-                                                  schema.isDefined, colIDs)
+                                                  schema.isDefined, colIDs, planId)
             qLogger.debug(s"Discovered schema ${sch.name} and created inner plan $newPlan")
             newxformers.foreach { xf => newPlan.addRangeVectorTransformer(xf) }
             newPlan
@@ -115,7 +115,7 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
             qLogger.debug(s"No time series found for filters $filters... employing empty plan")
             SelectRawPartitionsExec(queryContext, dispatcher, dataset,
                                     None, Some(lookupRes),
-                                    schema.isDefined, Nil)
+                                    schema.isDefined, Nil, planId)
           }
   }
   // scalastyle:on method.length

--- a/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SelectRawPartitionsExec.scala
@@ -111,7 +111,8 @@ final case class SelectRawPartitionsExec(queryContext: QueryContext,
                                          dataSchema: Option[Schema],
                                          lookupRes: Option[PartLookupResult],
                                          filterSchemas: Boolean,
-                                         colIds: Seq[Types.ColumnId]) extends LeafExecPlan {
+                                         colIds: Seq[Types.ColumnId],
+                                         override val planId: String) extends LeafExecPlan {
   def dataset: DatasetRef = datasetRef
 
   private def schemaOfDoExecute(): ResultSchema = {

--- a/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
@@ -99,7 +99,7 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
           queryParams.promQl match {
             case """foo{app="app1"}"""  => sendNonEmptyTestResponse.foreach(x => responseObserver.onNext(x.toProto))
             case """error_metric{app="app1"}""" => responseObserver.onNext(
-                  StreamQueryError("errorId", QueryStats(), new Throwable("Inevitable has happened")).toProto)
+                  StreamQueryError("errorId", "planId", QueryStats(), new Throwable("Inevitable has happened")).toProto)
             case _                      => // empty results
           }
           responseObserver.onCompleted()
@@ -107,7 +107,7 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   private def sendNonEmptyTestResponse: Seq[StreamQueryResponse] = {
-    val header = StreamQueryResultHeader("someId", resultSchema)
+    val header = StreamQueryResultHeader("someId", "planId", resultSchema)
 
 
     val builder = SerializedRangeVector.newBuilder()
@@ -122,11 +122,11 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
       RvRange(0, 100, 1000))
     val stats = QueryStats()
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", stats)
-    val streamingQueryBody = StreamQueryResult("someId", srv)
+    val streamingQueryBody = StreamQueryResult("someId", "planId", Seq(srv))
 
     val warnings = QueryWarnings()
 
-    val footer = StreamQueryResultFooter("someId", stats, warnings, true, Some("Reason"))
+    val footer = StreamQueryResultFooter("someId", "planId", stats, warnings, true, Some("Reason"))
     Seq(header, streamingQueryBody, footer)
   }
 
@@ -140,13 +140,11 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it ("should convert the streaming records from gRPC service to a QueryResponse with data") {
 
-
     val params = PromQlQueryParams("""foo{app="app1"}""", 0, 0, 0)
     val queryContext = QueryContext(origQueryParams = params)
     val session = QuerySession(queryContext, QueryConfig.unitTestingQueryConfig)
 
     val exec = PromQLGrpcRemoteExec(channel, 60000, queryContext, dispatcher, timeseriesDataset.ref, "plannerSelector")
-
 
     val qr = exec.execute(UnsupportedChunkSource(), session).runToFuture.futureValue.asInstanceOf[QueryResult]
     qr.resultSchema shouldEqual resultSchema
@@ -189,6 +187,5 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
     er.queryStats shouldEqual QueryStats()
     er.t.getMessage shouldEqual "Inevitable has happened"
   }
-
 
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?


Improve performance of Query Result Streaming by 

1. Adding multiple (configurable number) RVs within one streaming StreamQueryResult  message. This was needed since performance tests with one RV per akka message created a bottleneck in Akka Remoting. `[2023-03-23 12:45:13,666] WARN  filo-standalone-akka.actor.default-dispatcher-34 akka.remote.EndpointWriter [akka.tcp://filo-standalone@127.0.0.1:2552/system/endpointManager/reliableEndpointWriter-akka.tcp%3A%2F%2Ffilo-standalone%40127.0.0.1%3A63524-1/endpointWriter] - [79284] buffered messages in EndpointWriter for [akka.tcp://filo-standalone@127.0.0.1:63524]. You should probably implement flow control to avoid flooding the remote connection.`
2. Use one result actor to receive streaming query results from callee. Since there was a overload of `LocalActorRef`s in heap dumps. This required (a) externalizing QueryScheduler outside of QueryActor so it can be used from ResultActor as well. (b) Adding new unique planId UUID to each execPlan so we can distinguish between streamed query results across various plans and route it to the right consumer query pipeline. 
3. Invoke child plans in parallel rather than sequential

With this change I was able to bring performance of raw query throughput and latency on one-node-setup on par with non-streaming solution. More iterations are needed to improve the performance. The bottleneck appears to arise from the fact that Prom HTTP API is non-streaming and requires accumulation of new swaths of data in memory. In any case, FiloDB is relieved from this and would be more reliable than without streaming.

Briefly here are the remaining TODOs:
1. On a setup with one FiloDB, and one query facade service node, I was able to see equivalent latencies for 5QPS. There was improved GC performance on FiloDB, but increased memory usage on Query Facade process. Scaling streaming setup to 6QPS produced more timeouts than fat response.
2. There are some functional issues on Apple M1. The query monix pipeline seems to be canceled abruptly. Whereas the same setup in Intel-Mac works functionally.
3. There is probably a lurking bug when I occasional see some additional result RVs than expected.

