### PR TITLE
fix(query) Order of range vectors is not respected when converting from streaming to QueryResult

### DIFF
--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -655,7 +655,7 @@ object ProtoConverters {
         (
           "",
           ResultSchema.empty,
-          List.empty[SerializableRangeVector],
+          Seq.empty[SerializableRangeVector],
           QueryStats(),
           QueryWarnings(),
           false, Option.empty[String], Option.empty[Throwable]
@@ -665,7 +665,7 @@ object ProtoConverters {
           if (response.hasBody) {
               val body = response.getBody
               (id, schema,
-                body.getResultList.asScala.map(_.fromProto).toList::: rvs, stats, warnings, isPartial, partialReason, t)
+                rvs ++ body.getResultList.asScala.map(_.fromProto).toList, stats, warnings, isPartial, partialReason, t)
           } else if (response.hasFooter) {
             val footer = response.getFooter
             (


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

When converting streaming Query response to a single list we assemble the range vectors in following manner

Consider we get the following range vector in batches serialized

``[[1, 2, 3], [4, 5, 6], [7, 8]]``

When assembling the result becomes

``[[7, 8], [4, 5, 6], [1, 2, 3]]``

This was due to the fact we used the cons operator (``::``) to prepend the latest streamed response essentially reversing the order of these batched response. We thus see issues when operations like ``sort_desc`` where the response is strictly ordered but goes out of order in batches.

**New behavior :**

The cons operator (``::``) is removed and ``Seq`` to preserve the ordering. The unit test reproduces this phenomena and validates the fix. 


**BREAKING CHANGES**

None