### PR TITLE
fix(query) Configurable record container sizes for topK, bottomK and countValues

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -7,7 +7,6 @@ import com.typesafe.scalalogging.StrictLogging
 import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
 import filodb.core.query._
 import filodb.query._
-import filodb.query.AggregationOperator.{BottomK, CountValues, TopK}
 import filodb.query.LogicalPlan._
 import filodb.query.exec._
 
@@ -208,26 +207,19 @@ trait  DefaultPlanner {
         AggregateMapReduce(lp.operator, lp.params, renamedLabelsClauseOpt)
       )
     }
-    val recordContainerSize = lp.operator match {
-      case TopK | BottomK | CountValues =>
-          queryConfig.recordContainerOverrides("filodb-query-exec-localpartitionreduceaggregateexec-topbottomk")
-      case _ => SerializedRangeVector.MaxContainerSize
-    }
+
     val toReduceLevel2 =
       if (toReduceLevel.plans.size >= 16) {
         // If number of children is above a threshold, parallelize aggregation
         val groupSize = Math.sqrt(toReduceLevel.plans.size).ceil.toInt
         toReduceLevel.plans.grouped(groupSize).map { nodePlans =>
           val reduceDispatcher = nodePlans.head.dispatcher
-          LocalPartitionReduceAggregateExec(qContext, reduceDispatcher, nodePlans, lp.operator,
-            lp.params, recordContainerSize)
+          LocalPartitionReduceAggregateExec(qContext, reduceDispatcher, nodePlans, lp.operator, lp.params)
         }.toList
       } else toReduceLevel.plans
 
     val reduceDispatcher = forceRootDispatcher.getOrElse(PlannerUtil.pickDispatcher(toReduceLevel2))
-     val reducer =
-         LocalPartitionReduceAggregateExec(qContext, reduceDispatcher, toReduceLevel2, lp.operator, lp.params,
-           recordContainerSize)
+    val reducer = LocalPartitionReduceAggregateExec(qContext, reduceDispatcher, toReduceLevel2, lp.operator, lp.params)
 
     if (!qContext.plannerParams.skipAggregatePresent)
       reducer.addRangeVectorTransformer(AggregatePresenter(lp.operator, lp.params, RangeParams(

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -113,14 +113,14 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
           rootLogicalPlan match {
             case lp: LabelValues         => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
                                             PlannerUtil.getLabelValuesUrlParams(lp, queryParams), newQueryContext,
-                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient)
+                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
             case lp: LabelNames         => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
                                             Map("match[]" -> queryParams.promQl), newQueryContext,
-                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient)
+                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
             case lp: SeriesKeysByFilters => val urlParams = Map("match[]" -> queryParams.promQl)
                                             MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
                                               urlParams, newQueryContext, inProcessPlanDispatcher,
-                                              dsRef, remoteExecHttpClient)
+                                              dsRef, remoteExecHttpClient, queryConfig)
             case _                       =>
               if (remoteGrpcEndpoint.isDefined && !(queryConfig.grpcPartitionsDenyList.contains("*") ||
                 queryConfig.grpcPartitionsDenyList.contains(partitionName.toLowerCase))) {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -651,6 +651,6 @@ class MultiPartitionPlanner(partitionLocationProvider: PartitionLocationProvider
     val httpEndpoint = partitionAssignment.httpEndPoint +
       finalQueryContext.origQueryParams.asInstanceOf[PromQlQueryParams].remoteQueryPath.getOrElse("")
     MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-      urlParams, finalQueryContext, inProcessPlanDispatcher, dataset.ref, remoteExecHttpClient)
+      urlParams, finalQueryContext, inProcessPlanDispatcher, dataset.ref, remoteExecHttpClient, queryConfig)
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2125,7 +2125,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     ep.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual(true)
     val presenterTime = ep.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head.asInstanceOf[AggregatePresenter].rangeParams
     val periodicSamplesMapper = ep.children.head.rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    ep.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 40960
+    ep.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 65536
     presenterTime.startSecs shouldEqual(periodicSamplesMapper.startMs/1000)
     presenterTime.endSecs shouldEqual(periodicSamplesMapper.endMs/1000)
   }
@@ -2286,7 +2286,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       if (op == AggregationOperator.TopK
         || op == AggregationOperator.BottomK
         || op == AggregationOperator.CountValues) {
-        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 40960
+        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 65536
       } else {
         execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 4096
       }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2125,7 +2125,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     ep.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual(true)
     val presenterTime = ep.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head.asInstanceOf[AggregatePresenter].rangeParams
     val periodicSamplesMapper = ep.children.head.rangeVectorTransformers.head.asInstanceOf[PeriodicSamplesMapper]
-    ep.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 40960
+    ep.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 40960
     presenterTime.startSecs shouldEqual(periodicSamplesMapper.startMs/1000)
     presenterTime.endSecs shouldEqual(periodicSamplesMapper.endMs/1000)
   }
@@ -2150,7 +2150,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     execPlan.rangeVectorTransformers.head.isInstanceOf[AbsentFunctionMapper] shouldEqual true
     execPlan.children(0).isInstanceOf[MultiSchemaPartitionsExec] shouldEqual(true)
     val multiSchemaExec = execPlan.children(0).asInstanceOf[MultiSchemaPartitionsExec]
-    execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 4096
+    execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 4096
 
     multiSchemaExec.rangeVectorTransformers.head.isInstanceOf[PeriodicSamplesMapper] shouldEqual(true)
     val rvt = multiSchemaExec.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper]
@@ -2286,9 +2286,9 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       if (op == AggregationOperator.TopK
         || op == AggregationOperator.BottomK
         || op == AggregationOperator.CountValues) {
-        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 40960
+        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 40960
       } else {
-        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize shouldEqual 4096
+        execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 4096
       }
       for (child <- execPlan.children) {
         child.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2285,7 +2285,8 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val op = execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].aggrOp
       if (op == AggregationOperator.TopK
         || op == AggregationOperator.BottomK
-        || op == AggregationOperator.CountValues) {
+        || op == AggregationOperator.CountValues
+        || op == AggregationOperator.Quantile) {
         execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 65536
       } else {
         execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].maxRecordContainerSize(queryConfig) shouldEqual 4096

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -323,7 +323,7 @@ filodb {
     # Choices are "legacy", "antlr", and "shadow". Shadow mode uses legacy but also checks antlr for errors.
     parser = "antlr"
     container-size-overrides {
-        filodb-query-exec-localpartitionreduceaggregateexec-topbottomk = 40960
+        filodb-query-exec-aggregate-large-container                    = 65536
         filodb-query-exec-metadataexec                                 = 65536
     }
     grpc {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -324,6 +324,7 @@ filodb {
     parser = "antlr"
     container-size-overrides {
         filodb-query-exec-localpartitionreduceaggregateexec-topbottomk = 40960
+        filodb-query-exec-metadataexec                                 = 65536
     }
     grpc {
       # Override used to disable call to the multi partition calls over gRPC. Specify comma separated partition names

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -53,9 +53,8 @@ object QueryConfig {
                                            allowPartialResultsRangeQuery = false,
                                            allowPartialResultsMetadataQuery = true,
                                            recordContainerOverrides =
-                                             Map("filodb-query-exec-localpartitionreduceaggregateexec-topbottomk"
-                                                     -> 40960,
-                                                  "filodb-query-exec-metadataexec" -> 8192))
+                                             Map("filodb-query-exec-aggregate-large-container" -> 65536,
+                                                  "filodb-query-exec-metadataexec"             -> 8192))
 }
 
 case class QueryConfig(askTimeout: FiniteDuration,

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -51,7 +51,11 @@ object QueryConfig {
                                            remoteGrpcEndpoint = None,
                                            enforceResultByteLimit = false,
                                            allowPartialResultsRangeQuery = false,
-                                           allowPartialResultsMetadataQuery = true)
+                                           allowPartialResultsMetadataQuery = true,
+                                           recordContainerOverrides =
+                                             Map("filodb-query-exec-localpartitionreduceaggregateexec-topbottomk"
+                                                     -> 40960,
+                                                  "filodb-query-exec-metadataexec" -> 8192))
 }
 
 case class QueryConfig(askTimeout: FiniteDuration,

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -120,7 +120,7 @@ filodb {
     parser = "antlr"
     enforce-result-byte-limit = true
     container-size-overrides {
-        filodb-query-exec-localpartitionreduceaggregateexec-topbottomk = 40960
+        filodb-query-exec-aggregate-large-container                    = 65536
         filodb-query-exec-metadataexec                                 = 65536
     }
     grpc {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -121,6 +121,7 @@ filodb {
     enforce-result-byte-limit = true
     container-size-overrides {
         filodb-query-exec-localpartitionreduceaggregateexec-topbottomk = 40960
+        filodb-query-exec-metadataexec                                 = 65536
     }
     grpc {
           partitions-deny-list = ""

--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -65,9 +65,7 @@ final case class LocalPartitionReduceAggregateExec(queryContext: QueryContext,
                                                    dispatcher: PlanDispatcher,
                                                    childAggregates: Seq[ExecPlan],
                                                    aggrOp: AggregationOperator,
-                                                   aggrParams: Seq[Any],
-                                                   override val maxRecordContainerSize: Int =
-                                                   SerializedRangeVector.MaxContainerSize) extends ReduceAggregateExec {
+                                                   aggrParams: Seq[Any]) extends ReduceAggregateExec {
   /**
    * Requiring strict result schema match for Aggregation within filodb cluster
    * since fixedVectorLen presence will enable fast-reduce when possible

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -81,7 +81,8 @@ trait ExecPlan extends QueryCommand {
       case _: MetadataRemoteExec |
            _: PartKeysExec |
            _: MetadataDistConcatExec |
-           _: LabelValuesExec                                         =>  64 * 1024
+           _: LabelValuesExec                                         =>
+        cfg.recordContainerOverrides("filodb-query-exec-metadataexec")
       case _                                                          =>  SerializedRangeVector.MaxContainerSize
     }
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -28,8 +28,6 @@ trait MetadataDistConcatExec extends NonLeafExecPlan {
 
   override def enforceSampleLimit: Boolean = false
 
-  override val maxRecordContainerSize: Int = 64 * 1024
-
   /**
    * Args to use for the ExecPlan for printTree purposes only.
    * DO NOT change to a val. Increases heap usage.
@@ -311,8 +309,7 @@ final case class PartKeysExec(queryContext: QueryContext,
                               filters: Seq[ColumnFilter],
                               fetchFirstLastSampleTimes: Boolean,
                               start: Long,
-                              end: Long,
-                              override val maxRecordContainerSize: Int = 64 * 1024) extends LeafExecPlan {
+                              end: Long) extends LeafExecPlan {
 
   override def enforceSampleLimit: Boolean = false
 
@@ -348,8 +345,6 @@ final case class LabelValuesExec(queryContext: QueryContext,
                                  endMs: Long) extends LeafExecPlan {
 
   override def enforceSampleLimit: Boolean = false
-
-  override val maxRecordContainerSize: Int = 64 * 1024
 
   def doExecute(source: ChunkSource,
                 querySession: QuerySession)

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -18,7 +18,8 @@ case class MetadataRemoteExec(queryEndpoint: String,
                               queryContext: QueryContext,
                               dispatcher: PlanDispatcher,
                               dataset: DatasetRef,
-                              remoteExecHttpClient: RemoteExecHttpClient) extends RemoteExec {
+                              remoteExecHttpClient: RemoteExecHttpClient,
+                              config: QueryConfig) extends RemoteExec {
 
   private val lvColumns = Seq(ColumnInfo("metadataMap", ColumnType.MapColumn))
   private val resultSchema = ResultSchema(lvColumns, 1)
@@ -31,9 +32,7 @@ case class MetadataRemoteExec(queryEndpoint: String,
   private val lcLabelNameField  = "label"
   private val lcLabelCountField = "count"
 
-  override val maxRecordContainerSize: Int = 64 * 1024
-
-  private val builder = SerializedRangeVector.newBuilder(maxRecordContainerSize)
+  private val builder = SerializedRangeVector.newBuilder(maxRecordContainerSize(config))
 
   private val dummyQueryStats = QueryStats()
   override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -238,7 +238,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     val execPlan = PartKeysExec(
       QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = limit -1))),
       executeDispatcher,
-      timeseriesDatasetMultipleShardKeys.ref, 0, filters, false, now - 5000, now, maxRecordContainerSize = 8 * 1024)
+      timeseriesDatasetMultipleShardKeys.ref, 0, filters, false, now - 5000, now)
 
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     resp match {
@@ -246,7 +246,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
                                           ex.getMessage shouldEqual "requirement failed: Record too big for container"
       case _                                                   =>
                                             fail(s"Expected to see an exception for exceeding the default " +
-                                              s"container limit of ${execPlan.maxRecordContainerSize}")
+                                              s"container limit of ${execPlan.maxRecordContainerSize(queryConfig)}")
     }
 
 

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -2,8 +2,7 @@ package filodb.query.exec
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
-
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
@@ -11,7 +10,6 @@ import monix.reactive.Observable
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-
 import filodb.core.MetricsTestData._
 import filodb.core.TestData
 import filodb.core.binaryrecord2.BinaryRecordRowReader
@@ -21,11 +19,8 @@ import filodb.core.query._
 import filodb.core.store.{ChunkSource, InMemoryMetaStore, NullColumnStore}
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.query._
-import filodb.query.exec.TsCardExec.CardCounts
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
-import scala.collection.Seq
 
 class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
 
@@ -240,7 +235,12 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
       executeDispatcher,
       timeseriesDatasetMultipleShardKeys.ref, 0, filters, false, now - 5000, now)
 
-    val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
+    val queryConfigOverridden = QueryConfig(config.getConfig("query"
+    ).withValue("container-size-overrides.filodb-query-exec-metadataexec",
+      ConfigValueFactory.fromAnyRef(8 * 1024)))
+    val querySessionOverridden = QuerySession(QueryContext(), queryConfigOverridden)
+    execPlan.maxRecordContainerSize(queryConfigOverridden) shouldEqual 8192
+    val resp = execPlan.execute(memStore, querySessionOverridden).runToFuture.futureValue
     resp match {
       case QueryError(_, _, ex: IllegalArgumentException)  =>
                                           ex.getMessage shouldEqual "requirement failed: Record too big for container"
@@ -255,7 +255,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
       QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = limit -1))),
       executeDispatcher,
       timeseriesDatasetMultipleShardKeys.ref, 0, filters, false, now - 5000, now)
-
+    execPlan1.maxRecordContainerSize(querySession.queryConfig) shouldEqual 65536
     val resp1 = execPlan1.execute(memStore, querySession).runToFuture.futureValue
     val result = resp1 match {
       case QueryResult(id, _, response, _, _, _, _) => {

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -7,9 +7,8 @@ import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
 import filodb.core.metadata.{Dataset, DatasetOptions}
-import filodb.core.query.{PromQlQueryParams, QueryContext}
+import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext}
 import filodb.core.store.ChunkSource
 import filodb.memory.format.vectors.MutableHistogram
 import filodb.query
@@ -70,7 +69,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
   it ("should convert vector Data to QueryResponse for MetadataQuery") {
     val exec = MetadataRemoteExec("", 60000, Map.empty,
-      queryContext, dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
+      queryContext, dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient, QueryConfig.unitTestingQueryConfig)
     val map1 = Map("instance" -> "inst-1", "last-sample" -> "6377838" )
     val map2 = Map("instance" -> "inst-2", "last-sample" -> "6377834" )
     val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataMapSampl(map1), MetadataMapSampl(map2))), "id", Kamon.currentSpan())
@@ -83,7 +82,7 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
   it ("should convert vector Data to QueryResponse for Metadata series query") {
     val exec = MetadataRemoteExec("", 60000, Map.empty, queryContext,
-      dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient)
+      dummyDispatcher, timeseriesDataset.ref, RemoteHttpClient.defaultClient, QueryConfig.unitTestingQueryConfig)
     val map1 = Map("instance" -> "inst-1", "last-sample" -> "6377838" )
     val map2 = Map("instance" -> "inst-2", "last-sample" -> "6377834" )
     val res = exec.toQueryResponse(MetadataSuccessResponse(Seq(MetadataMapSampl(map1), MetadataMapSampl(map2))), "id", Kamon.currentSpan())

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -146,7 +146,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   it ("series matcher remote exec") {
     val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/series", 10000L, Map("filter" -> "a=b,c=d"),
       QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/series"))),
-      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend), queryConfig)
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
@@ -163,7 +163,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   it ("empty response series matcher remote exec") {
     val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/series", 10000L, Map("filter" -> "a=b,c=d", "empty" -> "true"),
       QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/series"))),
-      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend), queryConfig)
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
@@ -182,7 +182,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   it ("label values remote metadata exec") {
     val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/label/__name__/values", 10000L, Map("filter" -> "a=b,c=d"),
       QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/label"))),
-      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend), queryConfig)
 
     val exec2: LabelValuesExec = LabelValuesExec(QueryContext(), executeDispatcher,
       timeseriesDataset.ref, 1, Seq(ColumnFilter("a", Equals("b"))), Seq("__name__"), 123L, 234L)
@@ -206,7 +206,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   it ("empty response label values remote metadata exec") {
     val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/label/__name__/values", 10000L, Map("filter" -> "a=b,c=d", "empty" -> "true"),
       QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/label"))),
-      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend), queryConfig)
 
     val exec2: LabelValuesExec = LabelValuesExec(QueryContext(), executeDispatcher,
       timeseriesDataset.ref, 1, Seq(ColumnFilter("a", Equals("b"))), Seq("__name__"), 123L, 234L)
@@ -231,7 +231,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   it ("labels metadata remote exec") {
     val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/labels", 10000L, Map("filter" -> "a=b,c=d"),
       QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/labels"))),
-      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend))
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend), queryConfig)
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {
@@ -267,7 +267,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val exec: MetadataRemoteExec = MetadataRemoteExec("http://localhost:31007/api/v1/metering/cardinality/timeseries", 10000L,
       Map("match[]" -> """{_ws_="foo", _ns_="bar"}""", "numGroupByFields" -> "3"),
       QueryContext(origQueryParams=PromQlQueryParams("test", 123L, 234L, 15L, Option("http://localhost:31007/api/v1/metering/cardinality/timeseries"))),
-      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackendTsCard))
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackendTsCard), queryConfig)
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
     val result = (resp: @unchecked) match {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
We use a fixed 4k buffer for record containers 

**New behavior :**

We change the container size 40k or any other configurable value for ``Topk``, ``BottomK`` and ``CountValue`` aggregation

