### PR TITLE
fix(query) Handle Akka AskTimeoutException serialization explicitly

### DIFF
--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -1,10 +1,12 @@
 package filodb.query
 
+
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
 import scala.collection.JavaConverters._
 
+import akka.pattern.AskTimeoutException
 import com.google.protobuf.ByteString
 import com.typesafe.scalalogging.StrictLogging
 
@@ -455,6 +457,8 @@ object ProtoConverters {
           val errorType = metaMap.getOrDefault("errorType", "")
           val errorMessage = metaMap.getOrDefault("errorMessage", "")
           RemoteQueryFailureException(statusCode, requestStatus, errorType, errorMessage)
+        case "akka.pattern.AskTimeoutException"               =>
+          cause.map(new AskTimeoutException(message, _)).getOrElse(new AskTimeoutException(message))
         case _          =>
             cause.map(new Throwable(message, _)).getOrElse(new Throwable(message))
       }

--- a/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
+++ b/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import filodb.core.query._
 import ProtoConverters._
+import akka.pattern.AskTimeoutException
 import filodb.core.QueryTimeoutException
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore.SchemaMismatch
@@ -704,7 +705,20 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     val rqfe = RemoteQueryFailureException(200, "OK", "none", "no error")
     rqfe.toProto.fromProto shouldEqual rqfe
 
-    // Case 10: Anything else should throw Throwable
+    // case 10: Should deserialize AskTimeoutException
+    val ate = new AskTimeoutException("message")
+    val deserAte = ate.toProto.fromProto
+    deserAte.isInstanceOf[AskTimeoutException] shouldBe true
+    deserAte.getMessage shouldBe ate.getMessage
+
+    val ate1 = new AskTimeoutException("message", new IllegalArgumentException("root"))
+    val deserAte1 = ate1.toProto.fromProto
+    deserAte1.isInstanceOf[AskTimeoutException] shouldBe true
+    deserAte1.getMessage shouldBe ate.getMessage
+    deserAte1.getCause.isInstanceOf[IllegalArgumentException] shouldBe true
+    deserAte1.getCause.getMessage shouldBe "root"
+
+    // Case 11: Anything else should throw Throwable
     val isecause = SchemaMismatch(expected = "expectedSchema", found = "foundSchema", clazz = "SomeClass")
     val ise = new IllegalStateException("Illegal state", isecause)
     val deserializedise = ise.toProto.fromProto


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
``AskTimeoutException`` is deserialized as ``Throwable``


**New behavior :**

Fixes the deserialization to deserialize the specific exception class.

