### PR TITLE
Fixing 404 issue while downloading cassandra for unit tests

### DIFF
--- a/.github/workflows/runtests.sh
+++ b/.github/workflows/runtests.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
+set -e
 wget -q -O - https://archive.apache.org/dist/cassandra/KEYS | sudo apt-key add -
 sudo sh -c 'echo "deb http://archive.apache.org/dist/cassandra/debian 40x main" > /etc/apt/sources.list.d/cassandra.list'
 sudo apt update
 sudo apt install cassandra
+set +e
 sbt coverage test coverageAggregate

--- a/.github/workflows/runtests.sh
+++ b/.github/workflows/runtests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-wget -q -O - https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
-sudo sh -c 'echo "deb http://www.apache.org/dist/cassandra/debian 40x main" > /etc/apt/sources.list.d/cassandra.list'
+wget -q -O - https://archive.apache.org/dist/cassandra/KEYS | sudo apt-key add -
+sudo sh -c 'echo "deb http://archive.apache.org/dist/cassandra/debian 40x main" > /etc/apt/sources.list.d/cassandra.list'
 sudo apt update
 sudo apt install cassandra
 sbt coverage test coverageAggregate


### PR DESCRIPTION
**Pull Request checklist**

Fixing 404 issue while downloading cassandra for unit tests. Updating to use the archive.apache dist to avoid 404 errors.

**Current behavior :** unit tests *are not* successfully completing for pull requests


**New behavior :** unit tests *are* successfully completing for pull requests