### PR TITLE
bug(query): Query result streaming execution allocated too much mem via RB

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -235,31 +235,28 @@ trait ExecPlan extends QueryCommand {
       @volatile var numResultSamples = 0 // BEWARE - do not modify concurrently!!
       @volatile var resultSize = 0L
       val queryResults = rv.doOnStart(_ => Task.eval(span.mark("before-first-materialized-result-rv")))
-        .map {
-          case srvable: SerializableRangeVector => srvable
-          case rv: RangeVector =>
-            // materialize, and limit rows per RV
-            val execPlanString = queryWithPlanName(queryContext)
-            val builder = SerializedRangeVector.newBuilder(maxRecordContainerSize(querySession.queryConfig))
-            val srv = SerializedRangeVector(rv, builder, recordSchema, execPlanString, querySession.queryStats)
-            if (rv.outputRange.isEmpty)
-              qLogger.debug(s"Empty rangevector found. Rv class is:  ${rv.getClass.getSimpleName}, " +
-                s"execPlan is: $execPlanString, execPlan children ${this.children}")
-            srv
-        }
-        .map { srv =>
-          // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
-          numResultSamples += srv.numRowsSerialized
-          checkSamplesLimit(numResultSamples, querySession.warnings)
-          val srvBytes = srv.estimatedSerializedBytes
-          resultSize += srvBytes
-          querySession.queryStats.getResultBytesCounter(Nil).addAndGet(srvBytes)
-          checkResultBytes(resultSize, querySession.queryConfig, querySession.warnings)
-          srv
-        }
-        .filter(_.numRowsSerialized > 0)
         .bufferTumbling(querySession.queryConfig.numRvsPerResultMessage)
-        .map(StreamQueryResult(queryContext.queryId, planId, _))
+        .map { f =>
+          val builder = SerializedRangeVector.newBuilder(maxRecordContainerSize(querySession.queryConfig))
+          val srvs = f.map {
+            case srvable: SerializableRangeVector => srvable
+            case rv: RangeVector =>
+              val execPlanString = queryWithPlanName(queryContext)
+              SerializedRangeVector(rv, builder, recordSchema, execPlanString, querySession.queryStats)
+          }
+          .map { srv =>
+            // fail the query instead of limiting range vectors and returning incomplete/inaccurate results
+            numResultSamples += srv.numRowsSerialized
+            checkSamplesLimit(numResultSamples, querySession.warnings)
+            val srvBytes = srv.estimatedSerializedBytes
+            resultSize += srvBytes
+            querySession.queryStats.getResultBytesCounter(Nil).addAndGet(srvBytes)
+            checkResultBytes(resultSize, querySession.queryConfig, querySession.warnings)
+            srv
+          }
+          .filter(_.numRowsSerialized > 0)
+          StreamQueryResult(queryContext.queryId, planId, srvs)
+        }
         .guarantee(Task.eval {
           Kamon.histogram("query-execute-time-elapsed-step2-result-materialized",
             MeasurementUnit.time.milliseconds)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Query result streaming execution used to allocate one RecordBuilder per result SerializedRangeVector.
This is too much allocation and waste of memory.
Instead buffer+group the results and then use one RecordBuilder for several SRVs.
This will result in much less memory use.

Tip: See diff by disabling whitespace changes

