### PR TITLE
fix(query) Regex equals .* must ignore the label and match series even without the label

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -822,7 +822,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     filter match {
       case EqualsRegex(value) =>
         val regex = removeRegexAnchors(value.toString)
-        if(regex.r.pattern.matcher("").matches()) {
+        if(regex.replaceAll("\\.\\*", "") == "") {
           // Check if the given regex matches the empty string, if yes, then do not consider this label
           new MatchAllDocsQuery
         } else {

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -822,11 +822,9 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     filter match {
       case EqualsRegex(value) =>
         val regex = removeRegexAnchors(value.toString)
-        if(regex.r.unapplySeq("").isDefined) {
+        if(regex.r.pattern.matcher("").matches()) {
           // Check if the given regex matches the empty string, if yes, then do not consider this label
-          val booleanQuery = new BooleanQuery.Builder
-          val allDocs = new MatchAllDocsQuery
-          booleanQuery.add(allDocs, Occur.FILTER).build()
+          new MatchAllDocsQuery
         } else {
           if (regex.nonEmpty) new RegexpQuery(new Term(column, regex), RegExp.NONE)
           else leafFilter(column, NotEqualsRegex(".+")) // value="" means the label is absent or has an empty value.

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -822,13 +822,9 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     filter match {
       case EqualsRegex(value) =>
         val regex = removeRegexAnchors(value.toString)
-        if(regex.replaceAll("\\.\\*", "") == "") {
-          // Check if the given regex matches the empty string, if yes, then do not consider this label
-          new MatchAllDocsQuery
-        } else {
-          if (regex.nonEmpty) new RegexpQuery(new Term(column, regex), RegExp.NONE)
-          else leafFilter(column, NotEqualsRegex(".+")) // value="" means the label is absent or has an empty value.
-        }
+        if (regex.replaceAll("\\.\\*", "").nonEmpty) new RegexpQuery(new Term(column, regex), RegExp.NONE)
+        else leafFilter(column, NotEqualsRegex(".+")) // value="" means the label is absent or has an empty value.
+
       case NotEqualsRegex(value) =>
         val term = new Term(column, removeRegexAnchors(value.toString))
         val allDocs = new MatchAllDocsQuery

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -1042,5 +1042,21 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val filter5 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
     val result3 = keyIndex.partKeyRecordsFromFilters(Seq(filter4, filter5), 0, Long.MaxValue)
     result3 shouldEqual Seq()
+
+    // Query with non existent label name with an empty regex
+    val filter6 = ColumnFilter("dummy", EqualsRegex("".utf8))
+    val filter7 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+    val result4 = keyIndex.partKeyRecordsFromFilters(Seq(filter6, filter7), 0, Long.MaxValue)
+    val expected4 = Seq(pkrs(7), pkrs(8), pkrs(9))
+    result4.map(_.partKey.toSeq) shouldEqual expected4.map(_.partKey.toSeq)
+    result4.map(p => (p.startTime, p.endTime)) shouldEqual expected4.map(p => (p.startTime, p.endTime))
+
+    // Query with non existent label name with an empty equals
+    val filter8 = ColumnFilter("dummy", Equals("".utf8))
+    val filter9 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+    val result5 = keyIndex.partKeyRecordsFromFilters(Seq(filter8, filter9), 0, Long.MaxValue)
+    val expected5 = Seq(pkrs(7), pkrs(8), pkrs(9))
+    result5.map(_.partKey.toSeq) shouldEqual expected5.map(_.partKey.toSeq)
+    result5.map(p => (p.startTime, p.endTime)) shouldEqual expected5.map(p => (p.startTime, p.endTime))
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Queries like ``foo{dummy=~".*"}`` are expected to match all timeseries with metric name foo even without the label dummy, in short, the filter should have same behavior as not having the filter. However, currently the matches are only made for series with the label present

**New behavior :**
 The above behavior is fixed and now the label is not considered in matching if it matches an empty string ``""``
