### PR TITLE
Changes in CardinalityTracker to store cardinality count in Downsample cluster

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -263,7 +263,7 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
   }
 
   /**
-    * EXPENSIVE to do at server side. Creates a stringified array with contents of this BinaryRecord.
+    * EXPENSIVE to do at server side. Creates a stringified map with contents of this BinaryRecord.
     */
   def toStringPairs(base: Any, offset: Long): Seq[(String, String)] = {
     import Column.ColumnType._
@@ -288,47 +288,6 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
     }
     result
   }
-
-
-  /**
-   * Reads all the label key-value pairs from the BinaryRecord and creates a map.
-   * If multiple labels with same key --> then the last writer wins.
-   * @param base data source
-   * @param offset offset to read from
-   * @return Map of all the tags/labels. key is label-name, value is label-value
-   */
-  def toStringPairsMap(base: Any, offset: Long): mutable.Map[String, String] = {
-    import Column.ColumnType._
-    val result = mutable.Map[String, String]()
-    columnTypes.zipWithIndex.foreach {
-      case (IntColumn, i) => result(colNames(i)) = getInt(base, offset, i).toString
-      case (LongColumn, i) => result(colNames(i)) = getLong(base, offset, i).toString
-      case (DoubleColumn, i) => result(colNames(i)) = getDouble(base, offset, i).toString
-      case (StringColumn, i) => result(colNames(i)) = asJavaString(base, offset, i)
-      case (TimestampColumn, i) => result(colNames(i)) = getLong(base, offset, i).toString
-      case (MapColumn, i) => val consumer = new StringifyMapItemConsumer
-        consumeMapItems(base, offset, i, consumer)
-        result ++= consumer.stringPairs
-      case (BinaryRecordColumn, i) => result ++= brSchema(i).toStringPairs(blobBase(base, offset, i),
-        blobOffset(base, offset, i))
-        result += ("_type_" ->
-          Schemas.global.schemaName(
-            RecordSchema.schemaID(blobBase(base, offset, i),
-              blobOffset(base, offset, i))))
-      case (HistogramColumn, i) =>
-        result(colNames(i)) = bv.BinaryHistogram.BinHistogram(blobAsBuffer(base, offset, i)).toString
-    }
-    result
-  }
-
-  /**
-   * Reads all the label key-value pairs from the BinaryRecord and creates a map.
-   * If multiple labels with same key --> then the last writer wins.
-   * @param bytes data source
-   * @return Map of all the tags/labels. key is label-name, value is label-value.
-   */
-  def toStringPairsMap(bytes: Array[Byte]): mutable.Map[String, String] =
-    toStringPairsMap(bytes, UnsafeUtils.arayOffset)
 
   def colNames(base: Any, offset: Long): Seq[String] = {
     import Column.ColumnType._

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -32,6 +32,9 @@ case class QuotaReachedException(cannotSetShardKey: Seq[String], prefix: Seq[Str
   * @param defaultChildrenQuota the default quota at each level if no explicit quota is set
   * @param store fast memory or disk based store where cardinality and quota can be read and written
   * @param quotaExceededProtocol action to be taken when quota is breached
+  * @param flushCount threshold to flush the cardinality count records to rocksDB. This is also used to toggle between
+  *    the aggregated (agg using in-memory map. caller has to call function `flushCardinalityCount` to ensure write) vs.
+  *    non-aggregated way (calling rocksDB.store() after update) of storing cardinality count
   */
 class CardinalityTracker(ref: DatasetRef,
                          shard: Int,
@@ -39,7 +42,7 @@ class CardinalityTracker(ref: DatasetRef,
                          defaultChildrenQuota: Seq[Int],
                          val store: CardinalityStore,
                          quotaExceededProtocol: QuotaExceededProtocol = NoActionQuotaProtocol,
-                         dsCardinalityMapFlushCount: Int = 5000) extends StrictLogging {
+                         flushCount: Option[Int] = None) extends StrictLogging {
 
   require(defaultChildrenQuota.length == shardKeyLen + 1)
   require(defaultChildrenQuota.forall(q => q > 0))
@@ -56,7 +59,7 @@ class CardinalityTracker(ref: DatasetRef,
    * the records in RocksDB too frequently, causing a slowdown because of heavy disk writes.
    * Hence we are using this map to help us aggregate in memory and then flush to RocksDB periodically
    */
-  private val cardinalityCountMapDS : Map[Seq[String], (Int, Int)] = Map()
+  private val cardinalityCountMap : Map[Seq[String], (Int, Int)] = Map()
 
   /**
    * Call when a new time series with the given shard key has been added to the system.
@@ -79,46 +82,53 @@ class CardinalityTracker(ref: DatasetRef,
             totalDelta == 0 && activeDelta == -1, // existing active ts that became inactive
             "invalid values for totalDelta / activeDelta")
 
-    val toStore = ArrayBuffer[CardinalityRecord]()
-    // first make sure there is no breach for any prefix
-    (0 to shardKey.length).foreach { i =>
-      val prefix = shardKey.take(i)
-      val old = store.getOrZero(prefix,
-        CardinalityRecord(shard, prefix, CardinalityValue(0, 0, 0, defaultChildrenQuota(i))))
+    val cardinalityRecords = flushCount match {
+      case Some(threshold) => modifyCountWithAggregation(shardKey, threshold, totalDelta)
+      case None => {
+        val toStore = ArrayBuffer[CardinalityRecord]()
+        // first make sure there is no breach for any prefix
+        (0 to shardKey.length).foreach { i =>
+          val prefix = shardKey.take(i)
+          val old = store.getOrZero(prefix,
+            CardinalityRecord(shard, prefix, CardinalityValue(0, 0, 0, defaultChildrenQuota(i))))
 
-      val neu = old.copy(value = old.value.copy(tsCount = old.value.tsCount + totalDelta,
-                         activeTsCount = old.value.activeTsCount + activeDelta,
-        childrenCount = if (i == shardKeyLen) old.value.childrenCount + totalDelta else old.value.childrenCount))
+          val neu = old.copy(value = old.value.copy(tsCount = old.value.tsCount + totalDelta,
+            activeTsCount = old.value.activeTsCount + activeDelta,
+            childrenCount = if (i == shardKeyLen) old.value.childrenCount + totalDelta else old.value.childrenCount))
 
-      if (i == shardKeyLen && neu.value.tsCount > neu.value.childrenQuota) {
-        quotaExceededProtocol.quotaExceeded(ref, shard, prefix, neu.value.childrenQuota)
-        throw QuotaReachedException(shardKey, prefix, neu.value.childrenQuota)
-      }
+          if (i == shardKeyLen && neu.value.tsCount > neu.value.childrenQuota) {
+            quotaExceededProtocol.quotaExceeded(ref, shard, prefix, neu.value.childrenQuota)
+            throw QuotaReachedException(shardKey, prefix, neu.value.childrenQuota)
+          }
 
-      // Updating children count of the parent prefix, when a new child is added
-      if (i > 0 && neu.value.tsCount == 1 && totalDelta == 1) { // parent's new child
-        val parent = toStore(i - 1)
-        val neuParent = parent.copy(value = parent.value.copy(childrenCount = parent.value.childrenCount + 1))
-        toStore(i - 1) = neuParent
-        if (neuParent.value.childrenCount > neuParent.value.childrenQuota) {
-          quotaExceededProtocol.quotaExceeded(ref, shard, parent.prefix, neuParent.value.childrenQuota)
-          throw QuotaReachedException(shardKey, parent.prefix, neuParent.value.childrenQuota)
+          // Updating children count of the parent prefix, when a new child is added
+          if (i > 0 && neu.value.tsCount == 1 && totalDelta == 1) { // parent's new child
+            val parent = toStore(i - 1)
+            val neuParent = parent.copy(value = parent.value.copy(childrenCount = parent.value.childrenCount + 1))
+            toStore(i - 1) = neuParent
+            if (neuParent.value.childrenCount > neuParent.value.childrenQuota) {
+              quotaExceededProtocol.quotaExceeded(ref, shard, parent.prefix, neuParent.value.childrenQuota)
+              throw QuotaReachedException(shardKey, parent.prefix, neuParent.value.childrenQuota)
+            }
+          }
+          toStore += neu
+        }
+
+        toStore.map { case neu =>
+          store.store(neu)
+          neu
         }
       }
-      toStore += neu
     }
-
-    toStore.map { case neu =>
-      store.store(neu)
-      neu
-    }
+    cardinalityRecords
   }
 
   /**
    * Updates the DOWNSAMPLE CLUSTER's cardinality count in the cardinalityCountMap. Flushes the data to RocksDB
    * when `dsCardinalityMapFlushCount` threshold reached
    *
-   *  NOTE: The cardinality count increment happens by `1`.
+   *  NOTE: We are only cardinality count for total TS in aggregated fashion. We will add support for active TS if
+   *  needed
    *
    * Cardinality count at each level of shardKey needs to be updated
    * For example: if shardKey = (my_ws, my_ns, my_metric), then we have to update
@@ -130,23 +140,22 @@ class CardinalityTracker(ref: DatasetRef,
    *
    * @param shardKey
    */
-  def updateCardinalityCountsDS(shardKey: Seq[String]): Unit = synchronized {
+  private def modifyCountWithAggregation(shardKey: Seq[String], threshold: Int,
+                                         totalDelta: Int): Seq[CardinalityRecord] = synchronized {
     (0 to shardKey.length).foreach { i =>
-
       // update current prefix's cardinality count
       val prefix = shardKey.take(i)
-      val cardCountRecord = cardinalityCountMapDS.get(prefix)
-        .map(x => (x._1 + 1, x._2))
+      val cardCountRecord = cardinalityCountMap.get(prefix)
+        .map(x => (x._1 + totalDelta, x._2))
         .getOrElse((1, 0)) // child prefix update parent's childrenCount
-      cardinalityCountMapDS.put(prefix, cardCountRecord)
-
+      cardinalityCountMap.put(prefix, cardCountRecord)
       // update children count of parent and throw exception if quota reached
       if (i > 0) {
         val parentPrefix = shardKey.take(i - 1)
 
         // we always add parent before the child, hence it is okay to get the parent prefix's record directly
         // without the None check
-        val updatedCountRecord = cardinalityCountMapDS.get(parentPrefix)
+        val updatedCountRecord = cardinalityCountMap.get(parentPrefix)
           .map(x => (x._1, x._2 + 1)).get
 
         // check if number of children is higher than the given quota. This allows us guard our physical resources
@@ -158,13 +167,15 @@ class CardinalityTracker(ref: DatasetRef,
         }
 
         // store the updated parent's childrenCount
-        cardinalityCountMapDS.put(parentPrefix, updatedCountRecord)
+        cardinalityCountMap.put(parentPrefix, updatedCountRecord)
       }
     }
-
-    if (cardinalityCountMapDS.size > dsCardinalityMapFlushCount) {
-      flushCardinalityDataToRocksDB()
+    if (cardinalityCountMap.size > threshold) {
+      flushCardinalityCount()
     }
+    // NOTE: We are not using the returned CardinalityRecord records when modifying count
+    // using an aggregation map. We will update it when it is required but keeping things simple for now
+    Seq()
   }
 
   /**
@@ -172,14 +183,14 @@ class CardinalityTracker(ref: DatasetRef,
   * scratch at a periodic interval and the caller of CardinalityTracker can also call this method to ensure all data
   * is flushed to RocksDB
   */
-  def flushCardinalityDataToRocksDB(): Unit = {
-    if (cardinalityCountMapDS.size > 0) {
+  def flushCardinalityCount(): Unit = {
+    if (cardinalityCountMap.size > 0) {
       // iterate through map and store each prefix and count to the rocksDB
-      cardinalityCountMapDS.foreach(kv => {
-        modifyCountDS(kv._1, kv._2._1, kv._2._1, kv._2._2)
+      cardinalityCountMap.foreach(kv => {
+        storeCardinalityCountInRocksDB(kv._1, kv._2._1, kv._2._1, kv._2._2)
       })
       // clear the map
-      cardinalityCountMapDS.clear()
+      cardinalityCountMap.clear()
     }
   }
 
@@ -193,7 +204,7 @@ class CardinalityTracker(ref: DatasetRef,
    * @param activeDelta Increase in active timeseries
    * @param childrenDelta Increase in children count
    */
-  private def modifyCountDS(prefix: Seq[String],
+  private def storeCardinalityCountInRocksDB(prefix: Seq[String],
                             totalDelta: Int, activeDelta: Int, childrenDelta: Int): Unit = {
 
     // get the current cardinality count from RocksDB for the given prefix. Also add a default if not present
@@ -295,9 +306,6 @@ class CardinalityTracker(ref: DatasetRef,
     require(depth >= shardKeyPrefix.size,
       s"depth $depth must be at least the size of the prefix ${shardKeyPrefix.size}")
 
-    // flush any pending key value pairs to rocksDB ( useful in down-sample cardinality )
-    flushCardinalityDataToRocksDB()
-
     if (shardKeyPrefix.size == depth) {
       // directly fetch the single cardinality
       Seq(getCardinality(shardKeyPrefix))
@@ -308,13 +316,17 @@ class CardinalityTracker(ref: DatasetRef,
 
   def close(): Unit = {
     store.close()
-    cardinalityCountMapDS.clear()
+
+    // WHY are we not flushing before the close? This is because in our current implementation of
+    // RocksDbCardinalityStore.close(), we delete the RocksDB itself. so to avoid any additional writes, we are just
+    // clearing the map to clean the state
+    cardinalityCountMap.clear()
   }
 
   /**
    * returns a clone of cardinalityCountMapDS map for testing purposes
    */
   def getCardinalityCountMapDSClone(): Map[Seq[String], (Int, Int)] = {
-    cardinalityCountMapDS.clone()
+    cardinalityCountMap.clone()
   }
 }

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -130,7 +130,7 @@ class CardinalityTracker(ref: DatasetRef,
    *
    * @param shardKey
    */
-  def updateCardinalityCountsDS(shardKey: Seq[String]): Unit = {
+  def updateCardinalityCountsDS(shardKey: Seq[String]): Unit = synchronized {
     (0 to shardKey.length).foreach { i =>
 
       // update current prefix's cardinality count
@@ -167,12 +167,12 @@ class CardinalityTracker(ref: DatasetRef,
     }
   }
 
-  /*
+  /**
   * Flush the cardinality data to RocksDB before reading the counts. The downsample cardinality count is built from
   * scratch at a periodic interval and the caller of CardinalityTracker can also call this method to ensure all data
   * is flushed to RocksDB
-  * */
-  def flushCardinalityDataToRocksDB(): Unit = {
+  */
+  def flushCardinalityDataToRocksDB(): Unit = synchronized {
     if (cardinalityCountMapDS.size > 0) {
       // iterate through map and store each prefix and count to the rocksDB
       cardinalityCountMapDS.foreach(kv => {
@@ -305,8 +305,8 @@ class CardinalityTracker(ref: DatasetRef,
   }
 
   def close(): Unit = {
+    flushCardinalityDataToRocksDB()
     store.close()
-    cardinalityCountMapDS.clear()
   }
 
   /**

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -813,7 +813,7 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     containers.head.consumeRecords(binConsumer)
 
     for (elem <- binRecords) {
-      val labelKV = partSchema.binSchema.toStringPairsMap(elem._1, elem._2)
+      val labelKV = partSchema.binSchema.toStringPairs(elem._1, elem._2).toMap
       for(tag <- extraTags){
         labelKV(tag._1.toString) shouldEqual tag._2.toString
       }

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -3,8 +3,9 @@ package filodb.core.memstore
 import com.googlecode.javaewah.IntIterator
 import filodb.core._
 import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
-import filodb.core.metadata.Schemas
+import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
 import filodb.core.query.{ColumnFilter, Filter}
+import filodb.memory.{BinaryRegionConsumer, MemFactory}
 import filodb.memory.format.UnsafeUtils.ZeroPointer
 import filodb.memory.format.UTF8Wrapper
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -784,6 +785,39 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
     val filter2 = ColumnFilter("Actor2Code", Equals("NonExist".utf8))
     keyIndex.singlePartKeyFromFilters(Seq(filter2), 4, 10) shouldBe None
+  }
+
+  it("toStringPairsMap should return a map of label key value pairs") {
+    val columns = Seq("timestamp:ts", "min:double", "avg:double", "max:double", "count:long", "tags:map")
+    val options = DatasetOptions.DefaultOptions.copy(metricColumn = "_metric_")
+    val dataset1 = Dataset("metrics1",
+      Seq("timestamp:ts", "min:double", "avg:double", "max:double", "count:long", "_metric_:string", "tags:map"),
+      columns, options)
+    val partSchema = dataset1.schema.partition
+    val builder = new RecordBuilder(MemFactory.onHeapFactory)
+
+    val extraTags = Map(
+      "_ws_".utf8 -> "my_ws".utf8,
+      "_ns_".utf8 -> "my_ns".utf8,
+      "job".utf8 -> "test_job".utf8
+    )
+    val binRecords = new collection.mutable.ArrayBuffer[(Any, Long)]
+    val binConsumer = new BinaryRegionConsumer {
+      def onNext(base: Any, offset: Long): Unit = binRecords += ((base, offset))
+    }
+    val data = MachineMetricsData.withMap(
+      MachineMetricsData.linearMultiSeries(numSeries = 1),
+      extraTags = extraTags).take(1)
+    MachineMetricsData.addToBuilder(builder, data, dataset1.schema)
+    val containers = builder.allContainers
+    containers.head.consumeRecords(binConsumer)
+
+    for (elem <- binRecords) {
+      val labelKV = partSchema.binSchema.toStringPairsMap(elem._1, elem._2)
+      for(tag <- extraTags){
+        labelKV(tag._1.toString) shouldEqual tag._2.toString
+      }
+    }
   }
 
   it("should match the regex after anchors stripped") {

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -2,8 +2,9 @@ package filodb.core.memstore.ratelimit
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
 import filodb.core.{DatasetRef, MachineMetricsData}
+
+import scala.collection.Seq
 
 class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
@@ -50,9 +51,9 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     ex.prefix shouldEqual (Seq("a", "aa"))
 
     // increment should not have been applied for any prefix
-    t.getCardinality(Seq("a")) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(2, 1, 1, 1))
-    t.getCardinality(Seq("a", "aa")) shouldEqual CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 1, 2, 2))
-    t.getCardinality(Seq("a", "aa", "aac")) shouldEqual
+    t.scan(Seq("a"), 1)(0) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(2, 1, 1, 1))
+    t.scan(Seq("a", "aa"), 2)(0) shouldEqual CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 1, 2, 2))
+    t.scan(Seq("a", "aa", "aac"), 3)(0) shouldEqual
       CardinalityRecord(0, Seq("a", "aa", "aac"), CardinalityValue(0, 0, 0, 4))
 
     // aab was purged
@@ -219,11 +220,11 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
         CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 1, 10)),
         CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 4, 20)))
 
-    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual
+    t.scan(Seq("a", "aa", "aab"), 3)(0) shouldEqual
       CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 4, 20))
 
     t.setQuota(Seq("a", "aa", "aab"), 3)
-    t.getCardinality(Seq("a", "aa", "aab")) shouldEqual
+    t.scan(Seq("a", "aa", "aab"), 3)(0) shouldEqual
       CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 4, 3))
     val ex2 = intercept[QuotaReachedException] {
       t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
@@ -236,13 +237,13 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     val t = new CardinalityTracker(ref, 0, 3, Seq(50000, 50000, 50000, 50000), newCardStore)
 
     (1 to 30000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 1, 1))
-    t.getCardinality(Seq("a", "b", "c")) shouldEqual
+    t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
       CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(30000, 30000, 30000, 50000))
     (1 to 30000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 0, -1))
-    t.getCardinality(Seq("a", "b", "c")) shouldEqual
+    t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
       CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(30000, 0, 30000, 50000))
     (1 to 30000).foreach(_ => t.decrementCount(Seq("a", "b", "c")))
-    t.getCardinality(Seq("a", "b", "c")) shouldEqual
+    t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
       CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(0, 0, 0, 50000))
   }
 
@@ -300,14 +301,109 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     t.close()
   }
 
-  it ("modifyCountDS should update count correctly") {
-    val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
-    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
-    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
-    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
-    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
-    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
-    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
-    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
+  it ("updateCardinalityCountsDS should update count correctly") {
+    val t = new CardinalityTracker(ref, 1, 3, Seq(50000, 50000, 50000, 50000), dsCardStore)
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("a", "b", "c")))
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("a", "b", "d")))
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("a", "c", "d")))
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("b", "c", "d")))
+
+    t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
+      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(1000, 1000, 0, 50000))
+    t.scan(Seq("a", "b"), 2)(0) shouldEqual
+      CardinalityRecord(1, Seq("a", "b"), CardinalityValue(2000, 2000, 2000, 50000))
+    t.scan(Seq("a", "b", "d"), 3)(0) shouldEqual
+      CardinalityRecord(1, Seq("a", "b", "d"), CardinalityValue(1000, 1000, 0, 50000))
+    t.scan(Seq("b", "c"), 2)(0) shouldEqual
+      CardinalityRecord(1, Seq("b", "c"), CardinalityValue(1000, 1000, 1000, 50000))
+    t.scan(Seq("b", "c", "d"), 3)(0) shouldEqual
+      CardinalityRecord(1, Seq("b", "c", "d"), CardinalityValue(1000, 1000, 0, 50000))
+    t.scan(Seq("a"), 1)(0) shouldEqual
+      CardinalityRecord(1, Seq("a"), CardinalityValue(3000, 3000, 3000, 50000))
+    t.scan(Seq("b"), 1)(0) shouldEqual
+      CardinalityRecord(1, Seq("b"), CardinalityValue(1000, 1000, 1000, 50000))
+    t.scan(Seq(), 0)(0) shouldEqual
+      CardinalityRecord(1, Seq(), CardinalityValue(4000, 4000, 4000, 50000))
+
+    t.close()
+  }
+
+  it ("updateCardinalityCountsDS should throw QuotaReachedException when childrenCount breached") {
+    val t = new CardinalityTracker(ref, 1, 3, Seq(2, 2, 2, 2), dsCardStore)
+    t.updateCardinalityCountsDS(Seq("a", "b", "c"))
+    t.updateCardinalityCountsDS(Seq("a", "b", "d"))
+    val ex = intercept[QuotaReachedException] {
+      t.updateCardinalityCountsDS(Seq("a", "b", "e"))
+    }
+    ex.prefix shouldEqual Seq("a")
+    t.close()
+  }
+
+  it("updateCardinalityCountsDS should flush counts to RocksDB if threshold reached") {
+    val t = new CardinalityTracker(ref, 1, 3, Seq(5, 5, 5, 5),
+      dsCardStore, dsCardinalityMapFlushCount = 5)
+    t.updateCardinalityCountsDS(Seq("a", "b", "c"))
+    t.updateCardinalityCountsDS(Seq("a", "b", "d"))
+
+    // check not flushed until now since threshold not crossed
+    t.getCardinalityCountMapDSClone().size shouldEqual 5
+
+    t.updateCardinalityCountsDS(Seq("a", "b", "e"))
+
+    // check if map is cleared after flush
+    t.getCardinalityCountMapDSClone().size shouldEqual 0
+
+    // check data integrity in RocksDB
+    t.scan(Seq(), 0)(0) shouldEqual
+      CardinalityRecord(1, Seq(), CardinalityValue(3, 3, 3, 5))
+    t.scan(Seq("a"), 1)(0) shouldEqual
+      CardinalityRecord(1, Seq("a"), CardinalityValue(3, 3, 3, 5))
+    t.scan(Seq("a", "b"), 2)(0) shouldEqual
+      CardinalityRecord(1, Seq("a", "b"), CardinalityValue(3, 3, 3, 5))
+    t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
+      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(1, 1, 0, 5))
+
+    t.close()
+  }
+
+  it("updateCardinalityCountsDS and modifyCount should give same tsCount and activeCount values") {
+    val s = new CardinalityTracker(ref, 0, 3, Seq(5000, 5000, 5000, 5000), newCardStore)
+    val t = new CardinalityTracker(ref, 1, 3, Seq(5000, 5000, 5000, 5000), dsCardStore)
+
+    // update raw card count
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "b", "c"), 1, 1))
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "b", "d"), 1, 1))
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "c", "d"), 1, 1))
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("b", "c", "d"), 1, 1))
+
+    // update ds card count
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("a", "b", "c")))
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("a", "b", "d")))
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("a", "c", "d")))
+    (1 to 1000).foreach(_ => t.updateCardinalityCountsDS(Seq("b", "c", "d")))
+
+    t.scan(Seq("a", "b", "c"), 3)(0).value.tsCount shouldEqual
+      s.scan(Seq("a", "b", "c"), 3)(0).value.tsCount
+
+    t.scan(Seq("a", "b"), 2)(0).value.tsCount shouldEqual
+      s.scan(Seq("a", "b"), 2)(0).value.tsCount
+
+    t.scan(Seq("a", "b", "d"), 3)(0).value.tsCount shouldEqual
+      s.scan(Seq("a", "b", "d"), 3)(0).value.tsCount
+
+    t.scan(Seq("b", "c"), 2)(0).value.tsCount shouldEqual
+      s.scan(Seq("b", "c"), 2)(0).value.tsCount
+
+    t.scan(Seq("b", "c", "d"), 3)(0).value.tsCount shouldEqual
+      s.scan(Seq("b", "c", "d"), 3)(0).value.tsCount
+
+    t.scan(Seq("a"), 1)(0).value.tsCount shouldEqual
+      s.scan(Seq("a"), 1)(0).value.tsCount
+
+    t.scan(Seq("b"), 1)(0).value.tsCount shouldEqual
+      s.scan(Seq("b"), 1)(0).value.tsCount
+
+    s.close()
+    t.close()
   }
 }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -13,6 +13,10 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     new RocksDbCardinalityStore(DatasetRef("test"), 0)
   }
 
+  private def dsCardStore = {
+    new RocksDbCardinalityStore(DatasetRef("ds_test"), 1)
+  }
+
   it("should enforce quota when set explicitly for all levels") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
     t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual
@@ -294,5 +298,16 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
     )
 
     t.close()
+  }
+
+  it ("modifyCountDS should update count correctly") {
+    val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
+    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
+    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
+    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
+    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
+    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
+    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**  CardinalityTracker support delta of cardinality counts in values of 0 or 1. All these updates is stored to RocksDB when the modifyCount is called. 

However, in downsample cluster, we have a burst write scenario, since we read all the partKeys from the index and update the cardinality count from scratch. With the existing `modifyCount` method, we are running into heavy disk write scenarios which increases the time needed to measure cardinality in downsample clusters.

**New behavior :** To mitigate the above scenario, I am adding additional data-structures in CardinalityTracker, which stores aggregates count in memory and flushes to RocksDB on a static threshold (to avoid storing all cardinality records in memory and to avoid the memory pressure).

**Test Results:** We ran a test on a kube pod, with `cpu : 1` and `memory: 2Gi` and following were the time taken to calculate cardinality - 

[With InMemoryAggregation] DocCount: 20296704 | TotalBytes: 375490632708 | TotalBytesInGB: 375.490632708 | **DurationInSecondsToCalculateCardinality: 160** | DurationSecondsScanRocksDB: 0

[WithOut Aggregation] DocCount: 20296704 | TotalBytes: 375490632708 | TotalBytesInGB: 375.490632708 | **DurationInSecondsToCalculateCardinality: 1162** | DurationSecondsScanRocksDB: 0

