### PR TITLE
feat(cluster): Enhancing liveness check to include cassandra and kafka connectivity at startup

### DIFF
--- a/http/src/main/scala/filodb/http/HealthRoute.scala
+++ b/http/src/main/scala/filodb/http/HealthRoute.scala
@@ -26,8 +26,11 @@ class HealthRoute(coordinatorActor: ActorRef, v2ClusterEnabled: Boolean, setting
                                          ShardStatusAssigned.getClass)
 
   /**
+   * Checks if the shardEvents are in active or recovery phase. If so, returns true else false.
+   * We also make sure that all the responses from the shards assigned to the local node is received before we
+   * continue with the liveness check
    * @param shardEvents
-   * @return
+   * @return true if all local shards are live else false
    */
   def checkIfAllShardsLiveClusterV1(shardEvents: collection.Map[DatasetRef, Seq[ShardEvent]]): Boolean = {
     val allShardEvents = shardEvents.values.flatten.toSeq
@@ -42,8 +45,11 @@ class HealthRoute(coordinatorActor: ActorRef, v2ClusterEnabled: Boolean, setting
   }
 
   /**
+   * Checks if the shard status are in active or recovery phase. If so, returns true else false
+   * We also make sure that all the responses from the shards assigned to the local node is received before we
+   * continue with the liveness check
    * @param shardHealthSeq
-   * @return
+   * @return true if all local shards are live else false
    */
   def checkIfAllShardsLiveClusterV2(shardHealthSeq: Seq[DatasetShardHealth]): Boolean = {
     val allShardStatus = shardHealthSeq.map(x => x.status)

--- a/http/src/test/scala/filodb/http/HealthRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/HealthRouteSpec.scala
@@ -1,0 +1,107 @@
+package filodb.http
+
+import akka.actor.ActorRef
+import filodb.coordinator._
+import filodb.coordinator.v2.DatasetShardHealth
+import filodb.core.{AsyncTest, DatasetRef}
+import org.scalatest.funspec.AnyFunSpec
+class HealthRouteSpec extends AnyFunSpec with AsyncTest {
+
+  val settings = new HttpSettings(PrometheusApiRouteSpec.config, new FilodbSettings())
+  val healthRouteClusterV1 = new HealthRoute(ActorRef.noSender, false, settings)
+  val healthRouteClusterV2 = new HealthRoute(ActorRef.noSender, true, settings)
+  val dsRef = DatasetRef("prometheus")
+
+  it("test checkIfAllShardsLiveClusterV1 all liveness scenarios") {
+
+    var ingestionNotStartedForAll = collection.immutable.Map(dsRef ->
+      Seq(
+        IngestionStarted(dsRef, 0, ActorRef.noSender),
+        IngestionStarted(dsRef, 1, ActorRef.noSender),
+        ShardAssignmentStarted(dsRef, 2, ActorRef.noSender),
+        RecoveryStarted(dsRef, 3, ActorRef.noSender, 0)
+      ))
+
+    ingestionNotStartedForAll match {
+      case m: collection.Map[DatasetRef, Seq[ShardEvent]] => {
+        healthRouteClusterV1.checkIfAllShardsLiveClusterV1(m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
+    ingestionNotStartedForAll = collection.immutable.Map(dsRef ->
+      Seq(
+        IngestionStarted(dsRef, 0, ActorRef.noSender),
+        IngestionStopped(dsRef, 1),
+        ShardAssignmentStarted(dsRef, 2, ActorRef.noSender),
+        RecoveryStarted(dsRef, 3, ActorRef.noSender, 0)
+      ))
+
+    ingestionNotStartedForAll match {
+      case m: collection.Map[DatasetRef, Seq[ShardEvent]] => {
+        healthRouteClusterV1.checkIfAllShardsLiveClusterV1(m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
+    val ingestionStartedForAll = collection.immutable.Map(dsRef ->
+      Seq(
+        IngestionStarted(dsRef, 0, ActorRef.noSender),
+        RecoveryInProgress(dsRef, 1, ActorRef.noSender, 10),
+        IngestionStarted(dsRef, 2, ActorRef.noSender),
+        RecoveryStarted(dsRef, 3, ActorRef.noSender, 0)
+      ))
+
+    ingestionStartedForAll match {
+      case m: collection.Map[DatasetRef, Seq[ShardEvent]] => {
+        healthRouteClusterV1.checkIfAllShardsLiveClusterV1(m) shouldEqual true
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+  }
+
+  it("test checkIfAllShardsLiveClusterV2 all liveness scenarios") {
+
+    var ingestionNotStartedForAll = Seq(
+      DatasetShardHealth(dsRef, 0, ShardStatusAssigned),
+      DatasetShardHealth(dsRef, 1, ShardStatusAssigned),
+      DatasetShardHealth(dsRef, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRef, 3, ShardStatusActive)
+    )
+
+    ingestionNotStartedForAll match {
+      case m: Seq[DatasetShardHealth]@unchecked => {
+        healthRouteClusterV1.checkIfAllShardsLiveClusterV2(m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
+    ingestionNotStartedForAll = Seq(
+      DatasetShardHealth(dsRef, 0, ShardStatusActive),
+      DatasetShardHealth(dsRef, 1, ShardStatusDown),
+      DatasetShardHealth(dsRef, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRef, 3, ShardStatusActive)
+    )
+
+    ingestionNotStartedForAll match {
+      case m: Seq[DatasetShardHealth]@unchecked => {
+        healthRouteClusterV1.checkIfAllShardsLiveClusterV2(m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
+    val ingestionStartedForAll = Seq(
+      DatasetShardHealth(dsRef, 0, ShardStatusActive),
+      DatasetShardHealth(dsRef, 1, ShardStatusActive),
+      DatasetShardHealth(dsRef, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRef, 3, ShardStatusActive)
+    )
+
+    ingestionStartedForAll match {
+      case m: Seq[DatasetShardHealth]@unchecked => {
+        healthRouteClusterV1.checkIfAllShardsLiveClusterV2(m) shouldEqual true
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+  }
+}

--- a/http/src/test/scala/filodb/http/HealthRouteSpec.scala
+++ b/http/src/test/scala/filodb/http/HealthRouteSpec.scala
@@ -1,25 +1,105 @@
 package filodb.http
 
 import akka.actor.ActorRef
+import com.typesafe.config.ConfigFactory
 import filodb.coordinator._
 import filodb.coordinator.v2.DatasetShardHealth
-import filodb.core.{AsyncTest, DatasetRef}
+import filodb.core.{AsyncTest, DatasetRef, TestData}
 import org.scalatest.funspec.AnyFunSpec
 class HealthRouteSpec extends AnyFunSpec with AsyncTest {
 
-  val settings = new HttpSettings(PrometheusApiRouteSpec.config, new FilodbSettings())
-  val healthRouteClusterV1 = new HealthRoute(ActorRef.noSender, false, settings)
-  val healthRouteClusterV2 = new HealthRoute(ActorRef.noSender, true, settings)
-  val dsRef = DatasetRef("prometheus")
+  val singleDatasetSourceConfigString =
+    s"""
+    filodb {
+      memstore.groups-per-shard = 4
+      min-num-nodes-in-cluster = 2
+      inline-dataset-configs = [
+        {
+          dataset = "prometheus"
+          schema = "gauge"
+          num-shards = 8
+          min-num-nodes = 2
+          sourcefactory = "${classOf[NoOpStreamFactory].getName}"
+          sourceconfig {
+            shutdown-ingest-after-stopped = false
+            ${TestData.sourceConfStr}
+          }
+        }
+      ]
+    }
+  """
+
+  val multipleDatasetSourceConfigString =
+    s"""
+    filodb {
+      memstore.groups-per-shard = 4
+      min-num-nodes-in-cluster = 2
+      inline-dataset-configs = [
+        {
+          dataset = "prometheus_rules_1m"
+          schema = "gauge"
+          num-shards = 8
+          min-num-nodes = 2
+          sourcefactory = "${classOf[NoOpStreamFactory].getName}"
+          sourceconfig {
+            shutdown-ingest-after-stopped = false
+            ${TestData.sourceConfStr}
+          }
+        },
+        {
+          dataset = "prometheus_rules_longterm"
+          schema = "gauge"
+          num-shards = 8
+          min-num-nodes = 2
+          sourcefactory = "${classOf[NoOpStreamFactory].getName}"
+          sourceconfig {
+            shutdown-ingest-after-stopped = false
+            ${TestData.sourceConfStr}
+          }
+        }
+      ]
+    }
+  """
+
+  val singleDatasetConfig = ConfigFactory.parseString(singleDatasetSourceConfigString)
+    .withFallback(ConfigFactory.parseResources("application_test.conf"))
+    .withFallback(ConfigFactory.load("filodb-defaults.conf"))
+
+  val multipleDatasetConfig = ConfigFactory.parseString(multipleDatasetSourceConfigString)
+    .withFallback(ConfigFactory.parseResources("application_test.conf"))
+    .withFallback(ConfigFactory.load("filodb-defaults.conf"))
+
+  val singleDatasetSettings = new HttpSettings(PrometheusApiRouteSpec.config, new FilodbSettings(singleDatasetConfig))
+  val multipleDatasetSettings = new HttpSettings(PrometheusApiRouteSpec.config,
+    new FilodbSettings(multipleDatasetConfig))
+  val healthRouteClusterV1 = new HealthRoute(ActorRef.noSender, false, singleDatasetSettings)
+  val healthRouteClusterV2 = new HealthRoute(ActorRef.noSender, true, singleDatasetSettings)
+  val healthRouteClusterV2Multiple = new HealthRoute(ActorRef.noSender, true, multipleDatasetSettings)
+  val dsRefPrometheus = DatasetRef("prometheus")
+  val dsRefPrometheusRules_1m = DatasetRef("prometheus_rules_1m")
+  val dsRefPrometheusRules_longterm = DatasetRef("prometheus_rules_longterm")
 
   it("test checkIfAllShardsLiveClusterV1 all liveness scenarios") {
 
-    var ingestionNotStartedForAll = collection.immutable.Map(dsRef ->
+    val testNotEnoughResponses = collection.immutable.Map(dsRefPrometheus ->
       Seq(
-        IngestionStarted(dsRef, 0, ActorRef.noSender),
-        IngestionStarted(dsRef, 1, ActorRef.noSender),
-        ShardAssignmentStarted(dsRef, 2, ActorRef.noSender),
-        RecoveryStarted(dsRef, 3, ActorRef.noSender, 0)
+        IngestionStarted(dsRefPrometheus, 0, ActorRef.noSender),
+        IngestionStarted(dsRefPrometheus, 1, ActorRef.noSender)
+      ))
+
+    testNotEnoughResponses match {
+      case m: collection.Map[DatasetRef, Seq[ShardEvent]] => {
+        healthRouteClusterV1.checkIfAllShardsLiveClusterV1 (m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
+    var ingestionNotStartedForAll = collection.immutable.Map(dsRefPrometheus ->
+      Seq(
+        IngestionStarted(dsRefPrometheus, 0, ActorRef.noSender),
+        IngestionStarted(dsRefPrometheus, 1, ActorRef.noSender),
+        ShardAssignmentStarted(dsRefPrometheus, 2, ActorRef.noSender),
+        RecoveryStarted(dsRefPrometheus, 3, ActorRef.noSender, 0)
       ))
 
     ingestionNotStartedForAll match {
@@ -29,12 +109,12 @@ class HealthRouteSpec extends AnyFunSpec with AsyncTest {
       case _ => throw new IllegalArgumentException("Should not reach here")
     }
 
-    ingestionNotStartedForAll = collection.immutable.Map(dsRef ->
+    ingestionNotStartedForAll = collection.immutable.Map(dsRefPrometheus ->
       Seq(
-        IngestionStarted(dsRef, 0, ActorRef.noSender),
-        IngestionStopped(dsRef, 1),
-        ShardAssignmentStarted(dsRef, 2, ActorRef.noSender),
-        RecoveryStarted(dsRef, 3, ActorRef.noSender, 0)
+        IngestionStarted(dsRefPrometheus, 0, ActorRef.noSender),
+        IngestionStopped(dsRefPrometheus, 1),
+        ShardAssignmentStarted(dsRefPrometheus, 2, ActorRef.noSender),
+        RecoveryStarted(dsRefPrometheus, 3, ActorRef.noSender, 0)
       ))
 
     ingestionNotStartedForAll match {
@@ -44,12 +124,12 @@ class HealthRouteSpec extends AnyFunSpec with AsyncTest {
       case _ => throw new IllegalArgumentException("Should not reach here")
     }
 
-    val ingestionStartedForAll = collection.immutable.Map(dsRef ->
+    val ingestionStartedForAll = collection.immutable.Map(dsRefPrometheus ->
       Seq(
-        IngestionStarted(dsRef, 0, ActorRef.noSender),
-        RecoveryInProgress(dsRef, 1, ActorRef.noSender, 10),
-        IngestionStarted(dsRef, 2, ActorRef.noSender),
-        RecoveryStarted(dsRef, 3, ActorRef.noSender, 0)
+        IngestionStarted(dsRefPrometheus, 0, ActorRef.noSender),
+        RecoveryInProgress(dsRefPrometheus, 1, ActorRef.noSender, 10),
+        IngestionStarted(dsRefPrometheus, 2, ActorRef.noSender),
+        RecoveryStarted(dsRefPrometheus, 3, ActorRef.noSender, 0)
       ))
 
     ingestionStartedForAll match {
@@ -62,44 +142,109 @@ class HealthRouteSpec extends AnyFunSpec with AsyncTest {
 
   it("test checkIfAllShardsLiveClusterV2 all liveness scenarios") {
 
+    val testNotEnoughResponses = Seq(
+      DatasetShardHealth(dsRefPrometheus, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRefPrometheus, 3, ShardStatusActive)
+    )
+
+    testNotEnoughResponses match {
+      case m: Seq[DatasetShardHealth]@unchecked => {
+        healthRouteClusterV2.checkIfAllShardsLiveClusterV2(m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
     var ingestionNotStartedForAll = Seq(
-      DatasetShardHealth(dsRef, 0, ShardStatusAssigned),
-      DatasetShardHealth(dsRef, 1, ShardStatusAssigned),
-      DatasetShardHealth(dsRef, 2, ShardStatusRecovery(10)),
-      DatasetShardHealth(dsRef, 3, ShardStatusActive)
+      DatasetShardHealth(dsRefPrometheus, 0, ShardStatusAssigned),
+      DatasetShardHealth(dsRefPrometheus, 1, ShardStatusAssigned),
+      DatasetShardHealth(dsRefPrometheus, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRefPrometheus, 3, ShardStatusActive)
     )
 
     ingestionNotStartedForAll match {
       case m: Seq[DatasetShardHealth]@unchecked => {
-        healthRouteClusterV1.checkIfAllShardsLiveClusterV2(m) shouldEqual false
+        healthRouteClusterV2.checkIfAllShardsLiveClusterV2(m) shouldEqual false
       }
       case _ => throw new IllegalArgumentException("Should not reach here")
     }
 
     ingestionNotStartedForAll = Seq(
-      DatasetShardHealth(dsRef, 0, ShardStatusActive),
-      DatasetShardHealth(dsRef, 1, ShardStatusDown),
-      DatasetShardHealth(dsRef, 2, ShardStatusRecovery(10)),
-      DatasetShardHealth(dsRef, 3, ShardStatusActive)
+      DatasetShardHealth(dsRefPrometheus, 0, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheus, 1, ShardStatusDown),
+      DatasetShardHealth(dsRefPrometheus, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRefPrometheus, 3, ShardStatusActive)
     )
 
     ingestionNotStartedForAll match {
       case m: Seq[DatasetShardHealth]@unchecked => {
-        healthRouteClusterV1.checkIfAllShardsLiveClusterV2(m) shouldEqual false
+        healthRouteClusterV2.checkIfAllShardsLiveClusterV2(m) shouldEqual false
       }
       case _ => throw new IllegalArgumentException("Should not reach here")
     }
 
     val ingestionStartedForAll = Seq(
-      DatasetShardHealth(dsRef, 0, ShardStatusActive),
-      DatasetShardHealth(dsRef, 1, ShardStatusActive),
-      DatasetShardHealth(dsRef, 2, ShardStatusRecovery(10)),
-      DatasetShardHealth(dsRef, 3, ShardStatusActive)
+      DatasetShardHealth(dsRefPrometheus, 0, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheus, 1, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheus, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRefPrometheus, 3, ShardStatusActive)
     )
 
     ingestionStartedForAll match {
       case m: Seq[DatasetShardHealth]@unchecked => {
-        healthRouteClusterV1.checkIfAllShardsLiveClusterV2(m) shouldEqual true
+        healthRouteClusterV2.checkIfAllShardsLiveClusterV2(m) shouldEqual true
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+  }
+
+  it("test checkIfAllShardsLiveClusterV2 for all liveness scenarios with multiple datasets") {
+
+    val testNotEnoughResponses = Seq(
+      DatasetShardHealth(dsRefPrometheusRules_1m, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 3, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 4, ShardStatusRecovery(30)),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 2, ShardStatusActive)
+    )
+
+    testNotEnoughResponses match {
+      case m: Seq[DatasetShardHealth]@unchecked => {
+        healthRouteClusterV2Multiple.checkIfAllShardsLiveClusterV2(m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
+    val ingestionNotStartedForAll = Seq(
+      DatasetShardHealth(dsRefPrometheusRules_1m, 0, ShardStatusAssigned),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 1, ShardStatusAssigned),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 3, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 0, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 2, ShardStatusAssigned),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 1, ShardStatusRecovery(20)),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 3, ShardStatusActive)
+    )
+
+    ingestionNotStartedForAll match {
+      case m: Seq[DatasetShardHealth]@unchecked => {
+        healthRouteClusterV2Multiple.checkIfAllShardsLiveClusterV2(m) shouldEqual false
+      }
+      case _ => throw new IllegalArgumentException("Should not reach here")
+    }
+
+    val ingestionStartedForAll = Seq(
+      DatasetShardHealth(dsRefPrometheusRules_1m, 0, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 1, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 2, ShardStatusRecovery(10)),
+      DatasetShardHealth(dsRefPrometheusRules_1m, 3, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 0, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 2, ShardStatusActive),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 1, ShardStatusRecovery(20)),
+      DatasetShardHealth(dsRefPrometheusRules_longterm, 3, ShardStatusActive)
+    )
+
+    ingestionStartedForAll match {
+      case m: Seq[DatasetShardHealth]@unchecked => {
+        healthRouteClusterV2Multiple.checkIfAllShardsLiveClusterV2(m) shouldEqual true
       }
       case _ => throw new IllegalArgumentException("Should not reach here")
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** The liveness check just returned `UP` response without any consideration.

**New behavior :** Liveness endpoint checks for connectivity to kafka and cassandra i.e. the shards to be in recovery or active state.