### PR TITLE
refactor(cassandra): Revisit config for read/write consistency levels

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
@@ -13,7 +13,8 @@ import filodb.core.store.PartKeyRecord
 
 sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
                                             val connector: FiloCassandraConnector,
-                                            writeConsistencyLevel: ConsistencyLevel)
+                                            writeConsistencyLevel: ConsistencyLevel,
+                                            readConsistencyLevel: ConsistencyLevel)
                                            (implicit ec: ExecutionContext) extends BaseDatasetTable {
 
   import filodb.cassandra.Util._
@@ -41,7 +42,7 @@ sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
   private lazy val readCql = session.prepare(
     s"SELECT * FROM $tableString " +
     s"WHERE shard = ? AND epochHour = ? AND split = ? ")
-    .setConsistencyLevel(ConsistencyLevel.ONE)
+    .setConsistencyLevel(readConsistencyLevel)
 
 
   def writePartKey(shard: Int, updateHour: Long, split: Int,

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
@@ -16,7 +16,8 @@ import filodb.core.store.PartKeyRecord
 sealed class PartitionKeysTable(val dataset: DatasetRef,
                                 val shard: Int,
                                 val connector: FiloCassandraConnector,
-                                writeConsistencyLevel: ConsistencyLevel)
+                                writeConsistencyLevel: ConsistencyLevel,
+                                readConsistencyLevel: ConsistencyLevel)
                                (implicit ec: ExecutionContext) extends BaseDatasetTable {
 
   import filodb.cassandra.Util._
@@ -44,7 +45,7 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
   private lazy val scanCql = session.prepare(
     s"SELECT * FROM $tableString " +
     s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ?")
-    .setConsistencyLevel(ConsistencyLevel.ONE)
+    .setConsistencyLevel(readConsistencyLevel)
 
   private lazy val scanCqlForStartEndTime = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
@@ -52,24 +53,24 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
       s"startTime >= ? AND startTime <= ? AND " +
       s"endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
-    .setConsistencyLevel(ConsistencyLevel.ONE)
+    .setConsistencyLevel(readConsistencyLevel)
 
   private lazy val scanCqlForStartTime = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
       s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND startTime >= ? AND startTime <= ? " +
       s"ALLOW FILTERING")
-    .setConsistencyLevel(ConsistencyLevel.ONE)
+    .setConsistencyLevel(readConsistencyLevel)
 
   private lazy val scanCqlForEndTime = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
       s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
-    .setConsistencyLevel(ConsistencyLevel.ONE)
+    .setConsistencyLevel(readConsistencyLevel)
 
   private lazy val readCql = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
       s"WHERE partKey = ? ")
-    .setConsistencyLevel(ConsistencyLevel.ONE)
+    .setConsistencyLevel(readConsistencyLevel)
 
   private lazy val deleteCql = session.prepare(
     s"DELETE FROM $tableString " +

--- a/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
@@ -16,8 +16,10 @@ import filodb.core.store.MetaStore
 class CassandraMetaStore(config: Config, session: Session)
                         (implicit val ec: ExecutionContext) extends MetaStore {
   private val ingestionConsistencyLevel = ConsistencyLevel.valueOf(config.getString("ingestion-consistency-level"))
+  private val checkpointReadConsistencyLevel = ConsistencyLevel.valueOf(
+    config.getString("checkpoint-read-consistency-level"))
 
-  val checkpointTable = new CheckpointTable(config, session, ingestionConsistencyLevel)
+  val checkpointTable = new CheckpointTable(config, session, ingestionConsistencyLevel, checkpointReadConsistencyLevel)
   private val createTablesEnabled = config.getBoolean("create-tables-enabled")
 
   val defaultKeySpace = config.getString("keyspace")

--- a/cassandra/src/main/scala/filodb.cassandra/metastore/CheckpointTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/CheckpointTable.scala
@@ -16,7 +16,8 @@ import filodb.cassandra.FiloCassandraConnector
   */
 sealed class CheckpointTable(val config: Config,
                              val session: Session,
-                             writeConsistencyLevel: ConsistencyLevel)
+                             writeConsistencyLevel: ConsistencyLevel,
+                             checkPointReadConsistencyLevel: ConsistencyLevel)
                              (implicit val ec: ExecutionContext) extends FiloCassandraConnector {
   val keyspace = config.getString("admin-keyspace")
   val tableString = s"${keyspace}.checkpoints"
@@ -36,7 +37,7 @@ sealed class CheckpointTable(val config: Config,
       s"""SELECT groupnum, offset FROM $tableString WHERE
          | databasename = ? AND
          | datasetname = ? AND
-         | shardnum = ? """.stripMargin).setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM)
+         | shardnum = ? """.stripMargin).setConsistencyLevel(checkPointReadConsistencyLevel)
     // we want consistent reads during recovery
 
   lazy val writeCheckpointCql = {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -385,7 +385,10 @@ filodb {
     retry-interval = 10s
     retry-interval-max-jitter = 10s
 
-    ingestion-consistency-level = "ONE"
+    # http://docs.datastax.com/en/drivers/java/2.1/com/datastax/driver/core/ConsistencyLevel.html
+    checkpoint-read-consistency-level = "LOCAL_QUORUM"
+    ingestion-consistency-level = "LOCAL_ONE"
+    default-read-consistency-level = "LOCAL_ONE"
 
     # Number of splits in the partitionKeysByUpdateTime table to keep cassandra partition size under control
     #  1mil max pks per shard per hour / 200 splits

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -14,6 +14,8 @@ filodb {
     retry-interval = 10s
     retry-interval-max-jitter = 10s
     ingestion-consistency-level = "ONE"
+    checkpoint-read-consistency-level = "LOCAL_QUORUM"
+    default-read-consistency-level = "LOCAL_ONE"
     pk-by-updated-time-table-num-splits = 200
     write-time-index-ttl = 1 day
     create-tables-enabled = true


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Current level of read/write consistency levels for  tables (across all datasets)


| Table      | Read Consistency | Write Consistency     |
| :---        |    :----:   |          ---: |
| IngestionTimeIndexTable      | ONE       | ONE  |
| PartitionKeysByUpdateTimeTable   | ONE        | ONE      |
| PartitionKeysTable   | ONE        | ONE      |
| TimeSeriesChunksTable   | ONE        | ONE      |
| CheckpointTable   | LOCAL_QUORUM        | ONE      |


**New behavior :**
Refactored read/write consistency levels for  tables (across all datasets)

| Table      | Read Consistency | Write Consistency     |
| :---        |    :----:   |          ---: |
| IngestionTimeIndexTable      | LOCAL_ONE       | LOCAL_ONE  |
| PartitionKeysByUpdateTimeTable   | LOCAL_ONE        | LOCAL_ONE      |
| PartitionKeysTable   | LOCAL_ONE        | LOCAL_ONE      |
| TimeSeriesChunksTable   | LOCAL_ONE        | LOCAL_ONE      |
| CheckpointTable   | LOCAL_QUORUM       | LOCAL_ONE      |

Hard coded settings have been moved to the config file.

