### PR TITLE
(misc-iceberg-export): Remove sortWithinPartitions to avoid spill(memory) and spill(disk)

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -189,7 +189,6 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
                               rdd: RDD[Row]): Unit = {
     spark.sql(sqlCreateDatabase(settings.exportDatabase))
     spark.sql(sqlCreateTable(settings.exportCatalog, settings.exportDatabase, exportTableConfig))
-    val partitionColNames = Seq("year", "month", "day") ++ exportTableConfig.partitionByCols ++ Seq("metric")
     // distribution mode: none, does not request any shuffles or sort to be performed automatically by Spark.
     // Because no work is done automatically by Spark, the data must be manually sorted by partition value.
     // The data must be sorted either within each spark task, or globally within the entire dataset.
@@ -197,7 +196,6 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     // shuffle the incoming write data before writing.
     // A global sort will minimize the number of output files.
     spark.createDataFrame(rdd, exportTableConfig.tableSchema)
-      .sortWithinPartitions(partitionColNames.head, partitionColNames.tail: _*)
       .write
       .format(settings.exportFormat)
       .mode(SaveMode.Append)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchExporter.scala
@@ -160,9 +160,13 @@ case class BatchExporter(downsamplerSettings: DownsamplerSettings, userStartTime
     val dataSeq = new mutable.ArrayBuffer[Any](exportTableConfig.tableSchema.fields.length)
     // append all dynamic column values
     exportTableConfig.labelColumnMapping.foreach { pair =>
-      val labelValue = exportData.labels.get(pair._1)
-      assert(labelValue.isDefined, s"${pair._1} label was expected but not found: ${exportData.labels}")
-      dataSeq.append(labelValue.get)
+      // scalastyle:off null
+      val result = exportData.labels.get(pair._1) match {
+        case Some(labelValue) => labelValue
+        case None => null
+      }
+      // scalastyle:on null
+      dataSeq.append(result)
     }
     // append all fixed column values
     dataSeq.append(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.25.2"
+version in ThisBuild := "0.9-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9-SNAPSHOT"
+version in ThisBuild := "0.9.25.2"


### PR DESCRIPTION
Current behavior :

In case of large volume of data to be exported, with sortWithinPartitions() is causing spill(disk) & spill(memory).

New behavior :

Removing this operation will not do sorting within partitions and will not cause memory & disk spill.