### PR TITLE
fix(metering): Overriding the cluster name passed to SingleClusterPanner for TenantIngestionMetering changes

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
@@ -65,7 +65,7 @@ case class TenantIngestionMetering(settings: FilodbSettings,
     dsIterProducer().foreach { dsRef =>
       val fut = Client.asyncAsk(
         coordActorProducer(),
-        LogicalPlan2Query(dsRef, TsCardinalities(prefix, numGroupByFields)),
+        LogicalPlan2Query(dsRef, TsCardinalities(prefix, numGroupByFields, 2, overrideClusterName = CLUSTER_TYPE)),
         ASK_TIMEOUT)
       fut.onComplete {
         case Success(QueryResult(_, _, rv, _, _, _, _)) =>

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -830,9 +830,15 @@ class SingleClusterPlanner(val dataset: Dataset,
   private def materializeTsCardinalities(qContext: QueryContext,
                                          lp: TsCardinalities,
                                          forceInProcess: Boolean): PlanResult = {
+    // If no clusterName is passed in the logical plan, we use the passed clusterName in the SingleClusterPlanner
+    // We are using the passed cluster name in logical plan for tenant metering apis
+    val clusterNameToPass = lp.overrideClusterName match {
+      case "" => clusterName
+      case _ => lp.overrideClusterName
+    }
     val metaExec = shardMapperFunc.assignedShards.map{ shard =>
       val dispatcher = dispatcherForShard(shard, forceInProcess, qContext)
-      exec.TsCardExec(qContext, dispatcher, dsRef, shard, lp.shardKeyPrefix, lp.numGroupByFields, clusterName,
+      exec.TsCardExec(qContext, dispatcher, dsRef, shard, lp.shardKeyPrefix, lp.numGroupByFields, clusterNameToPass,
         lp.version)
     }
     PlanResult(metaExec)

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -185,7 +185,8 @@ case class TsCardinalities(shardKeyPrefix: Seq[String],
                            numGroupByFields: Int,
                            version: Int = 1,
                            datasets: Seq[String] = Seq(),
-                           userDatasets: String = "") extends LogicalPlan {
+                           userDatasets: String = "",
+                           overrideClusterName: String = "") extends LogicalPlan {
   import TsCardinalities._
 
   require(numGroupByFields >= 1 && numGroupByFields <= 3,


### PR DESCRIPTION
Overriding the cluster name passed to SingleClusterPanner for TenantIngestionMetering changes.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

New behavior : Adding new cluster name to override the value in SingleClusterPlanner. This is necessary to provide the right cluster name value to SingleClusterPlanner.materializeTsCardinalities for FiloDB cardinality queries.

BREAKING CHANGES

Need an update to TsCardinalities LogicalPlan on the query planner side.