### PR TITLE
fix(downsample): scaladoc fix

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -61,8 +61,8 @@ final case class DownsampleConfig(config: Config) {
    *
    * For example:
    *   data-shape-key=[labelA, labelB]
-   *   data-shape-allow=[[valueA1, valueB1], [valueA2]]
-   *   data-shape-block=[[valueA2, valueB2]]
+   *   data-shape-allow=[(valueA1, valueB1), (valueA2)]
+   *   data-shape-block=[(valueA2, valueB2)]
    *
    *   --> Metrics are published for all series with labelA=valueA1,labelB=valueB1
    *       and all with labelA=valueA2 except where labelB=valueB2. Additionally, metrics


### PR DESCRIPTION
Recently-added documentation breaks `sbt doc`. This PR fixes the documentation.