### PR TITLE
fix(core) add debugging info for empty histogram.

### DIFF
--- a/core/src/main/scala/filodb.core/query/PartitionTimeRangeReader.scala
+++ b/core/src/main/scala/filodb.core/query/PartitionTimeRangeReader.scala
@@ -1,10 +1,12 @@
 package filodb.core.query
 
+import com.typesafe.scalalogging.StrictLogging
 import spire.syntax.cfor._
 
 import filodb.core.metadata.Dataset
 import filodb.core.store.{ChunkInfoIterator, ChunkSetInfoReader, ReadablePartition}
 import filodb.memory.format.{vectors => bv, RowReader, TypedIterator, UnsafeUtils, ZeroCopyUTF8String}
+import filodb.memory.format.vectors.EmptyHistogramException
 
 /**
  * A RowReader iterator which iterates over a time range in the ReadablePartition.  Designed to be relatively memory
@@ -16,7 +18,7 @@ final class PartitionTimeRangeReader(part: ReadablePartition,
                                      startTime: Long,
                                      endTime: Long,
                                      infos: ChunkInfoIterator,
-                                     columnIDs: Array[Int]) extends RangeVectorCursor {
+                                     columnIDs: Array[Int]) extends RangeVectorCursor with StrictLogging {
   // MinValue = no current chunk
   private var curChunkID = Long.MinValue
   private final val vectorIts = new Array[TypedIterator](columnIDs.size)
@@ -33,7 +35,23 @@ final class PartitionTimeRangeReader(part: ReadablePartition,
     def getDouble(columnNo: Int): Double = vectorIts(columnNo).asDoubleIt.next
     def getFloat(columnNo: Int): Float = ???
     def getString(columnNo: Int): String = ???
-    override def getHistogram(columnNo: Int): bv.Histogram = vectorIts(columnNo).asHistIt.next
+    override def getHistogram(columnNo: Int): bv.Histogram = {
+      try {
+        vectorIts(columnNo).asHistIt.next
+      } catch {
+        case e : EmptyHistogramException => {
+          var message = s"EmptyHistogramException ${e.getMessage} infos=["
+           while (infos.hasNext) {
+             val info = infos.nextInfo
+             message +=
+               s"""${info.debugString} """
+           }
+          message += "]"
+          logger.error(s"message $message")
+          throw new IllegalArgumentException("requirement length > 0 failed.")
+        }
+      }
+    }
     def getAny(columnNo: Int): Any = ???
 
     override def filoUTF8String(columnNo: Int): ZeroCopyUTF8String = vectorIts(columnNo).asUTF8It.next

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -556,6 +556,7 @@ final case class HistogramCorrection(lastValue: LongHistogram, correction: LongH
 trait CounterHistogramReader extends HistogramReader with CounterVectorReader {
   def correctedValue(n: Int, meta: CorrectionMeta): HistogramWithBuckets
 }
+case class EmptyHistogramException(message: String) extends IllegalArgumentException(message)
 
 /**
  * A reader for SectDelta encoded histograms, including correction/drop functionality
@@ -578,7 +579,10 @@ class SectDeltaHistogramReader(acc2: MemoryReader, histVect: Ptr.U8)
   }
 
   override def apply(index: Int): HistogramWithBuckets = {
-    require(length > 0)
+    if (length <= 0) {
+      throw EmptyHistogramException(s"""length = $length memory=${toHexString(acc, histVect.addr)}""")
+    }
+
     val histPtr = locate(index)
 
     // Just return the base histogram if we are at start of section


### PR DESCRIPTION
Some queries occasionally hit exceptions because of empty histogram. However, the same exception could not be reproduced later. The hunch is that the bug is caused by a race condition. So, adding additional debugging log to print out the chunk id chunk info and the memory dump.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: