### PR TITLE
fix(cardinality): Records with overflow doesn't pass dataset + Aggregation issue in TsCardReduceExec

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -1,16 +1,15 @@
 package filodb.query.exec
 
 import scala.collection.mutable
-
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import org.apache.datasketches.cpc.{CpcSketch, CpcUnion}
-
 import filodb.core.DatasetRef
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, MapItemConsumer}
 import filodb.core.memstore.TimeSeriesStore
+import filodb.core.memstore.ratelimit.CardinalityStore
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.Column.ColumnType.{MapColumn, StringColumn}
 import filodb.core.query._
@@ -82,7 +81,7 @@ final case class TsCardReduceExec(queryContext: QueryContext,
 
   override protected def args: String = ""
 
-  private def mapFold(acc: mutable.HashMap[ZeroCopyUTF8String, CardCounts], rv: RangeVector):
+  private def mapFold(acc: mutable.HashMap[ZeroCopyUTF8String, CardCounts], rv: RangeVector, rs: ResultSchema):
       mutable.HashMap[ZeroCopyUTF8String, CardCounts] = {
     rv.rows().foreach{ r =>
       val data = RowData.fromRowReader(r)
@@ -92,7 +91,17 @@ final case class TsCardReduceExec(queryContext: QueryContext,
       val (groupKey, accCounts) = if (accCountsOpt.nonEmpty || acc.size < MAX_RESULT_SIZE) {
         (data.group, accCountsOpt.getOrElse(CardCounts(0, 0)))
       } else {
-        (OVERFLOW_GROUP, acc.getOrElseUpdate(OVERFLOW_GROUP, CardCounts(0, 0)))
+        // handle overflow group based on result schema given
+        if (rs.hasSameColumnsAs(TsCardExec.RESULT_SCHEMA)) {
+          // aggregate by dataset as well
+          val groupArray = data.group.toString.split(TsCardExec.PREFIX_DELIM)
+          val dataset = groupArray(groupArray.size - 1)
+          val dataGroup = prefixToGroupWithDataset(CardinalityStore.OVERFLOW_PREFIX, dataset)
+          (dataGroup, acc.getOrElseUpdate(dataGroup, CardCounts(0, 0)))
+        }
+        else {
+          (OVERFLOW_GROUP, acc.getOrElseUpdate(OVERFLOW_GROUP, CardCounts(0, 0)))
+        }
       }
       acc.update(groupKey, accCounts.add(data.counts))
     }
@@ -106,8 +115,17 @@ final case class TsCardReduceExec(queryContext: QueryContext,
   override protected def compose(childResponses: Observable[(QueryResult, Int)],
                                  firstSchema: Task[ResultSchema],
                                  querySession: QuerySession): Observable[RangeVector] = {
-    val taskOfResults = childResponses.flatMap(res => Observable.fromIterable(res._1.result))
-      .foldLeftL(new mutable.HashMap[ZeroCopyUTF8String, CardCounts])(mapFold)
+
+    // capture the result schema of responses
+    var rs = ResultSchema.empty
+    val flatMapData = childResponses.flatMap(res => {
+      if (rs == ResultSchema.empty) {
+        rs = res._1.resultSchema
+      }
+      Observable.fromIterable(res._1.result)
+    })
+    val taskOfResults = flatMapData
+      .foldLeftL(new mutable.HashMap[ZeroCopyUTF8String, CardCounts])((x, y) => mapFold(x, y, rs))
       .map{ aggMap =>
         val it = aggMap.toSeq.sortBy(-_._2.shortTerm).map{ case (group, counts) =>
           CardRowReader(group, counts)

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -1,11 +1,13 @@
 package filodb.query.exec
 
 import scala.collection.mutable
+
 import com.typesafe.scalalogging.StrictLogging
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import org.apache.datasketches.cpc.{CpcSketch, CpcUnion}
+
 import filodb.core.DatasetRef
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, MapItemConsumer}
 import filodb.core.memstore.TimeSeriesStore

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -472,6 +472,11 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
         respRows.size shouldEqual 2
         // should have one overflow prefix
         val overFlowRow = respRows.filter(x => x.group.toString.startsWith(CardinalityStore.OVERFLOW_PREFIX(0)))(0)
+
+        val expectedOverflowGroup = prefixToGroupWithDataset(CardinalityStore.OVERFLOW_PREFIX,
+          timeseriesDatasetMultipleShardKeys.ref.dataset)
+        overFlowRow.group shouldEqual expectedOverflowGroup
+
         val nonOverflowRow = respRows.filter(x => !x.group.toString.startsWith(CardinalityStore.OVERFLOW_PREFIX(0)))(0)
         // now check for the count
 


### PR DESCRIPTION
**Current behavior :**

PR fixes two issues:

1. Cardinality records with `_overflow_` prefix doesn't pass dataset as expected by the QueryService in V2 APIs. 

2. Correctness issue: Incorrect aggregation when the hashmap reaches the map size. As of today, we would skip the keys already present in the map and always aggregate the overflow bucket.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?


**New behavior :**
The fixes and unit tests are added for the above issues. 