### PR TITLE
throwing QueryLimitException instead of BadQueryException

### DIFF
--- a/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
+++ b/query/src/main/scala/filodb/query/exec/BinaryJoinExec.scala
@@ -154,7 +154,7 @@ final case class BinaryJoinExec(queryContext: QueryContext,
 
             // OneToOne cardinality case is already handled. this condition handles OneToMany case
             if (results.size >= queryContext.plannerParams.enforcedLimits.joinQueryCardinality)
-              throw new BadQueryException(s"The result of this join query has cardinality ${results.size} and has " +
+              throw new QueryLimitException(s"The result of this join query has cardinality ${results.size} and has " +
                 s"reached the limit of ${queryContext.plannerParams.enforcedLimits.joinQueryCardinality}. " +
                 s"Try applying more filters.")
 


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Currently we throw BadQueryException when we hit individual query limit.


**New behavior :**
We throw QueryLimit exception. 


**BREAKING CHANGES**

no breaking changes

**Other information**: