### PR TITLE
adding warning and enforcement for ts scans/exec plan outputs

### DIFF
--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -32,7 +32,6 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              evictedPkBfCapacity: Int,
                              // filters on ingested records to log in detail
                              traceFilters: Map[String, String],
-                             maxDataPerShardQuery: Long,
                              meteringEnabled: Boolean,
                              acceptDuplicateSamples: Boolean,
                              // approx data resolution, used for estimating the size of data to be scanned for
@@ -57,7 +56,6 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "multi-partition-odp" -> multiPartitionODP,
                                "demand-paging-parallelism" -> demandPagingParallelism,
                                "demand-paging-enabled" -> demandPagingEnabled,
-                               "max-data-per-shard-query" -> maxDataPerShardQuery,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
                                "metering-enabled" -> meteringEnabled,
                                "accept-duplicate-samples" -> acceptDuplicateSamples,
@@ -134,7 +132,6 @@ object StoreConfig {
                 config.getBoolean("demand-paging-enabled"),
                 config.getInt("evicted-pk-bloom-filter-capacity"),
                 config.as[Map[String, String]]("trace-filters"),
-                config.getMemorySize("max-data-per-shard-query").toBytes,
                 config.getBoolean("metering-enabled"),
                 config.getBoolean("accept-duplicate-samples"),
                 config.getInt("ingest-resolution-millis"))

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -88,7 +88,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
         val joinQueryWarnCardinalityLimit = queryContext.plannerParams.warnLimits.joinQueryCardinality
         if (result.size > joinQueryWarnCardinalityLimit && cardinality == Cardinality.OneToOne) {
           logger.info(queryContext.getQueryLogLine(
-            s"Exceeded warn binary join input cardinality limit=${joinQueryWarnCardinalityLimit}, " +
+            s"Exceeded warning binary join input cardinality limit=${joinQueryWarnCardinalityLimit}, " +
               s" encountered input cardinality ${result.size}"
           ))
         }


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
We check if number of data scanned and produced by exec plan is within the limits given properties and defaults in the codebase. 


**New behavior :**
We add explicit check on the number of time series and allow to WARN the users that he is breaching a soft limit. We get the quotas from outside of FiloDB runtime. 


**BREAKING CHANGES**

Removal of property max-data-per-shard-query

**Other information**: