### PR TITLE
fix(exec): fix RemoteExec transformer deadlock

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
@@ -56,7 +56,8 @@ trait GrpcRemoteExec extends RemoteExec {
               .timed
               .map { case (elapsed, qresp) =>
                   val timeRemaining = Duration(requestTimeoutMs, TimeUnit.MILLISECONDS) - elapsed
-                  applyTransformers(qresp, querySession, source, timeRemaining)
+                  applyTransformers(qresp, querySession, source,
+                    timeRemaining)(monix.execution.Scheduler.Implicits.global)
               }
         }
     }

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -82,7 +82,8 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
         .timed
         .map{ case (elapsed, qresp) =>
           val timeRemaining = Duration(requestTimeoutMs, TimeUnit.MILLISECONDS) - elapsed
-          applyTransformers(qresp, querySession, source, timeRemaining)
+          applyTransformers(qresp, querySession, source,
+            timeRemaining)(monix.execution.Scheduler.Implicits.global)
         }
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, `RemoteExec` plans sometimes hang during execution when `RangeVectorTransformer`s are applied. This PR instead schedules transformer application on the `global` `Scheduler` to prevent possible deadlock.