### PR TITLE
fix(query) misleading message when label filter is too long.

### DIFF
--- a/prometheus/src/main/scala/filodb/prometheus/parse/AntlrParser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/AntlrParser.scala
@@ -64,13 +64,14 @@ object AntlrParser extends StrictLogging {
         return expr
       }
     } catch {
-      case e: ParseCancellationException => {}
-      case exc: Throwable => exc.printStackTrace
+      case e: ParseCancellationException => println(e.getMessage)
+      case regexException: RegexLengthLimitException => errors.append(regexException.getMessage)
+      case exc: Throwable => exc.printStackTrace()
     }
 
     var msg = "Cannot parse [" + query + "]"
     if (errors.length() != 0) {
-      msg = msg + " because " + errors.toString
+      msg = msg + "\n because" + errors.toString
     }
     throw new IllegalArgumentException(msg)
   }

--- a/prometheus/src/main/scala/filodb/prometheus/parse/AntlrParser.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/parse/AntlrParser.scala
@@ -64,7 +64,7 @@ object AntlrParser extends StrictLogging {
         return expr
       }
     } catch {
-      case e: ParseCancellationException => println(e.getMessage)
+      case e: ParseCancellationException => {}
       case regexException: RegexLengthLimitException => errors.append(regexException.getMessage)
       case exc: Throwable => exc.printStackTrace()
     }

--- a/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
+++ b/prometheus/src/test/scala/filodb/prometheus/parse/ParserSpec.scala
@@ -81,6 +81,11 @@ class ParserSpec extends AnyFunSpec with Matchers {
     lp.toString shouldEqual queryToLpString._2
   }
 
+  it("Parse error when regex is too long filter query") {
+    val exception = parseError(s"""last_over_time(http_requests_total{label=~"${"toolong" * 1024}.*"}[5m])""")
+    exception.getMessage.contains("Regular expression filters should be <=") shouldEqual true
+  }
+
   it("parse basic scalar expressions") {
     parseSuccessfully("-5")
     parseSuccessfully("+5")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Error code does not indicate that the regex is too long.
`valid_query: Cannot parse […]`


**New behavior :**
Error code will indicate that the regex is too long.
The error will contain meaningful message
`Regular expression filters should be <=`


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: