### PR TITLE
fix(sparkJobs): make DS-job metrics serializable

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -76,10 +76,10 @@ object DownsamplerMain extends App {
 
 class Downsampler(settings: DownsamplerSettings) extends Serializable {
 
-  lazy val exportLatency =
+  @transient lazy val exportLatency =
     Kamon.histogram("export-latency", MeasurementUnit.time.milliseconds).withoutTags()
 
-  lazy val numRowsExported = Kamon.counter("num-rows-exported").withoutTags()
+  @transient lazy val numRowsExported = Kamon.counter("num-rows-exported").withoutTags()
 
   /**
    * Exports an RDD for a specific export key.


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, Spark jobs may fail if tasks must be serialized/redistributed; some task metrics are not serializable. This PR adds the `@transient` tag to make them serializable.