### PR TITLE
fix(prometheus): incorrect config method

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -43,7 +43,7 @@ object PrometheusModel {
           case MatchType.NOT_EQUAL => Filter.NotEquals(m.getValue)
           case MatchType.REGEX_MATCH =>
             // Relax the length limit only for matchers that contain at most the "|" special character.
-            val shouldRelax = queryConfig.getBoolean("relaxed-pipe-only-equals-regex-limit") &&
+            val shouldRelax = queryConfig.hasPath("relaxed-pipe-only-equals-regex-limit") &&
                                 QueryUtils.containsPipeOnlyRegex(m.getValue)
             if (shouldRelax) {
               val limit = queryConfig.getInt("relaxed-pipe-only-equals-regex-limit");


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, an `int`-type config is accessed as a `boolean`. This PR instead invokes the correct `Config` method.