### PR TITLE
perf(coord) ensure the first SRV does not contain all record containers

### DIFF
--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -471,7 +471,7 @@ object SerializedRangeVector extends StrictLogging {
       // If there weren't containers before, then take all of them.  If there were, discard earlier ones, just
       // start with the most recent one we started adding to
       val containers = oldContainerOpt match {
-        case None => builder.allContainers
+        case None => builder.allContainers.toList
         case Some(firstContainer) => builder.allContainers.dropWhile(_ != firstContainer)
       }
       val srv = new SerializedRangeVector(rv.key, numRows, containers, schema, startRecordNo, rv.outputRange)

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -471,6 +471,13 @@ object SerializedRangeVector extends StrictLogging {
       // If there weren't containers before, then take all of them.  If there were, discard earlier ones, just
       // start with the most recent one we started adding to
       val containers = oldContainerOpt match {
+        // The toList ensures we have an immutable representation of containers those are required just for this
+        // SerializedRangeVector. By not having a toList we end up pointing to a mutable ArrayBuffer which gets multiple
+        // record containers, including all others where this builder was used. While Kryo is smart enough to not
+        // serialize the same RecordContainer twice and just send the reference, we end up double counting the result
+        // bytes and in serialization with gRPC where we dont maintain the graph of pointers to serialize the record
+        // just once, we end up serializing almost twice the amount of data and also exceed our 4MB recommended limit
+        // or a gRPC message
         case None => builder.allContainers.toList
         case Some(firstContainer) => builder.allContainers.dropWhile(_ != firstContainer)
       }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
While serializing range vectors the first ``SerializedRangeVector`` (SRVs) contains a reference to all the ``RecordContainers`` and when multiple SRVs are serialized the behavior causes two problems
-  The result bytes are double counted, once as part of the first SRV and another time as part of subsequent SRVs that contain just the required record containers
- When serializing using gRPC, the message may exceed the 4 MB limit and transmits twice the required bytes over the wire. 

The issue isn't seen as part of Kryo serializer as the serialization is smart enough to preserve the references and not serialize the container twice. Also on the receiving side the deserialized values reference the same Record container not creating duplicate containers in memory unlike in gRPC based serialization.  

The streaming response uses a new RecordContainer builder for each ``RangeVector`` and thus this issue will not show up.  


**New behavior :**

- The first SRV doesn't just hold the reference to all containers but we force a snapshot of the record containers those we need  to serialize as part of first SRV
- The result bytes in the stats will show the real number of bytes we serialize (uncompressed) which would roughly be half of what we send today


