### PR TITLE
Check for the binary join input cardinality

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -95,8 +95,12 @@ final case class QueryContext(origQueryParams: TsdbQueryParams = UnavailableProm
   }
 
   def getQueryLogLine(msg: String): String = {
+    val promQl = origQueryParams match {
+      case PromQlQueryParams(promQl: String, _, _, _, _, _) => s" promQL = -=# ${promQl} #=-"
+      case UnavailablePromQlQueryParams => "-=# unknown query #=-"
+    }
     val logLine = msg +
-      s" promQL = -=# ${origQueryParams.asInstanceOf[PromQlQueryParams].promQl} #=-" +
+      s" promQL = -=# ${promQl} #=-" +
       s" queryOrigin = ${plannerParams.queryOrigin}" +
       s" queryPrincipal = ${plannerParams.queryPrincipal}" +
       s" queryOriginId = ${plannerParams.queryOriginId}"

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -96,8 +96,8 @@ final case class QueryContext(origQueryParams: TsdbQueryParams = UnavailableProm
 
   def getQueryLogLine(msg: String): String = {
     val promQl = origQueryParams match {
-      case PromQlQueryParams(promQl: String, _, _, _, _, _) => s" promQL = -=# ${promQl} #=-"
-      case UnavailablePromQlQueryParams => "-=# unknown query #=-"
+      case PromQlQueryParams(query: String, _, _, _, _, _) => query
+      case UnavailablePromQlQueryParams => "unknown query"
     }
     val logLine = msg +
       s" promQL = -=# ${promQl} #=-" +

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -26,7 +26,7 @@ case class PerQueryLimits(
         execPlanSamples: Int = 1000000,       // Limit on ExecPlan results in samples, default is 100K
         execPlanResultBytes: Long = 18000000, // Limit on ExecPlan results in bytes, default is 18MB
         groupByCardinality: Int = 100000,     // Limit on "group by" clause results, default is 100K
-        joinQueryCardinality: Int = 100000,   // Limit on binary join results, default is 100K
+        joinQueryCardinality: Int = 100000,   // Limit on binary join input size, default is 100K
         timeSeriesSamplesScannedBytes: Long = 300000000, // Limit on max data scanned per shard, default is 300 MB
         timeSeriesScanned: Int = 1000000)    // Limit on max number of time series scanned, default is 1M
 

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -2,6 +2,7 @@ package filodb.query.exec
 
 import scala.collection.mutable
 
+import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import monix.eval.Task
@@ -45,7 +46,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
                                 ignoring: Seq[String],
                                 include: Seq[String],
                                 metricColumn: String,
-                                outputRvRange: Option[RvRange]) extends NonLeafExecPlan {
+                                outputRvRange: Option[RvRange]) extends NonLeafExecPlan with StrictLogging {
 
   require(cardinality != Cardinality.ManyToMany,
     "Many To Many cardinality is not supported for BinaryJoinExec")
@@ -72,14 +73,29 @@ final case class BinaryJoinExec(queryContext: QueryContext,
                               querySession: QuerySession): Observable[RangeVector] = {
     val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, _, result, _, _, _), _)
-        if (
-          result.size  > queryContext.plannerParams.enforcedLimits.joinQueryCardinality &&
-          cardinality == Cardinality.OneToOne
-        ) => throw new BadQueryException(s"The join in this query has input cardinality of ${result.size} which" +
-          s" is more than limit of ${queryContext.plannerParams.enforcedLimits.joinQueryCardinality}." +
-          s" Try applying more filters or reduce time range.")
-      case (QueryResult(_, _, result, _, _, _), i) => (result, i)
+      tuple : (QueryResult, Int) => {
+        val result : Seq[RangeVector] = tuple._1.result
+        val joinQueryEnforcedCardinalityLimit = queryContext.plannerParams.enforcedLimits.joinQueryCardinality
+        if (result.size > joinQueryEnforcedCardinalityLimit && cardinality == Cardinality.OneToOne) {
+          logger.warn(queryContext.getQueryLogLine(
+            s"Exceeded enforced binary join input cardinality limit ${joinQueryEnforcedCardinalityLimit}," +
+              s" encountered input cardinality ${tuple._1.result.size}"
+          ))
+          throw new BadQueryException(s"The join in this query has input cardinality of ${result.size} which" +
+            s" is more than limit of ${queryContext.plannerParams.enforcedLimits.joinQueryCardinality}." +
+            s" Encountered input cardinality ${result.size}." +
+            s" Try applying more filters or reduce time range."
+          )
+        }
+        val joinQueryWarnCardinalityLimit = queryContext.plannerParams.warnLimits.joinQueryCardinality
+        if (result.size > joinQueryWarnCardinalityLimit && cardinality == Cardinality.OneToOne) {
+          logger.info(queryContext.getQueryLogLine(
+            s"Exceeded warn binary join input cardinality limit=${joinQueryWarnCardinalityLimit}, " +
+              s" encountered input cardinality ${result.size}"
+          ))
+        }
+        (result, tuple._2)
+      }
     }.toListL.map { resp =>
       val startNs = Utils.currentThreadCpuTimeNanos
       try {

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -79,13 +79,11 @@ final case class BinaryJoinExec(queryContext: QueryContext,
         if (result.size > joinQueryEnforcedCardinalityLimit && cardinality == Cardinality.OneToOne) {
           logger.warn(queryContext.getQueryLogLine(
             s"Exceeded enforced binary join input cardinality limit ${joinQueryEnforcedCardinalityLimit}," +
-              s" encountered input cardinality ${tuple._1.result.size}"
+              s" encountered input cardinality ${result.size}"
           ))
           throw new BadQueryException(s"The join in this query has input cardinality of ${result.size} which" +
             s" is more than limit of ${queryContext.plannerParams.enforcedLimits.joinQueryCardinality}." +
-            s" Encountered input cardinality ${result.size}." +
-            s" Try applying more filters or reduce time range."
-          )
+            s" Try applying more filters or reduce time range.")
         }
         val joinQueryWarnCardinalityLimit = queryContext.plannerParams.warnLimits.joinQueryCardinality
         if (result.size > joinQueryWarnCardinalityLimit && cardinality == Cardinality.OneToOne) {


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Current behavior :

Currently we throw an exception if binary join input cardinality is high.

New behavior :

Throw an exception for high binary join cardinality but also add warning if we go beyond warning level. We also properly record in the logs the query and where it comes from.