### PR TITLE
feat(query): adding warnings to QuerySession

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -487,9 +487,10 @@ object CliMain extends StrictLogging {
       case Some(intervalSecs) =>
         val fut = Observable.intervalAtFixedRate(intervalSecs.seconds).foreach { n =>
           client.logicalPlan2Query(ref, plan, qOpts) match {
-            case QueryResult(_, _, result, stats, _, _) =>
+            case QueryResult(_, _, result, stats, warnings, _, _) =>
               result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
               println(s"QueryStats: $stats")
+              println(s"QueryWarnings: $warnings")
             case err: QueryError                => throw new ClientException(err)
           }
         }.recover {
@@ -500,11 +501,12 @@ object CliMain extends StrictLogging {
       case None =>
         try {
           client.logicalPlan2Query(ref, plan, qOpts) match {
-            case QueryResult(_, schema, result, stats, _, _) =>
+            case QueryResult(_, schema, result, stats, warnings, _, _) =>
                                                    println(s"Output schema: $schema")
                                                    println(s"Number of Range Vectors: ${result.size}")
                                                    result.take(options.limit).foreach(rv => println(rv.prettyPrint()))
                                                    println(s"QueryStats: $stats")
+                                                   println(s"QueryWarnings: $warnings")
             case QueryError(_, stats, ex)  =>
                                                    println(s"QueryError: ${ex.getClass.getSimpleName} ${ex.getMessage}")
                                                    println(s"QueryStats: $stats")

--- a/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
@@ -14,7 +14,7 @@ import monix.reactive.subjects.ConcurrentSubject
 
 import filodb.coordinator.ActorSystemHolder.system
 import filodb.core.QueryTimeoutException
-import filodb.core.query.{QueryStats, ResultSchema}
+import filodb.core.query.{QueryStats, QueryWarnings, ResultSchema}
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, QueryResult, StreamQueryError, StreamQueryResponse, StreamQueryResultFooter}
 import filodb.query.Query.qLogger
@@ -31,7 +31,7 @@ case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends Pl
     val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
     val remainingTime = plan.clientParams.deadline - queryTimeElapsed
     lazy val emptyPartialResult: QueryResult = QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil,
-      QueryStats(), true, Some("Result may be partial since query on some shards timed out"))
+      QueryStats(), QueryWarnings(), true, Some("Result may be partial since query on some shards timed out"))
 
     // Don't send if time left is very small
     if (remainingTime < 1) {
@@ -70,7 +70,7 @@ case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends Pl
     val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
     val remainingTime = plan.clientParams.deadline - queryTimeElapsed
     lazy val emptyPartialResult = StreamQueryResultFooter(plan.execPlan.queryContext.queryId,
-      QueryStats(), true, Some("Result may be partial since query on some shards timed out"))
+      QueryStats(), QueryWarnings(), true, Some("Result may be partial since query on some shards timed out"))
 
     // Don't send if time left is very small
     if (remainingTime < 1) {

--- a/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
@@ -67,7 +67,7 @@ case class TenantIngestionMetering(settings: FilodbSettings,
         LogicalPlan2Query(dsRef, TsCardinalities(prefix, numGroupByFields)),
         ASK_TIMEOUT)
       fut.onComplete {
-        case Success(QueryResult(_, _, rv, _, _, _)) =>
+        case Success(QueryResult(_, _, rv, _, _, _, _)) =>
           rv.foreach(_.rows().foreach{ rr =>
             // publish a cardinality metric for each namespace
             val data = RowData.fromRowReader(rr)

--- a/coordinator/src/main/scala/filodb.coordinator/queryengine/Utils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryengine/Utils.scala
@@ -153,7 +153,7 @@ object Utils extends StrictLogging {
             case f: StreamQueryResultFooter => f
           }.getOrElse(StreamQueryResultFooter(queryContext.queryId))
           QueryResult(queryContext.queryId, header.resultSchema, rvs,
-            footer.queryStats, footer.mayBePartial, footer.partialResultReason)
+            footer.queryStats, footer.warnings, footer.mayBePartial, footer.partialResultReason)
         }
     }
   }

--- a/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
+++ b/coordinator/src/multi-jvm/scala/filodb.coordinator/ClusterRecoverySpec.scala
@@ -152,7 +152,7 @@ abstract class ClusterRecoverySpec extends ClusterSpec(ClusterRecoverySpecConfig
                  100L, 1000L, 100L, window = 1000L, function = RangeFunctionId.CountOverTime), qOpt)
     coordinatorActor ! q2
     expectMsgPF(10.seconds.dilated) {
-      case QueryResult(_, schema, vectors, _, _, _) =>
+      case QueryResult(_, schema, vectors, _, _, _, _) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", ColumnType.LongColumn, false),
                                        ColumnInfo("value", ColumnType.DoubleColumn, true))
         // query is counting each partition....

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -155,7 +155,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       probe.send(coordinatorActor, q1)
       val info1 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, srvs, _, _, _) =>
+        case QueryResult(_, schema, srvs, _, _, _, _) =>
           schema.columns shouldEqual timeMinSchema.columns
           srvs should have length (1)
           srvs(0).rows.toSeq should have length (2)   // 2 samples per series
@@ -166,7 +166,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
         Seq("min"), Some(300000), None), qOpt)
       probe.send(coordinatorActor, q2)
       val info2 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, Nil, _, _, _) =>
+        case QueryResult(_, schema, Nil, _, _, _, _) =>
           schema.columns shouldEqual Nil
       }
     }
@@ -202,7 +202,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
       memStore.refreshIndexForTesting(dataset1.ref)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
@@ -215,7 +215,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                      RawSeries(AllChunksSelector, multiFilter, Seq("count"), Some(300000), None), 120000L, 10000L, 130000L)), qOpt)
       probe.send(coordinatorActor, q3)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(98.0, 108.0)
@@ -229,7 +229,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                      10000L, 130000L)),  qOpt)
       probe.send(coordinatorActor, q4)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _, _) =>
           schema.columns shouldEqual Nil
           vectors should have length (0)
       }
@@ -254,7 +254,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
 
       (0 until numQueries).foreach { _ =>
         probe.expectMsgPF() {
-          case QueryResult(_, schema, vectors, _, _, _) =>
+          case QueryResult(_, schema, vectors, _, _, _, _) =>
             schema.columns shouldEqual valueSchema.columns
             vectors should have length (1)
             vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0)
@@ -284,7 +284,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                       queryOpt)
       probe.send(coordinatorActor, q2)
       probe.expectMsgPF() {
-        case QueryResult(_, schema, vectors, _, _, _) =>
+        case QueryResult(_, schema, vectors, _, _, _, _) =>
           schema.columns shouldEqual valueSchema.columns
           vectors should have length (1)
           vectors(0).rows.map(_.getDouble(1)).toSeq shouldEqual Seq(14.0, 24.0, 14.0)
@@ -308,7 +308,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
         queryOpt)
       probe.send(coordinatorActor, q2)
       val info1 = probe.expectMsgPF(3.seconds.dilated) {
-        case QueryResult(_, schema, srvs, _, _, _) =>
+        case QueryResult(_, schema, srvs, _, _, _, _) =>
           schema.columns shouldEqual timeMinSchema.columns
           srvs should have length (6)
           val groupedByKey = srvs.groupBy(_.key.labelValues)
@@ -380,7 +380,7 @@ class NodeCoordinatorActorSpec extends ActorTest(NodeCoordinatorActorSpec.getNew
                    RawSeries(AllChunksSelector, Seq(ColumnFilter("notALabel", NotEquals("foo"))), Seq("AvgTone")), 0, 10, 99)), qOpt)
     probe.send(coordinatorActor, q2)
     probe.expectMsgPF() {
-      case QueryResult(_, schema, vectors, _, _, _) =>
+      case QueryResult(_, schema, vectors, _, _, _, _) =>
         schema.columns shouldEqual Seq(ColumnInfo("GLOBALEVENTID", LongColumn, false),
                                        ColumnInfo("value", DoubleColumn, true))
         vectors should have length (1)

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -104,13 +104,16 @@ case class QueryWarnings(
   }
 
   override def equals(w2Compare: Any): Boolean = {
-    val w2 = w2Compare.asInstanceOf[QueryWarnings]
-    execPlanSamples.get().equals(w2.execPlanSamples.get()) &&
-    execPlanResultBytes.get().equals(w2.execPlanResultBytes.get()) &&
-    groupByCardinality.get().equals(w2.groupByCardinality.get()) &&
-    joinQueryCardinality.get().equals(w2.joinQueryCardinality.get()) &&
-    timeSeriesSamplesScannedBytes.get().equals(w2.timeSeriesSamplesScannedBytes.get()) &&
-    timeSeriesScanned.get().equals(w2.timeSeriesScanned.get())
+    w2Compare match {
+      case w2: QueryWarnings =>
+        execPlanSamples.get().equals(w2.execPlanSamples.get()) &&
+          execPlanResultBytes.get().equals(w2.execPlanResultBytes.get()) &&
+          groupByCardinality.get().equals(w2.groupByCardinality.get()) &&
+          joinQueryCardinality.get().equals(w2.joinQueryCardinality.get()) &&
+          timeSeriesSamplesScannedBytes.get().equals(w2.timeSeriesSamplesScannedBytes.get()) &&
+          timeSeriesScanned.get().equals(w2.timeSeriesScanned.get())
+      case _ => false
+    }
   }
 
   override def hashCode(): Int = {

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -1,7 +1,7 @@
 package filodb.core.query
 
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
 import scala.collection.Seq
 import scala.collection.concurrent.TrieMap
@@ -48,6 +48,82 @@ object PerQueryLimits {
   }
 
 }
+
+object QueryWarnings {
+
+}
+case class QueryWarnings(
+  execPlanSamples: AtomicInteger = new AtomicInteger(0),
+  execPlanResultBytes: AtomicLong = new AtomicLong(0),
+  groupByCardinality: AtomicInteger = new AtomicInteger(0),
+  joinQueryCardinality: AtomicInteger = new AtomicInteger(0),
+  timeSeriesSamplesScannedBytes: AtomicLong = new AtomicLong(0),
+  timeSeriesScanned: AtomicInteger = new AtomicInteger(0)
+) {
+
+  def hasWarnings() : Boolean = {
+    execPlanSamples.get() > 0 ||
+    execPlanResultBytes.get() > 0 ||
+    groupByCardinality.get() > 0 ||
+    joinQueryCardinality.get() > 0 ||
+    timeSeriesSamplesScannedBytes.get() > 0 ||
+    timeSeriesScanned.get() > 0
+  }
+
+  def merge(warnings: QueryWarnings) : Unit = {
+    updateExecPlanSamples(warnings.execPlanSamples.get())
+    updateExecPlanResultBytes(warnings.execPlanResultBytes.get())
+    updateGroupByCardinality(warnings.groupByCardinality.get())
+    updateJoinQueryCardinality(warnings.joinQueryCardinality.get())
+    updateTimeSeriesSampleScannedBytes(warnings.timeSeriesSamplesScannedBytes.get())
+    updateTimeSeriesScanned(warnings.timeSeriesScanned.get())
+  }
+
+  def updateExecPlanSamples(samples: Int): Unit = {
+    execPlanSamples.updateAndGet(s => if (s < samples) samples else s)
+  }
+
+  def updateExecPlanResultBytes(bytes: Long): Unit = {
+    execPlanResultBytes.updateAndGet(b => if (b < bytes) bytes else b)
+  }
+
+  def updateGroupByCardinality(cardinality: Int): Unit = {
+    groupByCardinality.updateAndGet(c => if (c < cardinality) cardinality else c)
+  }
+
+  def updateJoinQueryCardinality(cardinality: Int): Unit = {
+    joinQueryCardinality.updateAndGet(c => if (c < cardinality) cardinality else c)
+  }
+
+  def updateTimeSeriesScanned(series: Int): Unit = {
+    timeSeriesScanned.updateAndGet(s => if (s<series) series else s)
+  }
+
+  def updateTimeSeriesSampleScannedBytes(bytes: Long): Unit = {
+    timeSeriesSamplesScannedBytes.updateAndGet(b => if (b<bytes) bytes else b)
+  }
+
+  override def equals(w2Compare: Any): Boolean = {
+    val w2 = w2Compare.asInstanceOf[QueryWarnings]
+    execPlanSamples.get().equals(w2.execPlanSamples.get()) &&
+    execPlanResultBytes.get().equals(w2.execPlanResultBytes.get()) &&
+    groupByCardinality.get().equals(w2.groupByCardinality.get()) &&
+    joinQueryCardinality.get().equals(w2.joinQueryCardinality.get()) &&
+    timeSeriesSamplesScannedBytes.get().equals(w2.timeSeriesSamplesScannedBytes.get()) &&
+    timeSeriesScanned.get().equals(w2.timeSeriesScanned.get())
+  }
+
+  override def hashCode(): Int = {
+    var c = execPlanSamples.get().hashCode()
+    c = 31 * c + execPlanResultBytes.get().hashCode()
+    c = 31 * c + groupByCardinality.get().hashCode()
+    c = 31 * c + joinQueryCardinality.get().hashCode()
+    c = 31 * c + timeSeriesSamplesScannedBytes.get().hashCode()
+    c = 31 * c + timeSeriesScanned.get().hashCode()
+    c
+  }
+}
+
 case class PlannerParams(applicationId: String = "filodb",
                          spread: Option[Int] = None,
                          spreadOverride: Option[SpreadProvider] = None,
@@ -209,6 +285,7 @@ case class QuerySession(qContext: QueryContext,
                         catchMultipleLockSetErrors: Boolean = false) {
 
   val queryStats: QueryStats = QueryStats()
+  val warnings: QueryWarnings = QueryWarnings()
   private var lock: Option[EvictionLock] = None
   var resultCouldBePartial: Boolean = false
   var partialResultsReason: Option[String] = None

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -73,6 +73,7 @@ message StreamingFooterResponse {
   bool mayBePartial                              = 3;
   optional string partialResultReason            = 4;
   string planId                                  = 5;
+  optional QueryWarnings warnings                = 6;
 }
 
 
@@ -117,6 +118,7 @@ message Response {
   repeated SerializableRangeVector result        = 5;
   optional bool mayBePartial                     = 6;
   optional string partialResultReason            = 7;
+  optional QueryWarnings warnings                = 8;
 }
 
 // Objects for Query stats
@@ -134,6 +136,14 @@ message QueryResultStats {
   map<string, Stat> stats     = 1;
 }
 
+message QueryWarnings {
+  uint32 execPlanSamples               = 1;
+  uint64 execPlanResultBytes           = 2;
+  uint32 groupByCardinality            = 3;
+  uint32 joinQueryCardinality          = 4;
+  uint64 timeSeriesSamplesScannedBytes = 5;
+  uint32 timeSeriesScanned             = 6;
+}
 
 
 service RemoteExec {

--- a/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
+++ b/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
@@ -92,10 +92,16 @@ class PromQLGrpcServer(queryPlannerSelector: String => QueryPlanner,
                     // Not the cleanest way, but we need to convert these IteratorBackedRangeVectors to a
                     // serializable one If we have a result, its definitely is a QueryResult
                     val strQueryResult = (result.result, qr) match {
-                      case (irv: IteratorBackedRangeVector, QueryResult(_, resultSchema, _, queryStats, _, _)) =>
-                        result.copy(result = SerializedRangeVector.apply(irv, rb,
+                      case (
+                        irv: IteratorBackedRangeVector,
+                        QueryResult(_, resultSchema, _, queryStats, _, _, _)
+                      ) => result.copy(
+                        result = SerializedRangeVector.apply(
+                          irv, rb,
                           SerializedRangeVector.toSchema(resultSchema.columns, resultSchema.brSchemas),
-                          "GrpcServer", queryStats))
+                          "GrpcServer", queryStats
+                        )
+                      )
                       case _ => result
                     }
                     responseObserver.onNext(strQueryResult.toProto)

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -92,8 +92,13 @@ object PrometheusModel {
                     qr.result.map(toHistResult(_, verbose, qr.resultType))
                   else
                     qr.result.map(toPromResult(_, verbose, qr.resultType))
-    SuccessResponse(Data(toPromResultType(qr.resultType), results.filter(r => r.values.nonEmpty || r.value.isDefined)),
-                    "success", Some(qr.mayBePartial), qr.partialResultReason, Some(toQueryStatistics(qr.queryStats)))
+    SuccessResponse(
+      Data(toPromResultType(qr.resultType), results.filter(r => r.values.nonEmpty || r.value.isDefined)),
+      "success",
+      Some(qr.mayBePartial), qr.partialResultReason,
+      Some(toQueryStatistics(qr.queryStats)),
+      Some(toQueryWarningsResponse(qr.warnings))
+    )
   }
 
   def toPromExplainPlanResponse(ex: ExecPlan): ExplainPlanResponse = {
@@ -223,5 +228,16 @@ object PrometheusModel {
     QueryStatistics(stat._1, stat._2.timeSeriesScanned.get(),
       stat._2.dataBytesScanned.get(), stat._2.resultBytes.get(), stat._2.cpuNanos.get())
   ).toSeq
+
+  def toQueryWarningsResponse(qw: QueryWarnings): QueryWarningsResponse = {
+    QueryWarningsResponse(
+      execPlanSamples = qw.execPlanSamples.get(),
+      execPlanResultBytes = qw.execPlanResultBytes.get(),
+      groupByCardinality = qw.groupByCardinality.get(),
+      joinQueryCardinality = qw.joinQueryCardinality.get(),
+      timeSeriesSamplesScannedBytes = qw.timeSeriesSamplesScannedBytes.get(),
+      timeSeriesScanned = qw.timeSeriesScanned.get()
+    )
+  }
 
 }

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -10,7 +10,8 @@ final case class ErrorResponse(errorType: String, error: String, status: String 
 final case class SuccessResponse(data: Data, status: String = "success",
                                  partial: Option[Boolean] = None,
                                  message: Option[String] = None,
-                                 queryStats: Option[Seq[QueryStatistics]]) extends PromQueryResponse
+                                 queryStats: Option[Seq[QueryStatistics]],
+                                 queryWarnings: Option[QueryWarningsResponse]) extends PromQueryResponse
 
 final case class ExplainPlanResponse(debugInfo: Seq[String], status: String = "success",
                                      partial: Option[Boolean]= None,
@@ -18,6 +19,14 @@ final case class ExplainPlanResponse(debugInfo: Seq[String], status: String = "s
 
 final case class QueryStatistics(group: Seq[String], timeSeriesScanned: Long,
                                  dataBytesScanned: Long, resultBytes: Long, cpuNanos: Long)
+final case class QueryWarningsResponse(
+  execPlanSamples: Int = 0,
+  execPlanResultBytes: Long  = 0,
+  groupByCardinality: Int = 0,
+  joinQueryCardinality: Int = 0,
+  timeSeriesSamplesScannedBytes: Long = 0,
+  timeSeriesScanned: Int = 0
+)
 
 final case class Data(resultType: String, result: Seq[Result])
 

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -50,7 +50,8 @@ trait ReduceAggregateExec extends NonLeafExecPlan {
           val aggregator = RowAggregator(aggrOp, aggrParams, schema)
           RangeVectorAggregator.mapReduce(
             aggregator, skipMapPhase = true, results, rv => rv.key,
-            queryContext)
+            queryContext, querySession.warnings
+          )
         }
       }
     Observable.fromTask(task).flatten
@@ -140,10 +141,14 @@ final case class AggregateMapReduce(aggrOp: AggregationOperator,
       sourceSchema.fixedVectorLen.filter(_ <= querySession.queryConfig.fastReduceMaxWindows).map { numWindows =>
         RangeVectorAggregator.fastReduce(aggregator, false, source, numWindows)
       }.getOrElse {
-        RangeVectorAggregator.mapReduce(aggregator, skipMapPhase = false, source, grouping, querySession.qContext)
+        RangeVectorAggregator.mapReduce(
+          aggregator, skipMapPhase = false, source, grouping, querySession.qContext, querySession.warnings
+        )
       }
     } else {
-      RangeVectorAggregator.mapReduce(aggregator, skipMapPhase = false, source, grouping, querySession.qContext)
+      RangeVectorAggregator.mapReduce(
+        aggregator, skipMapPhase = false, source, grouping, querySession.qContext, querySession.warnings
+      )
     }
   }
 
@@ -198,7 +203,8 @@ object RangeVectorAggregator extends StrictLogging {
                 skipMapPhase: Boolean,
                 source: Observable[RangeVector],
                 grouping: RangeVector => RangeVectorKey,
-                queryContext: QueryContext): Observable[RangeVector] = {
+                queryContext: QueryContext,
+                queryWarnings: QueryWarnings): Observable[RangeVector] = {
     // reduce the range vectors using the foldLeft construct. This results in one aggregate per group.
     val task = source.toListL.map { rvs =>
       val period = rvs.headOption.flatMap(_.outputRange)
@@ -221,6 +227,7 @@ object RangeVectorAggregator extends StrictLogging {
         logger.info(queryContext.getQueryLogLine(
           s"Exceeded warning group-by cardinality limit ${groupByWarnLimit}. "
         ))
+        queryWarnings.updateGroupByCardinality(groupedResult.size)
       }
       groupedResult.map { case (rvk, aggHolder) =>
         val rowIterator = new CustomCloseCursor(aggHolder.map(_.toRowReader))(aggHolder.close())

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -87,6 +87,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
         }
         val joinQueryWarnCardinalityLimit = queryContext.plannerParams.warnLimits.joinQueryCardinality
         if (result.size > joinQueryWarnCardinalityLimit && cardinality == Cardinality.OneToOne) {
+          querySession.warnings.updateJoinQueryCardinality(result.size)
           qLogger.info(queryContext.getQueryLogLine(
             s"Exceeded warning binary join input cardinality limit=${joinQueryWarnCardinalityLimit}, " +
               s" encountered input cardinality ${result.size}"

--- a/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
+++ b/query/src/main/scala/filodb/query/exec/EmptyResultExec.scala
@@ -5,7 +5,7 @@ import monix.execution.Scheduler
 
 import filodb.core.DatasetRef
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.query.{ColumnInfo, QueryContext, QuerySession, QueryStats, ResultSchema}
+import filodb.core.query.{ColumnInfo, QueryContext, QuerySession, QueryStats, QueryWarnings, ResultSchema}
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, QueryResult}
 
@@ -19,7 +19,7 @@ case class EmptyResultExec(queryContext: QueryContext,
     Task(QueryResult(queryContext.queryId,
       new ResultSchema(Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
                            ColumnInfo("value", ColumnType.DoubleColumn)), 1),
-      Seq.empty, QueryStats(), false, None))
+      Seq.empty, QueryStats(), QueryWarnings(), false, None))
   }
 
   override def doExecute(source: ChunkSource,

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -2,18 +2,19 @@ package filodb.query.exec
 
 import java.net.InetAddress
 
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.DurationLong
+
 import kamon.Kamon
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
-import scala.concurrent.TimeoutException
-import scala.concurrent.duration.DurationLong
 
 import filodb.core.{DatasetRef, Types}
 import filodb.core.memstore.PartLookupResult
 import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata.Schemas
-import filodb.core.query.{QueryConfig, QuerySession, QueryStats, ResultSchema}
+import filodb.core.query.{QueryConfig, QuerySession, QueryStats, QueryWarnings, ResultSchema}
 import filodb.core.store._
 import filodb.query.{QueryResponse, QueryResult, StreamQueryResponse}
 import filodb.query.Query.qLogger
@@ -28,7 +29,7 @@ import filodb.query.Query.qLogger
   override def dispatch(plan: ExecPlanWithClientParams,
                         source: ChunkSource)(implicit sched: Scheduler): Task[QueryResponse] = {
     lazy val emptyPartialResult = QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil,
-      QueryStats(), true, Some("Result may be partial since query on some shards timed out"))
+      QueryStats(), QueryWarnings(), true, Some("Result may be partial since query on some shards timed out"))
 
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -131,7 +131,7 @@ final case class LabelValuesDistConcatExec(queryContext: QueryContext,
                         querySession: QuerySession): Observable[RangeVector] = {
     qLogger.debug(s"NonLeafMetadataExecPlan: Concatenating results")
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, schema, result, _, _, _), _) => (schema, result)
+      case (QueryResult(_, schema, result, _, _, _, _), _) => (schema, result)
     }.toListL.map { resp =>
       val colType = resp.head._1.columns.head.colType
       if (colType == MapColumn) {

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -123,7 +123,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
       val srvSeq = Seq(SerializedRangeVector(rangeVector, builder, labelsRecordSchema,
         queryWithPlanName(queryContext), dummyQueryStats))
 
-      QueryResult(id, labelsResultSchema, srvSeq, QueryStats(),
+      QueryResult(id, labelsResultSchema, srvSeq, QueryStats(), QueryWarnings(),
         if (response.partial.isDefined) response.partial.get else false, response.message)
     } else {
       val iteratorMap = data.map { r => r.value.map { v => (v._1.utf8, v._2.utf8) }}
@@ -138,7 +138,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
 
       val schema = if (data.isEmpty) ResultSchema.empty else resultSchema
       // FIXME need to send and parse query stats in remote calls
-      QueryResult(id, schema, srvSeq, QueryStats(),
+      QueryResult(id, schema, srvSeq, QueryStats(), QueryWarnings(),
         if (response.partial.isDefined) response.partial.get else false, response.message)
     }
 
@@ -158,7 +158,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
 
     val schema = if (data.isEmpty) ResultSchema.empty else labelsResultSchema
     // FIXME need to send and parse query stats in remote calls
-    QueryResult(id, schema, srvSeq, QueryStats(),
+    QueryResult(id, schema, srvSeq, QueryStats(), QueryWarnings(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 }

--- a/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarBinaryOperationExec.scala
@@ -59,8 +59,11 @@ case class ScalarBinaryOperationExec(queryContext: QueryContext,
                       (implicit sched: Scheduler): Task[QueryResponse] = {
     val rangeVectors : Seq[RangeVector] = Seq(ScalarFixedDouble(params, evaluate))
     Task.eval { // not async
-      QueryResult(queryContext.queryId, resultSchema, rangeVectors, QueryStats(), querySession.resultCouldBePartial,
-        querySession.partialResultsReason)
+      QueryResult(
+        queryContext.queryId, resultSchema, rangeVectors, QueryStats(), QueryWarnings(),
+        querySession.resultCouldBePartial,
+        querySession.partialResultsReason
+      )
     }
   }
 }

--- a/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
+++ b/query/src/main/scala/filodb/query/exec/ScalarFixedDoubleExec.scala
@@ -61,8 +61,10 @@ case class ScalarFixedDoubleExec(queryContext: QueryContext,
           (transf.apply(acc._1, querySession, queryContext.plannerParams.enforcedLimits.execPlanSamples, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          QueryResult(queryContext.queryId, resultSchema, _, QueryStats(), querySession.resultCouldBePartial,
-            querySession.partialResultsReason)
+          QueryResult(queryContext.queryId, resultSchema, _,
+            QueryStats(), QueryWarnings(), querySession.resultCouldBePartial,
+            querySession.partialResultsReason
+          )
         })
       }.flatten
     }

--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -60,7 +60,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
                               querySession: QuerySession): Observable[RangeVector] = {
     val span = Kamon.currentSpan()
     val taskOfResults = childResponses.map {
-      case (QueryResult(_, schema, result, _, _, _), i) => (schema, result, i)
+      case (QueryResult(_, schema, result, _, _, _, _), i) => (schema, result, i)
     }.toListL.map { resp =>
       val startNs = Utils.currentThreadCpuTimeNanos
       try {

--- a/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/TimeScalarGeneratorExec.scala
@@ -70,8 +70,10 @@ case class TimeScalarGeneratorExec(queryContext: QueryContext,
           (transf.apply(acc._1, querySession, queryContext.plannerParams.enforcedLimits.execPlanSamples, acc._2,
             paramRangeVector), transf.schema(acc._2))
         }._1.toListL.map({
-          QueryResult(queryContext.queryId, resultSchema, _, QueryStats(), querySession.resultCouldBePartial,
-            querySession.partialResultsReason)
+          QueryResult(queryContext.queryId, resultSchema, _,
+            QueryStats(), QueryWarnings(), querySession.resultCouldBePartial,
+            querySession.partialResultsReason
+          )
         })
       }.flatten
     }

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -47,7 +47,9 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Sum
     val agg1 = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
-    val resultObs = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping, queryContext = qc)
+    val resultObs = RangeVectorAggregator.mapReduce(
+      agg1, false, Observable.fromIterable(samples), noGrouping, queryContext = qc, QueryWarnings()
+    )
     val result = resultObs.toListL.runToFuture.futureValue
     result.size shouldEqual 1
     result(0).key shouldEqual noKey
@@ -56,7 +58,9 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Min
     val agg2 = RowAggregator(AggregationOperator.Min, Nil, tvSchema)
-    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, false, Observable.fromIterable(samples), noGrouping, queryContext = qc)
+    val resultObs2 = RangeVectorAggregator.mapReduce(
+      agg2, false, Observable.fromIterable(samples), noGrouping, queryContext = qc, QueryWarnings()
+    )
     val result2 = resultObs2.toListL.runToFuture.futureValue
     result2.size shouldEqual 1
     result2(0).key shouldEqual noKey
@@ -65,8 +69,12 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Count
     val agg3 = RowAggregator(AggregationOperator.Count, Nil, tvSchema)
-    val resultObs3a = RangeVectorAggregator.mapReduce(agg3, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs3 = RangeVectorAggregator.mapReduce(agg3, true, resultObs3a, rv=>rv.key,  queryContext = qc)
+    val resultObs3a = RangeVectorAggregator.mapReduce(
+      agg3, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings()
+    )
+    val resultObs3 = RangeVectorAggregator.mapReduce(
+      agg3, true, resultObs3a, rv=>rv.key,  queryContext = qc, QueryWarnings()
+    )
     val result3 = resultObs3.toListL.runToFuture.futureValue
     result3.size shouldEqual 1
     result3(0).key shouldEqual noKey
@@ -75,8 +83,12 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Avg
     val agg4 = RowAggregator(AggregationOperator.Avg, Nil, tvSchema)
-    val resultObs4a = RangeVectorAggregator.mapReduce(agg4, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs4 = RangeVectorAggregator.mapReduce(agg4, true, resultObs4a, rv=>rv.key,  queryContext = qc)
+    val resultObs4a = RangeVectorAggregator.mapReduce(
+      agg4, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings()
+    )
+    val resultObs4 = RangeVectorAggregator.mapReduce(
+      agg4, true, resultObs4a, rv=>rv.key,  queryContext = qc, QueryWarnings()
+    )
     val result4 = resultObs4.toListL.runToFuture.futureValue
     result4.size shouldEqual 1
     result4(0).key shouldEqual noKey
@@ -87,8 +99,12 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // BottomK
     val agg5 = RowAggregator(AggregationOperator.BottomK, Seq(3.0), tvSchema)
-    val resultObs5a = RangeVectorAggregator.mapReduce(agg5, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs5 = RangeVectorAggregator.mapReduce(agg5, true, resultObs5a, rv=>rv.key,  queryContext = qc)
+    val resultObs5a = RangeVectorAggregator.mapReduce(
+      agg5, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings()
+    )
+    val resultObs5 = RangeVectorAggregator.mapReduce(
+      agg5, true, resultObs5a, rv=>rv.key,  queryContext = qc, QueryWarnings()
+    )
     val result5 = resultObs5.toListL.runToFuture.futureValue
     result5.size shouldEqual 1
     result5(0).key shouldEqual noKey
@@ -100,8 +116,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // TopK
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(3.0), tvSchema)
-    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
+    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping, queryContext = qc, QueryWarnings())
+    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6.size shouldEqual 1
     result6(0).key shouldEqual noKey
@@ -113,8 +129,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Quantile
     val agg7 = RowAggregator(AggregationOperator.Quantile, Seq(0.70), tvSchema)
-    val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping, queryContext = qc)
-    val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key, queryContext = qc)
+    val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping, queryContext = qc, QueryWarnings())
+    val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key, queryContext = qc, QueryWarnings())
     val resultObs7b = RangeVectorAggregator.present(agg7, resultObs7, 1000, rangeParams, queryStats)
     val result7 = resultObs7b.toListL.runToFuture.futureValue
     result7.size shouldEqual 1
@@ -126,8 +142,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stdvar
     val agg8 = RowAggregator(AggregationOperator.Stdvar, Nil, tvSchema)
-    val resultObs8a = RangeVectorAggregator.mapReduce(agg8, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs8 = RangeVectorAggregator.mapReduce(agg8, true, resultObs8a, rv=>rv.key, queryContext = qc)
+    val resultObs8a = RangeVectorAggregator.mapReduce(agg8, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs8 = RangeVectorAggregator.mapReduce(agg8, true, resultObs8a, rv=>rv.key, queryContext = qc, QueryWarnings())
     val result8 = resultObs8.toListL.runToFuture.futureValue
     result8.size shouldEqual 1
     result8(0).key shouldEqual noKey
@@ -139,8 +155,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stddev
     val agg9 = RowAggregator(AggregationOperator.Stddev, Nil, tvSchema)
-    val resultObs9a = RangeVectorAggregator.mapReduce(agg9, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs9 = RangeVectorAggregator.mapReduce(agg9, true, resultObs9a, rv=>rv.key, queryContext = qc)
+    val resultObs9a = RangeVectorAggregator.mapReduce(agg9, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs9 = RangeVectorAggregator.mapReduce(agg9, true, resultObs9a, rv=>rv.key, queryContext = qc, QueryWarnings())
     val result9 = resultObs9.toListL.runToFuture.futureValue
     result9.size shouldEqual 1
     result9(0).key shouldEqual noKey
@@ -152,8 +168,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Group
     val agg10 = RowAggregator(AggregationOperator.Group, Nil, tvSchema)
-    val resultObs10a = RangeVectorAggregator.mapReduce(agg10, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs10 = RangeVectorAggregator.mapReduce(agg10, true, resultObs10a, rv=>rv.key, queryContext = qc)
+    val resultObs10a = RangeVectorAggregator.mapReduce(agg10, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs10 = RangeVectorAggregator.mapReduce(agg10, true, resultObs10a, rv=>rv.key, queryContext = qc, QueryWarnings())
     val result10 = resultObs10.toListL.runToFuture.futureValue
     result10.size shouldEqual 1
     result10(0).key shouldEqual noKey
@@ -199,7 +215,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Sum
     val agg1 = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
-    val resultObs = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
+    val resultObs = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
     val result = resultObs.toListL.runToFuture.futureValue
     result.size shouldEqual 1
     result(0).key shouldEqual noKey
@@ -207,7 +223,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Min
     val agg2 = RowAggregator(AggregationOperator.Min, Nil, tvSchema)
-    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
+    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
     val result2 = resultObs2.toListL.runToFuture.futureValue
     result2.size shouldEqual 1
     result2(0).key shouldEqual noKey
@@ -215,8 +231,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Count
     val agg3 = RowAggregator(AggregationOperator.Count, Nil, tvSchema)
-    val resultObs3a = RangeVectorAggregator.mapReduce(agg3, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs3 = RangeVectorAggregator.mapReduce(agg3, true, resultObs3a, rv=>rv.key,  queryContext = qc)
+    val resultObs3a = RangeVectorAggregator.mapReduce(agg3, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs3 = RangeVectorAggregator.mapReduce(agg3, true, resultObs3a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result3 = resultObs3.toListL.runToFuture.futureValue
     result3.size shouldEqual 1
     result3(0).key shouldEqual noKey
@@ -224,8 +240,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Avg
     val agg4 = RowAggregator(AggregationOperator.Avg, Nil, tvSchema)
-    val resultObs4a = RangeVectorAggregator.mapReduce(agg4, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs4 = RangeVectorAggregator.mapReduce(agg4, true, resultObs4a, rv=>rv.key,  queryContext = qc)
+    val resultObs4a = RangeVectorAggregator.mapReduce(agg4, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs4 = RangeVectorAggregator.mapReduce(agg4, true, resultObs4a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result4 = resultObs4.toListL.runToFuture.futureValue
     result4.size shouldEqual 1
     result4(0).key shouldEqual noKey
@@ -233,8 +249,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // BottomK
     val agg5 = RowAggregator(AggregationOperator.BottomK, Seq(2.0), tvSchema)
-    val resultObs5a = RangeVectorAggregator.mapReduce(agg5, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs5 = RangeVectorAggregator.mapReduce(agg5,true, resultObs5a, rv=>rv.key,  queryContext = qc)
+    val resultObs5a = RangeVectorAggregator.mapReduce(agg5, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs5 = RangeVectorAggregator.mapReduce(agg5,true, resultObs5a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val resultObs5b = RangeVectorAggregator.present(agg5, resultObs5, 1000, rangeParams, queryStats)
     val result5 = resultObs5.toListL.runToFuture.futureValue
     result5.size shouldEqual 1
@@ -251,8 +267,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // TopK
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(2.0), tvSchema)
-    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
+    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, rangeParams, queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6.size shouldEqual 1
@@ -271,8 +287,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Quantile
     val agg7 = RowAggregator(AggregationOperator.Quantile, Seq(0.5), tvSchema)
-    val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key,  queryContext = qc)
+    val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val resultObs7b = RangeVectorAggregator.present(agg7, resultObs7, 1000, rangeParams, queryStats)
     val result7 = resultObs7b.toListL.runToFuture.futureValue
     result7.size shouldEqual 1
@@ -281,8 +297,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stdvar
     val agg8 = RowAggregator(AggregationOperator.Stdvar, Nil, tvSchema)
-    val resultObs8a = RangeVectorAggregator.mapReduce(agg8, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs8 = RangeVectorAggregator.mapReduce(agg8, true, resultObs8a, rv=>rv.key,  queryContext = qc)
+    val resultObs8a = RangeVectorAggregator.mapReduce(agg8, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs8 = RangeVectorAggregator.mapReduce(agg8, true, resultObs8a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result8 = resultObs8.toListL.runToFuture.futureValue
     result8.size shouldEqual 1
     result8(0).key shouldEqual noKey
@@ -290,8 +306,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stddev
     val agg9 = RowAggregator(AggregationOperator.Stddev, Nil, tvSchema)
-    val resultObs9a = RangeVectorAggregator.mapReduce(agg9, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs9 = RangeVectorAggregator.mapReduce(agg9, true, resultObs9a, rv=>rv.key,  queryContext = qc)
+    val resultObs9a = RangeVectorAggregator.mapReduce(agg9, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs9 = RangeVectorAggregator.mapReduce(agg9, true, resultObs9a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result9 = resultObs9.toListL.runToFuture.futureValue
     result9.size shouldEqual 1
     result9(0).key shouldEqual noKey
@@ -299,8 +315,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Group
     val agg10 = RowAggregator(AggregationOperator.Group, Nil, tvSchema)
-    val resultObs10a = RangeVectorAggregator.mapReduce(agg10, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs10 = RangeVectorAggregator.mapReduce(agg10, true, resultObs10a, rv=>rv.key,  queryContext = qc)
+    val resultObs10a = RangeVectorAggregator.mapReduce(agg10, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs10 = RangeVectorAggregator.mapReduce(agg10, true, resultObs10a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result10 = resultObs10.toListL.runToFuture.futureValue
     result10.size shouldEqual 1
     result10(0).key shouldEqual noKey
@@ -316,8 +332,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Quantile
     val agg7 = RowAggregator(AggregationOperator.Quantile, Seq(0.5), tvSchema)
-    val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key, queryContext = qc)
+    val resultObs7a = RangeVectorAggregator.mapReduce(agg7, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs7 = RangeVectorAggregator.mapReduce(agg7, true, resultObs7a, rv=>rv.key, queryContext = qc, QueryWarnings())
     val result7 = resultObs7.toListL.runToFuture.futureValue
     result7.size shouldEqual 1
 
@@ -352,7 +368,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val mapped1 = aggMR(Observable.fromIterable(Seq(toRv(s1))), querySession, 1000, tvSchema)
     val mapped2 = aggMR(Observable.fromIterable(Seq(toRv(s2))), querySession, 1000, tvSchema)
 
-    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped1 ++ mapped2, rv=>rv.key, queryContext = qc)
+    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped1 ++ mapped2, rv=>rv.key, queryContext = qc, QueryWarnings())
     val result4 = resultObs4.toListL.runToFuture.futureValue
     result4.size shouldEqual 1
     result4(0).key shouldEqual noKey
@@ -377,8 +393,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stdvar
     val agg1 = RowAggregator(AggregationOperator.Stdvar, Nil, tvSchema)
-    val resultObs1a = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, true, resultObs1a, rv=>rv.key,  queryContext = qc)
+    val resultObs1a = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, true, resultObs1a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result1 = resultObs1.toListL.runToFuture.futureValue
     result1.size shouldEqual 1
     result1(0).key shouldEqual noKey
@@ -386,8 +402,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stddev
     val agg2 = RowAggregator(AggregationOperator.Stddev, Nil, tvSchema)
-    val resultObs2a = RangeVectorAggregator.mapReduce(agg2, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, true, resultObs2a, rv=>rv.key,  queryContext = qc)
+    val resultObs2a = RangeVectorAggregator.mapReduce(agg2, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, true, resultObs2a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result2 = resultObs2.toListL.runToFuture.futureValue
     result2.size shouldEqual 1
     result2(0).key shouldEqual noKey
@@ -404,7 +420,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Sum
     val agg1 = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
-    val resultObs = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
+    val resultObs = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
     val result = resultObs.toListL.runToFuture.futureValue
     result.size shouldEqual 1
     result(0).key shouldEqual noKey
@@ -412,7 +428,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Min
     val agg2 = RowAggregator(AggregationOperator.Min, Nil, tvSchema)
-    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
+    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
     val result2 = resultObs2.toListL.runToFuture.futureValue
     result2.size shouldEqual 1
     result2(0).key shouldEqual noKey
@@ -420,8 +436,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Count
     val agg3 = RowAggregator(AggregationOperator.Count, Nil, tvSchema)
-    val resultObs3a = RangeVectorAggregator.mapReduce(agg3, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs3 = RangeVectorAggregator.mapReduce(agg3, true, resultObs3a, rv=>rv.key,  queryContext = qc)
+    val resultObs3a = RangeVectorAggregator.mapReduce(agg3, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs3 = RangeVectorAggregator.mapReduce(agg3, true, resultObs3a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result3 = resultObs3.toListL.runToFuture.futureValue
     result3.size shouldEqual 1
     result3(0).key shouldEqual noKey
@@ -429,8 +445,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Avg
     val agg4 = RowAggregator(AggregationOperator.Avg, Nil, tvSchema)
-    val resultObs4a = RangeVectorAggregator.mapReduce(agg4, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs4 = RangeVectorAggregator.mapReduce(agg4, true, resultObs4a, rv=>rv.key,  queryContext = qc)
+    val resultObs4a = RangeVectorAggregator.mapReduce(agg4, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs4 = RangeVectorAggregator.mapReduce(agg4, true, resultObs4a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result4 = resultObs4.toListL.runToFuture.futureValue
     result4.size shouldEqual 1
     result4(0).key shouldEqual noKey
@@ -438,8 +454,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // BottomK
     val agg5 = RowAggregator(AggregationOperator.BottomK, Seq(2.0), tvSchema)
-    val resultObs5a = RangeVectorAggregator.mapReduce(agg5, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs5 = RangeVectorAggregator.mapReduce(agg5, true, resultObs5a, rv=>rv.key,  queryContext = qc)
+    val resultObs5a = RangeVectorAggregator.mapReduce(agg5, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs5 = RangeVectorAggregator.mapReduce(agg5, true, resultObs5a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result5 = resultObs5.toListL.runToFuture.futureValue
     result5.size shouldEqual 1
     result5(0).key shouldEqual noKey
@@ -458,8 +474,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // TopK
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(2.0), tvSchema)
-    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
+    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1,1,2), queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6.size shouldEqual 1
@@ -476,8 +492,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stdvar
     val agg8 = RowAggregator(AggregationOperator.Stdvar, Nil, tvSchema)
-    val resultObs8a = RangeVectorAggregator.mapReduce(agg8, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs8 = RangeVectorAggregator.mapReduce(agg8, true, resultObs8a, rv=>rv.key,  queryContext = qc)
+    val resultObs8a = RangeVectorAggregator.mapReduce(agg8, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs8 = RangeVectorAggregator.mapReduce(agg8, true, resultObs8a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result8 = resultObs8.toListL.runToFuture.futureValue
     result8.size shouldEqual 1
     result8(0).key shouldEqual noKey
@@ -485,8 +501,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Stddev
     val agg9 = RowAggregator(AggregationOperator.Stddev, Nil, tvSchema)
-    val resultObs9a = RangeVectorAggregator.mapReduce(agg9, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs9 = RangeVectorAggregator.mapReduce(agg9, true, resultObs9a, rv=>rv.key,  queryContext = qc)
+    val resultObs9a = RangeVectorAggregator.mapReduce(agg9, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs9 = RangeVectorAggregator.mapReduce(agg9, true, resultObs9a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result9 = resultObs9.toListL.runToFuture.futureValue
     result9.size shouldEqual 1
     result9(0).key shouldEqual noKey
@@ -494,8 +510,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Group
     val agg10 = RowAggregator(AggregationOperator.Group, Nil, tvSchema)
-    val resultObs10a = RangeVectorAggregator.mapReduce(agg10, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs10 = RangeVectorAggregator.mapReduce(agg10, true, resultObs10a, rv=>rv.key,  queryContext = qc)
+    val resultObs10a = RangeVectorAggregator.mapReduce(agg10, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs10 = RangeVectorAggregator.mapReduce(agg10, true, resultObs10a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result10 = resultObs10.toListL.runToFuture.futureValue
     result10.size shouldEqual 1
     result10(0).key shouldEqual noKey
@@ -510,8 +526,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     )
 
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(5.0), tvSchema)
-    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
+    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744,1,1556745), queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6(0).key shouldEqual noKey
@@ -529,8 +545,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val samples: Array[RangeVector] = Array(rv1, rv2)
 
     val agg1 = RowAggregator(AggregationOperator.Sum, Nil, histSchema)
-    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc)
+    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc, QueryWarnings())
 
     val result = resultObs.toListL.runToFuture.futureValue
     result.size shouldEqual 1
@@ -546,8 +562,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     // Test mapReduce of empty histogram sums
     val agg2 = RowAggregator(AggregationOperator.Sum, Nil, histSchema)
-    val emptyObs = RangeVectorAggregator.mapReduce(agg2, false, Observable.empty, noGrouping,  queryContext = qc)
-    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, true, emptyObs ++ resultObs1, rv=>rv.key,  queryContext = qc)
+    val emptyObs = RangeVectorAggregator.mapReduce(agg2, false, Observable.empty, noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs2 = RangeVectorAggregator.mapReduce(agg2, true, emptyObs ++ resultObs1, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val result2 = resultObs2.toListL.runToFuture.futureValue
     result2.size shouldEqual 1
     result2(0).key shouldEqual noKey
@@ -559,8 +575,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val samples: Array[RangeVector] = Array(rv1, rv2)
 
     val agg1 = RowAggregator(AggregationOperator.Count, Nil, histSchema)
-    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc)
+    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc, QueryWarnings())
 
     val result = resultObs.toListL.runToFuture.futureValue
     result.size shouldEqual 1
@@ -583,8 +599,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     val agg = RowAggregator(AggregationOperator.TopK, Seq(1.0), tvSchema)
     val resultObsa = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(samples),
-      noGrouping,  queryContext = qc)
-    val resultObsb = RangeVectorAggregator.mapReduce(agg, true, resultObsa, rv=>rv.key,  queryContext = qc)
+      noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObsb = RangeVectorAggregator.mapReduce(agg, true, resultObsa, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val resultObsc = RangeVectorAggregator.present(agg, resultObsb, 1000, rangeParams, queryStats)
     val result = resultObsc.toListL.runToFuture.futureValue
 
@@ -608,8 +624,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val samples: Array[RangeVector] = Array(rv1, rv2)
 
     val agg1 = RowAggregator(AggregationOperator.Sum, Nil, histMaxSchema)
-    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc)
+    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc, QueryWarnings())
 
     val result = resultObs.toListL.runToFuture.futureValue
     result.size shouldEqual 1
@@ -641,8 +657,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     )
 
     val agg = RowAggregator(AggregationOperator.CountValues, Seq("freq"), tvSchema)
-    val resultObs = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs1 = RangeVectorAggregator.mapReduce(agg, true, resultObs,  rv=>rv.key,  queryContext = qc)
+    val resultObs = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs1 = RangeVectorAggregator.mapReduce(agg, true, resultObs,  rv=>rv.key,  queryContext = qc, QueryWarnings())
 
     val resultObs2 = RangeVectorAggregator.present(agg, resultObs1, 1000, RangeParams(0,1,0), queryStats )
     val result = resultObs2.toListL.runToFuture.futureValue
@@ -659,8 +675,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     )
 
     val agg6 = RowAggregator(AggregationOperator.TopK, Seq(1.0), tvSchema)
-    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc)
+    val resultObs6a = RangeVectorAggregator.mapReduce(agg6, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs6 = RangeVectorAggregator.mapReduce(agg6, true, resultObs6a, rv=>rv.key,  queryContext = qc, QueryWarnings())
     val resultObs6b = RangeVectorAggregator.present(agg6, resultObs6, 1000, RangeParams(1556744, 0, 1556744), queryStats)
     val result6 = resultObs6.toListL.runToFuture.futureValue
     result6(0).key shouldEqual noKey
@@ -678,8 +694,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     val samples: Array[RangeVector] = Array(rv1, rv2)
 
     val agg1 = RowAggregator(AggregationOperator.Sum, Nil, histSchema)
-    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc)
-    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc)
+    val resultObs1 = RangeVectorAggregator.mapReduce(agg1, false, Observable.fromIterable(samples), noGrouping,  queryContext = qc, QueryWarnings())
+    val resultObs = RangeVectorAggregator.mapReduce(agg1, true, resultObs1, rv=>rv.key,  queryContext = qc, QueryWarnings())
 
     val result = resultObs.toListL.runToFuture.futureValue
     result.size shouldEqual 1
@@ -798,8 +814,8 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
 
     for ((aggOp, params, presenterFunc, bValExpected) <- testTuples) {
       val agg = RowAggregator(aggOp, params, tvSchema)
-      val resultObsLeaf = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(samples), grouping, queryContext = qc)
-      val resultObs = RangeVectorAggregator.mapReduce(agg, true, resultObsLeaf, rv=>rv.key,  queryContext = qc)
+      val resultObsLeaf = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(samples), grouping, queryContext = qc, QueryWarnings())
+      val resultObs = RangeVectorAggregator.mapReduce(agg, true, resultObsLeaf, rv=>rv.key,  queryContext = qc, QueryWarnings())
       val resultObsPresent = presenterFunc(agg, resultObs)
       val result = resultObsPresent.toListL.runToFuture.futureValue
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -209,7 +209,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
                                    AggregateClause.byOpt(Seq("instance", "job")))
     val mapped = aggMR(Observable.fromIterable(sampleNodeCpu), querySession, 1000, tvSchema)
 
-    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key, queryContext = QueryContext())
+    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key, queryContext = QueryContext(), QueryWarnings())
     val samplesRhs = resultObs4.toListL.runToFuture.futureValue
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
@@ -289,7 +289,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
                                    AggregateClause.byOpt(Seq("instance", "job")))
     val mapped = aggMR(Observable.fromIterable(sampleNodeCpu), querySession, 1000, tvSchema)
 
-    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key, queryContext = QueryContext())
+    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key, queryContext = QueryContext(), QueryWarnings())
     val samplesRhs = resultObs4.toListL.runToFuture.futureValue
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
@@ -476,7 +476,7 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
                                    AggregateClause.byOpt(Seq("instance", "job")))
     val mapped = aggMR(Observable.fromIterable(sampleNodeCpu), querySession, 1000, tvSchema)
 
-    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key, queryContext = QueryContext())
+    val resultObs4 = RangeVectorAggregator.mapReduce(agg, true, mapped, rv=>rv.key, queryContext = QueryContext(), QueryWarnings())
     val samplesRhs = resultObs4.toListL.runToFuture.futureValue
 
     val execPlan = BinaryJoinExec(queryContext, dummyDispatcher,

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -154,7 +154,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _,  _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
@@ -178,7 +178,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     (resp: @unchecked) match {
-      case QueryResult(_, _, results, _, _, _) => results.size shouldEqual 0
+      case QueryResult(_, _, results, _, _, _, _) => results.size shouldEqual 0
     }
   }
 
@@ -195,7 +195,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) =>
+      case QueryResult(id, _, response, _, _, _, _) =>
         response.size shouldEqual 1
         response(0).rows.map { row =>
           val r = row.asInstanceOf[BinaryRecordRowReader]
@@ -218,7 +218,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         response.size shouldEqual 1
         response(0).rows.map { row =>
           val r = row.asInstanceOf[BinaryRecordRowReader]
@@ -258,7 +258,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp1 = execPlan1.execute(memStore, querySession).runToFuture.futureValue
     val result = resp1 match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
@@ -285,7 +285,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual expectedLabels.size
         rv.rows.map(row => {
@@ -309,7 +309,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next().asInstanceOf[BinaryRecordRowReader]
@@ -339,7 +339,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) =>
+      case QueryResult(id, _, response, _, _, _, _) =>
         response.size shouldEqual 1
         val rv1 = response(0)
         rv1.rows.size shouldEqual 1
@@ -406,7 +406,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
       val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
       val result = (resp: @unchecked) match {
-        case QueryResult(id, _, response, _, _, _) =>
+        case QueryResult(id, _, response, _, _, _, _) =>
           // should only have a single RangeVector
           response.size shouldEqual 1
 

--- a/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
@@ -124,7 +124,9 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", stats)
     val streamingQueryBody = StreamQueryResult("someId", srv)
 
-    val footer = StreamQueryResultFooter("someId", stats, true, Some("Reason"))
+    val warnings = QueryWarnings()
+
+    val footer = StreamQueryResultFooter("someId", stats, warnings, true, Some("Reason"))
     Seq(header, streamingQueryBody, footer)
   }
 

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -41,7 +41,10 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     val exec = PromQlRemoteExec("", 60000, queryContext, dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
     val result = query.Result (Map("instance" -> "inst1"), Some(Seq(Sampl(1000, 1), Sampl(2000, 2), Sampl(3000, 3))),
       None)
-    val res = exec.toQueryResponse(SuccessResponse(Data("vector", Seq(result)), queryStats = None), "id", Kamon.currentSpan())
+    val res = exec.toQueryResponse(
+      SuccessResponse(Data("vector", Seq(result)), queryStats = None, queryWarnings = None),
+      "id", Kamon.currentSpan()
+    )
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     queryResult.result(0).numRows.get shouldEqual(3)
@@ -53,7 +56,10 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     val expectedResult = List((1000000, 1.0))
     val exec = PromQlRemoteExec("", 60000, queryContext, dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
     val result = query.Result (Map("instance" -> "inst1"), None, Some(Sampl(1000, 1)))
-    val res = exec.toQueryResponse(SuccessResponse(Data("vector", Seq(result)), queryStats = None), "id", Kamon.currentSpan())
+    val res = exec.toQueryResponse(
+      SuccessResponse(Data("vector", Seq(result)), queryStats = None, queryWarnings = None),
+      "id", Kamon.currentSpan()
+    )
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     queryResult.result(0).numRows.get shouldEqual(1)
@@ -91,7 +97,10 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
   it ("should convert histogram to QueryResponse ") {
     val exec = PromQlRemoteExec("", 60000, queryContext, dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
     val result = query.Result (Map("instance" -> "inst1"), None, Some(HistSampl(1000, Map("1" -> 2, "+Inf" -> 3))))
-    val res = exec.toQueryResponse(SuccessResponse(Data("vector", Seq(result)), queryStats = None), "id", Kamon.currentSpan())
+    val res = exec.toQueryResponse(
+      SuccessResponse(Data("vector", Seq(result)), queryStats = None, queryWarnings = None),
+      "id", Kamon.currentSpan()
+    )
     res.isInstanceOf[QueryResult] shouldEqual true
     val queryResult = res.asInstanceOf[QueryResult]
     queryResult.result(0).numRows.get shouldEqual(1)

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -150,7 +150,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 1
         val record = rv.rows.next.asInstanceOf[BinaryRecordRowReader]
@@ -167,7 +167,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 0
         rv.rows.map { row =>
@@ -191,7 +191,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val rootDistConcatExec: LabelValuesDistConcatExec = LabelValuesDistConcatExec(QueryContext(), InProcessPlanDispatcher(queryConfig) , Seq(distConcatExec, exec))
     val resp = rootDistConcatExec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 2
         rv.rows.map(row => {
@@ -215,7 +215,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val rootDistConcatExec: LabelValuesDistConcatExec = LabelValuesDistConcatExec(QueryContext(), InProcessPlanDispatcher(queryConfig) , Seq(distConcatExec, exec))
     val resp = rootDistConcatExec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         response.flatMap(rv => {
           rv.rows.size shouldEqual 0
           rv.rows.map(row => {
@@ -235,7 +235,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.rows.size shouldEqual 4
         rv.rows.map(row => {
@@ -271,7 +271,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) =>
+      case QueryResult(id, _, response, _, _, _, _) =>
         // should only contain a single RV where each row describes a single group's cardinalities
         response.size shouldEqual 1
         val rows = response.head.rows().map{ rr =>

--- a/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/ScalarFunctionSpec.scala
@@ -144,7 +144,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[TimeScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList
@@ -160,7 +160,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[HourScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList
@@ -177,7 +177,7 @@ class ScalarFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
     import monix.execution.Scheduler.Implicits.global
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
-      case QueryResult(id, _, response, _, _, _) => {
+      case QueryResult(id, _, response, _, _, _, _) => {
         val rv = response(0)
         rv.isInstanceOf[DayOfWeekScalar] shouldEqual(true)
         val res = rv.rows.map(x=>(x.getLong(0), x.getDouble(1))).toList

--- a/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
@@ -153,8 +153,12 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
       CustomRangeVectorKey(groupBy)
     }
    val agg = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
-   val resultObs1 = RangeVectorAggregator.mapReduce(agg, false, Observable.fromIterable(testSample), grouping, queryContext = QueryContext())
-   val resultObs2 = RangeVectorAggregator.mapReduce(agg, true, resultObs1, grouping, queryContext = QueryContext())
+   val resultObs1 = RangeVectorAggregator.mapReduce(
+     agg, false, Observable.fromIterable(testSample), grouping, queryContext = QueryContext(), QueryWarnings()
+   )
+   val resultObs2 = RangeVectorAggregator.mapReduce(
+     agg, true, resultObs1, grouping, queryContext = QueryContext(), queryWarnings = QueryWarnings()
+   )
    val resultAgg = resultObs2.toListL.runToFuture.futureValue
    resultAgg.size shouldEqual 2
    resultAgg.flatMap(_.rows.map(_.getDouble(1)).toList) shouldEqual(List(5.0, 1.0))

--- a/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/StandaloneMultiJvmSpec.scala
@@ -191,7 +191,7 @@ abstract class StandaloneMultiJvmSpec(config: MultiNodeConfig) extends MultiNode
     val chunkMetaQuery = "_filodb_chunkmeta_all(heap_usage{dc=\"DC0\",_ws_=\"demo\",_ns_=\"App-2\"})"
     val logicalPlan = Parser.queryRangeToLogicalPlan(chunkMetaQuery, TimeStepParams(0, 60, Int.MaxValue))
     client.logicalPlan2Query(dataset, logicalPlan) match {
-      case QueryResult2(_, _, result, _, _, _) => result.foreach(rv => println(rv.prettyPrint()))
+      case QueryResult2(_, _, result, _, _, _, _) => result.foreach(rv => println(rv.prettyPrint()))
       case e: QueryError => fail(e.t)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently as queries get executed there is no way to convey to the user that the query runs close to the maximum capacity of FiloDB.

**New behavior :**
This PR introduces an object allowing to pass the information back to the user.


**BREAKING CHANGES**

no breaking changes

**Other information**: