### PR TITLE
Cherry Pick: fix(QueryStats): return namespace regex value as given instead of using "multiple" string

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1913,6 +1913,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     shardKeyColumns.map { col =>
       filters.collectFirst {
         case ColumnFilter(c, Filter.Equals(filtVal: String)) if c == col => filtVal
+        case ColumnFilter(c, Filter.EqualsRegex(filtVal: String)) if c == col => filtVal
       }.getOrElse("multiple")
     }.toList
   }


### PR DESCRIPTION
Cherry picking the query stats field to integration branch.