### PR TITLE
fix(cardinality): converting cardinality storage and query types from int to long to avoid integer overflow

### DIFF
--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -197,7 +197,7 @@ object CliMain extends StrictLogging {
             printf("%40s %20s %20s %15s %15s\n", "Child", "TotalTimeSeries", "ActiveTimeSeries", "Children", "Children")
             printf("%40s %20s %20s %15s %15s\n", "Name", "Count", "Count", "Count", "Quota")
             println("==============================================================================================================================")
-            crs._2.sortBy(c => if (addInactive) c.value.tsCount else c.value.activeTsCount)(Ordering.Int.reverse)
+            crs._2.sortBy(c => if (addInactive) c.value.tsCount else c.value.activeTsCount)(Ordering.Long.reverse)
               .foreach { cr =>
                 printf("%40s %20d %20d %15d %15d\n", cr.prefix, cr.value.tsCount,
                        cr.value.activeTsCount, cr.value.childrenCount, cr.value.childrenQuota)

--- a/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryActor.scala
@@ -266,8 +266,8 @@ final class QueryActor(memStore: TimeSeriesStore,
   private def execTopkCardinalityQuery(q: GetTopkCardinality, sender: ActorRef): Unit = {
     implicit val ord = new Ordering[CardinalityRecord]() {
       override def compare(x: CardinalityRecord, y: CardinalityRecord): Int = {
-        if (q.addInactive) x.value.tsCount - y.value.tsCount
-        else x.value.activeTsCount - y.value.activeTsCount
+        if (q.addInactive) if ((x.value.tsCount - y.value.tsCount) >= 0) 1 else -1
+        else if ((x.value.activeTsCount - y.value.activeTsCount) >= 0) 1 else -1
       }
     }.reverse
     try {

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -38,7 +38,7 @@ case class QuotaReachedException(cannotSetShardKey: Seq[String], prefix: Seq[Str
 class CardinalityTracker(ref: DatasetRef,
                          shard: Int,
                          shardKeyLen: Int,
-                         defaultChildrenQuota: Seq[Int],
+                         defaultChildrenQuota: Seq[Long],
                          val store: CardinalityStore,
                          quotaExceededProtocol: QuotaExceededProtocol = NoActionQuotaProtocol,
                          flushCount: Option[Int] = None) extends StrictLogging {

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -242,7 +242,7 @@ class CardinalityTracker(ref: DatasetRef,
    * @param childrenQuota maximum number of time series for this prefix
    * @return current CardinalityRecord for the prefix
    */
-  def setQuota(shardKeyPrefix: Seq[String], childrenQuota: Int): CardinalityRecord = {
+  def setQuota(shardKeyPrefix: Seq[String], childrenQuota: Long): CardinalityRecord = {
     require(shardKeyPrefix.length <= shardKeyLen, s"Too many shard keys in $shardKeyPrefix - max $shardKeyLen")
     require(childrenQuota > 0 && childrenQuota < 2000000, "Children quota invalid. Provide [1, 2000000)")
 

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.StrictLogging
 
 import filodb.core.DatasetRef
 
-case class QuotaReachedException(cannotSetShardKey: Seq[String], prefix: Seq[String], quota: Int)
+case class QuotaReachedException(cannotSetShardKey: Seq[String], prefix: Seq[String], quota: Long)
   extends RuntimeException
 
 /**
@@ -99,7 +99,7 @@ class CardinalityTracker(ref: DatasetRef,
     (0 to shardKey.length).foreach { i =>
       val prefix = shardKey.take(i)
       val old = store.getOrZero(prefix,
-        CardinalityRecord(shard, prefix, CardinalityValue(0, 0, 0, defaultChildrenQuota(i))))
+        CardinalityRecord(shard, prefix, CardinalityValue(0L, 0L, 0L, defaultChildrenQuota(i))))
 
       val neu = old.copy(value = old.value.copy(tsCount = old.value.tsCount + totalDelta,
         activeTsCount = old.value.activeTsCount + activeDelta,

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaExceededProtocol.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaExceededProtocol.scala
@@ -22,12 +22,12 @@ trait QuotaExceededProtocol {
    * @param shardKeyPrefix the shardKeyPrefix for which quota was breached
    * @param quota the actual quota number that was breached
    */
-  def quotaExceeded(ref: DatasetRef, shardNum: Int, shardKeyPrefix: Seq[String], quota: Int): Unit
+  def quotaExceeded(ref: DatasetRef, shardNum: Int, shardKeyPrefix: Seq[String], quota: Long): Unit
 }
 
 /**
  * Default implementation which takes no action.
  */
 object NoActionQuotaProtocol extends QuotaExceededProtocol {
-  def quotaExceeded(ref: DatasetRef, shardNum: Int, shardKeyPrefix: Seq[String], quota: Int): Unit = {}
+  def quotaExceeded(ref: DatasetRef, shardNum: Int, shardKeyPrefix: Seq[String], quota: Long): Unit = {}
 }

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaSource.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/QuotaSource.scala
@@ -6,7 +6,7 @@ import net.ceedubs.ficus.readers.ValueReader
 
 import filodb.core.DatasetRef
 
-case class QuotaRecord(shardKeyPrefix: Seq[String], quota: Int)
+case class QuotaRecord(shardKeyPrefix: Seq[String], quota: Long)
 
 /**
  * Source of quotas for shard key prefixes.
@@ -27,7 +27,7 @@ trait QuotaSource {
    * Hence number of items in the returned sequence should be
    * shardKeyLen + 1
    */
-  def getDefaults(dataset: DatasetRef): Seq[Int]
+  def getDefaults(dataset: DatasetRef): Seq[Long]
 }
 
 /**
@@ -36,7 +36,7 @@ trait QuotaSource {
 class ConfigQuotaSource(filodbConfig: Config, shardKeyLen: Int) extends QuotaSource {
   implicit val quotaReader: ValueReader[QuotaRecord] = ValueReader.relative { quotaConfig =>
     QuotaRecord(quotaConfig.as[Seq[String]]("shardKeyPrefix"),
-                quotaConfig.as[Int]("quota"))
+                quotaConfig.as[Long]("quota"))
   }
 
   def getQuotas(dataset: DatasetRef): Iterator[QuotaRecord] = {
@@ -47,13 +47,13 @@ class ConfigQuotaSource(filodbConfig: Config, shardKeyLen: Int) extends QuotaSou
     }
   }
 
-  def getDefaults(dataset: DatasetRef): Seq[Int] = {
+  def getDefaults(dataset: DatasetRef): Seq[Long] = {
     if (filodbConfig.hasPath(s"quotas.$dataset.custom")) {
-      val defaults = filodbConfig.as[Seq[Int]](s"quotas.$dataset.defaults")
+      val defaults = filodbConfig.as[Seq[Long]](s"quotas.$dataset.defaults")
       require(defaults.length == shardKeyLen + 1, s"Quota defaults $defaults was not of length ${shardKeyLen + 1}")
       defaults
     } else {
-      val default = filodbConfig.as[Int]("quotas.default")
+      val default = filodbConfig.as[Long]("quotas.default")
       Seq.fill(shardKeyLen + 1)(default)
     }
   }

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
@@ -27,8 +27,8 @@ import filodb.memory.format.UnsafeUtils
  *   (1) only the least-significant prefix name is stored.
  *   (2) no shard ID is store
  */
-case class CardinalityValue(tsCount: Int, activeTsCount: Int,
-                            childrenCount: Int, childrenQuota: Int)
+case class CardinalityValue(tsCount: Long, activeTsCount: Long,
+                            childrenCount: Long, childrenQuota: Long)
 
 case object CardinalityValue {
   def toCardinalityRecord(card: CardinalityValue,
@@ -40,10 +40,10 @@ case object CardinalityValue {
 
 class CardinalityNodeSerializer extends Serializer[CardinalityValue] {
   def write(kryo: Kryo, output: Output, card: CardinalityValue): Unit = {
-    output.writeInt(card.tsCount, true)
-    output.writeInt(card.activeTsCount, true)
-    output.writeInt(card.childrenCount, true)
-    output.writeInt(card.childrenQuota, true)
+    output.writeLong(card.tsCount, true)
+    output.writeLong(card.activeTsCount, true)
+    output.writeLong(card.childrenCount, true)
+    output.writeLong(card.childrenQuota, true)
   }
 
   def read(kryo: Kryo, input: Input, t: Class[CardinalityValue]): CardinalityValue = {
@@ -291,7 +291,7 @@ class RocksDbCardinalityStore(ref: DatasetRef, shard: Int) extends CardinalitySt
       // result reached MAX_RESULT_SIZE, but still more cardinalities
       if (it.isValid() && !complete) {
         // sum the remaining counts into these values
-        var tsCount, activeTsCount, childrenCount, childrenQuota = 0
+        var tsCount, activeTsCount, childrenCount, childrenQuota = 0L
         breakable {
           do {
             // note: the iterator is valid here on the first iteration

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
@@ -47,8 +47,8 @@ class CardinalityNodeSerializer extends Serializer[CardinalityValue] {
   }
 
   def read(kryo: Kryo, input: Input, t: Class[CardinalityValue]): CardinalityValue = {
-    CardinalityValue(input.readInt(true), input.readInt(true),
-                    input.readInt(true), input.readInt(true))
+    CardinalityValue(input.readLong(true), input.readLong(true),
+                    input.readLong(true), input.readLong(true))
   }
 }
 

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -68,8 +68,8 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
     class MyQEP extends QuotaExceededProtocol {
       var breachedPrefix: Seq[String] = Nil
-      var breachedQuota = -1
-      def quotaExceeded(ref: DatasetRef, shard: Int, shardKeyPrefix: Seq[String], quota: Int): Unit = {
+      var breachedQuota = -1L
+      def quotaExceeded(ref: DatasetRef, shard: Int, shardKeyPrefix: Seq[String], quota: Long): Unit = {
         breachedPrefix = shardKeyPrefix
         breachedQuota = quota
       }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreSpec.scala
@@ -2,7 +2,6 @@ package filodb.core.memstore.ratelimit
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
 import filodb.core.memstore.ratelimit.CardinalityStore._
 import filodb.core.MetricsTestData
 
@@ -24,6 +23,30 @@ class RocksDbCardinalityStoreSpec extends AnyFunSpec with Matchers {
       res.size shouldEqual MAX_RESULT_SIZE + 1  // one extra for the overflow CardinalityRecord
       res.contains(CardinalityRecord(shard, OVERFLOW_PREFIX,
         CardinalityValue(numOverflow, numOverflow, numOverflow, numOverflow))) shouldEqual true
+    }
+  }
+
+  it("test rocksdb store can correctly store and retrieve a long value") {
+    val dset = MetricsTestData.timeseriesDatasetMultipleShardKeys
+    val shard = 0
+    val db = new RocksDbCardinalityStore(dset.ref, shard)
+
+    (0 until 1000).foreach{ i =>
+      val prefix = Seq("ws", "ns", s"metric-$i")
+      // storing 3 billion ( this value is greater than ~2.15 billion max limit of int32)
+      val cardnalityVal = CardinalityValue(3000000000L+i, 3000000000L+i, 3000000000L+i, 3000000000L+i)
+      db.store(CardinalityRecord(shard, prefix, cardnalityVal))
+    }
+
+    Seq(Nil, Seq("ws"), Seq("ws", "ns")).foreach{ prefix =>
+      val res = db.scanChildren(prefix, 3)
+      res.size shouldEqual 1000
+      res.foreach{ record =>
+        record.value.tsCount should be >= (3000000000L)
+        record.value.activeTsCount should be >= (3000000000L)
+        record.value.childrenCount should be >= (3000000000L)
+        record.value.childrenQuota should be >= (3000000000L)
+      }
     }
   }
 }

--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -60,7 +60,7 @@ object PromCirceSupport {
           // This is for TsCardinalities response
           for {
             group <- c.get[Map[String, String]]("group")
-            card <- c.get[Map[String, Int]]("cardinality")
+            card <- c.get[Map[String, Long]]("cardinality")
             dataset <- c.get[String]("dataset")
             _type <- c.get[String]("_type")
           } yield TsCardinalitiesSamplV2(group, card, dataset, _type)

--- a/query/src/main/scala/filodb/query/PromQueryResponse.scala
+++ b/query/src/main/scala/filodb/query/PromQueryResponse.scala
@@ -76,6 +76,6 @@ final case class LabelCardinalitySampl(metric: Map[String, String],
  *              prometheus_rules_longterm, prometheus_rules_1m
  */
 final case class TsCardinalitiesSamplV2(group: Map[String, String],
-                                        cardinality: Map[String, Int],
+                                        cardinality: Map[String, Long],
                                         dataset: String,
                                         _type: String) extends MetadataSampl

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -479,9 +479,9 @@ final case object TsCardExec {
    * to represent the cardinality count of downsample clusters
    */
   val RESULT_SCHEMA = ResultSchema(Seq(ColumnInfo("group", ColumnType.StringColumn),
-                                       ColumnInfo("active", ColumnType.IntColumn),
-                                       ColumnInfo("shortTerm", ColumnType.IntColumn),
-                                       ColumnInfo("longTerm", ColumnType.IntColumn)), 1)
+                                       ColumnInfo("active", ColumnType.LongColumn),
+                                       ColumnInfo("shortTerm", ColumnType.LongColumn),
+                                       ColumnInfo("longTerm", ColumnType.LongColumn)), 1)
 
   /**
    * @param prefix ShardKeyPrefix from the Cardinality Record
@@ -497,7 +497,7 @@ final case object TsCardExec {
    * @param shortTerm This is the 7 day running Cardinality Count
    * @param longTerm upto 6 month running Cardinality Count
    */
-  case class CardCounts(active: Int, shortTerm: Int, longTerm: Int = 0) {
+  case class CardCounts(active: Long, shortTerm: Long, longTerm: Long = 0) {
     if (shortTerm < active) {
       qLogger.warn(s"CardCounts created with total < active; shortTerm: $shortTerm, active: $active")
     }
@@ -511,13 +511,13 @@ final case object TsCardExec {
   case class CardRowReader(group: ZeroCopyUTF8String, counts: CardCounts) extends RowReader {
     override def notNull(columnNo: Int): Boolean = ???
     override def getBoolean(columnNo: Int): Boolean = ???
-    override def getInt(columnNo: Int): Int = columnNo match {
+    override def getInt(columnNo: Int): Int = ???
+    override def getLong(columnNo: Int): Long = columnNo match {
       case 1 => counts.active
       case 2 => counts.shortTerm
       case 3 => counts.longTerm
       case _ => throw new IllegalArgumentException(s"illegal getInt columnNo: $columnNo")
     }
-    override def getLong(columnNo: Int): Long = ???
     override def getDouble(columnNo: Int): Double = ???
     override def getFloat(columnNo: Int): Float = ???
     override def getString(columnNo: Int): String = {
@@ -539,7 +539,7 @@ final case object TsCardExec {
   object RowData {
     def fromRowReader(rr: RowReader): RowData = {
       val group = rr.getAny(0).asInstanceOf[ZeroCopyUTF8String]
-      val counts = CardCounts(rr.getInt(1), rr.getInt(2), rr.getInt(3))
+      val counts = CardCounts(rr.getLong(1), rr.getLong(2), rr.getLong(3))
       RowData(group, counts)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** `CardinalityValue` and `CardinalityRowReader` store and retrieve the cardinality data using `Int` type. This is causing overflow issues for various `_ns_` and `_ws_` cardinality queries.   


**New behavior :** Changing the above types from `Int` to `Long` 

**BREAKING CHANGES**

Breaking changes may include:
- RESULT_SCHEMA changes for `CardinalityResult`
