### PR TITLE
misc(iceberg-export): remove assert and allow None label-values as some labels may not exist in all timeseries

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -610,9 +610,6 @@ filodb {
       # These labels will be dropped from every exported row.
       drop-labels = ["_ws_", "drop-label1"]
 
-      # default label value to export when an expected dynamic column does not exist
-      default-dynamic-column-value = "none"
-
       # Each row's labels are compared against all rule-group keys. If a match is found,
       #   the row's labels are compared *sequentially* against each of the group's rules until
       #   a rule meets both of the following criteria:

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -160,12 +160,12 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     val dataSeq = new mutable.ArrayBuffer[Any](exportTableConfig.tableSchema.fields.length)
     // append all dynamic column values
     exportTableConfig.labelColumnMapping.foreach { pair =>
-      // scalastyle: off null
+      // scalastyle:off null
       val result = exportData.labels.get(pair._1) match {
         case Some(labelValue) => labelValue
         case None => null
       }
-      // scalastyle: on null
+      // scalastyle:on null
       dataSeq.append(result)
     }
     // append all fixed column values

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -160,10 +160,12 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     val dataSeq = new mutable.ArrayBuffer[Any](exportTableConfig.tableSchema.fields.length)
     // append all dynamic column values
     exportTableConfig.labelColumnMapping.foreach { pair =>
+      // scalastyle: off null
       val result = exportData.labels.get(pair._1) match {
         case Some(labelValue) => labelValue
-        case None => None
+        case None => null
       }
+      // scalastyle: on null
       dataSeq.append(result)
     }
     // append all fixed column values

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -162,7 +162,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     exportTableConfig.labelColumnMapping.foreach { pair =>
       val result = exportData.labels.get(pair._1) match {
         case Some(labelValue) => labelValue
-        case None => null
+        case None => None
       }
       dataSeq.append(result)
     }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -160,8 +160,11 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     val dataSeq = new mutable.ArrayBuffer[Any](exportTableConfig.tableSchema.fields.length)
     // append all dynamic column values
     exportTableConfig.labelColumnMapping.foreach { pair =>
-      val labelValue = exportData.labels.get(pair._1)
-      dataSeq.append(labelValue.getOrElse(downsamplerSettings.exportDefaultDynamicColumnValue))
+      val result = exportData.labels.get(pair._1) match {
+        case Some(labelValue) => labelValue
+        case None => None
+      }
+      dataSeq.append(result)
     }
     // append all fixed column values
     dataSeq.append(

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -162,7 +162,7 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     exportTableConfig.labelColumnMapping.foreach { pair =>
       val result = exportData.labels.get(pair._1) match {
         case Some(labelValue) => labelValue
-        case None => None
+        case None => null
       }
       dataSeq.append(result)
     }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -86,9 +86,6 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val exportDropLabels = downsamplerConfig.as[Seq[String]]("data-export.drop-labels")
 
-  @transient lazy val exportDefaultDynamicColumnValue =
-    downsamplerConfig.as[String]("data-export.default-dynamic-column-value")
-
   @transient lazy val exportKeyToRules = {
     val keyRulesPairs = downsamplerConfig.as[Seq[Config]]("data-export.groups").map { group =>
       val key = group.as[Seq[String]]("key")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.25.1"
+version in ThisBuild := "0.9.25.2"


### PR DESCRIPTION
Current behavior :

Some labels as configured in label-column-mapping (to add as more columns in the table) may not exist in all the timeseries. So, the assert statement can fail the export job if the label may not exist in the timeseries and hence, label-value can be None.

Currently, `none` strings are appearing in the Iceberg Table when some column has no values. 

New behavior :

- Remove the assert statement such that, if the label doesn't exist in the timeseries. 
- Remove dynamic setting of `none` string in favor of Iceberg columns can be of only NULL Type or NOT NULL Type.
- When there is no value for a label, write it as `None` from spark to the Iceberg Table column, iceberg will automatically treat it as a `null` value and will show empty values in the table's column. 
- Remove assert and handle key not found in Map gracefully.