### PR TITLE
feat(downsample): add substitute data-shape-key labels

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
+++ b/core/src/main/scala/filodb.core/memstore/IndexBootstrapper.scala
@@ -180,7 +180,7 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
 
   private def updateStatsWithTags(shapeStats: ShapeStats): Unit = {
     var builder = TagSet.builder()
-    for ((key, value) <- downsampleConfig.dataShapeKey.zip(shapeStats.key)) {
+    for ((key, value) <- downsampleConfig.dataShapeKeyPublishLabels.zip(shapeStats.key)) {
       builder = builder.add(key, value)
     }
     val tags = builder.build()
@@ -221,7 +221,7 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
     if (!shapeStats.isDefined) {
       return
     }
-    if (downsampleConfig.enableDataShapeKeyLabels) {
+    if (downsampleConfig.dataShapeKeyPublishLabels.nonEmpty) {
       updateStatsWithTags(shapeStats.get)
     } else {
       updateStatsWithoutTags(shapeStats.get)
@@ -259,7 +259,7 @@ class DownsampleIndexBootstrapper(colStore: ColumnStore,
    * If configured, update data-shape stats.
    */
   def updateDataShapeStatsIfEnabled(pk: PartKeyRecord, shardNum: Int): Unit = {
-    if (downsampleConfig.enableDataShapeStats) {
+    if (downsampleConfig.dataShapeKey.nonEmpty) {
       try {
         val schema = schemas(schemaID(pk.partKey, UnsafeUtils.arayOffset))
         updateDataShapeStats(pk, shardNum, schema)

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1757,9 +1757,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     //   (4) Compare the index/bootstrap-generated stats with the stats from (1.a).
     val rawConf =
     """
-      |enable-data-shape-stats: true
       |data-shape-key: [_ws_,_ns_]
-      |enable-data-shape-key-labels: true
+      |data-shape-key-publish-labels: [workspace, namespace]
       |data-shape-allow: [[foo_ws]]
       |data-shape-block: [[foo_ws,block_ns]]
       |enable-data-shape-bucket-count: true


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, data-shape-key labels are published if `enable-data-shape-key-labels=true`. For example, suppose data-shape stats are updated for the time-series:
```
my_metric{label1="foo", label2="bar"}
```
If `data-shape-keys=[label1, label2]` and `enable-data-shape-key-labels=true`, then the stats would be updated as e.g.:
```
data_shape{dimension="label-count", label1="foo", label2="bar"}
```
But if the `data_shape` metric is, by default, published with its own `label1` and `label2`, then these labels will not be updated to reflect those from `my_metric`.

This PR adds substitute labels `data-shape-key-publish-labels`. Now, if data-shape stats were updated for the same metric above,  and:
```
data-shape-key-publish-labels=[substitute1, substutute2]
```
then the data-shape metrics will be published as:
```
data_shape{dimension="label-count", substitute1="foo", substitute2="bar"}
```