### PR TITLE
feat(core): support for per dataset cassandra keyspace overrides

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -657,8 +657,10 @@ trait CassandraChunkSource extends RawChunkSource with StrictLogging {
   private def getClusterConnector(dataset: DatasetRef): FiloCassandraConnector =
     clusterConnectors.getOrElseUpdate(dataset.dataset, newClusterConnector(ConfigFactory.empty))
 
-  protected def initClusterConnector(dataset: DatasetRef, resources: Config): Unit =
-    clusterConnectors(dataset.dataset) = newClusterConnector(resources)
+  protected def initClusterConnector(dataset: DatasetRef, resources: Config): Unit = {
+    if (!clusterConnectors.contains(dataset.dataset))
+      clusterConnectors(dataset.dataset) = newClusterConnector(resources)
+  }
 
   protected def shutdownConnector = clusterConnectors.headOption.map(_._2.shutdown())
 

--- a/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/MemstoreCassandraSinkSpec.scala
@@ -1,11 +1,11 @@
 package filodb.cassandra
 
+import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.duration._
-
 import monix.reactive.Observable
-
 import filodb.core._
-import filodb.core.memstore.{TimeSeriesMemStore}
+import filodb.core.memstore.TimeSeriesMemStore
 import filodb.core.metadata.Schemas
 import filodb.core.store.{FilteredPartitionScan, InMemoryChunkScan}
 import filodb.memory.format.UnsafeUtils
@@ -25,7 +25,7 @@ class MemstoreCassandraSinkSpec extends AllTablesTest {
   override def beforeAll(): Unit = {
     super.beforeAll()
     metaStore.initialize().futureValue
-    columnStore.initialize(dataset1.ref, numShards).futureValue
+    columnStore.initialize(dataset1.ref, numShards, ConfigFactory.empty).futureValue
   }
 
   before {

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -35,7 +35,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
   // First create the tables in C*
   override def beforeAll(): Unit = {
     super.beforeAll()
-    colStore.initialize(promDataset.ref, 1).futureValue
+    colStore.initialize(promDataset.ref, 1, ConfigFactory.empty).futureValue
     colStore.truncate(promDataset.ref, 1).futureValue
   }
 
@@ -66,7 +66,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
   "PartKey Reads, Writes and Deletes" should "work" in {
     val dataset = Dataset("prometheus", Schemas.gauge).ref
 
-    colStore.initialize(dataset, 1).futureValue
+    colStore.initialize(dataset, 1, ConfigFactory.empty).futureValue
     colStore.truncate(dataset, 1).futureValue
 
     // GOTCHA: these synthetic pks are not well-formed. We just use the bytes for Schemas to read some hash
@@ -95,7 +95,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
   "copyOrDeleteChunksByIngestionTimeRange" should "actually work" in {
     val dataset = Dataset("source", Schemas.gauge)
 
-    colStore.initialize(dataset.ref, 1).futureValue
+    colStore.initialize(dataset.ref, 1, ConfigFactory.empty).futureValue
     colStore.truncate(dataset.ref, 1).futureValue
 
     val targetConfigPath = "spark-jobs/src/test/resources/timeseries-filodb-buddy-server.conf"
@@ -104,7 +104,7 @@ class CassandraColumnStoreSpec extends ColumnStoreSpec {
     val targetSession = new DefaultFiloSessionProvider(targetConfig.getConfig("cassandra")).session
     val targetColStore = new CassandraColumnStore(targetConfig, s, targetSession)
 
-    targetColStore.initialize(dataset.ref, 1).futureValue
+    targetColStore.initialize(dataset.ref, 1, ConfigFactory.empty).futureValue
     targetColStore.truncate(dataset.ref, 1).futureValue
 
     val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8, "_ns_".utf8 -> "my_ns".utf8)

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
@@ -57,7 +57,7 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
   // First create the tables in C*
   override def beforeAll(): Unit = {
     super.beforeAll()
-    colStore.initialize(dataset.ref, 1).futureValue
+    colStore.initialize(dataset.ref, 1, ConfigFactory.empty).futureValue
     colStore.truncate(dataset.ref, 1).futureValue
   }
 

--- a/conf/timeseries-dev-preagg-source.conf
+++ b/conf/timeseries-dev-preagg-source.conf
@@ -1,0 +1,115 @@
+    dataset = "prometheus_preagg"
+
+    # Name of schema used for this dataset stream.  See filodb.schemas in filodb-defaults or any other server conf
+    schema = "prom-counter"
+
+    # Should not change once dataset has been set up on the server and data has been persisted to cassandra
+    num-shards = 4
+
+    # deprecated in favor of min-num-nodes-in-cluster config in filodb server config
+    # To be removed eventually. There is no reason to set a value for this for each dataset
+    min-num-nodes = 2
+
+    # Length of chunks to be written, roughly
+    sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"
+
+    sourceconfig {
+      # Required FiloDB configurations
+      filo-topic-name = "timeseries-dev"
+
+      # Standard kafka configurations, e.g.
+      # This accepts both the standard kafka value of a comma-separated
+      # string and a Typesafe list of String values
+      # EXCEPT: do not populate value.deserializer, as the Kafka format is fixed in FiloDB to be messages of RecordContainer's
+      bootstrap.servers = "localhost:9092"
+      group.id = "filo-db-timeseries-ingestion"
+
+      # For tests - do not shut down and release memory after ingestion stops (with status IngestionStopped)
+      shutdown-ingest-after-stopped = true
+
+      # Values controlling in-memory store chunking, flushing, etc.
+      store {
+        # Interval it takes to flush ALL time series in a shard.  This time is further divided by groups-per-shard
+        flush-interval = 1h
+
+        # TTL for on-disk / C* data.  Data older than this may be purged.
+        disk-time-to-live = 24 hours
+
+        # maximum userTime range allowed in a single chunk. This needs to be longer than flush interval
+        # to ensure that normal flushes result in only one chunk.
+        # If not specified, max-chunk-time = 1.1 * flush-interval
+        # max-chunk-time = 66 minutes
+
+        max-chunks-size = 400
+
+        # Write buffer size, in bytes, for blob columns (histograms, UTF8Strings).  Since these are variable data types,
+        # we need a maximum size, not a maximum number of items.
+        max-blob-buffer-size = 15000
+
+        # Number of bytes of offheap mem to allocate to chunk storage in each shard.  Ex. 1000MB, 1G, 2GB
+        # Assume 5 bytes per sample, should be roughly equal to (# samples per time series) * (# time series)
+        shard-mem-size = 512MB
+
+        # Maximum numer of write buffers to retain in each shard's WriteBufferPool.  Any extra buffers are released
+        # back to native memory, which helps memory reuse.
+        # max-buffer-pool-size = 10000
+
+        # Number of time series to evict at a time.
+        # num-partitions-to-evict = 1000
+
+        # Number of subgroups within each shard.  Persistence to a ChunkSink occurs one subgroup at a time, as does
+        # recovery from failure.  This many batches of flushes must occur to cover persistence of every partition
+        groups-per-shard = 20
+
+        # Use a "MultiPartitionScan" or Cassandra MULTIGET for on-demand paging. Might improve performance.
+        multi-partition-odp = false
+
+        # Amount of parallelism during on-demand paging
+        # demand-paging-parallelism = 4
+
+        # Number of retries for IngestionSource/Kafka initialization
+        # failure-retries = 3
+
+        # Amount of time to delay before retrying
+        # retry-delay = 15s
+
+        # Capacity of Bloom filter used to track evicted partitions.
+        # Tune this based on how much time series churn is expected before a FiloDB node
+        # will be restarted for upgrade/maintenance. Do not take into account churn created by
+        # time series that are purged due to retention. When a time series is not ingesting for retention
+        # period, it is purged, not evicted. Purged PartKeys are not added to Bloom Filter.
+        #
+        # To calculate Bloom Filter size:
+        # console> BloomFilter[String](5000000, falsePositiveRate = 0.01).numberOfBits
+        # res9: Long = 47925292
+        # Thats about 6MB
+        evicted-pk-bloom-filter-capacity = 50000
+
+        # Uncomment to log at DEBUG ingested samples matching these filters on Partition Key columns
+        # Only works for StringColumn fields in the partition key. Scope may be expanded later.
+        # trace-filters = {
+        #   metric = "bad-metric-to-log"
+        # }
+
+        # Limits maximum amount of data a single leaf query can scan
+        max-data-per-shard-query = 50 MB
+
+        # Set to true to enable metering of time series. Used for rate-limiting
+        metering-enabled = true
+
+        # Approx ingested data resolution. This is used in estimating/capping the number of samples that will be scanned
+        # during a query execution. specified in milliseconds. default is 60sec.
+        ingest-resolution-millis = 60000
+
+        # Set to true to enable processing of duplicate samples. Default behavior is to drop duplicates.
+        accept-duplicate-samples = false
+      }
+      downsample {
+        # Resolutions for downsampled data ** in ascending order **
+        resolutions = [ 1 minute, 5 minutes ]
+        # Retention of downsampled data for the corresponding resolution
+        ttls = [ 30 days, 183 days ]
+        # Raw schemas from which to downsample
+        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram", "delta-counter", "delta-histogram"]
+      }
+    }

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -13,6 +13,13 @@
     # Length of chunks to be written, roughly
     sourcefactory = "filodb.kafka.KafkaIngestionStreamFactory"
 
+    # Per dataset overrides. Optional, used only if the store is cassandra.
+    # This config enables us to configure datasets that can use different keyspaces.
+    # cassandra {
+    #   keyspace = "filodb_prom"
+    #   downsample-keyspace = "filodb_prom_downsample"
+    # }
+
     sourceconfig {
       # Required FiloDB configurations
       filo-topic-name = "timeseries-dev"

--- a/conf/timeseries-filodb-server-ds.conf
+++ b/conf/timeseries-filodb-server-ds.conf
@@ -1,11 +1,15 @@
 include "timeseries-filodb-server.conf"
-dataset-prometheus = { include required("timeseries-durable-downsample-index-dev-source.conf") }
+dataset-prometheus = { include required("timeseries-dev-source.conf") }
+dataset-prometheus_preagg = { include required("timeseries-dev-preagg-source.conf") }
 
 filodb {
   v2-cluster-enabled = false
   http.bind-port=9080
   store-factory = "filodb.cassandra.DownsampledTSStoreFactory"
+  inline-dataset-configs = [ ${dataset-prometheus}, ${dataset-prometheus_preagg}]
 }
+
+
 
 kamon {
   prometheus.embedded-server {

--- a/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
@@ -77,11 +77,12 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
     clusterDiscovery.registerDatasetForDiscovery(dataset.ref, ingestConfig.numShards)
     // FIXME initialization of cass tables below for dev environments is async - need to wait before continuing
     // for now if table is not initialized in dev on first run, simply restart server :(
-    memStore.store.initialize(dataset.ref, ingestConfig.numShards)
+    memStore.store.initialize(dataset.ref, ingestConfig.numShards, ingestConfig.resources)
     // if downsampling is enabled, then initialize downsample datasets
     ingestConfig.downsampleConfig
                 .downsampleDatasetRefs(dataset.ref.dataset)
-                .foreach { downsampleDataset => memStore.store.initialize(downsampleDataset, ingestConfig.numShards) }
+                  .foreach { downsampleDataset =>
+                    memStore.store.initialize(downsampleDataset, ingestConfig.numShards, ingestConfig.resources) }
 
     setupDataset( dataset,
                   ingestConfig.storeConfig, ingestConfig.numShards,

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import monix.execution.Scheduler
@@ -61,7 +62,7 @@ trait ChunkSink {
   /**
    * Initializes the ChunkSink for a given dataset.  Must be called once before writing.
    */
-  def initialize(dataset: DatasetRef, numShards: Int): Future[Response]
+  def initialize(dataset: DatasetRef, numShards: Int, resources: Config): Future[Response]
 
   /**
    * Truncates/clears all data from the ChunkSink for that given dataset.
@@ -141,7 +142,8 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
     Future.successful(Success)
   }
 
-  def initialize(dataset: DatasetRef, numShards: Int): Future[Response] = Future.successful(Success)
+  def initialize(dataset: DatasetRef, numShards: Int,
+                 resources: Config): Future[Response] = Future.successful(Success)
 
   def truncate(dataset: DatasetRef, numShards: Int): Future[Response] = {
     partitionKeys -= dataset

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -39,8 +39,8 @@ with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
   override def beforeAll(): Unit = {
     super.beforeAll()
     metaStore.initialize().futureValue
-    colStore.initialize(dataset.ref, 4).futureValue
-    colStore.initialize(GdeltTestData.dataset2.ref, 4).futureValue
+    colStore.initialize(dataset.ref, 4, ConfigFactory.empty).futureValue
+    colStore.initialize(GdeltTestData.dataset2.ref, 4, ConfigFactory.empty).futureValue
   }
 
   before {

--- a/filodb-dev-start.sh
+++ b/filodb-dev-start.sh
@@ -42,7 +42,7 @@ if [ ! -f standalone/target/scala-2.12/standalone-assembly-*-SNAPSHOT.jar ]; the
     sbt standalone/assembly
 fi
 
-FIXED_JAVA_OPTS="-Xmx2G -Dconfig.file=conf/timeseries-filodb-server.conf -Dlogback.configurationFile=conf/logback-dev.xml "
+FIXED_JAVA_OPTS="-Xmx2G -Dconfig.file=$CONFIG -Dlogback.configurationFile=conf/logback-dev.xml "
 
 echo "Starting FiloDB standalone server ..."
 echo "Java Opts Used: $FIXED_JAVA_OPTS $ADDL_JAVA_OPTS"

--- a/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryOnDemandBenchmark.scala
@@ -71,7 +71,7 @@ class QueryOnDemandBenchmark extends StrictLogging {
 
   Await.result(cluster.metaStore.initialize(), 3.seconds)
   Await.result(cluster.metaStore.clearAllData(), 5.seconds)  // to clear IngestionConfig
-  Await.result(cluster.memStore.store.initialize(dataset.ref, numShards), 5.seconds)
+  Await.result(cluster.memStore.store.initialize(dataset.ref, numShards, ConfigFactory.empty), 5.seconds)
   Await.result(cluster.memStore.store.truncate(dataset.ref, numShards), 5.seconds)
 
   cluster.join()

--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -50,6 +50,7 @@ object Submodules {
       commonSettings,
       name := "filodb-core",
       scalacOptions += "-language:postfixOps",
+      assemblySettings,
       libraryDependencies ++= coreDeps
     )
 
@@ -78,6 +79,7 @@ object Submodules {
       publishArtifact in (Compile, packageDoc) := false,
       publishArtifact in packageDoc := false,
       sources in (Compile, doc) := Seq.empty,
+      assemblySettings,
       libraryDependencies ++= promDeps
     )
 
@@ -88,6 +90,7 @@ object Submodules {
       libraryDependencies ++= queryDeps,
       commonSettings,
       scalacOptions += "-language:postfixOps",
+      assemblySettings,
       name := "filodb-query"
     )
 
@@ -107,6 +110,7 @@ object Submodules {
       commonSettings,
       name := "filodb-cli",
       libraryDependencies ++= cliDeps,
+      assemblySettings,
       cliAssemblySettings
     )
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -350,6 +350,8 @@ class BatchDownsampler(settings: DownsamplerSettings,
     @volatile var numChunks = 0
     // write all chunks to cassandra
     val writeFut = downsampledChunksToPersist.map { case (res, chunks) =>
+      downsampleCassandraColStore.initialize(downsampleRefsByRes(res), -1,
+        settings.rawDatasetIngestionConfig.resources)
       // FIXME if listener in chunkset below is not copied + overridden to no-op, we get a SEGV because
       // of a bug in either monix's mapAsync or cassandra driver where the future is completed prematurely.
       // This causes a race condition between free memory and chunkInfo.id access in updateFlushedId.

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -133,6 +133,7 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
         Kamon.init()
         KamonShutdownHook.registerShutdownHook()
         val rawDataSource = batchDownsampler.rawCassandraColStore
+        rawDataSource.initialize(batchDownsampler.rawDatasetRef, -1, settings.rawDatasetIngestionConfig.resources)
         val batchIter = rawDataSource.getChunksByIngestionTimeRangeNoAsync(
           datasetRef = batchDownsampler.rawDatasetRef,
           splits = splitIter, ingestionTimeStart = ingestionTimeStart,

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -95,6 +95,8 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
   def migrateWithDownsamplePartKeys(partKeys: Observable[PartKeyRecord], shard: Int): Int = {
     @volatile var count = 0
     val rawDataSource = rawCassandraColStore
+    rawDataSource.initialize(rawDatasetRef, -1, dsSettings.rawDatasetIngestionConfig.resources)
+    downsampleCassandraColStore.initialize(dsDatasetRef, -1, dsSettings.rawDatasetIngestionConfig.resources)
     val pkRecords = partKeys.filter { pk =>
       val rawSchemaId = RecordSchema.schemaID(pk.partKey, UnsafeUtils.arayOffset)
       val schema = schemas(rawSchemaId)

--- a/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
+++ b/spark-jobs/src/main/scala/filodb/repair/PartitionKeysCopier.scala
@@ -102,6 +102,16 @@ class PartitionKeysCopier(conf: SparkConf) {
     targetConfig, readSched, targetSession, isDownsampleCopy
   )(writeSched)
 
+  def getDatasetCassConfig(datasetConfig: Config): Config = {
+    if (datasetConfig.hasPath("cassandra"))
+      datasetConfig.getConfig("cassandra")
+    else
+      ConfigFactory.empty
+  }
+
+  sourceCassandraColStore.initialize(datasetRef, -1, getDatasetCassConfig(sourceDatasetConfig))
+  targetCassandraColStore.initialize(datasetRef, -1, getDatasetCassConfig(targetDatasetConfig))
+
   // Disable the copy phase either for fully deleting with no replacement, or for no-op testing.
   private[repair] val noCopy = conf.getBoolean("spark.filodb.partitionkeys.copier.noCopy", false)
   private[repair] val numSplitsForScans = sourceCassConfig.getInt("num-token-range-splits-for-scans")

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -115,10 +115,10 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
   override def beforeAll(): Unit = {
     batchDownsampler.downsampleRefsByRes.values.foreach { ds =>
-      downsampleColStore.initialize(ds, 4).futureValue
+      downsampleColStore.initialize(ds, 4, settings.rawDatasetIngestionConfig.resources).futureValue
       downsampleColStore.truncate(ds, 4).futureValue
     }
-    rawColStore.initialize(batchDownsampler.rawDatasetRef, 4).futureValue
+    rawColStore.initialize(batchDownsampler.rawDatasetRef, 4, settings.rawDatasetIngestionConfig.resources).futureValue
     rawColStore.truncate(batchDownsampler.rawDatasetRef, 4).futureValue
   }
 

--- a/spark-jobs/src/test/scala/filodb/repair/ChunkCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/ChunkCopierSpec.scala
@@ -108,7 +108,7 @@ class ChunkCopierSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll wi
   }
 
   def initColStore(colStore: CassandraColumnStore, datasetRef: DatasetRef) = {
-    colStore.initialize(datasetRef, 1).futureValue
+    colStore.initialize(datasetRef, 1, ConfigFactory.empty).futureValue
     colStore.truncate(datasetRef, 1).futureValue
   }
 

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -129,7 +129,7 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
   }
 
   def truncateColStore(colStore: CassandraColumnStore, dataset: Dataset): Unit = {
-    colStore.initialize(dataset.ref, numOfShards).futureValue
+    colStore.initialize(dataset.ref, numOfShards, ConfigFactory.empty).futureValue
     colStore.truncate(dataset.ref, numOfShards).futureValue
   }
 

--- a/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/ClusterSingletonFailoverSpec.scala
@@ -87,11 +87,11 @@ abstract class ClusterSingletonFailoverSpec extends StandaloneMultiJvmSpec(Clust
       implicit val patienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(100, Millis))
       metaStore.initialize().futureValue shouldBe Success
       metaStore.clearAllData().futureValue shouldBe Success
-      colStore.initialize(dataset, numShards).futureValue shouldBe Success
+      colStore.initialize(dataset, numShards, ConfigFactory.empty).futureValue shouldBe Success
       colStore.truncate(dataset, numShards).futureValue shouldBe Success
 
       val datasetObj = TestTimeseriesProducer.dataset
-      colStore.initialize(dataset, 4).futureValue shouldBe Success
+      colStore.initialize(dataset, 4, ConfigFactory.empty).futureValue shouldBe Success
       logger.info("Dataset created")
     }
     enterBarrier("existing-data-cleared-and-dataset-created")

--- a/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
+++ b/standalone/src/multi-jvm/scala/filodb/standalone/IngestionAndRecoverySpec.scala
@@ -77,7 +77,7 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
     runOn(first) {
       metaStore.initialize().futureValue shouldBe Success
       metaStore.clearAllData().futureValue shouldBe Success
-      colStore.initialize(dataset, numShards).futureValue shouldBe Success
+      colStore.initialize(dataset, numShards, ConfigFactory.empty).futureValue shouldBe Success
       colStore.truncate(dataset, numShards).futureValue shouldBe Success
     }
     enterBarrier("existing-data-cleared")
@@ -85,7 +85,7 @@ abstract class IngestionAndRecoverySpec extends StandaloneMultiJvmSpec(Ingestion
 
   it should "be able to create dataset on node 1" in {
     runOn(first) {
-      colStore.initialize(dataset, numShards).futureValue shouldBe Success
+      colStore.initialize(dataset, numShards, ConfigFactory.empty).futureValue shouldBe Success
       info("Dataset created")
     }
     enterBarrier("dataset-created")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

As of now there is a stipulation that all the datasets that are configured in a FiloDB cluster needs to use one Keyspace for raw (actively ingesting) data. With this change, keyspaces can be configured per dataset with the exception of MetaStore (checkpoints).
This is especially useful to merge two clusters for better resource utilization without the need for data migration. With the caveat that checkpoint records need to be migrated from source cluster to target cluster.