### PR TITLE
maint(kafka): update consumer client id

### DIFF
--- a/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
+++ b/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
@@ -59,6 +59,7 @@ class KafkaIngestionStream(config: Config,
       if (sourceConfig.LogConfig) logger.info(s"Consumer properties: $props")
 
       blocking {
+        props.put("client.id", s"${props.get("group.id")}.${System.getenv("INSTANCE_ID")}.$shard")
         val consumer = new KafkaConsumer(props)
         consumer.assign(List(topicPartition).asJava)
         offset.foreach { off => consumer.seek(topicPartition, off) }


### PR DESCRIPTION
Manually create a more-informative client ID for per-shard Kafka consumers.
Local tests log the following output (`INSTANCE_ID=1234` and `shard=0`):
```
[Consumer clientId=filo-db-timeseries-ingestion.1234.0, groupId=filo-db-timeseries-ingestion]
```