### PR TITLE
fix(core) add RecordOutOfContainerCapacityException.

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -248,7 +248,7 @@ final class QueryActor(memStore: TimeSeriesStore,
           logger.warn(s"Query Limit Breached " +
             s"${q.queryContext.origQueryParams} ${t.getMessage}")
         case _: RecordOutOfContainerCapacityException =>
-          logger.warn(s"Query is greater than container capacity" +
+          logger.warn(s"The intermediate or final result of the Query is greater than container capacity" +
             s"${q.queryContext.origQueryParams} ${t.getMessage}")
         case e: Throwable =>
           logger.error(s"Query Error queryId=${q.queryContext.queryId} " +

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -2,12 +2,10 @@ package filodb.coordinator
 
 import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
-
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
-
 import akka.actor.{ActorRef, Props}
 import akka.pattern.AskTimeoutException
 import kamon.Kamon
@@ -31,6 +29,7 @@ import filodb.core.query.QueryContext
 import filodb.core.query.QueryLimitException
 import filodb.core.query.QuerySession
 import filodb.core.query.QueryStats
+import filodb.core.query.RecordOutOfContainerCapacityException
 import filodb.core.query.SerializedRangeVector
 import filodb.core.store.CorruptVectorException
 import filodb.memory.data.Shutdown
@@ -247,6 +246,9 @@ final class QueryActor(memStore: TimeSeriesStore,
             s"${q.queryContext.origQueryParams} ${t.getMessage}")
         case _: QueryLimitException =>
           logger.warn(s"Query Limit Breached " +
+            s"${q.queryContext.origQueryParams} ${t.getMessage}")
+        case _: RecordOutOfContainerCapacityException =>
+          logger.warn(s"Query is greater than container capacity" +
             s"${q.queryContext.origQueryParams} ${t.getMessage}")
         case e: Throwable =>
           logger.error(s"Query Error queryId=${q.queryContext.queryId} " +

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -541,7 +541,7 @@ class RecordBuilder(memFactory: MemFactory,
       if (reuseOneContainer) resetContainerPointers() else newContainer()
       logger.trace(s"Moving $recordNumBytes bytes from end of old container to new container")
       if((containerSize - ContainerHeaderLen) <= (recordNumBytes + numBytes))
-        throw new RecordOutOfContainerCapacityException();
+        throw new RecordOutOfContainerCapacityException("record too big for container");
       unsafe.copyMemory(oldBase, oldOffset, curBase, curRecordOffset, recordNumBytes)
       if (mapOffset != -1L) mapOffset = curRecordOffset + (mapOffset - oldOffset)
       curRecEndOffset = curRecordOffset + recordNumBytes

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -177,3 +177,9 @@ class QueryLimitException(message: String, queryId: String) extends RuntimeExcep
     s"${super.getMessage}, queryId=${queryId}"
   }
 }
+
+/**
+ * Thrown when number of bytes is greater than container.
+ */
+class RecordOutOfContainerCapacityException() extends RuntimeException(
+  "The intermediate or final result for the query is too big. Please try to add more query filters or time range.") {}

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -181,5 +181,7 @@ class QueryLimitException(message: String, queryId: String) extends RuntimeExcep
 /**
  * Thrown when number of bytes is greater than container.
  */
-class RecordOutOfContainerCapacityException() extends RuntimeException(
+class RecordOutOfContainerCapacityException(message: String) extends IllegalArgumentException(message) {}
+
+class QueryRecordOutOfContainerCapacityException() extends RecordOutOfContainerCapacityException(
   "The intermediate or final result for the query is too big. Please try to add more query filters or time range.") {}


### PR DESCRIPTION
Add a more user friendly message for exceptions happen when queries involved with records too big.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: