### PR TITLE
(misc-export): Remove sortWithinPartitions to avoid spill(memory) and spill(disk)

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -197,7 +197,6 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     // shuffle the incoming write data before writing.
     // A global sort will minimize the number of output files.
     spark.createDataFrame(rdd, exportTableConfig.tableSchema)
-      .sortWithinPartitions(partitionColNames.head, partitionColNames.tail: _*)
       .write
       .format(settings.exportFormat)
       .mode(SaveMode.Append)


### PR DESCRIPTION
**Current behavior :**

In case of large volume of data to be exported, with `sortWithinPartitions()` is causing spill(disk) & spill(memory). 


**New behavior :**

Removing this operation will not do sorting within partitions and will not cause memory & disk spill.