### PR TITLE
fix(downsample): remove Option wrapper around export values

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -588,6 +588,7 @@ filodb {
 
     data-export {
       enabled = false
+      log-all-row-errors = true
       parallelism = 10
       # Catalog under Unified Catalog
       catalog = ""

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -37,6 +37,8 @@ case class ExportTableConfig(tableName: String,
 case class ExportRowData(metric: String,
                          labels: collection.Map[String, String],
                          epoch_timestamp: Long,
+                         // IMPORTANT: a Spark-compatible value must be used here (something
+                         //   like LocalDateTime will throw exceptions).
                          timestamp: java.sql.Timestamp,
                          value: Double,
                          year: Int,

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -154,6 +154,8 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportDatabase = downsamplerConfig.getString("data-export.database")
 
+  @transient lazy val logAllRowErrors = downsamplerConfig.getBoolean("data-export.log-all-row-errors")
+
   /**
    * Two conditions should satisfy for eligibility:
    * (a) If allow list is nonEmpty partKey should match a filter in the allow list.

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -59,15 +59,14 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
        |    "enabled": ${exportToFile.isDefined},
        |    "catalog": "",
        |    "database": "",
-       |    "key-labels": [],
        |    "format": "iceberg",
+       |    "key-labels": [_ns_],
        |    "groups": [
        |      {
-       |        "key": [],
+       |        "key": [my_ns],
        |        "table": "",
        |        "table-path": "${exportToFile.getOrElse("")}",
        |        "label-column-mapping": [
-       |         "_ws_", "workspace", "NOT NULL",
        |         "_ns_", "namespace", "NOT NULL"
        |        ]
        |        "partition-by-columns": ["namespace"]


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, exported column values might include e.g. `Some(~)` around an actual label value. This PR instead exports only the value itself.

Additionally, the `timestamp` column's value was a `LocalDateTime`; this is incompatible with Spark. The value is now a `java.sql.Timestamp`.