### PR TITLE
fix(metering) Tenant metering in one region and removing unused data structures for cluster V2

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardManager.scala
@@ -37,7 +37,6 @@ private[coordinator] final class ShardManager(settings: FilodbSettings,
   private val _coordinators = new mutable.LinkedHashMap[Address, ActorRef]
   private val _errorShardReassignedAt = new mutable.HashMap[DatasetRef, mutable.HashMap[Int, Long]]
 
-  // TODO move to startup-v2
   private val _tenantIngestionMeteringOpt =
     if (settings.config.getBoolean("shard-key-level-ingestion-metrics-enabled")) {
       val inst = TenantIngestionMetering(


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

**Current behavior :** Clustering V2 starts tenant ingestion metering when filo server is started. This is different from clustering v1 where it only starts if the config is enabled.

**New behavior :** Tenant ingestion metering is started when the desired config is enabled. 
