### PR TITLE
fix(exec): cherry-pick RemoteExec deadlock fix

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
@@ -56,7 +56,8 @@ trait GrpcRemoteExec extends RemoteExec {
               .timed
               .map { case (elapsed, qresp) =>
                   val timeRemaining = Duration(requestTimeoutMs, TimeUnit.MILLISECONDS) - elapsed
-                  applyTransformers(qresp, querySession, source, timeRemaining)
+                  applyTransformers(qresp, querySession, source,
+                    timeRemaining)(monix.execution.Scheduler.Implicits.global)
               }
         }
     }

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -82,7 +82,8 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
         .timed
         .map{ case (elapsed, qresp) =>
           val timeRemaining = Duration(requestTimeoutMs, TimeUnit.MILLISECONDS) - elapsed
-          applyTransformers(qresp, querySession, source, timeRemaining)
+          applyTransformers(qresp, querySession, source,
+            timeRemaining)(monix.execution.Scheduler.Implicits.global)
         }
     }
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.25.5"
+version in ThisBuild := "0.9.25.6"


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: