### PR TITLE
fix(query): ShardKeyRegexPlanner batching fix

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -161,7 +161,11 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
     //   That is a problem for e.g. scalars or absent().
     if (hasSameShardKeyFilters && partitions.size == 1) {
       val plans = generateExec(logicalPlan, shardKeys, qContext)
-      return PlanResult(plans)
+      // If !=1 plans were produced, additional high-level coordination may be needed
+      //   (e.g. joins / aggregations). In that case, proceed through the logic below.
+      if (plans.size == 1) {
+        return PlanResult(plans)
+      }
     }
     logicalPlan match {
       case lp: ApplyMiscellaneousFunction  => materializeApplyMiscellaneousFunction(qContext, lp)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Plans are materialized directly by inner planners when they draw data from one partition. However, when the ShardKeyRegexPlanner fanout batch size is small enough, multiple plans may be produced for one partition. Currently, these plans are concatenated and returned; they will be missing any root-level e.g. aggregations/joins.

This PR ignores the "if one partition then materialize with inner planners" logic when the inner planners return more than one plan.

For example, plans prior to this PR may be produced as:
```
Concat
    Agg
        RawData(localShardKey1)
        RawData(localShardKey1)
    Agg
        RawData(localShardKey2)
        RawData(localShardKey2)
```

Now, root plans will be correct because materialization proceeds through the ShardKeyRegexPlanner's `walkLogicalPlanTree` when inner planners produce more than one plan:
```
Agg
    Agg
        RawData(localShardKey1)
        RawData(localShardKey1)
    Agg
        RawData(localShardKey2)
        RawData(localShardKey2)
```