### PR TITLE
revert(exec): revert RemoteExec deadlock fixes

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -327,26 +327,6 @@ trait ExecPlan extends QueryCommand {
     }
   }
 
-  protected def applyTransformers(rvs: Observable[RangeVector], resSchema: ResultSchema,
-                                  querySession: QuerySession, source: ChunkSource)(implicit sched: Scheduler):
-  (Observable[RangeVector], ResultSchema) = {
-    allTransformers.foldLeft((rvs, resSchema)) { (acc, transf) =>
-      val paramRangeVector: Seq[Observable[ScalarRangeVector]] =
-        transf.funcParams.map(_.getResult(querySession, source))
-      val resultSchema: ResultSchema = acc._2
-      if (resultSchema == ResultSchema.empty && (!transf.canHandleEmptySchemas)) {
-        // It is possible a null schema is returned (due to no time series). In that case just skip the
-        // transformers that cannot handle empty results
-        (acc._1, resultSchema)
-      } else {
-        val rangeVector: Observable[RangeVector] = transf.apply(
-          acc._1, querySession, queryContext.plannerParams.enforcedLimits.execPlanSamples, acc._2, paramRangeVector
-        )
-        val schema = transf.schema(resultSchema)
-        (rangeVector, schema)
-      }
-    }
-  }
 
   /**
   * Facade for the execution orchestration of the plan sub-tree
@@ -415,7 +395,22 @@ trait ExecPlan extends QueryCommand {
       span.mark(s"execute-step2-start-${getClass.getSimpleName}")
       FiloSchedulers.assertThreadName(QuerySchedName)
       val resultTask = {
-        val finalRes = applyTransformers(res.rvs, resSchema, querySession, source)
+        val finalRes = allTransformers.foldLeft((res.rvs, resSchema)) { (acc, transf) =>
+          val paramRangeVector: Seq[Observable[ScalarRangeVector]] =
+                transf.funcParams.map(_.getResult(querySession, source))
+          val resultSchema : ResultSchema = acc._2
+          if (resultSchema == ResultSchema.empty && (!transf.canHandleEmptySchemas)) {
+            // It is possible a null schema is returned (due to no time series). In that case just skip the
+            // transformers that cannot handle empty results
+            (acc._1, resultSchema)
+          } else {
+            val rangeVector : Observable[RangeVector] = transf.apply(
+              acc._1, querySession, queryContext.plannerParams.enforcedLimits.execPlanSamples, acc._2, paramRangeVector
+            )
+            val schema = transf.schema(resultSchema)
+            (rangeVector, schema)
+          }
+        }
         if (finalRes._2 == ResultSchema.empty) {
           span.mark("empty-plan")
           span.mark(s"execute-step2-end-${getClass.getSimpleName}")

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -3,8 +3,8 @@ package filodb.query.exec
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.sys.ShutdownHookThread
 
 import com.softwaremill.sttp.{DeserializationError, Response, SttpBackend, SttpBackendOptions}
@@ -16,7 +16,6 @@ import kamon.Kamon
 import kamon.trace.Span
 import monix.eval.Task
 import monix.execution.Scheduler
-import monix.reactive.Observable
 import org.asynchttpclient.{AsyncHttpClientConfig, DefaultAsyncHttpClientConfig}
 import org.asynchttpclient.proxy.ProxyServer
 
@@ -48,23 +47,6 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
                 querySession: QuerySession)
                (implicit sched: Scheduler): ExecResult = ???
 
-  /**
-   * Applies all {@link RangeVectorTransformer}s to a remote response.
-   * FIXME: This is needed because RemoteExec plans override the default ExecPlan::execute()
-   *   logic; if possible, this override should eventually be removed.
-   */
-  protected def applyTransformers(resp: QueryResponse,
-                                  querySession: QuerySession,
-                                  source: ChunkSource,
-                                  timeout: Duration)(implicit sched: Scheduler): QueryResponse = resp match {
-    case qr: QueryResult =>
-      val (obs, schema) =
-        applyTransformers(Observable.fromIterable(qr.result), qr.resultSchema, querySession, source)
-      val fut = obs.toListL.map(rvs => qr.copy(result = rvs, resultSchema = schema)).runToFuture
-      Await.result(fut, timeout)
-    case qe: QueryError => qe
-  }
-
   override def execute(source: ChunkSource,
                        querySession: QuerySession)
                       (implicit sched: Scheduler): Task[QueryResponse] = {
@@ -79,12 +61,6 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(span, false) {
       Task.fromFuture(sendHttpRequest(span, requestTimeoutMs))
-        .timed
-        .map{ case (elapsed, qresp) =>
-          val timeRemaining = Duration(requestTimeoutMs, TimeUnit.MILLISECONDS) - elapsed
-          applyTransformers(qresp, querySession, source,
-            timeRemaining)(monix.execution.Scheduler.Implicits.global)
-        }
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.25.6"
+version in ThisBuild := "0.9.25.7"


### PR DESCRIPTION
Revert "fix(exec): cherry-pick RemoteExec deadlock fix" This reverts commit 08260b044df82b5fa6a5cb3b3ee6f7031909b4af, reversing changes made to 7c66afa80ff74823233ac1f48c62d4a84aa0cc82.

Revert "fix(query): 0.9.25.5 RemoteExec RVT hotfix (#1769)" This reverts commit 7c66afa80ff74823233ac1f48c62d4a84aa0cc82.