### PR TITLE
fix(query) Corner case for Set Operator OR with on()

### DIFF
--- a/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
+++ b/query/src/main/scala/filodb/query/exec/SetOperatorExec.scala
@@ -251,6 +251,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
                 value
               }
               idx += 1
+              println(s"${x.key} : \t${reader.getLong(0)} -> $res")
               cur.setValues(reader.getLong(0), res)
               cur
             }
@@ -279,6 +280,7 @@ final case class SetOperatorExec(queryContext: QueryContext,
                 reader.getDouble(1)
               }
               idx += 1
+              println(s"${x.key} : \t${reader.getLong(0)} -> $res")
               cur.setValues(reader.getLong(0), res)
               cur
             }
@@ -289,27 +291,34 @@ final case class SetOperatorExec(queryContext: QueryContext,
           }
           IteratorBackedRangeVector(x.key, rowsCursor, x.outputRange)
         })
-        // This order is important, when lhs Rvs are executed they set a bitmap which is used when iterating RHS
-        // DONOT flip this order
-        val mergedRvs = lhsRvs ++ rhsRvs
+
+        val lhsRvMap = lhsRvs.foldLeft(Map.empty[Map[Utf8Str, Utf8Str], List[RangeVector]]) {
+          case (acc, rv) =>
+            val key = rv.key.labelValues
+            val groupedRvs = acc.get(key).map(rv :: _).getOrElse(List(rv))
+            acc + (key -> groupedRvs)
+        }
 
         // Dedupe the LHS and RHS rvs by keys, if same key is found for multiple RVs, stitch them
         // For e.g sum(foo{}) OR sum(bar{}), both have empty RV Key, we want them to return one RV
         // instead of two both with empty RV Keys
-        val mergedGroupedRvs = mergedRvs.foldLeft(Map.empty[Map[Utf8Str, Utf8Str], List[RangeVector]]){
+        val mergedGroupedRvs = rhsRvs.foldLeft(lhsRvMap){
           case (acc, rv)  =>
           val key = rv.key.labelValues
-          val groupedRvs = acc.get(key).map(rv :: _).getOrElse(List(rv))
-          acc + (key -> groupedRvs)
+          acc.get(key) match {
+            case Some(lhsRvs)   => acc + (key -> (rv :: lhsRvs))
+            case None           => acc
+          }
         }
 
-        mergedGroupedRvs.map {
+        val joined = mergedGroupedRvs.map {
           case (_, rv :: Nil)   => rv
           case (key, rvs)       => IteratorBackedRangeVector(CustomRangeVectorKey(key),
                                         StitchRvsExec.merge(rvs.reverse.map(_.rows()), outputRvRange),
                                         outputRvRange)
-        }
-      }.toSeq
+        }.toSeq ++ rhsRvs.filter(rv => !mergedGroupedRvs.contains(rv.key.labelValues))
+        joined
+      }
     }
 
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current and New behavior :** 

SetOperator OR fixed in [PR](https://github.com/filodb/FiloDB/pull/1669) has a corner case specifically when using ``OR on``. This since we use a Map which doesn't follow the order of the keys, RHS Rvs were getting executed prior to all LHS rvs get executed. Since the correctness of result depends on the order or execution since we use a bitmap to track all time instants where some LHS RV has results, there were some time instants where RHS RV returns results when it should have returned ``NaN``. This PR fixes this edge case.

