### PR TITLE
misc(iceberg-export): sort within partitions before writing the data to table

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -596,9 +596,10 @@ filodb {
       database = ""
       # Table format
       format = "iceberg"
-      # This mode does not request any shuffles or sort to be performed automatically by Spark.
+      # None: does not request any shuffles or sort to be performed automatically by Spark.
+      # Hash: is the new default and requests that Spark uses a hash-based exchange to shuffle the incoming write data before writing.
       options = {
-        "distribution-mode": "none"
+        "distribution-mode": "hash"
       }
       # Describe the sequence of labels that compose a rule-group's key.
       # A time-series should match at most one key.

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -186,13 +186,15 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     spark.sql(sqlCreateDatabase(settings.exportDatabase))
     spark.sql(sqlCreateTable(settings.exportCatalog, settings.exportDatabase, exportTableConfig))
     val partitionColNames = Seq("year", "month", "day") ++ exportTableConfig.partitionByCols ++ Seq("metric")
-    var df = spark.createDataFrame(rdd, exportTableConfig.tableSchema)
     // distribution mode: none, does not request any shuffles or sort to be performed automatically by Spark.
     // Because no work is done automatically by Spark, the data must be manually sorted by partition value.
     // The data must be sorted either within each spark task, or globally within the entire dataset.
+    // distribution mode: hash, mode is the new default and requests that Spark uses a hash-based exchange to
+    // shuffle the incoming write data before writing.
     // A global sort will minimize the number of output files.
-    df = df.sortWithinPartitions(partitionColNames.head, partitionColNames.tail: _*)
-    df.write
+    spark.createDataFrame(rdd, exportTableConfig.tableSchema)
+      .sortWithinPartitions(partitionColNames.head, partitionColNames.tail: _*)
+      .write
       .format(settings.exportFormat)
       .mode(SaveMode.Append)
       .options(settings.exportOptions)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -185,8 +185,14 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
                               rdd: RDD[Row]): Unit = {
     spark.sql(sqlCreateDatabase(settings.exportDatabase))
     spark.sql(sqlCreateTable(settings.exportCatalog, settings.exportDatabase, exportTableConfig))
-    spark.createDataFrame(rdd, exportTableConfig.tableSchema)
-      .write
+    val partitionColNames = exportTableConfig.partitionByCols.mkString(", ")
+    var df = spark.createDataFrame(rdd, exportTableConfig.tableSchema)
+    // distribution mode: none, does not request any shuffles or sort to be performed automatically by Spark.
+    // Because no work is done automatically by Spark, the data must be manually sorted by partition value.
+    // The data must be sorted either within each spark task, or globally within the entire dataset.
+    // A global sort will minimize the number of output files.
+    df = df.sortWithinPartitions("year", "month", "day", ${partitionColNames}, "metric")
+    df.write
       .format(settings.exportFormat)
       .mode(SaveMode.Append)
       .options(settings.exportOptions)


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
- Distribution mode: none, does not request any shuffles or sort to be performed automatically by Spark. Because no work is done automatically by Spark, the data must be manually sorted by partition value. The data must be sorted either within each spark task, or globally within the entire dataset. A global sort will minimize the number of output files.
- Also, with no sort manually done, seeing `spilling sort data on disk` in logs. 

**New behavior :**

Trying to `sortWithinPartitions()`, to return a new Dataset with each partition sorted by the given expressions (partition columns) before writing to the table as mentioned above "the data must be manually sorted by partition value. The data must be sorted either within each spark task, or globally within the entire dataset"