### PR TITLE
perf(core): ~Two times throughput improvement for Lucene queries with enum and prefix regex filters

### DIFF
--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -282,7 +282,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
   }
 
-
   it("should add part keys and removePartKeys (without partIds) correctly for more than 1024 keys with del count") {
     // Identical to test
     // it("should add part keys and fetch partIdsEndedBefore and removePartKeys correctly for more than 1024 keys")
@@ -344,7 +343,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     // Important, while the unit test uses partIds to assert the presence or absence before and after deletion
     // it is no longer required to have partIds in the index on non unit test setup
   }
-
 
   it("should update part keys with endtime and parse filters correctly") {
     val start = System.currentTimeMillis()
@@ -445,6 +443,19 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
       ColumnFilter("Actor2Name", Equals("CHINA".utf8)))
     val partNums2 = keyIndex.partIdsFromFilters(filters2, 0, Long.MaxValue)
     partNums2 shouldEqual debox.Buffer.empty[Int]
+  }
+
+  it("should be able to convert pipe regex to TermInSetQuery") {
+    // Add the first ten keys and row numbers
+    partKeyFromRecords(dataset6, records(dataset6, readers.take(99)), Some(partBuilder))
+      .zipWithIndex.foreach { case (addr, i) =>
+      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+    }
+    keyIndex.refreshReadersBlocking()
+
+    val filters1 = Seq(ColumnFilter("Actor2Code", EqualsRegex("GOV|KHM|LAB|MED".utf8)))
+    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+    partNums1 shouldEqual debox.Buffer(7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 22, 23, 24, 25, 26, 28, 29, 73, 81, 90)
   }
 
   it("should ignore unsupported columns and return empty filter") {

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -458,6 +458,19 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     partNums1 shouldEqual debox.Buffer(7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 22, 23, 24, 25, 26, 28, 29, 73, 81, 90)
   }
 
+  it("should be able to convert prefix regex to PrefixQuery") {
+    // Add the first ten keys and row numbers
+    partKeyFromRecords(dataset6, records(dataset6, readers.take(99)), Some(partBuilder))
+      .zipWithIndex.foreach { case (addr, i) =>
+      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+    }
+    keyIndex.refreshReadersBlocking()
+
+    val filters1 = Seq(ColumnFilter("Actor2Name", EqualsRegex("C.*".utf8)))
+    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+    partNums1 shouldEqual debox.Buffer(3, 12, 22, 23, 24, 31, 59, 60, 66, 69, 72, 78, 79, 80, 88, 89)
+  }
+
   it("should ignore unsupported columns and return empty filter") {
     val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, true, true, 0, 1.hour.toMillis)
     partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -133,6 +133,25 @@ class PartKeyIndexBenchmark {
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   @OperationsPerInvocation(8)
+  def partIdsLookupWithEnumRegexFilter(): Unit = {
+    cforRange(0 until 8) { i =>
+      val c = partKeyIndex.partIdsFromFilters(
+        Seq(ColumnFilter("_ns_", Filter.Equals(s"App-0")),
+          ColumnFilter("_ws_", Filter.Equals("demo")),
+          ColumnFilter("_metric_", Filter.Equals("heap_usage0")),
+          ColumnFilter("instance",
+            Filter.EqualsRegex("Instance-1|Instance-2|Instance-3|Instance-4|Instance-5|Instance-6|Instance-7|Instance-8|Instance-9|Instance-10|" +
+              "Instance-11|Instance-12|Instance-13|Instance-14|Instance-15|Instance-16|Instance-17|Instance-18|Instance-19|Instance-20|" +
+              "Instance-21|Instance-22|Instance-23|Instance-24|Instance-25|Instance-26|Instance-27|Instance-28|Instance-29|Instance-30"))),
+        now,
+        now + 1000).length
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
   def startTimeLookupWithPartId(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       val pIds = debox.Buffer.empty[Int]

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -74,7 +74,7 @@ class PartKeyIndexBenchmark {
       partKeyIndex.partIdsFromFilters(
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
             ColumnFilter("_ws_", Filter.Equals("demo")),
-            ColumnFilter("host", Filter.EqualsRegex("H0")),
+            ColumnFilter("host", Filter.Equals("H0")),
             ColumnFilter("_metric_", Filter.Equals("heap_usage0"))),
         now,
         now + 1000)
@@ -90,7 +90,7 @@ class PartKeyIndexBenchmark {
       partKeyIndex.partIdsFromFilters(
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-${i + 200}")),
           ColumnFilter("_ws_", Filter.Equals("demo")),
-          ColumnFilter("host", Filter.EqualsRegex("H0")),
+          ColumnFilter("host", Filter.Equals("H0")),
           ColumnFilter("_metric_", Filter.Equals("heap_usage0"))),
         now,
         now + 1000)

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -101,7 +101,7 @@ class PartKeyIndexBenchmark {
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   @OperationsPerInvocation(8)
-  def partIdsLookupWithSuffixRegexFilters(): Unit = {
+  def partIdsLookupWithPrefixRegexFilters(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       partKeyIndex.partIdsFromFilters(
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
@@ -117,7 +117,7 @@ class PartKeyIndexBenchmark {
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   @OperationsPerInvocation(8)
-  def partIdsLookupWithPrefixRegexFilters(): Unit = {
+  def partIdsLookupWithSuffixRegexFilters(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       partKeyIndex.partIdsFromFilters(
         Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-sbt "jmh/jmh:run -rf json -i 15 -wi 10 -f3 -jvmArgsAppend -XX:MaxInlineLevel=20 \
+sbt "jmh/jmh:run -rf json -i 5 -wi 3 -f 1 -jvmArgsAppend -XX:MaxInlineLevel=20 \
  -jvmArgsAppend -Xmx4g -jvmArgsAppend -XX:MaxInlineSize=99 \
- -prof jfr:dir=/tmp/filo-jmh \
  filodb.jmh.QueryHiCardInMemoryBenchmark \
  filodb.jmh.QueryInMemoryBenchmark \
  filodb.jmh.QueryAndIngestBenchmark \


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Production profiling is showing that Lucene Regex automata is creating a hotspot in method and allocation profiling.

This PR optimizes two kinds of queries
1. Regex with enumerated values are converted to `TermInSetQuery`
2. Regex with prefix is converted to `PrefixQuery`

It also wraps Lucene queries in `ConstantScoreQuery` to prevent any scoring that may be happening.

Observed 
* 2.2x performance improvement in JMH benchmark for specific enum regex query
* 1.5x performance improvement in JMH benchmark for specific prefix regex query

Detailed Benchmark results

```
After
[info] Benchmark                                                   Mode  Cnt     Score    Error  Units
[info] PartKeyIndexBenchmark.partIdsLookupWithEnumRegexFilter     thrpt    5  7754.992 ± 31.444  ops/s
[info] PartKeyIndexBenchmark.partIdsLookupWithPrefixRegexFilters  thrpt    5  7124.124 ± 49.450  ops/s

Before
[info] Benchmark                                                   Mode  Cnt     Score    Error  Units
[info] PartKeyIndexBenchmark.partIdsLookupWithEnumRegexFilter     thrpt    5  3515.597 ± 17.021  ops/s
[info] PartKeyIndexBenchmark.partIdsLookupWithPrefixRegexFilters  thrpt    5  4661.993 ±  6.215  ops/s
```