### PR TITLE
feat(core) Allow tuning parallelism of index rebuild and housekeeping scheduler

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampleConfig.scala
@@ -118,6 +118,10 @@ final case class DownsampleConfig(config: Config) {
 
   val maxRefreshHours = config.getOrElse("max-refresh-hours", Long.MaxValue)
 
+  val indexRebuildParallelismMultiplier = config.getOrElse("index-rebuild-parallelism-multiplier", 1.0)
+
+  val housekeepingParallelismMultiplier = config.getOrElse("housekeeping-parallelism-multiplier", 1.0)
+
   val enablePersistentIndexing = indexLocation.isDefined
 
   val indexMetastoreImplementation = if (config.hasPath("index-metastore-implementation")) {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently index rebuild and housekeeping scheduler uses number of CPUs as a a factor for parallelism with no way to tune this. This PR introduces a multiplier that either allows is to increase or reduce the parallelism using a configuration. The default value is 1 which will use the existing parallelism, that is the value returned by ``Runtime.getRuntime.availableProcessors()``