### PR TITLE
perf(query): Remove boxed Double allocations from NaN checks during data scans

### DIFF
--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -462,7 +462,7 @@ object SerializedRangeVector extends StrictLogging {
           val nextRow = rows.next()
           // Don't encode empty / NaN data over the wire
           if (!canRemoveEmptyRows(rv.outputRange, schema) ||
-            schema.columns(1).colType == DoubleColumn && !nextRow.getDouble(1).isNaN ||
+            schema.columns(1).colType == DoubleColumn && !java.lang.Double.isNaN(nextRow.getDouble(1)) ||
             schema.columns(1).colType == HistogramColumn && !nextRow.getHistogram(1).isEmpty) {
             numRows += 1
             builder.addFromReader(nextRow, schema, 0)

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -242,7 +242,7 @@ object DoubleVectorDataReader64 extends DoubleVectorDataReader {
         val nextDbl = acc.getDouble(addr)
         // There are many possible values of NaN.  Use a function to ignore them reliably.
         if (!java.lang.Double.isNaN(nextDbl)) {
-          if (sum.isNaN) sum = 0d
+          if (java.lang.Double.isNaN(sum)) sum = 0d
           sum += nextDbl
         }
         addr += 8
@@ -323,7 +323,7 @@ extends DoubleVectorDataReader {
     var last = Double.MinValue
     cforRange { 0 until len } { pos =>
       var nextVal = it.next
-      if (nextVal.isNaN) nextVal = 0  // explicit counter reset due to end of time series marker
+      if (java.lang.Double.isNaN(nextVal)) nextVal = 0  // explicit counter reset due to end of time series marker
       if (nextVal < last) {   // reset!
         _correction += last
         _drops += pos
@@ -443,9 +443,9 @@ class DoubleCounterAppender(addr: BinaryRegion.NativePointer, maxBytes: Int, dis
 extends DoubleAppendingVector(addr, maxBytes, dispose) {
   private var last = Double.MinValue
   override final def addData(data: Double): AddResponse = {
-    if (data.isNaN || data < last)
+    if (java.lang.Double.isNaN(data) || data < last)
       PrimitiveVectorReader.markDrop(MemoryAccessor.nativePtrAccessor, addr)
-    if (!data.isNaN)
+    if (!java.lang.Double.isNaN(data))
       last = data
     super.addData(data)
   }
@@ -544,7 +544,7 @@ object DoubleLongWrapDataReader extends DoubleVectorDataReader {
   final def changes(acc: MemoryReader, vector: BinaryVectorPtr, start: Int, end: Int,
                     prev: Double, ignorePrev: Boolean = false):
   (Double, Double) = {
-    val ignorePrev = if (prev.isNaN) true
+    val ignorePrev = if (java.lang.Double.isNaN(prev)) true
     else false
     val changes = LongBinaryVector(acc, vector).changes(acc, vector, start, end, prev.toLong, ignorePrev)
     (changes._1.toDouble, changes._2.toDouble)

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -228,7 +228,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
     // Allow addition when type of bucket is different
     if (buckets.similarForMath(other.buckets)) {
       // If it was NaN before, reset to 0 to sum another hist
-      if (values(0).isNaN) java.util.Arrays.fill(values, 0.0)
+      if (java.lang.Double.isNaN(values(0))) java.util.Arrays.fill(values, 0.0)
       cforRange { 0 until numBuckets } { b =>
         values(b) += other.bucketValue(b)
       }
@@ -272,7 +272,7 @@ final case class MutableHistogram(buckets: HistogramBuckets, values: Array[Doubl
     cforRange { 0 until values.size } { b =>
       // When bucket no longer used NaN will be seen. Non-increasing values can be seen when
       // newer buckets are introduced and not all instances are updated with that bucket.
-      if (values(b) < max || values(b).isNaN) values(b) = max // assign previous max
+      if (values(b) < max || java.lang.Double.isNaN(values(b))) values(b) = max // assign previous max
       else if (values(b) > max) max = values(b) // update max
     }
   }

--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -439,7 +439,6 @@ trait ExecPlan extends QueryCommand {
       }
     }
 
-
     def makeResult(
       rv : Observable[RangeVector], recordSchema: RecordSchema, resultSchema: ResultSchema
     ): Task[QueryResult] = {
@@ -530,7 +529,9 @@ trait ExecPlan extends QueryCommand {
   }
 
   protected def queryWithPlanName(queryContext: QueryContext): String = {
-    s"${this.getClass.getSimpleName}-${queryContext.origQueryParams}"
+    // Disabling this since it showed up in local method profiles. Re-enable if needed for debugging
+    // s"${this.getClass.getSimpleName}-${queryContext.origQueryParams}"
+    s"${queryContext.queryId}:$planId"
   }
 
   def curNodeText(level: Int): String =

--- a/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQlRemoteExec.scala
@@ -153,7 +153,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
       }
       // dont add this size to queryStats since it was already added by callee use dummy QueryStats()
       SerializedRangeVector(rv, builder, recordSchema.get("default").get,
-        queryWithPlanName(queryContext), dummyQueryStats)
+        planId, dummyQueryStats)
       // TODO: Handle stitching with verbose flag
     }
     QueryResult(
@@ -235,7 +235,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
       }
       // dont add this size to queryStats since it was already added by callee use dummy QueryStats()
       SerializedRangeVector(rv, builder, recordSchema.get(Avg.entryName).get,
-        queryWithPlanName(queryContext), dummyQueryStats)
+        planId, dummyQueryStats)
     }
 
     // TODO: Handle stitching with verbose flag
@@ -273,7 +273,7 @@ case class PromQlRemoteExec(queryEndpoint: String,
       }
       // dont add this size to queryStats since it was already added by callee use dummy QueryStats()
       SerializedRangeVector(rv, builder, recordSchema.get(QueryFunctionConstants.stdVal).get,
-        queryWithPlanName(queryContext), dummyQueryStats)
+        planId, dummyQueryStats)
     }
 
     // TODO: Handle stitching with verbose flag

--- a/query/src/main/scala/filodb/query/exec/aggregator/SumRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/SumRowAggregator.scala
@@ -21,8 +21,8 @@ object SumRowAggregator extends RowAggregator {
   def map(rvk: RangeVectorKey, item: RowReader, mapInto: MutableRowReader): RowReader = item
   def reduceAggregate(acc: SumHolder, aggRes: RowReader): SumHolder = {
     acc.timestamp = aggRes.getLong(0)
-    if (!aggRes.getDouble(1).isNaN) {
-      if (acc.sum.isNaN) acc.sum = 0
+    if (!java.lang.Double.isNaN(aggRes.getDouble(1))) {
+      if (java.lang.Double.isNaN(acc.sum)) acc.sum = 0
       acc.sum += aggRes.getDouble(1)
     }
     acc


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Double.isNan involves conversion to boxed java Double
Local heap profiling showed that this is a significant allocation.

Conversion to the static java.lang.Double.isNan removes these.
