### PR TITLE
fix(query): Adding user datasets for Cardinality V2 RemoteMetadataExec calls

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -1095,11 +1095,12 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
 
     val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local",
       dataset, queryConfig)
-    val lp = TsCardinalities(Seq("a", "b"), 3, 2, Seq("longtime-prometheus","recordingrules-prometheus_rules_1m"))
+    val lp = TsCardinalities(Seq("a", "b"), 3, 2, Seq("longtime-prometheus","recordingrules-prometheus_rules_1m")
+    , "raw,recordingrules")
     val promQlQueryParams = PromQlQueryParams("", startSeconds, step, endSeconds,
       Some("/api/v2/metering/cardinality/timeseries"))
     val expectedUrlParams = Map("match[]" -> """{_ws_="a",_ns_="b"}""", "numGroupByFields" -> "3","verbose" -> "true",
-      "datasets" -> "longtime-prometheus,recordingrules-prometheus_rules_1m")
+      "datasets" -> "raw,recordingrules")
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams, plannerParams =
       PlannerParams(processMultiPartition = true)))

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -2,7 +2,6 @@ package filodb.query
 
 import filodb.core.query.{ColumnFilter, RangeParams, RvRange}
 import filodb.core.query.Filter.Equals
-import filodb.query.exec.TsCardExec
 
 //scalastyle:off number.of.types
 //scalastyle:off file.size.limit
@@ -185,7 +184,8 @@ object TsCardinalities {
 case class TsCardinalities(shardKeyPrefix: Seq[String],
                            numGroupByFields: Int,
                            version: Int = 1,
-                           datasets: Seq[String] = Seq()) extends LogicalPlan {
+                           datasets: Seq[String] = Seq(),
+                           userDatasets: String = "") extends LogicalPlan {
   import TsCardinalities._
 
   require(numGroupByFields >= 1 && numGroupByFields <= 3,
@@ -212,7 +212,7 @@ case class TsCardinalities(shardKeyPrefix: Seq[String],
                        .mkString(",") + "}"),
         "numGroupByFields" -> numGroupByFields.toString,
         "verbose" -> "true", // Using this plan to determine if we need to pass additional values in groupKey or not
-        "datasets" -> datasets.mkString(TsCardExec.PREFIX_DELIM)
+        "datasets" -> userDatasets
     )
   }
 }

--- a/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/LogicalPlanSpec.scala
@@ -327,11 +327,12 @@ class LogicalPlanSpec extends AnyFunSpec with Matchers {
   it ("TsCardinalities queryParams should have expected values") {
     val datasets = Seq("longtime-prometheus",
       "recordingrules-prometheus_rules_longterm")
-    val plan = TsCardinalities(Seq("a","b","c"), 3, 2, datasets)
+    val userDatasets = "\"raw\",\"recordingrules\""
+    val plan = TsCardinalities(Seq("a","b","c"), 3, 2, datasets, userDatasets)
     val queryParamsMap = plan.queryParams()
 
     queryParamsMap.get("numGroupByFields").get shouldEqual "3"
-    queryParamsMap.get("datasets").get shouldEqual datasets.mkString(",")
+    queryParamsMap.get("datasets").get shouldEqual userDatasets
     queryParamsMap.get("verbose").get shouldEqual "true"
     queryParamsMap.get("match[]").get shouldEqual "{_ws_=\"a\",_ns_=\"b\",__name__=\"c\"}"
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

**Current behavior :** For remote metadata exec calls, we are passing FiloDB datasets instead of user passed datasets.

**New behavior :** Updating the TsCardinalities logical plan to take userDatasets ( which is a csv string ) and using it for RemoteMetadataExec calls.