### PR TITLE
fix(core): Consolidate num-nodes duplicate config

### DIFF
--- a/conf/promperf-filodb-server.conf
+++ b/conf/promperf-filodb-server.conf
@@ -5,8 +5,8 @@ filodb {
     "conf/promperf-source.conf"
   ]
 
+  min-num-nodes-in-cluster = 1
   cluster-discovery {
-    num-nodes = 1
     failure-detection-interval = 20s
     host-list = [
       "127.0.0.1:2552"

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -1,9 +1,9 @@
 dataset-prometheus = { include required("timeseries-dev-source.conf") }
 
 filodb {
+  min-num-nodes-in-cluster = 2
   v2-cluster-enabled = false
   cluster-discovery {
-    num-nodes = 2
     failure-detection-interval = 20s
     host-list = [
        "127.0.0.1:2552",

--- a/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbSettings.scala
@@ -48,7 +48,6 @@ final class FilodbSettings(val conf: Config) {
 
   lazy val datasetConfPaths = config.as[Seq[String]]("dataset-configs")
 
-  lazy val numNodes = config.getInt("cluster-discovery.num-nodes")
   lazy val k8sHostFormat = config.as[Option[String]]("cluster-discovery.k8s-stateful-sets-hostname-format")
 
   // used for development mode only

--- a/coordinator/src/test/scala/filodb.coordinator/FiloDbClusterDiscoverySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/FiloDbClusterDiscoverySpec.scala
@@ -11,7 +11,7 @@ class FiloDbClusterDiscoverySpec extends AkkaSpec {
 
     val config = ConfigFactory.parseString(
       """
-        |filodb.cluster-discovery.num-nodes = 4
+        |filodb.min-num-nodes-in-cluster = 4
         |""".stripMargin)
 
     val settings = new FilodbSettings(config)
@@ -29,7 +29,7 @@ class FiloDbClusterDiscoverySpec extends AkkaSpec {
   "Should allocate the extra n shards to first n nodes" in {
     val config = ConfigFactory.parseString(
       """
-        |filodb.cluster-discovery.num-nodes = 5
+        |filodb.min-num-nodes-in-cluster = 5
         |""".stripMargin)
 
     val settings = new FilodbSettings(config)

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1,7 +1,9 @@
 filodb {
   v2-cluster-enabled = false
 
-  # Number of nodes in cluster; used to calculate per-dhard resources based on how many shards assigned to node
+  # Number of nodes in cluster; used to calculate per-shard resources based
+  # on how many shards assigned to node.
+  # Required config if v2-clustering or automatic memory-alloc is enabled
   # min-num-nodes-in-cluster = 2
 
   cluster-discovery {
@@ -9,7 +11,6 @@ filodb {
     // if FiloDB HTTP API is indeed the query entry point, this should be overridden to small value
     // so that failure detection is quick.
     failure-detection-interval = 15 minutes
-    num-nodes = 2
 
     # one of the two below properties should be enabled
     # enable this to use the k8s stateful sets mode and its hostname to extract ordinal


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

There are two configs for num-nodes used by clustering-v2 and automatic memory alloc code.
Consolidating them.