### PR TITLE
Disabling the orVectorDouble optimization

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -419,20 +419,21 @@ trait  DefaultPlanner {
    *
    * 05/01/2023: We are disabling this optimization until we handle the corner cases like:
    * 1. when the given metrics is not present or is not actively ingesting
+   * rdar://108803361 (Fix vector(0) optimzation corner cases)
    */
   def optimizeOrVectorDouble(qContext: QueryContext, logicalPlan: BinaryJoin): Option[PlanResult] = {
-    return None
-    if (logicalPlan.operator == BinaryOperator.LOR) {
-      logicalPlan.rhs match {
-        case VectorPlan(ScalarFixedDoublePlan(value, rangeParams)) =>
-          val planRes = materializeApplyInstantFunction(
-                              qContext, ApplyInstantFunction(logicalPlan.lhs,
-                                                             InstantFunctionId.OrVectorDouble,
-                                                             Seq(ScalarFixedDoublePlan(value, rangeParams))))
-          Some(planRes)
-        case _ => None // TODO add more matchers to cover cases where rhs is a fully scalar plan
-      }
-    } else None
+    None
+//    if (logicalPlan.operator == BinaryOperator.LOR) {
+//      logicalPlan.rhs match {
+//        case VectorPlan(ScalarFixedDoublePlan(value, rangeParams)) =>
+//          val planRes = materializeApplyInstantFunction(
+//                              qContext, ApplyInstantFunction(logicalPlan.lhs,
+//                                                             InstantFunctionId.OrVectorDouble,
+//                                                             Seq(ScalarFixedDoublePlan(value, rangeParams))))
+//          Some(planRes)
+//        case _ => None // TODO add more matchers to cover cases where rhs is a fully scalar plan
+//      }
+//    } else None
   }
 
   def materializeBinaryJoin(qContext: QueryContext,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -416,8 +416,12 @@ trait  DefaultPlanner {
    * Note that vector(0) on left side of operator, example `vector(0) or foo` is not
    * optimized yet since it is uncommon and almost unseen, and not worth the additional
    * complexity at the moment.
+   *
+   * 05/01/2023: We are disabling this optimization until we handle the corner cases like:
+   * 1. when the given metrics is not present or is not actively ingesting
    */
   def optimizeOrVectorDouble(qContext: QueryContext, logicalPlan: BinaryJoin): Option[PlanResult] = {
+    return None
     if (logicalPlan.operator == BinaryOperator.LOR) {
       logicalPlan.rhs match {
         case VectorPlan(ScalarFixedDoublePlan(value, rangeParams)) =>

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -1559,16 +1559,18 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
 
       val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
 
-      val expected = """T~InstantVectorFunctionMapper(function=OrVectorDouble)
-                        |-FA1~StaticFuncArgs(0.0,RangeParams(1634086130,60,1634755730))
-                        |-T~AggregatePresenter(aggrOp=Sum, aggrParams=List(), rangeParams=RangeParams(1634086130,60,1634755730))
-                        |--E~LocalPartitionReduceAggregateExec(aggrOp=Sum, aggrParams=List()) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1823110189],downsample)
-                        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
-                        |----T~PeriodicSamplesMapper(start=1634086130000, step=60000, end=1634755730000, window=Some(2592000000), functionId=Some(Rate), rawSource=true, offsetMs=None)
-                        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=11, chunkMethod=TimeRangeChunkScan(1631494130000,1634755730000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(bar))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1823110189],downsample)
-                        |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
-                        |----T~PeriodicSamplesMapper(start=1634086130000, step=60000, end=1634755730000, window=Some(2592000000), functionId=Some(Rate), rawSource=true, offsetMs=None)
-                        |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=27, chunkMethod=TimeRangeChunkScan(1631494130000,1634755730000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(bar))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1823110189],downsample)""".stripMargin
+      val expected = """E~SetOperatorExec(binaryOp=LOR, on=List(), ignoring=List()) on InProcessPlanDispatcher(QueryConfig(10 seconds,300000,1,50,antlr,true,true,None,None,None,None,true,false,true,Set(),None))
+                       |-T~AggregatePresenter(aggrOp=Sum, aggrParams=List(), rangeParams=RangeParams(1634086130,60,1634755730))
+                       |--E~LocalPartitionReduceAggregateExec(aggrOp=Sum, aggrParams=List()) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-1009481049],downsample)
+                       |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+                       |----T~PeriodicSamplesMapper(start=1634086130000, step=60000, end=1634755730000, window=Some(2592000000), functionId=Some(Rate), rawSource=true, offsetMs=None)
+                       |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=11, chunkMethod=TimeRangeChunkScan(1631494130000,1634755730000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(bar))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-1009481049],downsample)
+                       |---T~AggregateMapReduce(aggrOp=Sum, aggrParams=List(), without=List(), by=List())
+                       |----T~PeriodicSamplesMapper(start=1634086130000, step=60000, end=1634755730000, window=Some(2592000000), functionId=Some(Rate), rawSource=true, offsetMs=None)
+                       |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=27, chunkMethod=TimeRangeChunkScan(1631494130000,1634755730000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(bar))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-1009481049],downsample)
+                       |-T~VectorFunctionMapper(funcParams=List())
+                       |--E~ScalarFixedDoubleExec(params = RangeParams(1634086130,60,1634755730), value = 0.0) on InProcessPlanDispatcher(QueryConfig(10 seconds,300000,1,50,antlr,true,true,None,None,None,None,true,false,true,Set(),None))""".stripMargin
+
       validatePlan(ep, expected)
     }
   }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -24,7 +24,6 @@ import filodb.query.LogicalPlan.getRawSeriesFilters
 import filodb.query.exec.aggregator.{CountRowAggregator, SumRowAggregator}
 import org.scalatest.exceptions.TestFailedException
 
-
 import scala.concurrent.duration._
 
 class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFutures with PlanValidationSpec {
@@ -503,7 +502,8 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     binaryJoinNode.asInstanceOf[BinaryJoinExec].rhs.size shouldEqual 4
   }
 
-  it("should optimize or vector(0) queries by using InstantVectorFunctionMapper instead of SetOperatorExec") {
+  // Ignoring the test until we pickup this radar - rdar://108803361 (Fix vector(0) optimzation corner cases)
+  ignore("should optimize or vector(0) queries by using InstantVectorFunctionMapper instead of SetOperatorExec") {
 
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
       Seq(SpreadChange(0, 2))


### PR DESCRIPTION
Disabling the orVectorDouble optimization

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :** Disabled the `or vector(double)` optimization until we fix the required corner cases