### PR TITLE
Updating CardinalityRecord class to use CardinalityValue

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -197,10 +197,10 @@ object CliMain extends StrictLogging {
             printf("%40s %20s %20s %15s %15s\n", "Child", "TotalTimeSeries", "ActiveTimeSeries", "Children", "Children")
             printf("%40s %20s %20s %15s %15s\n", "Name", "Count", "Count", "Count", "Quota")
             println("==============================================================================================================================")
-            crs._2.sortBy(c => if (addInactive) c.tsCount else c.activeTsCount)(Ordering.Int.reverse)
+            crs._2.sortBy(c => if (addInactive) c.value.tsCount else c.value.activeTsCount)(Ordering.Int.reverse)
               .foreach { cr =>
-                printf("%40s %20d %20d %15d %15d\n", cr.prefix, cr.tsCount,
-                       cr.activeTsCount, cr.childrenCount, cr.childrenQuota)
+                printf("%40s %20d %20d %15d %15d\n", cr.prefix, cr.value.tsCount,
+                       cr.value.activeTsCount, cr.value.childrenCount, cr.value.childrenQuota)
               }
           }
 

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -315,8 +315,8 @@ final class QueryActor(memStore: TimeSeriesStore,
   private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
     implicit val ord = new Ordering[CardinalityRecord]() {
       override def compare(x: CardinalityRecord, y: CardinalityRecord): Int = {
-        if (q.addInactive) x.tsCount - y.tsCount
-        else x.activeTsCount - y.activeTsCount
+        if (q.addInactive) x.value.tsCount - y.value.tsCount
+        else x.value.activeTsCount - y.value.activeTsCount
       }
     }.reverse
     try {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -918,7 +918,7 @@ class TimeSeriesShard(val ref: DatasetRef,
             p.schema.options.shardKeyColumns)
           val newCard = cardTracker.modifyCount(shardKey, 0, -1)
           // temporary debugging since we are seeing some negative counts
-          if (newCard.exists(_.activeTsCount < 0))
+          if (newCard.exists(_.value.activeTsCount < 0))
             logger.error(s"For some reason, activeTs count negative when updating card for " +
               s"partKey: ${p.stringPartition} newCard: $newCard oldActivelyIngestingSize=$oldActivelyIngestingSize " +
               s"newActivelyIngestingSize=${activelyIngesting.size}")

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -11,8 +11,7 @@ package filodb.core.memstore.ratelimit
  * @param childrenCount number of immediate children for this shardKey (example, number of ns under ws)
  * @param childrenQuota quota for number of immediate children
  */
-case class CardinalityRecord(shard: Int, prefix: Seq[String], tsCount: Int,
-                             activeTsCount: Int, childrenCount: Int, childrenQuota: Int)
+case class CardinalityRecord(shard: Int, prefix: Seq[String], value: CardinalityValue)
 
 /**
  *

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreSpec.scala
@@ -16,14 +16,14 @@ class RocksDbCardinalityStoreSpec extends AnyFunSpec with Matchers {
 
     (0 until MAX_RESULT_SIZE + numOverflow).foreach{ i =>
       val prefix = Seq("ws", "ns", s"metric-$i")
-      db.store(CardinalityRecord(shard, prefix, 1, 1, 1, 1))
+      db.store(CardinalityRecord(shard, prefix, CardinalityValue(1, 1, 1, 1)))
     }
 
     Seq(Nil, Seq("ws"), Seq("ws", "ns")).foreach{ prefix =>
       val res = db.scanChildren(prefix, 3)
       res.size shouldEqual MAX_RESULT_SIZE + 1  // one extra for the overflow CardinalityRecord
       res.contains(CardinalityRecord(shard, OVERFLOW_PREFIX,
-        numOverflow, numOverflow, numOverflow, numOverflow)) shouldEqual true
+        CardinalityValue(numOverflow, numOverflow, numOverflow, numOverflow))) shouldEqual true
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -560,7 +560,7 @@ final case class TsCardExec(queryContext: QueryContext,
             dataset, Seq(shard), shardKeyPrefix, numGroupByFields)
           val it = cards.map{ card =>
             CardRowReader(prefixToGroup(card.prefix),
-                          CardCounts(card.activeTsCount, card.tsCount))
+                          CardCounts(card.value.activeTsCount, card.value.tsCount))
             }.iterator
           IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty), NoCloseCursor(it), None)
         }


### PR DESCRIPTION
*Motivation:* Updating CardinalityRecord class to use CardinalityValue, since all the member variables of CardinalityValue is also duplicated in CardinalityRecord. Updating the CardinalityRecord to use CardinalityValue to simplify the class definition, which also reduces the need to convert CardinalityTracker to CardinalityValue, when writing to RocksDB. This will also help in future changes when the storage format changes ( let's say new member variables or reducing variables ) 

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

*Current Behaviour*: `CardinalityRecord` class contains the super set of member variables present in `CardinalityValue`. 

*New Behaviour*: Updating `CardinalityRecord` to use `CardinalityValue` class instead.