### PR TITLE
fix(query): histogram queries with PeriodSeriesWithWindowing logical plan don't apply le label filter

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -618,13 +618,16 @@ class SingleClusterPlanner(val dataset: Dataset,
     }
   }
 
+  // scalastyle:off method.length
   override private[queryplanner] def materializePeriodicSeriesWithWindowing(qContext: QueryContext,
                                                      lp: PeriodicSeriesWithWindowing,
                                                      forceInProcess: Boolean): PlanResult = {
 
-    val logicalPlanWithoutBucket = if (queryConfig.translatePromToFilodbHistogram) {
-       removeBucket(Right(lp))._3.right.get
-    } else lp
+    val (nameFilter: Option[String], leFilter: Option[String], logicalPlanWithoutBucket: PeriodicSeriesWithWindowing) =
+      if (queryConfig.translatePromToFilodbHistogram) {
+       val result = removeBucket(Right(lp))
+        (result._1, result._2, result._3.right.get)
+    } else (None, None, lp)
 
     val series = walkLogicalPlanTree(logicalPlanWithoutBucket.series, qContext, forceInProcess)
     val rawSource = logicalPlanWithoutBucket.series.isRaw
@@ -645,6 +648,15 @@ class SingleClusterPlanner(val dataset: Dataset,
       realScanStepMs, realScanEndMs, window, Some(execRangeFn), qContext,
       logicalPlanWithoutBucket.stepMultipleNotationUsed,
       paramsExec, logicalPlanWithoutBucket.offsetMs, rawSource)))
+
+    // Add the le filter transformer to select the required bucket
+    if (nameFilter.isDefined && nameFilter.head.endsWith("_bucket") && leFilter.isDefined) {
+      val paramsExec = StaticFuncArgs(leFilter.head.toDouble, RangeParams(realScanStartMs / 1000, realScanStepMs / 1000,
+        realScanEndMs / 1000))
+      series.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
+        Seq(paramsExec))))
+    }
+
     val result = if (logicalPlanWithoutBucket.function == RangeFunctionId.AbsentOverTime) {
       val aggregate = Aggregate(AggregationOperator.Sum, logicalPlanWithoutBucket, Nil,
                                 AggregateClause.byOpt(Seq("job")))
@@ -662,9 +674,9 @@ class SingleClusterPlanner(val dataset: Dataset,
       result.plans.foreach(p => p.addRangeVectorTransformer(RepeatTransformer(lp.startMs, lp.stepMs, lp.endMs,
         p.queryWithPlanName(qContext))))
     }
-
     result
   }
+  // scalastyle:on method.length
 
   override private[queryplanner] def removeBucket(lp: Either[PeriodicSeries, PeriodicSeriesWithWindowing]) = {
     val rawSeries = lp match {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -86,7 +86,7 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
       l1.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
       val l1Exec = l1.asInstanceOf[MultiSchemaPartitionsExec]
       SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l1Exec)
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual (100)
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual (0)
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual (10000)
     }
   }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -84,11 +84,10 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
 
     reduceAggregateExec.children.foreach { l1 =>
       l1.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
-      l1.rangeVectorTransformers.size shouldEqual 2
-      l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual (0)
+      val l1Exec = l1.asInstanceOf[MultiSchemaPartitionsExec]
+      SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l1Exec)
+      l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual (100)
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual (10000)
-      l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
   }
 
@@ -220,11 +219,10 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
         1010000
       l1.asInstanceOf[MultiSchemaPartitionsExec].chunkMethod.asInstanceOf[TimeRangeChunkScan].endTime shouldEqual
         2000000
-      l1.rangeVectorTransformers.size shouldEqual 2
-      l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+      val l1Exec = l1.asInstanceOf[MultiSchemaPartitionsExec]
+      SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l1Exec)
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual (1060000)
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual (2000000)
-      l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
     val queryParams = child2.queryContext.origQueryParams.
       asInstanceOf[PromQlQueryParams]
@@ -354,11 +352,10 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
         (1080000-lookBack)
       l1.asInstanceOf[MultiSchemaPartitionsExec].chunkMethod.asInstanceOf[TimeRangeChunkScan].endTime shouldEqual
         2000000
-      l1.rangeVectorTransformers.size shouldEqual 2
-      l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+      val l1Exec = l1.asInstanceOf[MultiSchemaPartitionsExec]
+      SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l1Exec)
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual 1080000
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual 2000000
-      l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
 
     val queryParams = child2.asInstanceOf[PromQlRemoteExec].queryContext.origQueryParams.
@@ -434,11 +431,10 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
 
     reduceAggregateExec.children.foreach { l1 =>
       l1.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
-      l1.rangeVectorTransformers.size shouldEqual 2
-      l1.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
+      val l1Exec = l1.asInstanceOf[MultiSchemaPartitionsExec]
+      SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l1Exec)
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].startMs shouldEqual from *1000
       l1.rangeVectorTransformers(0).asInstanceOf[PeriodicSamplesMapper].endMs shouldEqual  to * 1000
-      l1.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
     }
   }
 

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSplitSpec.scala
@@ -17,7 +17,7 @@ import filodb.core.store.TimeRangeChunkScan
 import filodb.prometheus.ast.{TimeStepParams, WindowConstants}
 import filodb.prometheus.parse.Parser
 import filodb.query._
-import filodb.query.exec._
+import filodb.query.exec.{MultiSchemaPartitionsExec, _}
 
 class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
@@ -139,9 +139,8 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
         l1.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
         l1.children.foreach { l2 =>
           l2.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
-          l2.rangeVectorTransformers.size shouldEqual 2
-          l2.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-          l2.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
+          val l2Exec = l2.asInstanceOf[MultiSchemaPartitionsExec]
+          SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l2Exec)
         }
       }
     }
@@ -169,9 +168,8 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
           l2.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
           l2.children.foreach { l3 =>
             l3.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
-            l3.rangeVectorTransformers.size shouldEqual 2
-            l3.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-            l3.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
+            val l3Exec = l3.asInstanceOf[MultiSchemaPartitionsExec]
+            SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l3Exec)
           }
         }
       }
@@ -372,13 +370,11 @@ class SingleClusterPlannerSplitSpec extends AnyFunSpec with Matchers with ScalaF
         l1.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
         l1.children.foreach { l2 =>
           l2.isInstanceOf[MultiSchemaPartitionsExec] shouldEqual true
-          l2.rangeVectorTransformers.size shouldEqual 2
-          l2.rangeVectorTransformers(0).isInstanceOf[PeriodicSamplesMapper] shouldEqual true
-          l2.rangeVectorTransformers(1).isInstanceOf[AggregateMapReduce] shouldEqual true
+          val l2Exec = l2.asInstanceOf[MultiSchemaPartitionsExec]
+          SingleClusterPlannerSpec.validateRangeVectorTransformersForPeriodicSeriesWithWindowingLogicalPlan(l2Exec)
         }
       }
     }
-
   }
 
   it("should generate SplitExec wrapper with appropriate splits " +


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**  Histogram bucket queries with PeriodSeriesWithWindowing logical plan (queries such as sum(rate) etc. use this logical plan) don't apply the InstantVectorFunctionMapper transformer correctly for le label filter. 

**New behavior :** Adding the required transformer to correctly pick up the required bucket given in the query.