### PR TITLE
fix(core): Bug in calculating size of SerializedRangeVector

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordContainer.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordContainer.scala
@@ -7,7 +7,7 @@ import scala.reflect.ClassTag
 import debox.Buffer
 
 import filodb.memory.{BinaryRegionConsumer, BinaryRegionLarge}
-import filodb.memory.format.{RowReader, UnsafeUtils}
+import filodb.memory.format.UnsafeUtils
 
 /**
  * A RecordContainer is a binary, wire-compatible container for BinaryRecords V2.
@@ -72,13 +72,13 @@ final class RecordContainer(val base: Any, val offset: Long, maxLength: Int,
    * Iterates through each BinaryRecord as a RowReader.  Results in two allocations: the Iterator
    * as well as a BinaryRecordRowReader.
    */
-  final def iterate(schema: RecordSchema): Iterator[RowReader] = new Iterator[RowReader] {
+  final def iterate(schema: RecordSchema): Iterator[BinaryRecordRowReader] = new Iterator[BinaryRecordRowReader] {
     val reader = new BinaryRecordRowReader(schema, base)
     val endOffset = offset + 4 + numBytes
     var curOffset = offset + ContainerHeaderLen
 
     final def hasNext: Boolean = curOffset < endOffset
-    final def next: RowReader = {
+    final def next: BinaryRecordRowReader = {
       val recordLen = BinaryRegionLarge.numBytes(base, curOffset)
       reader.recordOffset = curOffset
       curOffset += (recordLen + 7) & ~3   // +4, then aligned/rounded up to next 4 bytes

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -624,7 +624,12 @@ trait BinaryRecordRowReaderBase extends RowReader {
 
 final class BinaryRecordRowReader(val schema: RecordSchema,
                                   var recordBase: Any = UnsafeUtils.ZeroPointer,
-                                  var recordOffset: Long = 0L) extends BinaryRecordRowReaderBase
+                                  var recordOffset: Long = 0L) extends BinaryRecordRowReaderBase {
+  def recordLength: Int = {
+    val len = BinaryRegionLarge.numBytes(recordBase, recordOffset)
+    (len + 7) & ~3   // +4, then aligned/rounded up to next 4 bytes
+  }
+}
 
 final class MultiSchemaBRRowReader(var recordBase: Any = UnsafeUtils.ZeroPointer,
                                    var recordOffset: Long = 0L) extends BinaryRecordRowReaderBase {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -934,14 +934,8 @@ class TimeSeriesShard(val ref: DatasetRef,
         markPartAsNotIngesting(p, odp = false)
         if (storeConfig.meteringEnabled) {
           val shardKey = p.schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset,
-            p.schema.options.shardKeyColumns)
-          val newCard = cardTracker.modifyCount(shardKey, 0, -1)
-          // TODO remove temporary debugging since we are seeing some negative counts
-          if (newCard.exists(_.value.activeTsCount < 0) && p.partID % 100 < 5)
-            // log for 5% of the cases to reduce log volume
-            logger.error(s"For some reason, activeTs count negative when updating card for " +
-              s"partKey: ${p.stringPartition} newCard: $newCard oldActivelyIngestingSize=$oldActivelyIngestingSize " +
-              s"newActivelyIngestingSize=${activelyIngesting.size}")
+                                                          p.schema.options.shardKeyColumns)
+          cardTracker.modifyCount(shardKey, 0, -1)
         }
       }
     }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -490,11 +490,7 @@ object SerializedRangeVector extends StrictLogging {
         case None => builder.allContainers.toList
         case Some(firstContainer) => builder.allContainers.dropWhile(_ != firstContainer)
       }
-      val srv = new SerializedRangeVector(rv.key, numRows, containers, schema, startRecordNo, rv.outputRange)
-      val resultSize = srv.estimatedSerializedBytes
-      SerializedRangeVector.queryResultBytes.record(resultSize)
-      queryStats.getResultBytesCounter(Nil).addAndGet(resultSize)
-      srv
+      new SerializedRangeVector(rv.key, numRows, containers, schema, startRecordNo, rv.outputRange)
     } finally {
       queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentThreadCpuTimeNanos - startNs)
     }

--- a/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/SerializedRangeVectorSpec.scala
@@ -51,7 +51,6 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
     val queryStats = QueryStats()
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
     queryStats.getCpuNanosCounter(Nil).get() > 0 shouldEqual true
-    queryStats.getResultBytesCounter(Nil).get() shouldEqual 96
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 4
     srv.estimateSerializedRowBytes shouldEqual 80 // 4 non nan records each of 20 bytes
@@ -78,7 +77,6 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
     val queryStats = QueryStats()
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
     queryStats.getCpuNanosCounter(Nil).get() > 0 shouldEqual true
-    queryStats.getResultBytesCounter(Nil).get() shouldEqual 236
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 11
     srv.estimateSerializedRowBytes shouldEqual 220
@@ -107,7 +105,6 @@ class SerializedRangeVectorSpec  extends AnyFunSpec with Matchers {
     val queryStats = QueryStats()
     val srv = SerializedRangeVector.apply(rv, builder, recSchema, "someExecPlan", queryStats)
     queryStats.getCpuNanosCounter(Nil).get() > 0 shouldEqual true
-    queryStats.getResultBytesCounter(Nil).get() shouldEqual 176
     srv.numRows shouldEqual Some(11)
     srv.numRowsSerialized shouldEqual 4
     val res = srv.rows.map(r => (r.getLong(0), r.getHistogram(1))).toList

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -162,7 +162,9 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
           Some(RvRange(rangeParams.startSecs * 1000,
             rangeParams.stepSecs * 1000,
             rangeParams.endSecs * 1000)))
-        queryStats.getResultBytesCounter(Nil).getAndAdd(srv.estimatedSerializedBytes)
+        val resultSize = srv.estimatedSerializedBytes
+        queryStats.getResultBytesCounter(Nil).getAndAdd(resultSize)
+        SerializedRangeVector.queryResultBytes.record(resultSize)
         srv
       }.toSeq
     } finally {

--- a/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
+++ b/query/src/main/scala/filodb/query/exec/aggregator/TopBottomKRowAggregator.scala
@@ -158,14 +158,10 @@ class TopBottomKRowAggregator(k: Int, bottomK: Boolean) extends RowAggregator wi
       resRvs.map { case (key, builder) =>
         val numRows = builder.allContainers.map(_.countRecords()).sum
         logger.debug(s"TopkPresent before creating SRV key = ${key.labelValues.mkString(",")}")
-        val srv = new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0,
+        new SerializedRangeVector(key, numRows, builder.allContainers, recSchema, 0,
           Some(RvRange(rangeParams.startSecs * 1000,
             rangeParams.stepSecs * 1000,
             rangeParams.endSecs * 1000)))
-        val resultSize = srv.estimatedSerializedBytes
-        queryStats.getResultBytesCounter(Nil).getAndAdd(resultSize)
-        SerializedRangeVector.queryResultBytes.record(resultSize)
-        srv
       }.toSeq
     } finally {
       queryStats.getCpuNanosCounter(Nil).getAndAdd(Utils.currentThreadCpuTimeNanos - startNs)

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -138,6 +138,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
     val execPlan = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher,
                                              dsRef, 0, filters, TimeRangeChunkScan(startTime, endTime), "_metric_")
 
+    querySession.queryStats.clear() // so this can be run as a standalone test
     val resp = execPlan.execute(memStore, querySession).runToFuture.futureValue
     val result = resp.asInstanceOf[QueryResult]
     result.result.size shouldEqual 1
@@ -145,6 +146,10 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
     dataRead shouldEqual tuples.take(11)
     val partKeyRead = result.result(0).key.labelValues.map(lv => (lv._1.asNewString, lv._2.asNewString))
     partKeyRead shouldEqual partKeyKVWithMetric
+    querySession.queryStats.getResultBytesCounter().get() shouldEqual 297
+    querySession.queryStats.getCpuNanosCounter().get() > 0 shouldEqual true
+    querySession.queryStats.getDataBytesScannedCounter().get() shouldEqual 48
+    querySession.queryStats.getTimeSeriesScannedCounter().get() shouldEqual 1
   }
 
   it("should get empty schema if query returns no results") {

--- a/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
@@ -157,7 +157,7 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
     deserializedSrv.numRowsSerialized shouldEqual 4
     val res = deserializedSrv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
     deserializedSrv.key shouldEqual rvKey
-    qr.queryStats.getResultBytesCounter(List()).get()shouldEqual 96
+    // queryStats ResultBytes counter increment is not done as part of SRV constructor, so skipping that assertion
     (qr.queryStats.getCpuNanosCounter(List()).get() > 0) shouldEqual true
     res.length shouldEqual 11
     res.map(_._1) shouldEqual (0 to 1000 by 100)

--- a/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
@@ -157,7 +157,7 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
     deserializedSrv.numRowsSerialized shouldEqual 4
     val res = deserializedSrv.rows.map(r => (r.getLong(0), r.getDouble(1))).toList
     deserializedSrv.key shouldEqual rvKey
-    qr.queryStats.getResultBytesCounter(List()).get()shouldEqual 108
+    qr.queryStats.getResultBytesCounter(List()).get()shouldEqual 96
     (qr.queryStats.getCpuNanosCounter(List()).get() > 0) shouldEqual true
     res.length shouldEqual 11
     res.map(_._1) shouldEqual (0 to 1000 by 100)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

There was a bug in calculating size of SRV.
Earlier, for efficiency purposes, we were calculating the size of the containers associated with the SRV.
But actually, the container can home multiple SRVs. So the calculated size for several SRVs at a time can end up wrong with addition of cumulative counts.

The fix for now is to calculate the size by going through the records. It introduces a small inefficiency here, but submitting this PR for now since other ways to calculate this were more invasive and risk regression. We can have an optimization of this if really needed later. I have also reduced the number of calls to this method from two to one.

The unit tests didn't catch this since earlier since they played with one SRV only.
I have now added a unit test that adds multiple SRVs. It failed with earlier code.

