### PR TITLE
filodb(core) include the start time for range functions such as rate.

### DIFF
--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -449,7 +449,7 @@ extends Iterator[ChunkSetInfoReader] {
     // advance window pointers and reset read index
     if (curWindowEnd == -1L) {
       curWindowEnd = start
-      curWindowStart = start - Math.max(window - 1, 0)  // window cannot be below 0, ie start should never be > end
+      curWindowStart = start - Math.max(window, 0)  // window cannot be below 0, ie start should never be > end
     } else {
       curWindowEnd += step
       curWindowStart += step

--- a/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
@@ -189,7 +189,7 @@ abstract class ChunkedRateFunctionBase extends CounterChunkedRangeFunction[Trans
     if (highestTime > lowestTime) {
       // NOTE: It seems in order to match previous code, we have to adjust the windowStart by -1 so it's "inclusive"
       val result = RateFunctions.extrapolatedRate(
-                     windowStart - 1, windowEnd, numSamples,
+                     windowStart, windowEnd, numSamples,
                      lowestTime, lowestValue,
                      highestTime, highestValue,
                      isCounter, isRate)
@@ -286,7 +286,7 @@ abstract class HistogramRateFunctionBase extends CounterChunkedRangeFunction[Tra
         val rateArray = new Array[Double](lowestValue.numBuckets)
         cforRange { 0 until rateArray.size } { b =>
           rateArray(b) = RateFunctions.extrapolatedRate(
-                           windowStart - 1, windowEnd, numSamples,
+                           windowStart, windowEnd, numSamples,
                            lowestTime, lowestValue.bucketValue(b),
                            highestTime, highestValue.bucketValue(b),
                            isCounter, isRate)
@@ -330,7 +330,7 @@ class RateOverDeltaChunkedFunctionD extends ChunkedDoubleRangeFunction {
     sumFunc.addTimeDoubleChunks(doubleVectAcc, doubleVect, doubleReader, startRowNum, endRowNum)
 
   override def apply(windowStart: Long, windowEnd: Long, sampleToEmit: TransientRow): Unit =
-    sampleToEmit.setValues(windowEnd, sumFunc.sum / (windowEnd - (windowStart - 1)) * 1000)
+    sampleToEmit.setValues(windowEnd, sumFunc.sum / (windowEnd - (windowStart)) * 1000)
   override def apply(endTimestamp: Long, sampleToEmit: TransientRow): Unit = ???
 }
 
@@ -347,7 +347,7 @@ class RateOverDeltaChunkedFunctionL extends ChunkedLongRangeFunction {
     sumFunc.addTimeChunks(longVectAcc, longVect, longReader, startRowNum, endRowNum)
 
   override def apply(windowStart: Long, windowEnd: Long, sampleToEmit: TransientRow): Unit =
-    sampleToEmit.setValues(windowEnd, sumFunc.sum / (windowEnd - (windowStart - 1)) * 1000)
+    sampleToEmit.setValues(windowEnd, sumFunc.sum / (windowEnd - (windowStart)) * 1000)
 
   override def apply(endTimestamp: Long, sampleToEmit: TransientRow): Unit = ???
 }
@@ -363,7 +363,7 @@ class RateOverDeltaChunkedFunctionH(var h: bv.MutableHistogram = bv.Histogram.em
     cforRange {
       0 until rateArray.size
     } { b =>
-      rateArray(b) = hFunc.h.bucketValue(b) / (windowEnd - (windowStart - 1)) * 1000
+      rateArray(b) = hFunc.h.bucketValue(b) / (windowEnd - windowStart) * 1000
     }
     sampleToEmit.setValues(windowEnd, bv.MutableHistogram(hFunc.h.buckets, rateArray))
   }

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -239,9 +239,9 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher,
       dsRef, 0, filters, AllChunkScan, "_metric_")
-    val start = now - (numRawSamples-100) * reportingInterval
+    val start = now - (numRawSamples-100) * reportingInterval + 1
     val step = 0
-    val end = now - (numRawSamples-100) * reportingInterval
+    val end = now - (numRawSamples-100) * reportingInterval + 1
     execPlan.addRangeVectorTransformer(new PeriodicSamplesMapper(start, step, end, Some(reportingInterval * 3),
       Some(InternalRangeFunction.SumOverTime), QueryContext()))
 

--- a/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
@@ -98,9 +98,9 @@ class PeriodicSamplesMapperSpec extends AnyFunSpec with Matchers with ScalaFutur
     val rv = timeValueRVPk(samples, partKey)
 
     val expectedResults = List(
-      500000L -> 125d,
-      900000L ->100d,
-      1300000 -> 400d
+      500000L -> 100d,
+      900000L -> 80d,
+      1300000 -> 320d
     )
 
     // step == lookback here

--- a/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/WindowIteratorSpec.scala
@@ -197,7 +197,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
     val windowResults = Seq(
       150000->1.0,
       250000->5.0,
-      350000->9.0,
+      350000->12.0,
       450000->13.0,
       750000->17.0
     )
@@ -482,7 +482,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
     val windowResults = Seq(
       150000 -> 1.0,
       250000 -> 2.5,
-      350000 -> 4.5,
+      350000 -> 4.0,
       450000 -> 6.5
     )
 
@@ -518,7 +518,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
     val windowResults = Seq(
       150000 -> 1.0,
       250000 -> 2.0,
-      350000 -> 2.0,
+      350000 -> 3.0,
       450000 -> 2.0
     )
 
@@ -563,7 +563,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
     val avgWindowResults = Seq(
       150000 -> 4.0,
       250000 -> 4.875,
-      350000 -> 3.2,
+      350000 -> 3.533333333333333,
       450000 -> 6.916666666666667,
       750000 -> 4.2592592592592595
     )
@@ -579,7 +579,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
     val countWindowResults = Seq(
       150000 -> 5.0,
       250000 -> 8.0,
-      350000 -> 10.0,
+      350000 -> 15.0,
       450000 -> 12.0,
       750000 -> 27.0
     )
@@ -608,7 +608,7 @@ class WindowIteratorSpec extends RawDataWindowingSpec {
     val windowResults = Seq(
       150000 -> 1.0,
       250000 -> 2.0,
-      350000 -> 4.0,
+      350000 -> 3.0,
       450000 -> 6.0
     )
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
@@ -186,9 +186,9 @@ class PeriodicRateFunctionsSpec extends RawDataWindowingSpec with ScalaFutures {
     val rv = timeValueRVPk(samples, partKey)
 
     val expectedResults = List(
-      500000L -> 125d,
-      900000L -> 100d,
-      1300000 -> 400d
+      500000L -> 100d,
+      900000L -> 80d,
+      1300000 -> 320d,
     )
 
     // step == lookback here
@@ -233,9 +233,9 @@ class PeriodicRateFunctionsSpec extends RawDataWindowingSpec with ScalaFutures {
     val rv = timeValueRVPk(samples, partKey)
 
     val expectedResults = List(
-      500000L -> 125d,
-      900000L -> 100d,
-      1300000 -> 400d
+      500000L -> 100d,
+      900000L -> 80d,
+      1300000 -> 320d,
     )
 
     // step == lookback here
@@ -280,9 +280,9 @@ class PeriodicRateFunctionsSpec extends RawDataWindowingSpec with ScalaFutures {
     val rv = timeValueRVPk(samples, partKey)
 
     val expectedResults = List(
-      500000L -> 125d,
-      900000L -> 100d,
-      1300000 -> 400d
+      500000L -> 100d,
+      900000L -> 80d,
+      1300000 -> 320d,
     )
 
     // step == lookback here


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**
 
The result of a range vector function is based on the data in a range. Previous the first millisecond of data was excluded from the range, now it is included. Let's say, we have a  ts counter { [0s, 1.0], [5s, 6], [10s, 16].
```
Previously, rate(count)[10s] at timestamp 10 just has two data points [5s, 6] and [10s, 16] it may result in a result (16 - 6) /5 =2.

Now, the [0s, 1.0] is included so, the rate would be (16 - 1) / 10 = 1.5
```
After this change, Filodb will be compliant to Prometheus.
**BREAKING CHANGES**



Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: