### PR TITLE
fix(query): apply transformers to RemoteExecs

### DIFF
--- a/query/src/main/scala/filodb/query/exec/ExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/ExecPlan.scala
@@ -115,7 +115,7 @@ trait ExecPlan extends QueryCommand {
     */
   val rangeVectorTransformers = new ArrayBuffer[RangeVectorTransformer]()
 
-  final def addRangeVectorTransformer(mapper: RangeVectorTransformer): Unit = {
+  def addRangeVectorTransformer(mapper: RangeVectorTransformer): Unit = {
     rangeVectorTransformers += mapper
   }
 

--- a/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
@@ -35,24 +35,8 @@ trait GrpcRemoteExec extends RemoteExec {
 
     def remoteExecHttpClient: RemoteExecHttpClient = ???
 
-    override def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)(implicit sched: Scheduler):
-    Future[QueryResponse] = ???
-
-    // Since execute of overridden no one will invoke this
-    // TODO: note PromQLRemoteExec and this implementation should be using doExecute and not override execute.
-    //  execute in ExecPlan needs to be final
-    override def doExecute(source: ChunkSource, querySession: QuerySession)
-                          (implicit sched: Scheduler): ExecResult = ???
-
-    override def execute(source: ChunkSource,
-                         querySession: QuerySession)(implicit sched: Scheduler): Task[QueryResponse] = {
-        val span = Kamon.currentSpan()
-        // Dont finish span since this code didnt create it
-        Kamon.runWithSpan(span, finishSpan = false) {
-            sendGrpcRequest(span, requestTimeoutMs).toListL.map(_.toIterator.toQueryResponse)
-        }
-    }
-
+    override def sendRequest(span: Span, timeoutMs: Long)(implicit sched: Scheduler):
+    Task[QueryResponse] = sendGrpcRequest(span, requestTimeoutMs).toListL.map(_.toIterator.toQueryResponse)
 
     override def args: String = s"${promQlQueryParams.toString}, ${queryContext.plannerParams}, " +
       s"queryEndpoint=$queryEndpoint, " +

--- a/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/PromQLGrpcRemoteExec.scala
@@ -2,11 +2,8 @@ package filodb.query.exec
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Future
-
 import io.grpc.{Channel, Metadata}
 import io.grpc.stub.{MetadataUtils, StreamObserver}
-import kamon.Kamon
 import kamon.trace.Span
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -14,8 +11,7 @@ import monix.reactive.{MulticastStrategy, Observable}
 import monix.reactive.subjects.ConcurrentSubject
 
 import filodb.core.DatasetRef
-import filodb.core.query.{PromQlQueryParams, QueryContext, QuerySession}
-import filodb.core.store.ChunkSource
+import filodb.core.query.{PromQlQueryParams, QueryContext}
 import filodb.grpc._
 import filodb.grpc.GrpcMultiPartitionQueryService._
 import filodb.query.ProtoConverters._

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -67,7 +67,7 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
       val qResTask = sendRequest(span, requestTimeoutMs).map {
         case qr: QueryResult => qr
         case qe: QueryError => throw qe.t
-      }
+      }.memoize
       val schemaTask = qResTask.map(_.resultSchema)
       val rvObs = Observable.fromTask(qResTask)
         .map(_.result)

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -16,6 +16,7 @@ import kamon.Kamon
 import kamon.trace.Span
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 import org.asynchttpclient.{AsyncHttpClientConfig, DefaultAsyncHttpClientConfig}
 import org.asynchttpclient.proxy.ProxyServer
 
@@ -40,16 +41,9 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
 
   def limit: Int = ???
 
-  /**
-   * Since execute is already overrided here, doExecute() can be empty.
-   */
-  def doExecute(source: ChunkSource,
-                querySession: QuerySession)
-               (implicit sched: Scheduler): ExecResult = ???
-
-  override def execute(source: ChunkSource,
-                       querySession: QuerySession)
-                      (implicit sched: Scheduler): Task[QueryResponse] = {
+  override def doExecute(source: ChunkSource,
+                          querySession: QuerySession)
+                         (implicit sched: Scheduler): ExecResult = {
     if (queryEndpoint == null) {
       throw new BadQueryException("Remote Query endpoint can not be null in RemoteExec.")
     }
@@ -60,12 +54,20 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
     val span = Kamon.currentSpan()
     // Dont finish span since this code didnt create it
     Kamon.runWithSpan(span, false) {
-      Task.fromFuture(sendHttpRequest(span, requestTimeoutMs))
+      val qResTask = sendRequest(span, requestTimeoutMs).map {
+        case qr: QueryResult => qr
+        case qe: QueryError => throw qe.t
+      }
+      val schemaTask = qResTask.map(_.resultSchema)
+      val rvObs = Observable.fromTask(qResTask)
+        .map(_.result)
+        .flatMap(Observable.fromIterable(_))
+      ExecResult(rvObs, schemaTask)
     }
   }
 
-  def sendHttpRequest(execPlan2Span: Span, httpTimeoutMs: Long)
-                     (implicit sched: Scheduler): Future[QueryResponse]
+  def sendRequest(span: Span, timeoutMs: Long)
+                 (implicit sched: Scheduler): Task[QueryResponse]
 
   def getUrlParams(): Map[String, String] = {
     var finalUrlParams = urlParams ++

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -41,6 +41,16 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
 
   def limit: Int = ???
 
+  /**
+   * Logs each time a transformer is added.
+   * Transformations can always be pushed-down to the machines that serve the
+   *   remote data; they should never be applied to RemoteExec plans directly.
+   */
+  override def addRangeVectorTransformer(mapper: RangeVectorTransformer): Unit = {
+    super.addRangeVectorTransformer(mapper)
+    logger.info("RangeVectorTransformer added to RemoteExec; plan=" + this)
+  }
+
   override def doExecute(source: ChunkSource,
                           querySession: QuerySession)
                          (implicit sched: Scheduler): ExecResult = {

--- a/query/src/main/scala/filodb/query/exec/RemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/RemoteExec.scala
@@ -48,7 +48,7 @@ trait RemoteExec extends LeafExecPlan with StrictLogging {
    */
   override def addRangeVectorTransformer(mapper: RangeVectorTransformer): Unit = {
     super.addRangeVectorTransformer(mapper)
-    logger.info("RangeVectorTransformer added to RemoteExec; plan=" + this)
+    logger.info("RangeVectorTransformer added to RemoteExec; plan=" + printTree())
   }
 
   override def doExecute(source: ChunkSource,

--- a/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQLGrpcRemoteExecSpec.scala
@@ -147,7 +147,7 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
   it ("should convert the streaming records from gRPC service to a QueryResponse with data") {
 
     val params = PromQlQueryParams("""foo{app="app1"}""", 0, 0, 0)
-    val queryContext = QueryContext(origQueryParams = params)
+    val queryContext = QueryContext(origQueryParams = params, queryId = "someId")
     val session = QuerySession(queryContext, QueryConfig.unitTestingQueryConfig)
 
     val exec = PromQLGrpcRemoteExec(channel, 60000, queryContext, dispatcher, timeseriesDataset.ref, "plannerSelector")
@@ -184,7 +184,7 @@ class PromQLGrpcRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it ("should convert the streaming records from gRPC service to a error ") {
     val params = PromQlQueryParams("""error_metric{app="app1"}""", 0, 0 , 0)
-    val queryContext = QueryContext(origQueryParams = params)
+    val queryContext = QueryContext(origQueryParams = params, queryId = "errorId")
     val session = QuerySession(queryContext, QueryConfig.unitTestingQueryConfig)
 
     val exec = PromQLGrpcRemoteExec(channel, 60000, queryContext, dispatcher, timeseriesDataset.ref, "plannerSelector")

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -166,17 +166,11 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
       InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(), testingBackend), queryConfig)
 
     val resp = exec.execute(memStore, querySession).runToFuture.futureValue
-    val result = (resp: @unchecked) match {
+    (resp: @unchecked) match {
       case QueryResult(id, _, response, _, _, _, _) => {
-        val rv = response(0)
-        rv.rows.size shouldEqual 0
-        rv.rows.map { row =>
-          val record = row.asInstanceOf[BinaryRecordRowReader]
-          rv.asInstanceOf[SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset)
-        }
+        response.size shouldEqual 0
       }
     }
-    result.toArray shouldEqual Array.empty
   }
 
   it ("label values remote metadata exec") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, `RangeVectorTransformers` are never applied to `RemoteExec` plans; they are not applied because `RemoteExec` plans-- unlike others--  override the default `execute` method.

This PR removes the `execute` override and instead implements `doExecute` (similar to other plan types).

Note: this solution prioritizes result correctness over plan correctness; `RemoteExec` plans should never have `RangeVectorTransformers` attached, given that the transformations can be pushed-down to the machines serving the remote data. An `info` log is now written every time a `RangeVectorTransformer` is attached to a `RemoteExec` plan.