### PR TITLE
perf(query) Option to disable Lucene caching

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -751,6 +751,10 @@ filodb {
     # If all of the index-faceting-enabled-* properties are false, faceting is fully disabled.
     # Disable if performance cost of faceting all labels is too high
     index-faceting-enabled-for-all-labels = true
+
+    # Whether caching on index is disabled underlying Lucene index uses LRUCache enabled by default, the flag lets us
+    #disable this feature
+    disable-index-caching = false
   }
 
   # for standalone worker cluster configuration, see akka-bootstrapper

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -284,6 +284,8 @@ class TimeSeriesShard(val ref: DatasetRef,
                            filodbConfig.getBoolean("memstore.index-faceting-enabled-shard-key-labels")
   private val indexFacetingEnabledAllLabels = filodbConfig.getBoolean("memstore.index-faceting-enabled-for-all-labels")
   private val numParallelFlushes = filodbConfig.getInt("memstore.flush-task-parallelism")
+  private val disableIndexCaching = filodbConfig.getBoolean("memstore.disable-index-caching")
+
 
   /////// END CONFIGURATION FIELDS ///////////////////
 
@@ -311,7 +313,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     */
   private[memstore] final val partKeyIndex = new PartKeyLuceneIndex(ref, schemas.part,
     indexFacetingEnabledAllLabels, indexFacetingEnabledShardKeyLabels, shardNum,
-    storeConfig.diskTTLSeconds * 1000)
+    storeConfig.diskTTLSeconds * 1000, disableIndexCaching = disableIndexCaching)
 
   private val cardTracker: CardinalityTracker = initCardTracker()
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -106,6 +106,7 @@ filodb {
     track-queries-holding-eviction-lock = false
     index-faceting-enabled-shard-key-labels = true
     index-faceting-enabled-for-all-labels = true
+    disable-index-caching = false
 
   }
 

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -117,6 +117,35 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     result.map( p => (p.startTime, p.endTime)) shouldEqual expected.map( p => (p.startTime, p.endTime))
   }
 
+
+  it("should fetch part key records from filters correctly with index caching disabled") {
+    // Add the first ten keys and row numbers
+    val keyIndexNoCache =
+      new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition,
+        true,
+        true,
+        0,
+        1.hour.toMillis,
+        disableIndexCaching = true)
+    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+      .zipWithIndex.map { case (addr, i) =>
+      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+      keyIndexNoCache.addPartKey(pk, i, i, i + 10)()
+      PartKeyLuceneIndexRecord(pk, i, i + 10)
+    }
+    keyIndexNoCache.refreshReadersBlocking()
+
+    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+    Range(1, 100).foreach(_ => {
+      val result = keyIndexNoCache.partKeyRecordsFromFilters(Seq(filter2), 0, Long.MaxValue)
+      val expected = Seq(pkrs(7), pkrs(8), pkrs(9))
+
+      result.map(_.partKey.toSeq) shouldEqual expected.map(_.partKey.toSeq)
+      result.map(p => (p.startTime, p.endTime)) shouldEqual expected.map(p => (p.startTime, p.endTime))
+    })
+
+  }
+
   it("should fetch only two part key records from filters") {
     // Add the first ten keys and row numbers
     val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

When we profile a FIloDB instance with a large index and which sees a lot of repeating queries, we see the following flame graph (as taken by async profiler)

<img width="1975" alt="Screenshot 2024-02-02 at 10 00 10 AM" src="https://github.com/filodb/FiloDB/assets/1028064/961739ab-51c4-4065-82db-b3932dde02db">

We  see almost 80% stack traces are related to index searches and about 50% of them are related to caching.  Also [this](https://www.mail-archive.com/java-user@lucene.apache.org/msg51649.html) archive mentions disabling caching which may or may not work in our case   (also they mention disabling cache in a different way than what this PR does).  The idea is to have that knob to let us disable the caching and then profile again.

**New behavior :**

We now support flag based enable/disable caching. By default the caching is enabled (existing default)

