### PR TITLE
misc(export-iceberg) Iceberg export disable automatic shuffle while appending data to table

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -596,7 +596,10 @@ filodb {
       database = ""
       # Table format
       format = "iceberg"
-
+      # This mode does not request any shuffles or sort to be performed automatically by Spark.
+      options = {
+        "distribution-mode": "none"
+      }
       # Describe the sequence of labels that compose a rule-group's key.
       # A time-series should match at most one key.
       key-labels = ["_ws_"]

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -189,6 +189,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
       .write
       .format(settings.exportFormat)
       .mode(SaveMode.Append)
+      .options(settings.exportOptions)
       .insertInto(s"${settings.exportDatabase}.${exportTableConfig.tableName}")
   }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -150,6 +150,8 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportFormat = downsamplerConfig.getString("data-export.format")
 
+  @transient lazy val exportOptions = downsamplerConfig.as[Map[String, String]]("data-export.options")
+
   @transient lazy val exportCatalog = downsamplerConfig.getString("data-export.catalog")
 
   @transient lazy val exportDatabase = downsamplerConfig.getString("data-export.database")

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -60,6 +60,9 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
        |    "catalog": "",
        |    "database": "",
        |    "format": "iceberg",
+       |    "options": {
+       |        "distribution-mode": "none",
+       |     }
        |    "key-labels": [_ns_],
        |    "groups": [
        |      {


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

- Currently, `"distribution-mode": "hash"` is the new default and requests that Spark uses a hash-based exchange to shuffle the incoming write data before writing. Practically, this means that each row is hashed based on the row's partition value and then placed in a corresponding Spark task based upon that value.

**New behavior :**
Setting `"distribution-mode": "none"`, does not request any shuffles or sort to be performed automatically by Spark.

