### PR TITLE
fix(gateway): Filodb Gateway was publishing untyped schema instead of gauge schema for `gen-gauge-data` flag

### DIFF
--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -309,12 +309,27 @@ case class PrometheusInputRecord(tags: Map[String, String],
     InputRecord.writeUntypedRecord(builder, metric, tags, timestamp, value)
 }
 
-case class PrometheusGaugeRecord(override val tags: Map[String, String],
-                                 override val metric: String,
-                                 override val timestamp: Long,
-                                 override val value: Double)
-  extends PrometheusInputRecord(tags, metric, timestamp, value) {
-  override def addToBuilder(builder: RecordBuilder): Unit =
+case class PrometheusGaugeRecord(tags: Map[String, String],
+                                 metric: String,
+                                 timestamp: Long,
+                                 value: Double) extends InputRecord {
+  import filodb.core.metadata.Schemas.promCounter
+  import PrometheusInputRecord._
+  import collection.JavaConverters._
+
+  val trimmedMetric = RecordBuilder.trimShardColumn(promCounter.options, metricCol, metric)
+  val javaTags = new java.util.ArrayList(tags.toSeq.asJava)
+
+  // Get hashes and sort tags of the keys/values for shard calculation
+  val hashes = RecordBuilder.sortAndComputeHashes(javaTags)
+
+  final def shardKeyHash: Int = RecordBuilder.shardKeyHash(nonMetricShardValues, metricCol, trimmedMetric)
+  final def partitionKeyHash: Int = RecordBuilder.combineHashExcluding(javaTags, hashes, ignorePartKeyTags)
+
+  val nonMetricShardValues: Seq[String] = nonMetricShardCols.flatMap(tags.get)
+  final def getMetric: String = metric
+
+  def addToBuilder(builder: RecordBuilder): Unit =
     InputRecord.writeGaugeRecord(builder, metric, tags, timestamp, value)
 }
 

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -18,7 +18,7 @@ import filodb.core.metadata.{Dataset, Schema, Schemas}
 import filodb.core.metadata.Schemas.gauge
 import filodb.gateway.GatewayServer
 import filodb.gateway.conversion.{DeltaCounterRecord, InputRecord, MetricTagInputRecord, PrometheusCounterRecord,
-                                  PrometheusInputRecord}
+                                  PrometheusGaugeRecord}
 import filodb.memory.format.{vectors => bv, ZeroCopyUTF8String => ZCUTF8}
 
 /**
@@ -149,7 +149,7 @@ object TestTimeseriesProducer extends StrictLogging {
         if (schema == Schemas.deltaCounter)
           DeltaCounterRecord(tags, "heap_usage_delta" + i, timestamp, value)
         else
-          PrometheusInputRecord(tags, "heap_usage" + i, timestamp, value)
+          PrometheusGaugeRecord(tags, "heap_usage" + i, timestamp, value)
       }
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

**Current behavior :** Gateway server is publishing untyped record schemas for when gen-gauge-data is selected. 

**New behavior :** Publishing the gauge schema records when gen-gauge-data is selected.