### PR TITLE
feat(downsample): support data-shape metrics from DS shards

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -22,9 +22,9 @@ final case class DownsampleConfig(config: Config) {
    * If enabled, stats about downsampled data will be collected/published as the index is bootstrapped/refreshed.
    * These stats describe the data's "shape", e.g. label/value lengths and histogram bucket counts.
    */
-  val enableDataShapeStats = if (config.hasPath("enableDataShapeStats")) {
-                               config.as[Boolean]("enableDataShapeStats")
-                             } else false
+  val enableDataShapeStats = if (config.hasPath("enable-data-shape-stats")) {
+    config.as[Boolean]("enable-data-shape-stats")
+  } else false
 
   /**
     * TTL for downsampled data for the resolutions in same order

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -19,6 +19,14 @@ final case class DownsampleConfig(config: Config) {
                     else Seq.empty
 
   /**
+   * If enabled, stats about downsampled data will be collected/published as the index is bootstrapped/refreshed.
+   * These stats describe the data's "shape", e.g. label/value lengths and histogram bucket counts.
+   */
+  val enableDataShapeStats = if (config.hasPath("enableDataShapeStats")) {
+                               config.as[Boolean]("enableDataShapeStats")
+                             } else false
+
+  /**
     * TTL for downsampled data for the resolutions in same order
     */
   val ttls = if (config.hasPath ("ttls")) config.as[Seq[FiniteDuration]]("ttls")

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -58,6 +58,15 @@ final case class DownsampleConfig(config: Config) {
    * A sequence of label keys that constitute a "data-shape" key.
    * A series' corresponding label values are used to determine whether-or-not its data-shape stats are published.
    * Additionally, stats are published against these labels iff enable-data-shape-key-labels=true.
+   *
+   * For example:
+   *   data-shape-key=[labelA, labelB]
+   *   data-shape-allow=[[valueA1, valueB1], [valueA2]]
+   *   data-shape-block=[[valueA2, valueB2]]
+   *
+   *   --> Metrics are published for all series with labelA=valueA1,labelB=valueB1
+   *       and all with labelA=valueA2 except where labelB=valueB2. Additionally, metrics
+   *       are published with labelA=value and labelB=value tags iff enable-data-shape-key-labels=true.
    */
   val dataShapeKey = config.getOrElse[Seq[String]]("data-shape-key", Seq())
 

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -19,6 +19,7 @@ final case class DownsampleConfig(config: Config) {
   val resolutions = if (config.hasPath ("resolutions")) config.as[Seq[FiniteDuration]]("resolutions")
                     else Seq.empty
 
+  // FIXME: just initially create a immutable trie and remove this method.
   /**
    * DFS through nested mutable Maps, and return an equivalent tree of nested immutable Maps.
    */
@@ -32,10 +33,10 @@ final case class DownsampleConfig(config: Config) {
   }
 
   /**
-   * Convert data-shape keys into a map, where exactly the set of unique keys is described
-   *   by the set of unique paths through the maps.
+   * Convert data-shape keys into a trie, where exactly the set of unique keys is described
+   *   by the set of unique paths through the trie.
    */
-  private def dataShapeKeysToMap(keys: Seq[Seq[String]]): Map[String, Any] = {
+  private def dataShapeKeysToTrie(keys: Seq[Seq[String]]): Map[String, Any] = {
     val map = new mutable.HashMap[String, Any]
     for (key <- keys) {
       var ptr = map
@@ -80,9 +81,9 @@ final case class DownsampleConfig(config: Config) {
    *
    * Each sequence can have a length less than the length of a key.
    */
-  val dataShapeAllow: Map[String, Any] = dataShapeKeysToMap(
+  val dataShapeAllowTrie: Map[String, Any] = dataShapeKeysToTrie(
     config.getOrElse[Seq[Seq[String]]]("data-shape-allow", Seq()))
-  val dataShapeBlock: Map[String, Any] = dataShapeKeysToMap(
+  val dataShapeBlockTrie: Map[String, Any] = dataShapeKeysToTrie(
     config.getOrElse[Seq[Seq[String]]]("data-shape-block", Seq()))
 
   /**

--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -1,12 +1,12 @@
 package filodb.core.downsample
 
+import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
+
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
+
 import filodb.core.DatasetRef
-
-
-import scala.collection.mutable
 
 object IndexMetastoreImplementation extends Enumeration {
   val NoImp, File, Ephemeral = Value
@@ -80,8 +80,10 @@ final case class DownsampleConfig(config: Config) {
    *
    * Each sequence can have a length less than the length of a key.
    */
-  val dataShapeAllow: Map[String, Any] = dataShapeKeysToMap(config.getOrElse[Seq[Seq[String]]]("data-shape-allow", Seq()))
-  val dataShapeBlock: Map[String, Any] = dataShapeKeysToMap(config.getOrElse[Seq[Seq[String]]]("data-shape-block", Seq()))
+  val dataShapeAllow: Map[String, Any] = dataShapeKeysToMap(
+    config.getOrElse[Seq[Seq[String]]]("data-shape-allow", Seq()))
+  val dataShapeBlock: Map[String, Any] = dataShapeKeysToMap(
+    config.getOrElse[Seq[Seq[String]]]("data-shape-block", Seq()))
 
   /**
    * A bucket-count data-shape metric is published iff this is true.

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -107,7 +107,7 @@ private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, fa
 
   // used for initial index loading
   private val indexBootstrapper =
-    new DownsampleIndexBootstrapper(store, schemas, stats, rawDatasetRef, downsampleConfig)
+    new DownsampleIndexBootstrapper(store, schemas, stats, indexDataset, downsampleConfig)
 
   private val housekeepingSched = Scheduler.computation(
     name = "housekeeping",

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -43,6 +43,19 @@ class DownsampledTimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
     MeasurementUnit.time.milliseconds).withTags(TagSet.from(tags))
   val purgeIndexEntriesLatency = Kamon.histogram("downsample-store-purge-index-entries-latency",
     MeasurementUnit.time.milliseconds).withTags(TagSet.from(tags))
+
+  val dataShapeKeyLength = Kamon.histogram("data-shape")
+    .withTags(TagSet.from(tags)).withTag("dimension", "key-length")
+  val dataShapeValueLength = Kamon.histogram("data-shape")
+    .withTags(TagSet.from(tags)).withTag("dimension", "value-length")
+  val dataShapeLabelCount = Kamon.histogram("data-shape")
+    .withTags(TagSet.from(tags)).withTag("dimension", "label-count")
+  val dataShapeMetricLength = Kamon.histogram("data-shape")
+    .withTags(TagSet.from(tags)).withTag("dimension", "metric-length")
+  val dataShapeTotalLength = Kamon.histogram("data-shape")
+    .withTags(TagSet.from(tags)).withTag("dimension", "total-length")
+  val dataShapeBucketCount = Kamon.histogram("data-shape")
+    .withTags(TagSet.from(tags)).withTag("dimension", "bucket-count")
 }
 
 class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
@@ -92,14 +105,17 @@ private val partKeyIndex = new PartKeyLuceneIndex(indexDataset, schemas.part, fa
 
   private val indexUpdatedHour = new AtomicLong(0)
 
-  private val indexBootstrapper = new IndexBootstrapper(store) // used for initial index loading
+  // used for initial index loading
+  private val indexBootstrapper =
+    new DownsampleIndexBootstrapper(store, schemas, stats, rawDatasetRef, downsampleConfig)
 
   private val housekeepingSched = Scheduler.computation(
     name = "housekeeping",
     reporter = UncaughtExceptionReporter(logger.error("Uncaught Exception in Housekeeping Scheduler", _)))
 
   // used for periodic refresh of index, happens from raw tables
-  private val indexRefresher = new IndexBootstrapper(rawColStore)
+  private val indexRefresher =
+    new DownsampleIndexBootstrapper(rawColStore, schemas, stats, rawDatasetRef, downsampleConfig)
 
   private var houseKeepingFuture: CancelableFuture[Unit] = _
   private var gaugeUpdateFuture: CancelableFuture[Unit] = _

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -111,7 +111,7 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
         datasetRef,
         pk.endTime,
         SinglePartitionScan(pk.partKey, shardNum),
-        TimeRangeChunkScan(pk.endTime, pk.endTime))
+        TimeRangeChunkScan(pk.endTime, pk.endTime))  // we only want the most-recent chunk
       .headL
       .runToFuture(currentThreadScheduler)
     val readablePart = {

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -21,6 +21,7 @@ import filodb.core.metadata.{Schema, Schemas}
 import filodb.core.metadata.Column.ColumnType.HistogramColumn
 import filodb.core.store.{AllChunkScan, ColumnStore, PartKeyRecord, SinglePartitionScan, TimeRangeChunkScan}
 import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.vectors.HistogramVector
 
 class RawIndexBootstrapper(colStore: ColumnStore) {
 
@@ -124,7 +125,7 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
       val histCol = schemaHashToHistCol(schema.schemaHash)
       val ptr = info.vectorAddress(colId = histCol)
       val acc = info.vectorAccessor(colId = histCol)
-      readablePart.chunkReader(columnID = histCol, acc, ptr).asHistReader
+      HistogramVector(acc, ptr)
     }
     histReader.buckets.numBuckets
   }

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -261,7 +261,6 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
   def updateDataShapeStatsIfEnabled(pk: PartKeyRecord, schema: Schema, shardNum: Int): Unit = {
     if (downsampleConfig.enableDataShapeStats) {
       try {
-        val schema = schemas(schemaID(pk.partKey, UnsafeUtils.arayOffset))
         updateDataShapeStats(pk, shardNum, schema)
       } catch {
         case t: Throwable =>

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -290,8 +290,8 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
       .filter(_.endTime > start)
       .mapParallelUnordered(parallelism) { pk =>
         Task.evalAsync {
-          val schema = schemas(schemaID(pk.partKey, UnsafeUtils.arayOffset))
-          updateDataShapeStatsIfEnabled(pk, schema.downsample.getOrElse(schema), shardNum)
+          val dsSchema = schemas(schemaID(pk.partKey, UnsafeUtils.arayOffset)).downsample.get
+          updateDataShapeStatsIfEnabled(pk, dsSchema, shardNum)
           index.addPartKey(pk.partKey, partId = -1, pk.startTime, pk.endTime)(
             pk.partKey.length,
             PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk.partKey, 0, pk.partKey.length)

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -290,8 +290,8 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
       .filter(_.endTime > start)
       .mapParallelUnordered(parallelism) { pk =>
         Task.evalAsync {
-          val dsSchema = schemas(schemaID(pk.partKey, UnsafeUtils.arayOffset)).downsample.get
-          updateDataShapeStatsIfEnabled(pk, dsSchema, shardNum)
+          val schema = schemas(schemaID(pk.partKey, UnsafeUtils.arayOffset))
+          updateDataShapeStatsIfEnabled(pk, schema.downsample.getOrElse(schema), shardNum)
           index.addPartKey(pk.partKey, partId = -1, pk.startTime, pk.endTime)(
             pk.partKey.length,
             PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk.partKey, 0, pk.partKey.length)

--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -135,23 +135,23 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
   }
 
   /**
-   * Returns true iff the key is "covered" by the map.
+   * Returns true iff the key is "covered" by the trie.
    * The key is "covered" iff each of:
-   *   (a) there exists a path through the maps that sequentially
+   *   (a) there exists a path through the trie that sequentially
    *       steps through a prefix of the strings in `key`.
    *   (b) the path is ended by an empty Map.
    *
-   * For example, each of the following maps cover the key:
+   * For example, each of the following tries cover the key:
    *   key: [foo, bar]
-   *   map1: Map(foo -> Map(bar -> Map()))
-   *   map2: Map(foo -> Map())
-   *   map3: Map()  // The prefix can be empty!
+   *   trie1: Map(foo -> Map(bar -> Map()))
+   *   trie2: Map(foo -> Map())
+   *   trie3: Map()  // The prefix can be empty!
    *
-   * @param map a Map[String ,Map[String, Map[...]]]
+   * @param trie a Map[String ,Map[String, Map[...]]]
    */
-  private def keyIsCovered(key: Seq[String], map: Map[String, Any]): Boolean = {
+  private def keyIsCovered(key: Seq[String], trie: Map[String, Any]): Boolean = {
     var i = 0
-    var ptr = map
+    var ptr = trie
     while (ptr.nonEmpty) {
       val value = key(i)
       if (!ptr.contains(value)) {
@@ -167,15 +167,15 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
    * Returns true iff shape-stats should be published for the key.
    */
   private def shouldPublishShapeStats(key: Seq[String]): Boolean = {
-    val allowMap: Map[String, Any] = downsampleConfig.dataShapeAllow
-    val blockMap: Map[String, Any] = downsampleConfig.dataShapeBlock
-    if (!keyIsCovered(key, allowMap)) {
+    val allowTrie: Map[String, Any] = downsampleConfig.dataShapeAllowTrie
+    val blockTrie: Map[String, Any] = downsampleConfig.dataShapeBlockTrie
+    if (!keyIsCovered(key, allowTrie)) {
       return false
     }
-    if (blockMap.isEmpty) {
+    if (blockTrie.isEmpty) {
       return true
     }
-    !keyIsCovered(key, blockMap)
+    !keyIsCovered(key, blockTrie)
   }
 
   private def updateStatsWithTags(shapeStats: ShapeStats): Unit = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -684,7 +684,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   /////// START SHARD RECOVERY METHODS ///////////////////
 
   def recoverIndex(): Future[Long] = {
-    val indexBootstrapper = new IndexBootstrapper(colStore)
+    val indexBootstrapper = new RawIndexBootstrapper(colStore)
     indexBootstrapper.bootstrapIndexRaw(partKeyIndex, shardNum, ref)(bootstrapPartKey)
       .executeOn(ingestSched) // to make sure bootstrapIndex task is run on ingestion thread
       .map { count =>

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1748,6 +1748,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   }
 
   it ("should correctly calculate data-shape stats during bootstrap / refresh") {
+
     // The plan:
     //   (1) Write rows to the raw column store.
     //     (a) Populate a set of "expected" data-shape stats while iterating rows.
@@ -1765,6 +1766,14 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val commonLabels = Map("_ws_" -> "foo_ws", "_ns_" -> "foo_ns")
     val firstTimestampMs = 74372801000L
     val stepMs = 10000L
+
+    // ====== clear all previous state ========================================
+
+    beforeAll()  // truncate columnstores
+    val offheapMem = new OffHeapMemory(
+      Seq(Schemas.promCounter, Schemas.promHistogram), Map.empty, 100, rawDataStoreConfig)
+    val shardInfo = TimeSeriesShardInfo(
+      0, batchDownsampler.shardStats, offheapMem.bufferPools, offheapMem.nativeMemoryManager)
 
     // ====== configure the data to ingest / downsample =========================
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This PR adds support for "data-shape" metrics from downsample shards; these Kamon metrics expose data about downsampled time-series, namely:
- label key-length
- label value-length
- label count
- metric name length
- total label length (i.e. sum of all label key/value lengths)
- histogram bucket count

Importantly, these metrics are populated/published outside of any critical ingestion or query flow. The metrics are also enabled/disabled via a feature flag.