### PR TITLE
fix(query) gRPC exception serialization and container size fixes

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2125,7 +2125,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     ep.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual(true)
     val presenterTime = ep.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head.asInstanceOf[AggregatePresenter].rangeParams
     val periodicSamplesMapper = ep.children.head.rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-
+    ep.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 40960
     presenterTime.startSecs shouldEqual(periodicSamplesMapper.startMs/1000)
     presenterTime.endSecs shouldEqual(periodicSamplesMapper.endMs/1000)
   }
@@ -2150,6 +2150,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     execPlan.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
     execPlan.children(0).isInstanceOf[MultiSchemaPartitionsExec] shouldEqual(true)
     val multiSchemaExec = execPlan.children(0).asInstanceOf[MultiSchemaPartitionsExec]
+    execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 4096
 
     multiSchemaExec.rangeVectorTransformers.head.isInstanceOf[PeriodicSamplesMapper] shouldEqual(true)
     val rvt = multiSchemaExec.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper]
@@ -2281,6 +2282,14 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
       execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].aggrOp shouldEqual funcId
+      val op = execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].aggrOp
+      if (op == AggregationOperator.TopK
+        || op == AggregationOperator.BottomK
+        || op == AggregationOperator.CountValues) {
+        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 40960
+      } else {
+        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 4096
+      }
       for (child <- execPlan.children) {
         child.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
         child.children.size shouldEqual 0

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -37,6 +37,10 @@ filodb {
       keep-alive-timeout-seconds = 0  # keep alive ack will timeout and connection closed  if no response is seen in this time
       # Refer to https://github.com/grpc/grpc/blob/master/doc/load-balancing.md
       load-balancing-policy = "round_robin"
+      # Maximum permissible inbound message size in gRPC, defaults to 100MB. This is more than
+      # enough from the default 4MB, ideally the query response should not be this large and the other overrides for
+      # query response size should have kicked in first to fail the query.
+      max-inbound-message-size = 104857600
   }
 
   # list of paths to dataset + ingestion config files

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -318,7 +318,9 @@ filodb {
 
     # Choices are "legacy", "antlr", and "shadow". Shadow mode uses legacy but also checks antlr for errors.
     parser = "antlr"
-
+    container-size-overrides {
+        filodb-query-exec-localpartitionreduceaggregateexec-topbottomk = 40960
+    }
     grpc {
       # Override used to disable call to the multi partition calls over gRPC. Specify comma separated partition names
       # which should match partitionName in PartitionAssignment, if the partition name is present in the deny list,

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -103,7 +103,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
         s"Try one or more of these: " +
         s"(a) narrow your query filters to reduce to fewer than the current $numTsPartitions matches " +
         s"(b) reduce query time range, currently at ${queryDurationMs / 1000 / 60} minutes"
-      throw new QueryLimitException(exMessage, qContext.queryId)
+      throw QueryLimitException(exMessage, qContext.queryId)
     }
     if (numTsPartitions > enforcedLimits.timeSeriesScanned) {
       val exMessage =
@@ -112,7 +112,7 @@ TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryMa
           s"Try one or more of these: " +
           s"(a) narrow your query filters to reduce to fewer than the current $numTsPartitions matches " +
           s"(b) reduce query time range, currently at ${queryDurationMs / 1000 / 60} minutes"
-      throw new QueryLimitException(exMessage, qContext.queryId)
+      throw QueryLimitException(exMessage, qContext.queryId)
     }
     if (numTsPartitions > warnLimits.timeSeriesScanned) {
       val msg =

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -21,6 +21,7 @@ object QueryConfig {
     val allowPartialResultsMetadataQuery = queryConfig.getBoolean("allow-partial-results-metadataquery")
     val allowPartialResultsRangeQuery = queryConfig.getBoolean("allow-partial-results-rangequery")
     val grpcDenyList = queryConfig.getString("grpc.partitions-deny-list")
+    val containerOverrides = queryConfig.as[Map[String, Int]]("container-size-overrides")
     QueryConfig(askTimeout, staleSampleAfterMs, minStepMs, fastReduceMaxWindows, parser, translatePromToFilodbHistogram,
       fasterRateEnabled, routingConfig.as[Option[String]]("partition_name"),
       routingConfig.as[Option[Long]]("remote.http.timeout"),
@@ -28,7 +29,9 @@ object QueryConfig {
       routingConfig.as[Option[String]]("remote.grpc.endpoint"),
       enforceResultByteLimit,
       allowPartialResultsRangeQuery, allowPartialResultsMetadataQuery,
-      grpcDenyList.split(",").map(_.trim.toLowerCase).toSet)
+      grpcDenyList.split(",").map(_.trim.toLowerCase).toSet,
+      None,
+      containerOverrides)
   }
 
   import scala.concurrent.duration._
@@ -66,4 +69,5 @@ case class QueryConfig(askTimeout: FiniteDuration,
                        allowPartialResultsRangeQuery: Boolean = false,
                        allowPartialResultsMetadataQuery: Boolean = true,
                        grpcPartitionsDenyList: Set[String] = Set.empty,
-                       plannerSelector: Option[String] = None)
+                       plannerSelector: Option[String] = None,
+                       recordContainerOverrides: Map[String, Int] = Map.empty)

--- a/core/src/main/scala/filodb.core/query/ResultTypes.scala
+++ b/core/src/main/scala/filodb.core/query/ResultTypes.scala
@@ -172,7 +172,7 @@ class ServiceUnavailableException(message: String) extends RuntimeException(mess
  * This error means that the user exceeded the limit on the query size (for example
  * number of scanned bytes)
  */
-class QueryLimitException(message: String, queryId: String) extends RuntimeException(message) {
+case class QueryLimitException(message: String, queryId: String) extends RuntimeException(message) {
   override def getMessage: String = {
     s"${super.getMessage}, queryId=${queryId}"
   }

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -57,6 +57,7 @@ filodb {
     idle-timeout-seconds = 3600   # 1 hour
     keep-alive-time-seconds = 60  # every minute
     keep-alive-timeout-seconds = 60  # keep alive ack will timeout and connection closed  if no response is seen in this time
+    max-inbound-message-size = 104857600
   }
 
   shard-manager {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -118,6 +118,9 @@ filodb {
     translate-prom-to-filodb-histogram = true
     parser = "antlr"
     enforce-result-byte-limit = true
+    container-size-overrides {
+        filodb-query-exec-localpartitionreduceaggregateexec-topbottomk = 40960
+    }
     grpc {
           partitions-deny-list = ""
        }

--- a/grpc/src/main/scala/filodb/grpc/GrpcCommonUtils.scala
+++ b/grpc/src/main/scala/filodb/grpc/GrpcCommonUtils.scala
@@ -16,11 +16,13 @@ object GrpcCommonUtils {
     val keepAliveTime = grpcConfig.getInt("keep-alive-time-seconds")
     val keepAliveTimeOut = grpcConfig.getInt("keep-alive-timeout-seconds")
     val lbPolicy = grpcConfig.getString("load-balancing-policy")
+    val maxInboundMessageSize = grpcConfig.getInt("max-inbound-message-size")
     val builder = NettyChannelBuilder
       .forTarget(endpointUrl)
       .defaultLoadBalancingPolicy(lbPolicy)
       // TODO: Configure this to SSL/Plain text later based on config, currently only Plaintext supported
       .negotiationType(NegotiationType.PLAINTEXT)
+      .maxInboundMessageSize(maxInboundMessageSize)
 
     if (idleTimeout > 0) {
       builder.idleTimeout(idleTimeout, TimeUnit.SECONDS)

--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -389,6 +389,9 @@ object ProtoConverters {
     def toProto: GrpcMultiPartitionQueryService.Throwable = {
       val builder = GrpcMultiPartitionQueryService.Throwable.newBuilder()
       t match {
+        case filodb.core.query.QueryLimitException(message, queryId)                          =>
+                                                      builder.putMetadata("queryId", queryId)
+                                                      builder.putMetadata("message", message)
         case filodb.core.QueryTimeoutException(elapsedQueryTime, timedOutAt)                  =>
                                                       builder.putMetadata("timedOutAt", timedOutAt)
                                                       builder.putMetadata("elapsedQueryTime", s"$elapsedQueryTime")
@@ -424,6 +427,11 @@ object ProtoConverters {
       // to avoid multiple combinations, we will treat null message as an empty string
       val message  = if (throwableProto.hasMessage) throwableProto.getMessage else ""
       val t = throwableProto.getExceptionClass match {
+        case "filodb.core.query.QueryLimitException" =>
+                val metaMap = throwableProto.getMetadataMap
+                val queryId = metaMap.getOrDefault("queryId", "")
+                val message = metaMap.getOrDefault("message", "")
+                QueryLimitException(message, queryId)
         case "filodb.core.QueryTimeoutException"     =>
                   val metaMap = throwableProto.getMetadataMap
                   val eqt = metaMap.getOrDefault("elapsedQueryTime", "0").toLong

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -65,7 +65,9 @@ final case class LocalPartitionReduceAggregateExec(queryContext: QueryContext,
                                                    dispatcher: PlanDispatcher,
                                                    childAggregates: Seq[ExecPlan],
                                                    aggrOp: AggregationOperator,
-                                                   aggrParams: Seq[Any]) extends ReduceAggregateExec {
+                                                   aggrParams: Seq[Any],
+                                                   override val maxRecordContainerSize: Int =
+                                                   SerializedRangeVector.MaxContainerSize) extends ReduceAggregateExec {
   /**
    * Requiring strict result schema match for Aggregation within filodb cluster
    * since fixedVectorLen presence will enable fast-reduce when possible
@@ -217,7 +219,7 @@ object RangeVectorAggregator extends StrictLogging {
         logger.warn(queryContext.getQueryLogLine(
           s"Exceeded enforced group-by cardinality limit ${groupByEnforcedLimit}. "
         ))
-        throw new QueryLimitException(
+        throw QueryLimitException(
           s"Query exceeded group-by cardinality limit ${groupByEnforcedLimit}. " +
           "Try applying more filters or reduce query range. ", queryContext.queryId
         )

--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -81,7 +81,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
             s" encountered input cardinality ${result.size}"
           val logline = queryContext.getQueryLogLine(msg)
           qLogger.warn(logline)
-          throw new QueryLimitException(s"The join in this query has input cardinality of ${result.size} which" +
+          throw QueryLimitException(s"The join in this query has input cardinality of ${result.size} which" +
             s" is more than limit of ${queryContext.plannerParams.enforcedLimits.joinQueryCardinality}." +
             s" Try applying more filters or reduce time range.", queryContext.queryId)
         }

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -258,7 +258,7 @@ trait ExecPlan extends QueryCommand {
       val msg = s"Exceeded enforced limit of samples produced on a single shard or processing node. " +
         s"Max number of samples is ${queryContext.plannerParams.enforcedLimits.execPlanSamples}"
       qLogger.warn(queryContext.getQueryLogLine(msg))
-      throw new QueryLimitException(s"This query results in more than " +
+      throw QueryLimitException(s"This query results in more than " +
         s"${queryContext.plannerParams.enforcedLimits.execPlanSamples} samples. " +
         s"Try applying more filters or reduce time range.", queryContext.queryId)
     }
@@ -278,7 +278,7 @@ trait ExecPlan extends QueryCommand {
         s"(${math.round(size_mib)} MiB)."
       qLogger.warn(queryContext.getQueryLogLine(msg))
       if (queryConfig.enforceResultByteLimit) {
-        throw new QueryLimitException(
+        throw QueryLimitException(
           s"$msg Try to apply more filters, reduce the time range, and/or increase the step size.",
           queryContext.queryId
         )

--- a/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
+++ b/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
@@ -718,7 +718,12 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     deserAte1.getCause.isInstanceOf[IllegalArgumentException] shouldBe true
     deserAte1.getCause.getMessage shouldBe "root"
 
-    // Case 11: Anything else should throw Throwable
+    // case 11: Should deserialize QueryLimitException
+
+    val qle = QueryLimitException("message", "queryId")
+    qle.toProto.fromProto shouldEqual qle
+
+    // Case 12: Anything else should throw Throwable
     val isecause = SchemaMismatch(expected = "expectedSchema", found = "foundSchema", clazz = "SomeClass")
     val ise = new IllegalStateException("Illegal state", isecause)
     val deserializedise = ise.toProto.fromProto


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

- No configuration available for gRPC max inbound message size
- Fixed 4k record container size
- Deserializing  ``QueryLimitException`` gives ``Throwable``


**New behavior :**

- Adds default max incoming message size allows configuration of this value
- Default 40k record container size for ``TopK``, ``BottomK`` and ``CountValues``. Allows overriding these values in config
- Exception type preserved in deserialization of  ``QueryLimitException``

