### PR TITLE
fix(cassandra): Marking cassandra reads as idempotent

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -52,18 +52,21 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
     s"SELECT ingestion_time, start_time, info FROM $tableString " +
     s"WHERE partition = ?")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCql1 = session.prepare(
     s"SELECT partition, ingestion_time, start_time, info FROM $tableString " +
     s"WHERE TOKEN(partition) >= ? AND TOKEN(partition) < ? AND ingestion_time >= ? AND ingestion_time <= ? " +
     s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCql2 = session.prepare(
     s"SELECT partition FROM $tableString " +
     s"WHERE TOKEN(partition) >= ? AND TOKEN(partition) < ? AND ingestion_time >= ? AND ingestion_time <= ? " +
     s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   /**
     * Test method which returns all rows for a partition. Not async-friendly.

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysByUpdateTimeTable.scala
@@ -44,6 +44,7 @@ sealed class PartitionKeysByUpdateTimeTable(val dataset: DatasetRef,
     s"SELECT * FROM $tableString " +
     s"WHERE shard = ? AND epochHour = ? AND split = ? ")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
 
   def writePartKey(shard: Int, updateHour: Long, split: Int,

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysTable.scala
@@ -48,6 +48,7 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
     s"SELECT * FROM $tableString " +
     s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ?")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCqlForStartEndTime = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
@@ -56,28 +57,32 @@ sealed class PartitionKeysTable(val dataset: DatasetRef,
       s"endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCqlForStartTime = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
       s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND startTime >= ? AND startTime <= ? " +
       s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCqlForEndTime = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
       s"WHERE TOKEN(partKey) >= ? AND TOKEN(partKey) < ? AND endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val readCql = session.prepare(
     s"SELECT partKey, startTime, endTime FROM $tableString " +
       s"WHERE partKey = ? ")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val deleteCql = session.prepare(
     s"DELETE FROM $tableString " +
-    s"WHERE partKey = ?"
-  ).setConsistencyLevel(writeConsistencyLevel)
+    s"WHERE partKey = ?")
+    .setConsistencyLevel(writeConsistencyLevel)
 
   def writePartKey(pk: PartKeyRecord, diskTimeToLiveSeconds: Long): Future[Response] = {
     if (diskTimeToLiveSeconds <= 0) {

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysV2Table.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysV2Table.scala
@@ -47,8 +47,9 @@ sealed class PartitionKeysV2Table(val dataset: DatasetRef,
 
   private lazy val scanCql = session.prepare(
     s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
-      s"WHERE shard = ? and bucket = ?"
-  ).setConsistencyLevel(readConsistencyLevel)
+      s"WHERE shard = ? and bucket = ?")
+    .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCqlForStartEndTime = session.prepare(
     s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
@@ -57,23 +58,27 @@ sealed class PartitionKeysV2Table(val dataset: DatasetRef,
       s"endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCqlForStartTime = session.prepare(
     s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
       s"WHERE TOKEN(shard, bucket) >= ? AND TOKEN(shard, bucket) < ? AND startTime >= ? AND startTime <= ? " +
       s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanCqlForEndTime = session.prepare(
     s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
       s"WHERE TOKEN(shard, bucket) >= ? AND TOKEN(shard, bucket) < ? AND endTime >= ? AND endTime <= ? " +
       s"ALLOW FILTERING")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val readCql = session.prepare(
     s"SELECT partKey, startTime, endTime, shard FROM $tableString " +
       s"WHERE shard = ? and bucket = ? and partKey = ?")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val deleteCql = session.prepare(
     s"DELETE FROM $tableString " +

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -55,27 +55,31 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
     s"SELECT info, chunks FROM $tableString " +
     s"WHERE partition = ? AND chunkid IN ?")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val readChunksCql = session.prepare(
     s"SELECT chunkid, info, chunks FROM $tableString " +
     s"WHERE partition = ? AND chunkid IN ?")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val readAllChunksCql = session.prepare(
     s"SELECT chunkid, info, chunks FROM $tableString " +
     s"WHERE partition = ?")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val scanBySplit = session.prepare(
     s"SELECT partition, info, chunks FROM $tableString " +
     s"WHERE TOKEN(partition) >= ? AND TOKEN(partition) < ?")
     .setConsistencyLevel(readConsistencyLevel)
+    .setIdempotent(true)
 
   private lazy val readChunkRangeCql = session.prepare(
     s"SELECT partition, info, chunks FROM $tableString " +
     s"WHERE partition IN ? AND chunkid >= ? AND chunkid < ?")
     .setConsistencyLevel(readConsistencyLevel)
-
+    .setIdempotent(true)
 
   def writeChunks(partition: Array[Byte],
                   chunkInfo: ChunkSetInfo,


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Read queries is not retried by default since it is not marked as idempotent.

**New behavior :** Marking read queries as idempotent for better retry handling.