### PR TITLE
fix(export-iceberg): Enclose table location path in quotes in Iceberg export create sql query

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -197,7 +197,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
        | )
        | USING iceberg
        | PARTITIONED BY (year, month, day, $partitionColNames, metric)
-       | LOCATION ${exportTableConfig.tablePath}
+       | LOCATION '${exportTableConfig.tablePath}'
        |""".stripMargin
   }
 


### PR DESCRIPTION
Bug fix: Enclose table location path in quotes in Iceberg export create sql query

Table location in CREATE SQL query needs to be enclosed in quotes.
