### PR TITLE
fix(QueryStats): return namespace regex value as given instead of using "multiple" string

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1913,6 +1913,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     shardKeyColumns.map { col =>
       filters.collectFirst {
         case ColumnFilter(c, Filter.Equals(filtVal: String)) if c == col => filtVal
+        case ColumnFilter(c, Filter.EqualsRegex(filtVal: String)) if c == col => filtVal
       }.getOrElse("multiple")
     }.toList
   }


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** We send a string "multiple" when passing a regex for a shard key label/column filter. This doesn't give us visibility of of the actual value passed in the query stats.

**New behavior :** Added a match case which allows to return the column-filter regex values.