### PR TITLE
misc(fix): do not apply limits to metadata queries

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -167,5 +167,5 @@ case class MetadataRemoteExec(queryEndpoint: String,
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
 
-  override def checkSamplesLimit(numResultSamples: Int, queryWarnings: QueryWarnings) {}
+  override def checkSamplesLimit(numResultSamples: Int, queryWarnings: QueryWarnings): Unit = {}
 }

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -166,4 +166,6 @@ case class MetadataRemoteExec(queryEndpoint: String,
     QueryResult(id, schema, srvSeq, QueryStats(), QueryWarnings(),
       if (response.partial.isDefined) response.partial.get else false, response.message)
   }
+
+  override def checkSamplesLimit(numResultSamples: Int, queryWarnings: QueryWarnings) {}
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

reverting behavior, so that we do not apply limits on `MetadataRemoteExec`. Limits still get applied at leaf level