### PR TITLE
fix(query) Fix regression with regex match

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -822,7 +822,10 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     filter match {
       case EqualsRegex(value) =>
         val regex = removeRegexAnchors(value.toString)
-        if (regex.replaceAll("\\.\\*", "").nonEmpty) new RegexpQuery(new Term(column, regex), RegExp.NONE)
+        if (regex.replaceAll("\\.\\*", "") == "")
+          new MatchAllDocsQuery
+        else if (regex.nonEmpty)
+          new RegexpQuery(new Term(column, regex), RegExp.NONE)
         else leafFilter(column, NotEqualsRegex(".+")) // value="" means the label is absent or has an empty value.
 
       case NotEqualsRegex(value) =>

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -1058,5 +1058,11 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val expected5 = Seq(pkrs(7), pkrs(8), pkrs(9))
     result5.map(_.partKey.toSeq) shouldEqual expected5.map(_.partKey.toSeq)
     result5.map(p => (p.startTime, p.endTime)) shouldEqual expected5.map(p => (p.startTime, p.endTime))
+
+
+    val filter10 = ColumnFilter("Actor2Code", EqualsRegex(".*".utf8))
+    val result10= keyIndex.partKeyRecordsFromFilters(Seq(filter10), 0, Long.MaxValue)
+    result10.map(_.partKey.toSeq) shouldEqual pkrs.map(_.partKey.toSeq)
+    result10.map(p => (p.startTime, p.endTime)) shouldEqual pkrs.map(p => (p.startTime, p.endTime))
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Regression in behavior when ``.*`` is used as label filter

**New behavior :**

If ``.*`` is used in query label, just match all docs

Credit:
Thanks @vishramachandran for catching the regression.