### PR TITLE
Adding logging statement when warning is produced.

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -150,6 +150,10 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
     finalPlan.lookupRes.foreach(plr =>
       if (plr.dataBytesScannedCtr.get() > queryContext.plannerParams.warnLimits.rawScannedBytes) {
         queryWarnings.updateRawScannedBytes(plr.dataBytesScannedCtr.get())
+        val msg =
+          s"Query scanned ${plr.dataBytesScannedCtr.get()} bytes, which exceeds a max warn limit of " +
+            s"${queryContext.plannerParams.warnLimits.rawScannedBytes} bytes allowed to be scanned per shard. "
+        qLogger.info(queryContext.getQueryLogLine(msg))
       }
     )
   }


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
We don't produce logs when scan byte warnings are generated.


**New behavior :**
Produce logs when scan byte warnings are generated.


**BREAKING CHANGES**
n/a

**Other information**: