### PR TITLE
feat(prometheus): relax length limit for pipe-only EqualsRegex filters

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/Utils.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/Utils.scala
@@ -1,0 +1,28 @@
+package filodb.prometheus
+
+/**
+ * Storage for utility functions.
+ */
+object Utils {
+  /**
+   * Returns the set of unescaped special regex chars in the argument string.
+   * Special chars are: . ? + * | { } [ ] ( ) " \
+   */
+  def getUnescapedSpecialRegexChars(str: String): Set[Char] = {
+    // Match special chars preceded by any count of backslash pairs and either
+    //   some non-backslash character or the beginning of a line.
+    val regex = "(?<=(^|[^\\\\]))(\\\\\\\\)*([.?+*|{}\\[\\]()\"\\\\])".r
+    regex.findAllMatchIn(str)
+      .map(_.group(3)) // get the special char -- third capture group
+      .map(_(0)) // convert the string to a char
+      .toSet
+  }
+
+  /**
+   * Returns true iff the argument string contains no unescaped special regex characters.
+   * The pipe character ('|') is excluded from the set of special regex characters.
+   */
+  def isPipeOnlyRegex(str: String): Boolean = {
+    getUnescapedSpecialRegexChars(str).diff(Set('|')).isEmpty
+  }
+}

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -1,7 +1,8 @@
 package filodb.prometheus.ast
 
 import scala.util.Try
-import filodb.core.{GlobalConfig, query}
+
+import filodb.core.{query, GlobalConfig}
 import filodb.core.query.{ColumnFilter, RangeParams}
 import filodb.prometheus.Utils
 import filodb.prometheus.parse.Parser

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Vectors.scala
@@ -1,9 +1,9 @@
 package filodb.prometheus.ast
 
 import scala.util.Try
-
-import filodb.core.{query, GlobalConfig}
+import filodb.core.{GlobalConfig, query}
 import filodb.core.query.{ColumnFilter, RangeParams}
+import filodb.prometheus.Utils
 import filodb.prometheus.parse.Parser
 import filodb.query._
 
@@ -265,9 +265,14 @@ sealed trait Vector extends Expression {
         case NotRegexMatch   => require(labelValue.length <= Parser.REGEX_MAX_LEN,
                                          s"Regular expression filters should be <= ${Parser.REGEX_MAX_LEN} characters")
                                 ColumnFilter(labelMatch.label, query.Filter.NotEqualsRegex(labelValue))
-        case RegexMatch      => require(labelValue.length <= Parser.REGEX_MAX_LEN,
-                                         s"Regular expression filters should be <= ${Parser.REGEX_MAX_LEN} characters")
-                                ColumnFilter(labelMatch.label, query.Filter.EqualsRegex(labelValue))
+        case RegexMatch      =>
+          // Relax the length limit only for matchers that contain at most the "|" special character.
+          if (!Utils.isPipeOnlyRegex(labelValue)) {
+            require(labelValue.length <= Parser.REGEX_MAX_LEN,
+              s"Regular expression filters should be <= ${Parser.REGEX_MAX_LEN} characters " +
+                s"when non-`|` special characters are used.")
+          }
+          ColumnFilter(labelMatch.label, query.Filter.EqualsRegex(labelValue))
         case NotEqual(false) => ColumnFilter(labelMatch.label, query.Filter.NotEquals(labelValue))
         case other: Any      => throw new IllegalArgumentException(s"Unknown match operator $other")
       }

--- a/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/Parser.scala
@@ -1,6 +1,7 @@
 package filodb.prometheus.parse
 
 import com.typesafe.scalalogging.StrictLogging
+
 import filodb.core.GlobalConfig
 import filodb.core.query.{ColumnFilter, Filter, QueryConfig}
 import filodb.prometheus.Utils

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -1,6 +1,7 @@
 package filodb.prometheus.query
 
 import remote.RemoteStorage._
+
 import filodb.core.GlobalConfig
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, StringifyMapItemConsumer}
 import filodb.core.metadata.Column.ColumnType

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -1,12 +1,12 @@
 package filodb.prometheus.query
 
 import remote.RemoteStorage._
-
 import filodb.core.GlobalConfig
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, StringifyMapItemConsumer}
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.PartitionSchema
 import filodb.core.query.{Result => _, _}
+import filodb.prometheus.Utils
 import filodb.prometheus.parse.Parser.REGEX_MAX_LEN
 import filodb.query.{QueryResult => FiloQueryResult, _}
 import filodb.query.AggregationOperator.Avg
@@ -42,9 +42,13 @@ object PrometheusModel {
           case MatchType.EQUAL => Filter.Equals(m.getValue)
           case MatchType.NOT_EQUAL => Filter.NotEquals(m.getValue)
           case MatchType.REGEX_MATCH =>
-                            require(m.getValue.length <= REGEX_MAX_LEN, s"Regular expression filters should " +
-                              s"be <= ${REGEX_MAX_LEN} characters")
-                            Filter.EqualsRegex(m.getValue)
+            // Relax the length limit only for matchers that contain at most the "|" special character.
+            if (!Utils.isPipeOnlyRegex(m.getValue)) {
+              require(m.getValue.length <= REGEX_MAX_LEN,
+                s"Regular expression filters should be <= ${REGEX_MAX_LEN} characters " +
+                s"when non-`|` special characters are used.")
+            }
+            Filter.EqualsRegex(m.getValue)
           case MatchType.REGEX_NO_MATCH =>
                             require(m.getValue.length <= REGEX_MAX_LEN, s"Regular expression filters should " +
                               s"be <= ${REGEX_MAX_LEN} characters")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, regex filter lengths are limited to 1000 chars. However, given that a [recent optimization](https://github.com/filodb/FiloDB/pull/1641) converts EqualsRegex pipe-only (i.e. `|`-only) filters to Lucene `IN` queries, this limit can now be relaxed specifically for these queries.

This PR relaxes the length-limit for regex filters that contain _at most_ the pipe special regex character. For example, the query...
```
foo{label1=~"baz|bar|bat|...|zab", label2=~"hello", label3=~"foo|far[0-9]", label4!~"hello"}
```
...will relax the length limit only for `label1` and `label2`.