### PR TITLE
fix(query): add missing PlannerParams proto fields

### DIFF
--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -31,22 +31,24 @@ message PerQueryLimits {
 }
 
 message PlannerParams {
-    optional string applicationId          = 1;
-    optional uint32 queryTimeoutMillis     = 2;
-    optional PerQueryLimits enforcedLimits = 3;
-    optional PerQueryLimits warnLimits     = 4;
-    optional string queryOrigin            = 5;
-    optional string queryOriginId          = 6;
-    optional string queryPrincipal         = 7;
-    optional bool timeSplitEnabled         = 8;
-    optional uint64 minTimeRangeForSplitMs = 9;
-    optional uint64 splitSizeMs            = 10;
-    optional bool skipAggregatePresent     = 11;
-    optional bool processFailure           = 12;
-    optional bool processMultiPartition    = 13;
-    optional bool allowPartialResults      = 14;
-    optional bool histogramMap             = 15;
-    optional bool useProtoExecPlans        = 16;
+    optional string applicationId                   = 1;
+    optional uint32 queryTimeoutMillis              = 2;
+    optional PerQueryLimits enforcedLimits          = 3;
+    optional PerQueryLimits warnLimits              = 4;
+    optional string queryOrigin                     = 5;
+    optional string queryOriginId                   = 6;
+    optional string queryPrincipal                  = 7;
+    optional bool timeSplitEnabled                  = 8;
+    optional uint64 minTimeRangeForSplitMs          = 9;
+    optional uint64 splitSizeMs                     = 10;
+    optional bool skipAggregatePresent              = 11;
+    optional bool processFailure                    = 12;
+    optional bool processMultiPartition             = 13;
+    optional bool allowPartialResults               = 14;
+    optional bool histogramMap                      = 15;
+    optional bool useProtoExecPlans                 = 16;
+    optional bool reduceShardKeyRegexFanout         = 17;
+    optional uint32 maxShardKeyRegexFanoutBatchSize = 18;
 }
 
 message Request {

--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -228,6 +228,8 @@ object ProtoConverters {
       builder.setProcessMultiPartition(pp.processMultiPartition)
       builder.setAllowPartialResults(pp.allowPartialResults)
       builder.setUseProtoExecPlans(pp.useProtoExecPlans)
+      builder.setReduceShardKeyRegexFanout(pp.reduceShardKeyRegexFanout)
+      builder.setMaxShardKeyRegexFanoutBatchSize(pp.maxShardKeyRegexFanoutBatchSize)
       builder.build()
     }
   }
@@ -256,7 +258,11 @@ object ProtoConverters {
         processMultiPartition = if (gpp.hasProcessMultiPartition) gpp.getProcessMultiPartition
         else pp.processMultiPartition,
         allowPartialResults = if (gpp.hasAllowPartialResults) gpp.getAllowPartialResults else pp.allowPartialResults,
-        useProtoExecPlans = if (gpp.hasUseProtoExecPlans) gpp.getUseProtoExecPlans else pp.useProtoExecPlans
+        useProtoExecPlans = if (gpp.hasUseProtoExecPlans) gpp.getUseProtoExecPlans else pp.useProtoExecPlans,
+        reduceShardKeyRegexFanout = if (gpp.hasReduceShardKeyRegexFanout) gpp.getReduceShardKeyRegexFanout
+        else pp.reduceShardKeyRegexFanout,
+        maxShardKeyRegexFanoutBatchSize = if (gpp.hasMaxShardKeyRegexFanoutBatchSize)
+          gpp.getMaxShardKeyRegexFanoutBatchSize else pp.maxShardKeyRegexFanoutBatchSize
       )
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This PR adds the following fields missing from the `PlannerParams` proto definition:
- `reduceShardKeyRegexFanout`
- `maxShardKeyRegexFanoutBatchSize`