### PR TITLE
fix(query): Reverting the min max suffix replacement

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -67,7 +67,7 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
 
     /*
      * As part of Histogram query compatibility with Prometheus format histograms, we
-     * remove _sum, _count, _min, _max suffix from metric name here. _bucket & le are already
+     * remove _sum, _count suffix from metric name here. _bucket & le are already
      * removed in SingleClusterPlanner. We remove the suffix only when partition lookup does not return any results
      */
     if (lookupRes.firstSchemaId.isEmpty && querySession.queryConfig.translatePromToFilodbHistogram &&
@@ -76,10 +76,6 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
         removeSuffixAndGenerateLookupResult(filters, metricName.get, "sum", source, querySession)
       else if (metricName.get.endsWith("_count"))
         removeSuffixAndGenerateLookupResult(filters, metricName.get, "count", source, querySession)
-      else if (metricName.get.endsWith("_min"))
-        removeSuffixAndGenerateLookupResult(filters, metricName.get, "min", source, querySession)
-      else if (metricName.get.endsWith("_max"))
-        removeSuffixAndGenerateLookupResult(filters, metricName.get, "max", source, querySession)
       else (lookupRes, newColName)
 
       lookupRes = res._1


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Assertion error happening in cases where
1.  metric name has a suffix `_min`  or `_max` AND 
2. query have lots of label filters which causes some `TimeSeriesShard` returning `no` data AND
3. have another metric without the suffix.

**New behavior :** We are reverting the query change added with the support for min/max histograms to fix the bug in the short term. 