### PR TITLE
fix(query): prevent list.head on empty list

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -423,6 +423,9 @@ object LogicalPlanUtils extends StrictLogging {
         LogicalPlanUtils.getTargetSchemaIfUnchanging(targetSchemaProvider, filters, interval)
       }
     }
+    if (rsTschemaOpts.isEmpty) {
+      return None
+    }
     // make sure all tschemas are defined, and they all match
     val referenceSchema = rsTschemaOpts.head
     if (referenceSchema.isDefined


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, target-schema logic will throw an exception when a pushdown-candidate aggregation or join contains no column filters, e.g.:
```
sum(vector(123)) by(foo)
vector(123) + on(foo) vector(123)
```
This happens because a list of leaf column filters Is collected, and the head of that list is accessed without an `isEmpty` check.

This PR adds the missing check.