### PR TITLE
fix(downsample): Fixing exception when getting num-shards from config

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityManager.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityManager.scala
@@ -50,9 +50,7 @@ class CardinalityManager(datasetRef: DatasetRef,
           .asInstanceOf[List[Config]]
           .filter(x => x.getString("dataset") == datasetToSearch)
           .headOption
-      }
-      else None
-
+      } else None
       val configToUse = datasetConfig match {
         case Some(datasetConf) => Some(datasetConf)
         case None =>

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityManager.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityManager.scala
@@ -41,11 +41,7 @@ class CardinalityManager(datasetRef: DatasetRef,
    */
   private def getDataSetConfigs(filoConfig: Config): Seq[Config] = {
     val datasetConfPaths = filoConfig.as[Seq[String]]("dataset-configs")
-    if (datasetConfPaths.nonEmpty) {
-      datasetConfPaths.map { d => ConfigFactory.parseFile(new java.io.File(d)) }
-    } else {
-      Seq()
-    }
+    datasetConfPaths.map { d => ConfigFactory.parseFile(new java.io.File(d)) }
   }
 
   /**

--- a/core/src/test/resources/test_dataset.conf
+++ b/core/src/test/resources/test_dataset.conf
@@ -1,0 +1,14 @@
+    dataset = "prometheus"
+
+    schema = "prom-counter"
+
+    # Using the following config values for unit tests
+    num-shards = 4
+
+    min-num-nodes = 2
+
+    sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"
+
+    sourceconfig {
+      filo-topic-name = "timeseries-dev"
+    }

--- a/core/src/test/resources/test_dataset_not_prometheus.conf
+++ b/core/src/test/resources/test_dataset_not_prometheus.conf
@@ -1,0 +1,14 @@
+    dataset = "not-prometheus"
+
+    schema = "prom-counter"
+
+    # Using the following config values for unit tests
+    num-shards = 4
+
+    min-num-nodes = 2
+
+    sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"
+
+    sourceconfig {
+      filo-topic-name = "timeseries-dev"
+    }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityManagerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityManagerSpec.scala
@@ -111,6 +111,23 @@ class CardinalityManagerSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     conf = ConfigFactory.parseString(confWithInlineDatasetConfigs).getConfig("filodb")
     cardManager.getNumShardsPerNodeFromConfig("prometheus", conf) shouldEqual 2
 
+    val confWithEmptyDatasetConfigs =
+      """
+        |  filodb {
+        |    dataset-configs = [ ]
+        |
+        |    inline-dataset-configs = [
+        |      {
+        |        dataset = "prometheus"
+        |        min-num-nodes = 8
+        |        num-shards = 16
+        |      }
+        |    ]
+        |  }
+        |""".stripMargin
+    conf = ConfigFactory.parseString(confWithEmptyDatasetConfigs).getConfig("filodb")
+    cardManager.getNumShardsPerNodeFromConfig("prometheus", conf) shouldEqual 2
+
     // `dataset-configs` present, but doesn't have config for `prometheus` dataset. should use `inline-dataset-config`
     val confWithDatasetConfigMissingDataset =
       s"""

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityManagerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityManagerSpec.scala
@@ -9,7 +9,6 @@ import filodb.core.memstore.PartKeyLuceneIndex
 import filodb.core.metadata._
 import filodb.core.store.StoreConfig
 
-import java.io.File
 import scala.concurrent.duration.DurationInt
 
 class CardinalityManagerSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
@@ -20,9 +19,8 @@ class CardinalityManagerSpec extends AnyFunSpec with Matchers with BeforeAndAfte
   val shardKeyLen = MetricsTestData.timeseriesDatasetMultipleShardKeys.options.shardKeyColumns.length
   val quotaSource = new ConfigQuotaSource(filodbConfig, shardKeyLen)
   val partSchema = Schemas(MetricsTestData.timeseriesDatasetMultipleShardKeys.schema).part
-  val prometheusDatasetConfPath = new File("core/src/test/resources/test_dataset.conf").getAbsolutePath()
-  val notPrometheusDatasetConfPath = new File("core/src/test/resources/test_dataset_not_prometheus.conf")
-    .getAbsolutePath()
+  val prometheusDatasetConfPath = getClass.getResource("/test_dataset.conf").getPath
+  val notPrometheusDatasetConfPath = getClass.getResource("/test_dataset_not_prometheus.conf").getPath
 
   def getTestLuceneIndex(shardNum: Int, childPath: String): PartKeyLuceneIndex = {
     new PartKeyLuceneIndex(


### PR DESCRIPTION
**Pull Request checklist**

Fixing exception when getting num-shards from config. 

*Behaviour Before:* wrongly interpreted the dataset-config to be an array of Config object. Instead it is an array of string, where each string is the file path to the dataset config. Because of this mis-interpretation, we were throwing an exception.

*Behaviour After:* Fixed this misinterpretation and parsing the dataset-configs from the file. Referenced the parsing behavior from FiloSettings.scala

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] Tests have been added / updated 