### PR TITLE
feat(core): Simplify configuration to scale Filodb horizontally

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
@@ -34,7 +34,7 @@ class MemstoreCassandraSinkSpec extends AllTablesTest {
   }
 
   it("should flush MemStore data to C*, and be able to read back data from C* directly") {
-    memStore.setup(dataset1.ref, Schemas(dataset1.schema), 0, TestData.storeConf)
+    memStore.setup(dataset1.ref, Schemas(dataset1.schema), 0, TestData.storeConf, 1)
     memStore.store.sinkStats.chunksetsWritten.get shouldEqual 0
 
     // Flush every ~50 records

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
@@ -96,7 +96,7 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val policy = new FixedMaxPartitionsEvictionPolicy(20)
     val memStore = new TimeSeriesMemStore(config, colStore, new InMemoryMetaStore(), Some(policy))
     try {
-      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf)
+      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf, 1)
       memStore.recoverIndex(dataset.ref, 0).futureValue
       memStore.refreshIndexForTesting(dataset.ref)
 
@@ -112,7 +112,7 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val policy = new FixedMaxPartitionsEvictionPolicy(20)
     val memStore = new TimeSeriesMemStore(config, colStore, new InMemoryMetaStore(), Some(policy))
     try {
-      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf)
+      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf, 1)
       memStore.recoverIndex(dataset.ref, 0).futureValue
       memStore.refreshIndexForTesting(dataset.ref)
 
@@ -134,7 +134,7 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val policy = new FixedMaxPartitionsEvictionPolicy(20)
     val memStore = new TimeSeriesMemStore(config, colStore, new InMemoryMetaStore(), Some(policy))
     try {
-      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf)
+      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf, 1)
       memStore.recoverIndex(dataset.ref, 0).futureValue
       memStore.refreshIndexForTesting(dataset.ref)
 
@@ -157,7 +157,7 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val policy = new FixedMaxPartitionsEvictionPolicy(20)
     val memStore = new TimeSeriesMemStore(config, colStore, new InMemoryMetaStore(), Some(policy))
     try {
-      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf)
+      memStore.setup(dataset.ref, schemas, 0, TestData.storeConf, 1)
       memStore.recoverIndex(dataset.ref, 0).futureValue
       memStore.refreshIndexForTesting(dataset.ref)
 

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -6,7 +6,10 @@
     # Should not change once dataset has been set up on the server and data has been persisted to cassandra
     num-shards = 4
 
+    # deprecated in favor of min-num-nodes-in-cluster config in filodb server config
+    # To be removed eventually. There is no reason to set a value for this for each dataset
     min-num-nodes = 2
+
     # Length of chunks to be written, roughly
     sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"
 

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -55,6 +55,7 @@ final class FilodbSettings(val conf: Config) {
   lazy val hostList = config.as[Option[Seq[String]]]("cluster-discovery.host-list")
   lazy val localhostOrdinal = config.as[Option[Int]]("cluster-discovery.localhost-ordinal")
 
+  lazy val minNumNodes = config.as[Option[Int]]("min-num-nodes-in-cluster")
 
   /**
    * Returns IngestionConfig/dataset configuration from parsing dataset-configs file paths.

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -37,8 +37,9 @@ object IngestionActor {
             source: NodeClusterActor.IngestionSource,
             downsample: DownsampleConfig,
             storeConfig: StoreConfig,
+            numShards: Int,
             statusActor: ActorRef): Props =
-    Props(new IngestionActor(ref, schemas, memStore, source, downsample, storeConfig, statusActor))
+    Props(new IngestionActor(ref, schemas, memStore, source, downsample, storeConfig, numShards, statusActor))
 }
 
 /**
@@ -62,6 +63,7 @@ private[filodb] final class IngestionActor(ref: DatasetRef,
                                            source: NodeClusterActor.IngestionSource,
                                            downsample: DownsampleConfig,
                                            storeConfig: StoreConfig,
+                                           numShards: Int,
                                            statusActor: ActorRef) extends BaseActor {
 
   import IngestionActor._
@@ -170,7 +172,7 @@ private[filodb] final class IngestionActor(ref: DatasetRef,
 
   // scalastyle:off method.length
   private def startIngestion(shard: Int): Unit = {
-    try tsStore.setup(ref, schemas, shard, storeConfig, downsample) catch {
+    try tsStore.setup(ref, schemas, shard, storeConfig, numShards, downsample) catch {
       case ShardAlreadySetup(ds, s) =>
         logger.warn(s"dataset=$ds shard=$s already setup, skipping....")
         return

--- a/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
@@ -402,7 +402,8 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
         ackTo.foreach(_ ! DatasetExists(dataset.ref))
         Map.empty
       case None =>
-        val resources = DatasetResourceSpec(ingestConfig.numShards, ingestConfig.minNumNodes)
+        val minNumNodes = settings.minNumNodes.getOrElse(ingestConfig.minNumNodes)
+        val resources = DatasetResourceSpec(ingestConfig.numShards, minNumNodes)
         val mapper = new ShardMapper(resources.numShards)
         _shardMappers(dataset.ref) = mapper
         // Access the shardmapper through the HashMap so even if it gets replaced it will update the shard stats

--- a/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
@@ -84,7 +84,7 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
                 .foreach { downsampleDataset => memStore.store.initialize(downsampleDataset, ingestConfig.numShards) }
 
     setupDataset( dataset,
-                  ingestConfig.storeConfig,
+                  ingestConfig.storeConfig, ingestConfig.numShards,
                   IngestionSource(ingestConfig.streamFactoryClass, ingestConfig.sourceConfig),
                   ingestConfig.downsampleConfig)
     initShards(dataset, ingestConfig)
@@ -121,6 +121,7 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
     */
   private def setupDataset(dataset: Dataset,
                            storeConf: StoreConfig,
+                           numShards: Int,
                            source: IngestionSource,
                            downsample: DownsampleConfig,
                            schemaOverride: Boolean = false): Unit = {
@@ -132,7 +133,7 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
     val schemas = if (schemaOverride) Schemas(dataset.schema) else settings.schemas
     if (schemaOverride) logger.info(s"Overriding schemas from settings: this better be a test!")
     val props = IngestionActor.props(dataset.ref, schemas, memStore,
-                                     source, downsample, storeConf, self)
+                                     source, downsample, storeConf, numShards, self)
     val ingester = context.actorOf(props, s"$Ingestion-${dataset.name}")
     context.watch(ingester)
     ingestionActors(ref) = ingester

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -2,7 +2,7 @@ filodb {
   v2-cluster-enabled = false
 
   # Number of nodes in cluster; used to calculate per-dhard resources based on how many shards assigned to node
-  # num-nodes-in-cluster = 2
+  # min-num-nodes-in-cluster = 2
 
   cluster-discovery {
     // set this to a smaller value (like 30s) at thee query entry points
@@ -693,7 +693,7 @@ filodb {
       # automatic memory allocation is enabled if true
       automatic-alloc-enabled = false
 
-      # if not provided this is calculated as ContainerOrNodeMemory - 500MB for OS - CurrentJVMHeapMemory
+      # if not provided this is calculated as ContainerOrNodeMemory - os-memory-needs - CurrentJVMHeapMemory
       # available-memory-bytes = 5GB
 
       # memory dedicated for proper functioning of OS

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -699,16 +699,20 @@ filodb {
       # memory dedicated for proper functioning of OS
       os-memory-needs = 500MB
 
+      # NOTE
+      # lucene-memory-percent + native-memory-manager-percent + block-memory-manager-percent
+      # should equal 100
+
       # memory percent of available-memory reserved for Lucene memory maps
-      lucene-memory-percent = 20
+      lucene-memory-percent = 8
 
       # memory percent of available-memory reserved for native memory manager
       # (used for partKeys, chunkMaps, chunkInfos, writeBuffers)
-      native-memory-manager-percent = 20
+      native-memory-manager-percent = 23
 
       # memory percent of available-memory reserved for block memory manager
       # (used for storing chunks)
-      block-memory-manager-percent = 60
+      block-memory-manager-percent = 69
     }
 
     # At the cost of some extra heap memory, we can track queries holding shared lock for a long time

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -685,6 +685,28 @@ filodb {
     # Note: this memory is shared across all configued datasets on a node.
     ingestion-buffer-mem-size = 200MB
 
+    memory-alloc {
+      # automatic memory allocation is enabled if true
+      automatic-alloc-enabled = false
+
+      # if not provided this is calculated as ContainerOrNodeMemory - 500MB for OS - CurrentJVMHeapMemory
+      # available-memory-bytes = 5GB
+
+      # memory dedicated for proper functioning of OS
+      os-memory-needs = 500MB
+
+      # memory percent of available-memory reserved for Lucene memory maps
+      lucene-memory-percent = 20
+
+      # memory percent of available-memory reserved for native memory manager
+      # (used for partKeys, chunkMaps, chunkInfos, writeBuffers)
+      native-memory-manager-percent = 20
+
+      # memory percent of available-memory reserved for block memory manager
+      # (used for storing chunks)
+      block-memory-manager-percent = 60
+    }
+
     # At the cost of some extra heap memory, we can track queries holding shared lock for a long time
     # and starving the exclusive access of lock for eviction
     track-queries-holding-eviction-lock = true

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -699,20 +699,29 @@ filodb {
       # memory dedicated for proper functioning of OS
       os-memory-needs = 500MB
 
-      # NOTE
+      # NOTE: In the three configs below,
       # lucene-memory-percent + native-memory-manager-percent + block-memory-manager-percent
       # should equal 100
+      ##############################################################
+      #                    #                     #                 #
+      #  LuceneMemPercent  # NativeMemPercent    # BlockMemPercent #
+      #                    #                     #                 #
+      ##############################################################
 
-      # memory percent of available-memory reserved for Lucene memory maps
-      lucene-memory-percent = 8
+      # Memory percent of available-memory reserved for Lucene memory maps.
+      # Note we do not use this config to explicitly allocate space for lucene.
+      # But reserving this space ensures that more of the lucene memory maps are stored in memory
+      lucene-memory-percent = 5
 
       # memory percent of available-memory reserved for native memory manager
       # (used for partKeys, chunkMaps, chunkInfos, writeBuffers)
-      native-memory-manager-percent = 23
+      native-memory-manager-percent = 24
 
-      # memory percent of available-memory reserved for block memory manager
+      # Memory percent of available-memory reserved for block memory manager
       # (used for storing chunks)
-      block-memory-manager-percent = 69
+      # This is divvied amongst datasets on the node per configuration for dataset
+      # The shards of the dataset on the node get even amount of memory from this fraction
+      block-memory-manager-percent = 73
     }
 
     # At the cost of some extra heap memory, we can track queries holding shared lock for a long time

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1,5 +1,9 @@
 filodb {
   v2-cluster-enabled = false
+
+  # Number of nodes in cluster; used to calculate per-dhard resources based on how many shards assigned to node
+  # num-nodes-in-cluster = 2
+
   cluster-discovery {
     // set this to a smaller value (like 30s) at thee query entry points
     // if FiloDB HTTP API is indeed the query entry point, this should be overridden to small value

--- a/core/src/main/scala/filodb.core/Utils.scala
+++ b/core/src/main/scala/filodb.core/Utils.scala
@@ -16,17 +16,20 @@ object Utils extends StrictLogging {
   }
 
   def calculateAvailableOffHeapMemory(filodbConfig: Config): Long = {
-    if (filodbConfig.hasPath("memstore.memory-alloc.available-memory")) {
+    val availableMem = if (filodbConfig.hasPath("memstore.memory-alloc.available-memory")) {
+      logger.info("Using automatic-memory-config using overridden memory-alloc.available-memory")
       filodbConfig.getMemorySize("memstore.memory-alloc.available-memory").toBytes
     } else {
       val containerMemory = ManagementFactory.getOperatingSystemMXBean()
         .asInstanceOf[com.sun.management.OperatingSystemMXBean].getTotalPhysicalMemorySize()
       val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
       val osMemoryNeeds = filodbConfig.getMemorySize("memstore.memstore.os-memory-needs").toBytes
+      logger.info(s"Using automatic-memory-config using detected available memory containerMemory=$containerMemory" +
+        s" currentJavaHeapMemory=$currentJavaHeapMemory osMemoryNeeds=$osMemoryNeeds")
       containerMemory - currentJavaHeapMemory - osMemoryNeeds
-      // TODO info logging
     }
+    logger.info(s"Available memory calculated or configured as $availableMem")
+    availableMem
   }
-
 
 }

--- a/core/src/main/scala/filodb.core/Utils.scala
+++ b/core/src/main/scala/filodb.core/Utils.scala
@@ -2,7 +2,7 @@ package filodb.core
 
 import java.lang.management.ManagementFactory
 
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigRenderOptions}
 import com.typesafe.scalalogging.StrictLogging
 
 object Utils extends StrictLogging {
@@ -16,16 +16,22 @@ object Utils extends StrictLogging {
   }
 
   def calculateAvailableOffHeapMemory(filodbConfig: Config): Long = {
-    val availableMem = if (filodbConfig.hasPath("memstore.memory-alloc.available-memory")) {
-      logger.info("Using automatic-memory-config using overridden memory-alloc.available-memory")
-      filodbConfig.getMemorySize("memstore.memory-alloc.available-memory").toBytes
+    val containerMemory = ManagementFactory.getOperatingSystemMXBean()
+      .asInstanceOf[com.sun.management.OperatingSystemMXBean].getTotalPhysicalMemorySize()
+    val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
+    val osMemoryNeeds = filodbConfig.getMemorySize("memstore.memory-alloc.os-memory-needs").toBytes
+    logger.info(s"Detected available memory containerMemory=$containerMemory" +
+      s" currentJavaHeapMemory=$currentJavaHeapMemory osMemoryNeeds=$osMemoryNeeds")
+
+    logger.info(s"Memory Alloc Options: " +
+      s"${filodbConfig.getConfig("memstore.memory-alloc").root().render(ConfigRenderOptions.concise())}")
+
+    val availableMem = if (filodbConfig.hasPath("memstore.memory-alloc.available-memory-bytes")) {
+      val avail = filodbConfig.getMemorySize("memstore.memory-alloc.available-memory-bytes").toBytes
+      logger.info(s"Using automatic-memory-config using overridden memory-alloc.available-memory $avail")
+      avail
     } else {
-      val containerMemory = ManagementFactory.getOperatingSystemMXBean()
-        .asInstanceOf[com.sun.management.OperatingSystemMXBean].getTotalPhysicalMemorySize()
-      val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
-      val osMemoryNeeds = filodbConfig.getMemorySize("memstore.memstore.os-memory-needs").toBytes
-      logger.info(s"Using automatic-memory-config using detected available memory containerMemory=$containerMemory" +
-        s" currentJavaHeapMemory=$currentJavaHeapMemory osMemoryNeeds=$osMemoryNeeds")
+      logger.info(s"Using automatic-memory-config using without available memory override")
       containerMemory - currentJavaHeapMemory - osMemoryNeeds
     }
     logger.info(s"Available memory calculated or configured as $availableMem")

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -59,7 +59,7 @@ extends TimeSeriesStore with StrictLogging {
   override def metastore: MetaStore = ??? // Not needed
 
   // TODO: Change the API to return Unit Or ShardAlreadySetup, instead of throwing.  Make idempotent.
-  def setup(ref: DatasetRef, schemas: Schemas, shard: Int, storeConf: StoreConfig,
+  def setup(ref: DatasetRef, schemas: Schemas, shard: Int, storeConf: StoreConfig, numShards: Int,
             downsampleConfig: DownsampleConfig = DownsampleConfig.disabled): Unit = synchronized {
     val shards = datasets.getOrElseUpdate(ref, new NonBlockingHashMapLong[DownsampledTimeSeriesShard](32, false))
     val quotaSource = quotaSources.getOrElseUpdate(ref,

--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -26,6 +26,7 @@ import filodb.memory.NativeMemoryManager
 class OnDemandPagingShard(ref: DatasetRef,
                           schemas: Schemas,
                           storeConfig: StoreConfig,
+                          numShards: Int,
                           quotaSource: QuotaSource,
                           shardNum: Int,
                           bufferMemoryManager: NativeMemoryManager,
@@ -34,7 +35,7 @@ class OnDemandPagingShard(ref: DatasetRef,
                           evictionPolicy: PartitionEvictionPolicy,
                           filodbConfig: Config)
                          (implicit ec: ExecutionContext) extends
-TimeSeriesShard(ref, schemas, storeConfig, quotaSource, shardNum, bufferMemoryManager, rawStore,
+TimeSeriesShard(ref, schemas, storeConfig, numShards, quotaSource, shardNum, bufferMemoryManager, rawStore,
                 metastore, evictionPolicy, filodbConfig)(ec) {
   import TimeSeriesShard._
   import FiloSchedulers._

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -47,6 +47,11 @@ extends TimeSeriesStore with StrictLogging {
     if (filodbConfig.getBoolean("memstore.memory-alloc.automatic-alloc-enabled")) {
       val availableMemoryBytes: Long = Utils.calculateAvailableOffHeapMemory(filodbConfig)
       val nativeMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.native-memory-manager-percent")
+      val blockMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.block-memory-manager-percent")
+      val lucenePercent = filodbConfig.getDouble("memstore.memory-alloc.lucene-memory-percent")
+      require(nativeMemoryManagerPercent + blockMemoryManagerPercent + lucenePercent == 100.0,
+        s"Configured Block($nativeMemoryManagerPercent), Native($nativeMemoryManagerPercent) " +
+        s"and Lucene($lucenePercent) memory percents don't sum to 100.0")
       (availableMemoryBytes * nativeMemoryManagerPercent / 100).toLong
     } else filodbConfig.getMemorySize("memstore.ingestion-buffer-mem-size").toBytes
   }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -43,7 +43,7 @@ extends TimeSeriesStore with StrictLogging {
   private val partEvictionPolicy = evictionPolicy.getOrElse(
     new CompositeEvictionPolicy(ensureTspHeadroomPercent, ensureNmmHeadroomPercent))
 
-  private lazy val ingestionMemory = {
+  private[memstore] lazy val ingestionMemory = {
     if (filodbConfig.getBoolean("memstore.memory-alloc.automatic-alloc-enabled")) {
       val availableMemoryBytes: Long = Utils.calculateAvailableOffHeapMemory(filodbConfig)
       val nativeMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.native-memory-manager-percent")

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -48,7 +48,7 @@ extends TimeSeriesStore with StrictLogging {
       val availableMemoryBytes: Long = Utils.calculateAvailableOffHeapMemory(filodbConfig)
       val nativeMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.native-memory-manager-percent")
       (availableMemoryBytes * nativeMemoryManagerPercent / 100).toLong
-    } else filodbConfig.getMemorySize("memstore.memstore.ingestion-buffer-mem-size").toBytes
+    } else filodbConfig.getMemorySize("memstore.ingestion-buffer-mem-size").toBytes
   }
 
   private[this] lazy val ingestionMemFactory: NativeMemoryManager = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -366,7 +366,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   val ingestSched = Scheduler.singleThread(s"$IngestSchedName-$ref-$shardNum",
     reporter = UncaughtExceptionReporter(logger.error("Uncaught Exception in TimeSeriesShard.ingestSched", _)))
 
-  private val blockMemorySize = {
+  private[memstore] val blockMemorySize = {
     val size = if (filodbConfig.getBoolean("memstore.memory-alloc.automatic-alloc-enabled")) {
       val numNodes = filodbConfig.getInt("min-num-nodes-in-cluster")
       val availableMemoryBytes: Long = Utils.calculateAvailableOffHeapMemory(filodbConfig)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
@@ -75,7 +75,7 @@ trait TimeSeriesStore extends ChunkSource {
    * @param downsampleConfig configuration for downsampling operation. By default it is disabled.
    */
   def setup(ref: DatasetRef, schemas: Schemas, shard: Int,
-            storeConf: StoreConfig,
+            storeConf: StoreConfig, numShards: Int,
             downsampleConfig: DownsampleConfig = DownsampleConfig.disabled): Unit
 
   /**

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -17,6 +17,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              maxBlobBufferSize: Int,
                              // Number of bytes to allocate to chunk storage in each shard
                              shardMemSize: Long,
+                             shardMemPercent: Double,
                              maxBufferPoolSize: Int,
                              groupsPerShard: Int,
                              numPagesPerBlock: Int,
@@ -45,6 +46,7 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "max-chunks-size" -> maxChunksSize,
                                "max-blob-buffer-size" -> maxBlobBufferSize,
                                "shard-mem-size" -> shardMemSize,
+                               "shard-mem-percent" -> shardMemPercent,
                                "max-buffer-pool-size" -> maxBufferPoolSize,
                                "groups-per-shard" -> groupsPerShard,
                                "max-chunk-time" -> (maxChunkTime.toSeconds + "s"),
@@ -81,6 +83,7 @@ object StoreConfig {
                                            |max-blob-buffer-size = 15000
                                            |max-buffer-pool-size = 10000
                                            |groups-per-shard = 60
+                                           |shard-mem-percent = 100 # assume only one dataset per node by default
                                            |num-block-pages = 100
                                            |failure-retries = 3
                                            |retry-delay = 15 seconds
@@ -119,6 +122,7 @@ object StoreConfig {
                 config.getInt("max-chunks-size"),
                 config.getInt("max-blob-buffer-size"),
                 config.getMemorySize("shard-mem-size").toBytes,
+                config.getDouble("shard-mem-percent"),
                 config.getInt("max-buffer-pool-size"),
                 config.getInt("groups-per-shard"),
                 config.getInt("num-block-pages"),

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -88,6 +88,14 @@ filodb {
   spark.dataset-ops-timeout = 15s
 
   memstore {
+    memory-alloc {
+      automatic-alloc-enabled = false
+      os-memory-needs = 500MB
+      lucene-memory-percent = 20
+      native-memory-manager-percent = 20
+      block-memory-manager-percent = 60
+    }
+
     flush-task-parallelism = 1
     ensure-block-memory-headroom-percent = 5
     ensure-tsp-count-headroom-percent = 5
@@ -97,6 +105,7 @@ filodb {
     track-queries-holding-eviction-lock = false
     index-faceting-enabled-shard-key-labels = true
     index-faceting-enabled-for-all-labels = true
+
   }
 
   tasks {

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -90,6 +90,7 @@ filodb {
   memstore {
     memory-alloc {
       automatic-alloc-enabled = false
+      available-memory-bytes = 1GB
       os-memory-needs = 500MB
       lucene-memory-percent = 20
       native-memory-manager-percent = 20

--- a/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/DemandPagedChunkStoreSpec.scala
@@ -26,7 +26,7 @@ class DemandPagedChunkStoreSpec extends AnyFunSpec with AsyncTest {
                                                |shard-mem-size = 200MB""".stripMargin)
                                 .withFallback(TestData.sourceConf.getConfig("store"))
 
-  memStore.setup(dataset1.ref, Schemas(schema1), 0, StoreConfig(sourceConf))
+  memStore.setup(dataset1.ref, Schemas(schema1), 0, StoreConfig(sourceConf), 1)
   val onDemandPartMaker = memStore.getShardE(dataset1.ref, 0).partitionMaker
 
   after {

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -39,7 +39,7 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
   val container = createRecordContainer(0, 10)
 
   override def beforeAll(): Unit = {
-    memStore.setup(timeseriesDataset.ref, Schemas(timeseriesSchema), 0, TestData.storeConf)
+    memStore.setup(timeseriesDataset.ref, Schemas(timeseriesSchema), 0, TestData.storeConf, 1)
     memStore.ingest(timeseriesDataset.ref, 0, SomeData(container, 0))
     memStore.refreshIndexForTesting(timeseriesDataset.ref)
   }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -302,6 +302,35 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     10.until(20).foreach {i => tsShard.activelyIngesting(i) shouldEqual false}
   }
 
+  it("should configure memory automatically when enabled") {
+    val colStore = new NullColumnStore()
+
+    val config2 = ConfigFactory.parseString(
+      """
+        |min-num-nodes-in-cluster = 32
+        |memstore {
+        |    memory-alloc {
+        |      automatic-alloc-enabled = true
+        |      available-memory-bytes = 1GB
+        |      lucene-memory-percent = 10
+        |      native-memory-manager-percent = 30
+        |      block-memory-manager-percent = 60
+        |    }
+        |}
+        |""".stripMargin).withFallback(config)
+
+    val memStore = new TimeSeriesMemStore(config2, colStore, new InMemoryMetaStore())
+    memStore.setup(dataset1.ref, schemas1, 0, TestData.storeConf.copy(groupsPerShard = 2,
+      diskTTLSeconds = 1.hour.toSeconds.toInt,
+      flushInterval = 10.minutes, shardMemPercent = 40), 256)
+
+    memStore.ingestionMemory shouldEqual 300000000 // 1GB * 30%
+    val tsShard = memStore.getShard(dataset1.ref, 0).get
+    tsShard.blockMemorySize shouldEqual 30000000 // 1GB * 60% (for block memory) * 40% (for dataset memory) / (256/32)
+
+    memStore.shutdown()
+  }
+
   it("should recover index data from col store correctly") {
 
     val partBuilder = new RecordBuilder(TestData.nativeMem)

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -126,7 +126,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
   // TODO: FilteredPartitionScan() for ColumnStores does not work without an index right now
   ignore should "filter rows written with single partition key" in {
     import GdeltTestData._
-    memStore.setup(dataset2.ref, schemas, 0, TestData.storeConf)
+    memStore.setup(dataset2.ref, schemas, 0, TestData.storeConf, 1)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
     memStore.startIngestion(dataset2.ref, 0, stream, s, Task {}).futureValue
@@ -143,7 +143,7 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
   // "rangeVectors api" should "return Range Vectors for given filter and read all rows" in {
   ignore should "return Range Vectors for given filter and read all rows" in {
     import GdeltTestData._
-    memStore.setup(dataset2.ref, schemas, 0, TestData.storeConf)
+    memStore.setup(dataset2.ref, schemas, 0, TestData.storeConf, 1)
     val stream = Observable.now(records(dataset2))
     // Force flush of all groups at end
     memStore.startIngestion(dataset2.ref, 0, stream, s, Task {}).futureValue

--- a/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramIngestBenchmark.scala
@@ -68,8 +68,8 @@ class HistogramIngestBenchmark {
   val policy = new FixedMaxPartitionsEvictionPolicy(1000)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
   val ingestConf = TestData.storeConf.copy(shardMemSize = 512 * 1024 * 1024, maxChunksSize = 100)
-  memStore.setup(histDataset.ref, Schemas(histDataset.schema), 0, ingestConf)
-  memStore.setup(promDataset.ref, Schemas(promDataset.schema), 0, ingestConf)
+  memStore.setup(histDataset.ref, Schemas(histDataset.schema), 0, ingestConf, 1)
+  memStore.setup(promDataset.ref, Schemas(promDataset.schema), 0, ingestConf, 1)
 
   val hShard = memStore.getShardE(histDataset.ref, 0)
   val pShard = memStore.getShardE(promDataset.ref, 0)

--- a/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistogramQueryBenchmark.scala
@@ -53,7 +53,7 @@ class HistogramQueryBenchmark {
   histSchemaData.take(10 * 180).foreach(histSchemaBuilder.addFromReader(_, histDataset.schema))
 
   val histSchemas = Schemas(histDataset.schema)
-  memStore.setup(histDataset.ref, histSchemas, 0, ingestConf)
+  memStore.setup(histDataset.ref, histSchemas, 0, ingestConf, 1)
   val hShard = memStore.getShardE(histDataset.ref, 0)
   histSchemaBuilder.allContainers.foreach { c => hShard.ingest(c, 0) }
   memStore.refreshIndexForTesting(histDataset.ref) // commit lucene index
@@ -66,7 +66,7 @@ class HistogramQueryBenchmark {
   val promBuilder = new RecordBuilder(MemFactory.onHeapFactory, 4200000)
   promData.take(10*66*180).foreach(promBuilder.addFromReader(_, promDataset.schema))
 
-  memStore.setup(promDataset.ref, promSchemas, 0, ingestConf)
+  memStore.setup(promDataset.ref, promSchemas, 0, ingestConf, 1)
   val pShard = memStore.getShardE(promDataset.ref, 0)
   promBuilder.allContainers.foreach { c => pShard.ingest(c, 0) }
   memStore.refreshIndexForTesting(promDataset.ref) // commit lucene index

--- a/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IngestionBenchmark.scala
@@ -61,7 +61,7 @@ class IngestionBenchmark {
   val policy = new FixedMaxPartitionsEvictionPolicy(100)
   val memStore = new TimeSeriesMemStore(config, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
   val ingestConf = TestData.storeConf.copy(shardMemSize = 512 * 1024 * 1024, maxChunksSize = 200)
-  memStore.setup(dataset1.ref, Schemas(dataset1.schema), 0, ingestConf)
+  memStore.setup(dataset1.ref, Schemas(dataset1.schema), 0, ingestConf, 1)
 
   val shard = memStore.getShardE(dataset1.ref, 0)
 

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -36,13 +36,13 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
   import filodb.core.{MachineMetricsData => MMD}
 
   override def beforeAll(): Unit = {
-    memStore.setup(timeseriesDataset.ref, Schemas(timeseriesSchema), 0, TestData.storeConf)
+    memStore.setup(timeseriesDataset.ref, Schemas(timeseriesSchema), 0, TestData.storeConf, 1)
     memStore.ingest(timeseriesDataset.ref, 0, SomeData(container, 0))
-    memStore.setup(MMD.dataset1.ref, Schemas(MMD.schema1), 0, TestData.storeConf)
+    memStore.setup(MMD.dataset1.ref, Schemas(MMD.schema1), 0, TestData.storeConf, 1)
     memStore.ingest(MMD.dataset1.ref, 0, mmdSomeData)
-    memStore.setup(MMD.histDataset.ref, Schemas(MMD.histDataset.schema), 0, TestData.storeConf)
+    memStore.setup(MMD.histDataset.ref, Schemas(MMD.histDataset.schema), 0, TestData.storeConf, 1)
     memStore.ingest(MMD.histDataset.ref, 0, MMD.records(MMD.histDataset, histData))
-    memStore.setup(MMD.histMaxDS.ref, Schemas(MMD.histMaxDS.schema), 0, TestData.storeConf)
+    memStore.setup(MMD.histMaxDS.ref, Schemas(MMD.histMaxDS.schema), 0, TestData.storeConf, 1)
     memStore.ingest(MMD.histMaxDS.ref, 0, MMD.records(MMD.histMaxDS, histMaxData))
     memStore.refreshIndexForTesting(timeseriesDataset.ref)
     memStore.refreshIndexForTesting(MMD.dataset1.ref)

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -86,7 +86,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
       tuples.map { t => SeqRowReader(Seq(t._1, t._2, metric, partTagsUTF8)) }
         .foreach(builder.addFromReader(_, Schemas.promCounter))
     }
-    memStore.setup(timeseriesDatasetMultipleShardKeys.ref, Schemas(Schemas.promCounter), ishard, TestData.storeConf)
+    memStore.setup(timeseriesDatasetMultipleShardKeys.ref, Schemas(Schemas.promCounter), ishard, TestData.storeConf, 1)
     memStore.ingest(timeseriesDatasetMultipleShardKeys.ref, ishard, SomeData(builder.allContainers.head, 0))
 
     builder.reset()

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -88,16 +88,16 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
   implicit val execTimeout = 5.seconds
 
   override def beforeAll(): Unit = {
-    memStore.setup(dsRef, schemas, 0, TestData.storeConf)
+    memStore.setup(dsRef, schemas, 0, TestData.storeConf, 2)
     memStore.ingest(dsRef, 0, SomeData(container, 0))
     memStore.ingest(dsRef, 0, MMD.records(MMD.histDataset, histData))
 
     // set up shard, but do not ingest data to simulate an empty shard
-    memStore.setup(dsRef, schemas, 1, TestData.storeConf)
+    memStore.setup(dsRef, schemas, 1, TestData.storeConf, 2)
 
-    memStore.setup(MMD.dataset1.ref, Schemas(MMD.schema1), 0, TestData.storeConf)
+    memStore.setup(MMD.dataset1.ref, Schemas(MMD.schema1), 0, TestData.storeConf, 1)
     memStore.ingest(MMD.dataset1.ref, 0, mmdSomeData)
-    memStore.setup(MMD.histMaxDS.ref, Schemas(MMD.histMaxDS.schema), 0, TestData.storeConf)
+    memStore.setup(MMD.histMaxDS.ref, Schemas(MMD.histMaxDS.schema), 0, TestData.storeConf, 1)
     memStore.ingest(MMD.histMaxDS.ref, 0, MMD.records(MMD.histMaxDS, histMaxData))
 
     memStore.refreshIndexForTesting(dsRef)

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -85,7 +85,7 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
       tuples.map { t => SeqRowReader(Seq(t._1, t._2, metric, partTagsUTF8)) }
         .foreach(builder.addFromReader(_, Schemas.promCounter))
     }
-    memStore.setup(timeseriesDatasetMultipleShardKeys.ref, Schemas(Schemas.promCounter), ishard, TestData.storeConf)
+    memStore.setup(timeseriesDatasetMultipleShardKeys.ref, Schemas(Schemas.promCounter), ishard, TestData.storeConf, 1)
     memStore.ingest(timeseriesDatasetMultipleShardKeys.ref, ishard, SomeData(builder.allContainers.head, 0))
   }
 

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -86,10 +86,10 @@ class SplitLocalPartitionDistConcatExecSpec extends AnyFunSpec with Matchers wit
   implicit val execTimeout = 5.seconds
 
   override def beforeAll(): Unit = {
-    memStore.setup(dsRef, schemas, 0, TestData.storeConf)
+    memStore.setup(dsRef, schemas, 0, TestData.storeConf, 1)
     memStore.ingest(dsRef, 0, SomeData(container, 0))
 
-    memStore.setup(MMD.dataset1.ref, Schemas(MMD.schema1), 0, TestData.storeConf)
+    memStore.setup(MMD.dataset1.ref, Schemas(MMD.schema1), 0, TestData.storeConf, 1)
     memStore.ingest(MMD.dataset1.ref, 0, mmdSomeData)
 
     memStore.refreshIndexForTesting(dsRef)

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1412,7 +1412,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       settings.filodbConfig)
 
     downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
-      0, rawDataStoreConfig, settings.rawDatasetIngestionConfig.downsampleConfig)
+      0, rawDataStoreConfig, 1, settings.rawDatasetIngestionConfig.downsampleConfig)
 
     downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
 
@@ -1459,7 +1459,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     )
 
     downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
-      0, rawDataStoreConfig, durableIndexSettings.rawDatasetIngestionConfig.downsampleConfig)
+      0, rawDataStoreConfig, 1, durableIndexSettings.rawDatasetIngestionConfig.downsampleConfig)
 
     val recoveredRecords = downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
     recoveredRecords shouldBe 5
@@ -1474,7 +1474,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     )
 
     downsampleTSStore2.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
-      0, rawDataStoreConfig, durableIndexSettings.rawDatasetIngestionConfig.downsampleConfig)
+      0, rawDataStoreConfig, 1, durableIndexSettings.rawDatasetIngestionConfig.downsampleConfig)
 
     val recoveredRecords2 = downsampleTSStore2.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
     recoveredRecords2 shouldBe 0
@@ -1509,7 +1509,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       settings.filodbConfig)
 
     downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
-      0, rawDataStoreConfig, settings.rawDatasetIngestionConfig.downsampleConfig)
+      0, rawDataStoreConfig, 1, settings.rawDatasetIngestionConfig.downsampleConfig)
 
     downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
 
@@ -1540,7 +1540,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       settings.filodbConfig)
 
     downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
-      0, rawDataStoreConfig, settings.rawDatasetIngestionConfig.downsampleConfig)
+      0, rawDataStoreConfig, 1, settings.rawDatasetIngestionConfig.downsampleConfig)
 
     downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
 
@@ -1572,7 +1572,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       settings.filodbConfig)
 
     downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
-      0, rawDataStoreConfig, settings.rawDatasetIngestionConfig.downsampleConfig)
+      0, rawDataStoreConfig, 1, settings.rawDatasetIngestionConfig.downsampleConfig)
 
     downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
 
@@ -1602,7 +1602,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val downsampleTSStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore,
       settings.filodbConfig)
     downsampleTSStore.setup(batchDownsampler.rawDatasetRef, settings.filodbSettings.schemas,
-      0, rawDataStoreConfig, settings.rawDatasetIngestionConfig.downsampleConfig)
+      0, rawDataStoreConfig, 1, settings.rawDatasetIngestionConfig.downsampleConfig)
     downsampleTSStore.recoverIndex(batchDownsampler.rawDatasetRef, 0).futureValue
     val colFilters = seriesTags.map { case (t, v) => ColumnFilter(t.toString, Equals(v.toString)) }.toSeq
     val queryFilters = colFilters :+ ColumnFilter("_metric_", Equals(gaugeName))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

Today scaling filoDB horizontally involves re-calculation of memory settings in a manual way involving tribal knowledge.
This PR aims to automate it and make it simple math. It is backward compatible and behind feature flag.

* Min-num-nodes moved from dataset into server config.
* New server config will drive automatic memory calculation
* Each dataset requires another configuration that determines what fraction of resources each dataset gets.

```
   # Number of nodes in cluster; used to calculate per-shard resources based on how many shards assigned to node
   # min-num-nodes-in-cluster = 2

    memory-alloc {
      # automatic memory allocation is enabled if true
      automatic-alloc-enabled = false

      # if not provided this is calculated as ContainerOrNodeMemory - os-memory-needs - CurrentJVMHeapMemory
      # available-memory-bytes = 5GB

      # memory dedicated for proper functioning of OS
      os-memory-needs = 500MB

      # memory percent of available-memory reserved for Lucene memory maps
      lucene-memory-percent = 20

      # memory percent of available-memory reserved for native memory manager
      # (used for partKeys, chunkMaps, chunkInfos, writeBuffers)
      native-memory-manager-percent = 20

      # memory percent of available-memory reserved for block memory manager
      # (used for storing chunks)
      block-memory-manager-percent = 60
    }
```

