### PR TITLE
feat(downsample): support export to multiple paths in Iceberg format

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -561,6 +561,7 @@ filodb {
 
     data-export {
       enabled = false
+      parallelism = 10
       # Catalog under Unified Catalog
       catalog = ""
       # Database under Catalog

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -575,7 +575,7 @@ filodb {
       # These labels will be dropped from every exported row.
       drop-labels = ["_ws_", "drop-label1"]
 
-      bucket = "file://<path-to-file>"
+      destination-format = "file://<path-to-file>/$0"
 
       # Each row's labels are compared against all rule-group keys. If a match is found,
       #   the row's labels are compared *sequentially* against each of the group's rules until

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -561,21 +561,18 @@ filodb {
 
     data-export {
       enabled = false
-
-      # Spark SaveMode / options.
-      save-mode = "error"
-      format = "csv"
-      options = {
-        "header": "true"
-      }
+      # Catalog under Unified Catalog
+      catalog = ""
+      # Database under Catalog
+      database = ""
+      # Table format
+      format = "iceberg"
 
       # Describe the sequence of labels that compose a rule-group's key.
       # A time-series should match at most one key.
       key-labels = ["_ws_"]
       # These labels will be dropped from every exported row.
       drop-labels = ["_ws_", "drop-label1"]
-
-      destination-format = "file://<path-to-file>/$0"
 
       # Each row's labels are compared against all rule-group keys. If a match is found,
       #   the row's labels are compared *sequentially* against each of the group's rules until
@@ -588,6 +585,19 @@ filodb {
       groups = [
         {
           key = ["ws-foo"]
+          # Iceberg table name
+          table = "ws-foo"
+          # Table path
+          table-path = "s3a://<bucket>/<directory>/<catalog>/<database>/ws-foo"
+          # to add additional dynamic label-based columns to the table
+          # Eg: _ws_ is the label key in time series to populate column workspace
+          # Similary, _ns_ is the label key in time series to populate column namespace
+          label-column-mapping = [
+            "_ws_", "workspace",
+            "_ns_", "namespace"
+          ]
+          # Partition Iceberg Table by any of the col from label-column-mapping
+          partition-by-columns = ["namespace"]
           rules = [
             {
               allow-filters = [
@@ -601,26 +611,6 @@ filodb {
             }
           ]
         }
-      ]
-
-      # Specifies how to generate a path to an exported time-series.
-      # The sequence of key-value pairs describe a directory path, where the
-      #   time-series are exported to the final directory.
-      # For example, if the path-spec is:
-      #     path-spec = [
-      #       "key1", "value1",
-      #       "key2", "value2"
-      #     ]
-      # then the exported time-series will be stored at the path:
-      #     ~/key1=value1/key2=value2/<file>
-      # All {{label-name}} strings will be replaced with the time-series label's value.
-      # All <<time-spec>> strings will be replaced with the result of formatting
-      #   the export window's end time with the time-spec string.
-      path-spec = [
-        "ws",   "{{_ws_}}-suffix1",
-        "year", "<<YYYY>>-suffix2",
-        "api",  "v1",
-        "ns",   "{{_ns_}}-suffix3"
       ]
     }
   }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -1,17 +1,13 @@
 package filodb.downsampler.chunk
 
 import java.security.MessageDigest
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.{Instant, LocalDateTime, ZoneId}
 
-import scala.collection.mutable
-import scala.util.matching.Regex
-
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import kamon.Kamon
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.sql.types.StructType
+import scala.collection.mutable
 
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn}
@@ -20,7 +16,7 @@ import filodb.core.query.ColumnFilter
 import filodb.core.store.{ChunkSetInfoReader, ReadablePartition}
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.Utils._
-import filodb.downsampler.chunk.BatchExporter.{DATE_REGEX_MATCHER, LABEL_REGEX_MATCHER}
+import filodb.downsampler.chunk.ExportConstants._
 import filodb.memory.format.{TypedIterator, UnsafeUtils}
 import filodb.memory.format.vectors.LongIterator
 
@@ -28,27 +24,24 @@ case class ExportRule(allowFilterGroups: Seq[Seq[ColumnFilter]],
                       blockFilterGroups: Seq[Seq[ColumnFilter]],
                       dropLabels: Seq[String])
 
+case class ExportTableConfig(tableName: String,
+                             tableSchema: StructType,
+                             tablePath: String,
+                             exportRules: Seq[ExportRule],
+                             labelColumnMapping: Seq[(String, String)],
+                             partitionByCols: Seq[String])
 /**
  * All info needed to output a result Spark Row.
  */
-case class ExportRowData(partKeyMap: collection.Map[String, String],
-                         labelString: String,
-                         timestamp: Long,
+case class ExportRowData(metric: String,
+                         labels: collection.Map[String, String],
+                         epoch_timestamp: Long,
+                         timestamp: LocalDateTime,
                          value: Double,
-                         partitionStrings: Iterator[String],
-                         dropLabels: Set[String])
-
-object BatchExporter {
-  val LABEL_REGEX_MATCHER: Regex = """\{\{(.*)\}\}""".r
-  val DATE_REGEX_MATCHER: Regex = """<<(.*)>>""".r
-
-  val JSON_MAPPER: ObjectMapper = new ObjectMapper()
-  JSON_MAPPER.registerModule(DefaultScalaModule)
-
-  def makeLabelString(labels: collection.Map[String, String]): String = {
-    JSON_MAPPER.writeValueAsString(labels)
-  }
-}
+                         year: Int,
+                         month: Int,
+                         day: Int,
+                         hour: Int)
 
 /**
  * Exports a window of data to a bucket.
@@ -62,65 +55,18 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
   @transient lazy val numRowsExportPrepped = Kamon.counter("num-rows-export-prepped").withoutTags()
 
   val keyToRules = downsamplerSettings.exportKeyToRules
-  val exportSchema = {
-    // NOTE: ArrayBuffers are sometimes used instead of Seq's because otherwise
-    //   ArrayIndexOutOfBoundsExceptions occur when Spark exports a batch.
-    val fields = new mutable.ArrayBuffer[StructField](3 + downsamplerSettings.exportPathSpecPairs.size)
-    fields.append(
-      StructField("LABELS", StringType),
-      StructField("TIMESTAMP", LongType),
-      StructField("VALUE", DoubleType)
-    )
-    // append all partitioning columns as strings
-    fields.appendAll(downsamplerSettings.exportPathSpecPairs.map(f => StructField(f._1, StringType)))
-    StructType(fields)
-  }
-  val partitionByNames = {
-    val cols = new mutable.ArrayBuffer[String](downsamplerSettings.exportPathSpecPairs.size)
-    cols.appendAll(downsamplerSettings.exportPathSpecPairs.map(_._1))
-    cols
-  }
-
-  // One for each name; "template" because these still contain the {{}} notation to be replaced.
-  var partitionByValuesTemplate: Seq[String] = Nil
-  // The indices of partitionByValuesTemplate that contain {{}} notation to be replaced.
-  var partitionByValuesIndicesWithTemplate: Set[Int] = Set.empty
-
-  // Replace <<>> template notation with formatted dates.
-  {
-    val date = new Date(userStartTime)
-    partitionByValuesTemplate = downsamplerSettings.exportPathSpecPairs.map(_._2)
-      // replace the <<>> strings with dates
-      .map{ pathSpecString =>
-        DATE_REGEX_MATCHER.replaceAllIn(pathSpecString, matcher => {
-          val dateFormatter = new SimpleDateFormat(matcher.group(1))
-          dateFormatter.format(date)
-        })}
-    partitionByValuesIndicesWithTemplate = partitionByValuesTemplate.zipWithIndex.filter { case (label, i) =>
-      LABEL_REGEX_MATCHER.findFirstIn(label).isDefined
-    }.map(_._2).toSet
-  }
 
   /**
    * Returns the index of a column in the export schema.
    * E.g. "foo" will return `3` if "foo" is the name of the fourth column (zero-indexed)
    *   of each exported row.
    */
-  def getRowIndex(fieldName: String): Option[Int] = {
-    exportSchema.zipWithIndex.find(_._1.name == fieldName).map(_._2)
-  }
-
-  /**
-   * Returns the configured exportDestinationFormat with all $i (e.g. $0, $1, $2, etc)
-   * substrings replaced with the ith string of the argument export key.
-   */
-  def makeExportAddress(exportKey: Seq[String]): String = {
-    val replaceRegex = "\\$([0-9]+)".r
-    replaceRegex.replaceAllIn(downsamplerSettings.exportDestinationFormat, matcher => {
-      // Replace e.g. $0 with the 0th index of the export key.
-      val index = matcher.group(1).toInt
-      exportKey(index)
-    })
+  def getColumnIndex(colName: String, exportTableConfig: ExportTableConfig): Option[Int] = {
+    // check if fieldName is from dynamic schema
+    // if yes, then get the col name for that label from dynamic schema else search for fieldName
+    val dynamicColName = exportTableConfig.labelColumnMapping.find(_._1 == colName)
+    val fieldName = if (dynamicColName.isEmpty) colName else dynamicColName.get._2
+    exportTableConfig.tableSchema.fieldNames.zipWithIndex.find(_._1 == fieldName).map(_._2)
   }
 
   // Unused, but keeping here for convenience if needed later.
@@ -159,7 +105,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
   /**
    * Returns the Spark Rows to be exported.
    */
-  def getExportRows(readablePartitions: Seq[ReadablePartition]): Iterator[Row] = {
+  def getExportRows(readablePartitions: Seq[ReadablePartition], exportTableConfig: ExportTableConfig): Iterator[Row] = {
     readablePartitions
       .iterator
       .map { part =>
@@ -171,8 +117,8 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
           val pairMap = new mutable.HashMap[String, String]()
           pairMap ++= pairs
           // replace _metric_ label name with __name__
-          pairMap("__name__") = pairMap("_metric_")
-          pairMap.remove("_metric_")
+          pairMap(LABEL_NAME) = pairMap(LABEL_METRIC)
+          pairMap.remove(LABEL_METRIC)
           pairMap
         }
         val rule = getRuleIfShouldExport(partKeyMap)
@@ -180,51 +126,86 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
       }
       .filter { case (part, partKeyMap, rule) => rule.isDefined }
       .flatMap { case (part, partKeyMap, rule) =>
-        getExportDatas(part, partKeyMap, rule.get)
+        getExportData(part, partKeyMap, rule.get)
       }
       .map { exportData =>
         numRowsExportPrepped.increment()
-        exportDataToRow(exportData)
+        exportDataToRow(exportData, exportTableConfig)
       }
   }
 
   /**
    * Converts an ExportData to a Spark Row.
-   * The result Row *must* match this.exportSchema.
+   * The result Row *must* match exportSchema.
    */
-  private def exportDataToRow(exportData: ExportRowData): Row = {
-    val dataSeq = new mutable.ArrayBuffer[Any](3 + downsamplerSettings.exportPathSpecPairs.size)
+  private def exportDataToRow(exportData: ExportRowData, exportTableConfig: ExportTableConfig): Row = {
+    val dataSeq = new mutable.ArrayBuffer[Any](exportTableConfig.tableSchema.fields.length)
+    // append all dynamic column values
+    exportTableConfig.labelColumnMapping.foreach {pair => dataSeq.append(exportData.labels.get(pair._1))}
+    // append all fixed column values
     dataSeq.append(
-      exportData.labelString,
-      exportData.timestamp / 1000,
-      exportData.value
+      exportData.metric,
+      exportData.labels,
+      exportData.epoch_timestamp,
+      exportData.timestamp,
+      exportData.value,
+      exportData.year,
+      exportData.month,
+      exportData.day,
+      exportData.hour
     )
-    dataSeq.appendAll(exportData.partitionStrings)
     Row.fromSeq(dataSeq)
   }
 
-  /**
-   * Returns the column values used to partition the data.
-   * Value order should match the order of this.partitionByCols.
-   */
-  def getPartitionByValues(partKeyMap: collection.Map[String, String]): Iterator[String] = {
-    partitionByValuesTemplate.iterator.zipWithIndex.map{ case (value, i) =>
-      if (partitionByValuesIndicesWithTemplate.contains(i)) {
-        LABEL_REGEX_MATCHER.replaceAllIn(partitionByValuesTemplate(i), matcher => partKeyMap(matcher.group(1)))
-      } else {
-        value
-      }
-    }
+  def writeDataToIcebergTable(spark: SparkSession,
+                              settings: DownsamplerSettings,
+                              exportTableConfig: ExportTableConfig,
+                              rdd: RDD[Row]): Unit = {
+    spark.sql(sqlCreateDatabase(settings.exportDatabase))
+    spark.sql(sqlCreateTable(settings.exportCatalog, settings.exportDatabase, exportTableConfig))
+    spark.createDataFrame(rdd, exportTableConfig.tableSchema)
+      .write
+      .format(settings.exportFormat)
+      .mode(SaveMode.Append)
+      .insertInto(s"${settings.exportDatabase}.${exportTableConfig.tableName}")
+  }
+
+  private def sqlCreateDatabase(database: String) =
+    s"""
+       |CREATE DATABASE IF NOT EXISTS $database
+       |""".stripMargin
+
+  private def sqlCreateTable(catalog: String, database: String, exportTableConfig: ExportTableConfig) = {
+    // create dynamic col names with type to append to create table statement
+    val dynamicColNames = exportTableConfig.labelColumnMapping.map(pair => pair._2 + " string").mkString(", ")
+    val partitionColNames = exportTableConfig.partitionByCols.mkString(", ")
+    s"""
+       |CREATE TABLE IF NOT EXISTS $catalog.$database.${exportTableConfig.tableName} (
+       | $dynamicColNames,
+       | metric string,
+       | labels map<string, string>,
+       | epoch_timestamp long,
+       | timestamp timestamp,
+       | value double,
+       | year int,
+       | month int,
+       | day int,
+       | hour int
+       | )
+       | USING iceberg
+       | PARTITIONED BY (year, month, day, $partitionColNames, metric)
+       | LOCATION ${exportTableConfig.tablePath}
+       |""".stripMargin
   }
 
   def getRuleIfShouldExport(partKeyMap: collection.Map[String, String]): Option[ExportRule] = {
-    keyToRules.find { case (key, rules) =>
+    keyToRules.find { case (key, exportTableConfig) =>
       // find the group with a key that matches these label-values
       downsamplerSettings.exportRuleKey.zipWithIndex.forall { case (label, i) =>
         partKeyMap.get(label).contains(key(i))
       }
-    }.flatMap { case (key, rules) =>
-      rules.takeWhile{ rule =>
+    }.flatMap { case (key, exportTableConfig) =>
+      exportTableConfig.exportRules.takeWhile{ rule =>
         // step through rules while we still haven't matched a "block" filter
         !rule.blockFilterGroups.exists { filterGroup =>
           matchAllFilters(filterGroup, partKeyMap)
@@ -238,18 +219,14 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     }
   }
 
-  private def mergeLabelStrings(left: String, right: String): String = {
-    left.substring(0, left.size - 1) + "," + right.substring(1)
-  }
-
   // scalastyle:off method.length
   /**
    * Returns data about a single row to export.
    * exportDataToRow will convert these into Spark Rows that conform to this.exportSchema.
    */
-  private def getExportDatas(partition: ReadablePartition,
-                             partKeyMap: mutable.Map[String, String],
-                             rule: ExportRule): Iterator[ExportRowData] = {
+  private def getExportData(partition: ReadablePartition,
+                            partKeyMap: mutable.Map[String, String],
+                            rule: ExportRule): Iterator[ExportRowData] = {
     // Pseudo-struct for convenience.
     case class RangeInfo(irowStart: Int,
                          irowEnd: Int,
@@ -276,11 +253,10 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     }
     val tupleIter = columns(valueCol).columnType match {
       case DoubleColumn =>
-        val labelString = BatchExporter.makeLabelString(partKeyMap)
         rangeInfoIter.flatMap{ info =>
           val doubleIter = info.valueIter.asDoubleIt
           (info.irowStart to info.irowEnd).iterator.map{ _ =>
-            (partKeyMap, labelString, info.timestampIter.next, doubleIter.next)
+            (partKeyMap, info.timestampIter.next, doubleIter.next)
           }
         }
       case HistogramColumn =>
@@ -293,13 +269,12 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
         //    my_histo_bucket{l1=v1, l2=v2, le=20} 15
         //    my_histo_bucket{l1=v1, l2=v2, le=+Inf} 26
 
-        val nameWithoutBucket = partKeyMap("__name__")
+        val nameWithoutBucket = partKeyMap(LABEL_NAME)
         val nameWithBucket = nameWithoutBucket + "_bucket"
 
         // make labelString without __name__; will be replaced with _bucket-suffixed name
-        partKeyMap.remove("__name__")
-        val baseLabelString = BatchExporter.makeLabelString(partKeyMap)
-        partKeyMap.put("__name__", nameWithoutBucket)
+        partKeyMap.remove(LABEL_NAME)
+        partKeyMap.put(LABEL_NAME, nameWithoutBucket)
 
         rangeInfoIter.flatMap{ info =>
           val histIter = info.valueIter.asHistIt
@@ -311,10 +286,9 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
                 val raw = hist.bucketTop(i)
                 if (raw.isPosInfinity) "+Inf" else raw.toString
               }
-              val bucketMapping = Map("__name__" -> nameWithBucket, "le" -> bucketTopString)
+              val bucketMapping = Map(LABEL_NAME -> nameWithBucket, LABEL_LE -> bucketTopString)
               val bucketLabels = partKeyMap ++ bucketMapping
-              val labelString = mergeLabelStrings(baseLabelString, BatchExporter.makeLabelString(bucketMapping))
-              (bucketLabels, labelString, timestamp, hist.bucketValue(i))
+              (bucketLabels, timestamp, hist.bucketValue(i))
             }
           }
         }
@@ -329,11 +303,16 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
       numPartitionsExportPrepped.increment()
     }
 
-    val dropLabelSet = rule.dropLabels.toSet
-    tupleIter.map{ case (pkeyMapWithBucket, labelString, timestamp, value) =>
-      // NOTE: partition without histogram-adjusted labels, since we want the original metric name.
-      val partitionByValues = getPartitionByValues(partKeyMap)
-      ExportRowData(pkeyMapWithBucket, labelString, timestamp, value, partitionByValues, dropLabelSet)
+    tupleIter.map{ case (labels, epoch_timestamp, value) =>
+      val metric = labels(LABEL_NAME)
+      // to compute YYYY, MM, dd, hh
+      // to compute readable timestamp from unix timestamp
+      val timestamp = Instant.ofEpochMilli(epoch_timestamp).atZone(ZoneId.systemDefault()).toLocalDateTime()
+      val year = timestamp.getYear()
+      val month = timestamp.getMonthValue()
+      val day = timestamp.getDayOfMonth()
+      val hour = timestamp.getHour()
+      ExportRowData(metric, labels, epoch_timestamp, timestamp, value, year, month, day, hour)
     }
   }
   // scalastyle:on method.length

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -2,20 +2,21 @@ package filodb.downsampler.chunk
 
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.ForkJoinPool
+
+import scala.collection.parallel.ForkJoinTaskSupport
+
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
+
 import filodb.coordinator.KamonShutdownHook
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore.PagedReadablePartition
 import filodb.downsampler.DownsamplerContext
 import filodb.memory.format.UnsafeUtils
-
-
-import java.util.concurrent.ForkJoinPool
-import scala.collection.parallel.ForkJoinTaskSupport
 
 /**
  * Implement this trait and provide its fully-qualified name as the downsampler config:

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -6,7 +6,8 @@ import java.time.format.DateTimeFormatter
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{SparkSession}
 
 import filodb.coordinator.KamonShutdownHook
 import filodb.core.binaryrecord2.RecordSchema
@@ -74,6 +75,45 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
 
   lazy val exportLatency =
     Kamon.histogram("export-latency", MeasurementUnit.time.milliseconds).withoutTags()
+
+  /**
+   * Exports an RDD for a specific export key.
+   *   (1) Create the export destination address from the key.
+   *   (2) Generate all rows to be exported from the argument RDD.
+   *   (3) Filter for only rows relevant to the export key.
+   *   (4) Write the filtered rows to the destination address.
+   * NOTE: the export schema is required to define a column for each field of an export key.
+   *   E.g. if a key is defined as [foo, bar], then the result rows must contain a column
+   *   for each of "foo" and "bar".
+   */
+  private def exportForKey(rdd: RDD[Seq[PagedReadablePartition]],
+                           exportKey: Seq[String],
+                           batchExporter: BatchExporter,
+                           sparkSession: SparkSession): Unit = {
+    val exportStartMs = System.currentTimeMillis()
+
+    val rowKeyIndices = settings.exportRuleKey.map(colName => {
+      val index = batchExporter.getRowIndex(colName)
+      assert(index.isDefined, "export-key column name does not exist in pending-export row: " + colName)
+      index.get
+    })
+
+    val saveAddress = batchExporter.makeExportAddress(exportKey)
+    val filteredRowRdd = rdd.flatMap(batchExporter.getExportRows(_)).filter{ row =>
+      val rowKey = rowKeyIndices.map(row.get(_).toString)
+      rowKey == exportKey
+    }
+
+    sparkSession.createDataFrame(filteredRowRdd, batchExporter.exportSchema)
+      .write
+      .format(settings.exportFormat)
+      .mode(settings.exportSaveMode)
+      .options(settings.exportOptions)
+      .partitionBy(batchExporter.partitionByNames: _*)
+      .save(saveAddress)
+    val exportEndMs = System.currentTimeMillis()
+    exportLatency.record(exportEndMs - exportStartMs)
+  }
 
   // Gotcha!! Need separate function (Cannot be within body of a class)
   // to create a closure for spark to serialize and move to executors.
@@ -143,40 +183,40 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
           cassFetchSize = settings.cassFetchSize)
         batchIter
       }
-      .flatMap { rawPartsBatch =>
+      .map { rawPartsBatch =>
         Kamon.init()
         KamonShutdownHook.registerShutdownHook()
         // convert each RawPartData to a ReadablePartition
-        val readablePartsBatch = rawPartsBatch.map{ rawPart =>
+        rawPartsBatch.map{ rawPart =>
           val rawSchemaId = RecordSchema.schemaID(rawPart.partitionKey, UnsafeUtils.arayOffset)
           val rawPartSchema = batchDownsampler.schemas(rawSchemaId)
           new PagedReadablePartition(rawPartSchema, shard = 0, partID = 0, partData = rawPart, minResolutionMs = 1)
         }
-        // Downsample the data (this step does not contribute the the RDD).
-        if (settings.chunkDownsamplerIsEnabled) {
-          batchDownsampler.downsampleBatch(readablePartsBatch)
-        }
-        // Generate the data for the RDD.
-        if (settings.exportIsEnabled) {
-          batchExporter.getExportRows(readablePartsBatch)
-        } else Iterator.empty
       }
 
-    // Export the data produced by "getExportRows" above.
-    if (settings.exportIsEnabled) {
-      val exportStartMs = System.currentTimeMillis()
-      // NOTE: toDF(partitionCols: _*) seems buggy
-      spark.createDataFrame(rdd, batchExporter.exportSchema)
-        .write
-        .format(settings.exportFormat)
-        .mode(settings.exportSaveMode)
-        .options(settings.exportOptions)
-        .partitionBy(batchExporter.partitionByNames: _*)
-        .save(settings.exportBucket)
-      val exportEndMs = System.currentTimeMillis()
-      exportLatency.record(exportEndMs - exportStartMs)
+    val rddWithDs = if (settings.chunkDownsamplerIsEnabled) {
+      // Downsample the data.
+      // NOTE: this step returns each row of the RDD as-is; it does NOT return downsampled data.
+      rdd.map{ part =>
+        batchDownsampler.downsampleBatch(_)
+        part
+      }
+    } else rdd
+
+    if (settings.exportIsEnabled && settings.exportKeyToRules.nonEmpty) {
+      val exportKeys = settings.exportKeyToRules.keys.toSeq
+      val exportTasks = {
+        // downsample the data as the first key is exported
+        val headTask = Seq(() => exportForKey(rddWithDs, exportKeys.head, batchExporter, spark))
+        // export all remaining keys without the downsample step
+        val tailTasks = exportKeys.tail.map(key => () => exportForKey(rdd, key, batchExporter, spark))
+        headTask ++ tailTasks
+      }
+      // export/downsample RDDs in parallel
+      exportTasks.par.foreach(_.apply())
     } else {
-      rdd.foreach(_ => {})
+      // Just invoke the DS step.
+      rddWithDs.foreach(_ => {})
     }
 
     DownsamplerContext.dsLogger.info(s"Chunk Downsampling Driver completed successfully for downsample period " +

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -203,12 +203,12 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
       val exportKeyToRules = settings.exportKeyToRules.map(f => (f._1, f._2)).toSeq
       val exportTasks = {
         // downsample the data as the first key is exported
-        val headTask = Seq(() =>
+        val firstExportTaskWithDs = Seq(() =>
           exportForKey(rddWithDs, exportKeyToRules.head._1, exportKeyToRules.head._2, batchExporter, spark))
         // export all remaining keys without the downsample step
-        val tailTasks = exportKeyToRules.tail.map{spec => () =>
+        val remainingExportTasksWithoutDs = exportKeyToRules.tail.map{spec => () =>
           exportForKey(rdd, spec._1, spec._2, batchExporter, spark)}
-        headTask ++ tailTasks
+        firstExportTaskWithDs ++ remainingExportTasksWithoutDs
       }
       // export/downsample RDDs in parallel
       exportTasks.par.foreach(_.apply())

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -198,7 +198,7 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
       // Downsample the data.
       // NOTE: this step returns each row of the RDD as-is; it does NOT return downsampled data.
       rdd.map{ part =>
-        batchDownsampler.downsampleBatch(_)
+        batchDownsampler.downsampleBatch(part)
         part
       }
     } else rdd

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -80,7 +80,7 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")
 
-  @transient lazy val exportBucket = downsamplerConfig.as[String]("data-export.bucket")
+  @transient lazy val exportDestinationFormat = downsamplerConfig.as[String]("data-export.destination-format")
 
   @transient lazy val exportDropLabels = downsamplerConfig.as[Seq[String]]("data-export.drop-labels")
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -78,6 +78,8 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportIsEnabled = downsamplerConfig.getBoolean("data-export.enabled")
 
+  @transient lazy val exportParallelism = downsamplerConfig.getInt("data-export.parallelism")
+
   @transient lazy val sparkSessionFactoryClass = downsamplerConfig.getString("spark-session-factory")
 
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/ExportConstants.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/ExportConstants.scala
@@ -1,0 +1,21 @@
+package filodb.downsampler.chunk
+
+/**
+ * Iceberg Table columns derived from specific key labels from labels map
+ */
+object ExportConstants {
+  // labels keys in time series
+  val LABEL_NAME = "__name__"
+  val LABEL_METRIC = "_metric_"
+  val LABEL_LE = "le"
+  // column names in iceberg table
+  val COL_LABELS = "labels"
+  val COL_METRIC = "metric"
+  val COL_EPOCH_TIMESTAMP = "epoch_timestamp"
+  val COL_TIMESTAMP = "timestamp"
+  val COL_VALUE = "value"
+  val COL_YEAR = "year"
+  val COL_MONTH = "month"
+  val COL_DAY = "day"
+  val COL_HOUR = "hour"
+}

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -52,13 +52,13 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   // Add a path here to enable export during these tests. Useful for debugging export data.
-  val exportToFile = None  // Some("file:///path/to/dir/")
+  val exportToFile = None  // Some("file:///path/to/dir/$0")
   val exportConf =
     s"""{
        |  "filodb": { "downsampler": { "data-export": {
        |    "enabled": ${exportToFile.isDefined},
        |    "key-labels": [],
-       |    "bucket": "${exportToFile.getOrElse("")}",
+       |    "destination-format": "${exportToFile.getOrElse("")}",
        |    "format": "csv",
        |    "options": {
        |      "header": true,
@@ -398,6 +398,48 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
         batchExporter.getRuleIfShouldExport(partKeyMap).isDefined shouldEqual includedConf.contains(conf)
       }
     }
+  }
+
+  it ("should correctly generate export address from labels") {
+    val testConf = ConfigFactory.parseString(
+        """
+          |    filodb.downsampler.data-export {
+          |      enabled = true
+          |      key-labels = ["l1", "l2"]
+          |      destination-format = "address/foo/bar/$0/$1"
+          |    }
+          |""".stripMargin
+      ).withFallback(conf)
+
+    val dsSettings = new DownsamplerSettings(testConf.withFallback(conf))
+    val batchExporter = new BatchExporter(dsSettings, dummyUserTimeStart, dummyUserTimeStop)
+
+    batchExporter.makeExportAddress(Seq("l1a", "l2a")) shouldEqual "address/foo/bar/l1a/l2a"
+  }
+
+  it ("should give correct export-row index of column name") {
+    val testConf = ConfigFactory.parseString(
+      """
+        |    filodb.downsampler.data-export {
+        |      enabled = true
+        |      key-labels = ["l1", "l2"]
+        |      path-spec: [
+        |        year, "<<YYYY>>",
+        |        month, "<<M>>",
+        |        day, "<<d>>",
+        |        _metric_, "{{__name__}}"
+        |      ]
+        |    }
+        |""".stripMargin
+    ).withFallback(conf)
+
+    val dsSettings = new DownsamplerSettings(testConf.withFallback(conf))
+    val batchExporter = new BatchExporter(dsSettings, dummyUserTimeStart, dummyUserTimeStop)
+    batchExporter.getRowIndex("year").get shouldEqual 3
+    batchExporter.getRowIndex("month").get shouldEqual 4
+    batchExporter.getRowIndex("day").get shouldEqual 5
+    batchExporter.getRowIndex("_metric_").get shouldEqual 6
+
   }
 
   it ("should correctly generate export path names") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Adds support for export from the downsampler job to multiple destinations; data is now exported in the Iceberg format.
This PR will remove all support for export of CSV-formatted data. 

## From https://github.com/filodb/FiloDB/pull/1718:
**Current behavior :** 
Spark Downsampler job currently exports data in CSV format.

**New behavior :**
Implements changes in Spark Downsampler Job to export data in Iceberg format and write to Iceberg Table in a specific schema.

Changes includes the following:

- Updates in `BatchExporter.scala` to be able to be to create RDD in new schema and convert RDD to DF to be able to write to Iceberg Table. 
- `filodb-defaults.conf` changes for export includes the following: 

1. Adds catalog, database conf Iceberg properties in filodb-defaults.conf.
2. Under groups, each group should also include, additional dynamic time series label based columns in addition to fixed columns in Iceberg Table.  
3. Each group, should also include table name, table location.
4. Each group, can also specify, if partitioning needs to be done by some additional label based columns, 

- To implement above, additional changes are implemented in `DownsamplerSettings.scala`, `BatchExporter.scala`, `DownsamplerMain.scala`. 
- Implements a new ExportTableConfig Class to translate all data like table path, table names, export rules, per group from config. 
- ExportTableConfig is also used to generate ExportSchema dynamically.
- Adds create table and create database Iceberg methods.
- In Iceberg, data partitioning will be directly handled by the create table sql statement.
- Rename destination-format key in filodb-defaults.conf with destination-path.

Additional changes to remove old CSV based export: 
- Remove old CSV based partition-by-template handling to generate data partition keys.
- Remove CSV specific properties like options, path-spec from filodb-defaults.conf. As mentioned above, for Iceberg, path spec for partitioning is not required. It will be handled by Iceberg create table statement.
- Remove old CSV based make-label-string methods/properties. In Iceberg table, labels will be stored in column labels of type map<string, string>, hence, string labels are not required.