### PR TITLE
fix(downsample): Change semantic to not throw error to avoid query exceptions when metering is not enabled

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityManager.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityManager.scala
@@ -151,7 +151,7 @@ class CardinalityManager(datasetRef: DatasetRef,
           } catch {
             case ex: Exception =>
               logger.error(s"[CardinalityManager]Error while calculating cardinality using" +
-                s"PartKeyLuceneIndex! shardNum=$shardNum indexRefreshCount=$indexRefreshCount", ex)
+                s" PartKeyLuceneIndex! shardNum=$shardNum indexRefreshCount=$indexRefreshCount", ex)
               // cleanup resources used by the newCardTracker tracker to avoid leaking of resources
               newCardTracker.close()
           }
@@ -161,7 +161,7 @@ class CardinalityManager(datasetRef: DatasetRef,
               close()
               cardTracker = Some(newCardTracker)
               logger.info(s"[CardinalityManager] Triggered cardinality count successfully for" +
-                s"shardNum=$shardNum indexRefreshCount=$indexRefreshCount")
+                s" shardNum=$shardNum indexRefreshCount=$indexRefreshCount")
             } catch {
               case ex: Exception =>
                 // Very unlikely scenario, but can happen if the disk call fails.
@@ -216,7 +216,8 @@ class CardinalityManager(datasetRef: DatasetRef,
           Seq()
       }
     } else {
-      throw new IllegalArgumentException("Metering is not enabled")
+      logger.info(s"[CardinalityManager]Cardinality Metering is not enabled for shardNum=$shardNum")
+      Seq()
     }
   }
 


### PR DESCRIPTION
Change semantic to not throw error to avoid query exceptions when metering is not enabled

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** We would throw query exceptions if metering is not enabled in Tsdb dowsample. This will lead to complication on the query planner side to make sure the config is followed for remote partition calls. Hence, to simplify it, we are returning empty responses if metering is not enabled with a log.

**New behavior :** Return empty response instead of throwing exception.