### PR TITLE
bug-fix(export-iceberg): change type of labels column in StructType from StringType to MapType

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -117,7 +117,7 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
         // append all fixed columns
         fields.append(
           StructField(COL_METRIC, StringType, false),
-          StructField(COL_LABELS, StringType),
+          StructField(COL_LABELS, MapType(StringType, StringType)),
           StructField(COL_EPOCH_TIMESTAMP, LongType, false),
           StructField(COL_TIMESTAMP, TimestampType, false),
           StructField(COL_VALUE, DoubleType),

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -530,7 +530,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
         StructField("workspace", StringType, false),
         StructField("namespace", StringType, false),
         StructField("metric", StringType, false),
-        StructField("labels", StringType),
+        StructField("labels", MapType(StringType, StringType)),
         StructField("epoch_timestamp", LongType, false),
         StructField("timestamp", TimestampType, false),
         StructField("value", DoubleType),


### PR DESCRIPTION
Fix error: Cannot write 'labels': string is incompatible with map<string,string>.

Solution: Change type of labels column in `StructType` from` StringType` to `MapType`