### PR TITLE
misc(http): Adding a simple http endpoint for liveness checks

### DIFF
--- a/http/src/main/scala/filodb/http/HealthRoute.scala
+++ b/http/src/main/scala/filodb/http/HealthRoute.scala
@@ -48,6 +48,12 @@ class HealthRoute(coordinatorActor: ActorRef, v2ClusterEnabled: Boolean, setting
           }
         }
       }
+    } ~
+    // Adding a simple liveness endpoint to check if the FiloDB instance is reachable or not
+    path ("__liveness") {
+      get {
+        complete(StatusCodes.Success)
+      }
     }
   }
 }

--- a/http/src/main/scala/filodb/http/HealthRoute.scala
+++ b/http/src/main/scala/filodb/http/HealthRoute.scala
@@ -52,7 +52,7 @@ class HealthRoute(coordinatorActor: ActorRef, v2ClusterEnabled: Boolean, setting
     // Adding a simple liveness endpoint to check if the FiloDB instance is reachable or not
     path ("__liveness") {
       get {
-        complete(StatusCodes.Success)
+        complete(httpLiveness("UP"))
       }
     }
   }

--- a/http/src/main/scala/filodb/http/apiv1/HttpSchema.scala
+++ b/http/src/main/scala/filodb/http/apiv1/HttpSchema.scala
@@ -2,6 +2,12 @@ package filodb.http.apiv1
 
 // Prometheus API compatible response envelopes
 sealed trait HttpSuccess
+
+/**
+ * Schema for http liveness checks
+ * @param Status
+ */
+final case class HttpLiveness(Status: String) extends HttpSuccess
 final case class HttpList[A](status: String, data: Seq[A]) extends HttpSuccess
 final case class HttpError(errorType: String,
                            error: String,
@@ -14,6 +20,8 @@ object HttpSchema {
   def httpErr(exception: Exception): HttpError =
     HttpError(exception.getClass.getName, exception.getMessage,
               stackTrace = exception.getStackTrace.toSeq.map(_.toString))
+
+  def httpLiveness(status: String): HttpLiveness = HttpLiveness(status)
 }
 
 final case class HttpShardState(shard: Int, status: String, address: String)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

**New behavior :** Adding a new http endpoint for liveness checks of filodb instance. This api is a low cost endpoint to make sure the instance is reachable over the given network. 