### PR TITLE
feat(histograms): Supporting back compatibility of queries which spans across prom histograms and otel histograms for same metric

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -189,11 +189,11 @@ filodb {
       columns = ["timestamp:ts",
                  "sum:double:detectDrops=true",
                  "count:double:detectDrops=true",
+                 "h:hist:counter=true",
                  "min:double:detectDrops=true",
-                 "max:double:detectDrops=true",
-                 "h:hist:counter=true"]
+                 "max:double:detectDrops=true"]
       value-column = "h"
-      downsamplers = ["tTime(0)", "dLast(1)", "dLast(2)", "dMin(3)", "dMax(4)", "hLast(5)"]
+      downsamplers = ["tTime(0)", "dLast(1)", "dLast(2)", "hLast(3)", "dMin(4)", "dMax(5)"]
       # Downsample periods are determined by counter dips of the count column
       downsample-period-marker = "counter(2)"
       downsample-schema = "otel-cumulative-histogram"
@@ -203,11 +203,11 @@ filodb {
       columns = ["timestamp:ts",
         "sum:double:{detectDrops=false,delta=true}",
         "count:double:{detectDrops=false,delta=true}",
+        "h:hist:{counter=false,delta=true}",
         "min:double:{detectDrops=false,delta=true}",
-        "max:double:{detectDrops=false,delta=true}",
-        "h:hist:{counter=false,delta=true}"]
+        "max:double:{detectDrops=false,delta=true}"]
       value-column = "h"
-      downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "dMin(3)", "dMax(4)", "hSum(5)"]
+      downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "hSum(3)", "dMin(4)", "dMax(5)"]
       downsample-period-marker = "time(0)"
       downsample-schema = "otel-delta-histogram"
     }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -396,6 +396,8 @@ filodb {
       partitions-deny-list = ""
     }
 
+    # Config to disable workspaces where we don't want max min columns to be selected for back compatibility
+    workspaces-disabled-max-min = ["disabled_ws"]
 
     routing {
       enable-remote-raw-exports = false

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -397,6 +397,7 @@ filodb {
     }
 
     # Config to disable workspaces where we don't want max min columns to be selected for back compatibility
+    # If unspecified, all workspaces are disabled by default.
     workspaces-disabled-max-min = ["disabled_ws"]
 
     routing {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -245,7 +245,7 @@ filodb {
       columns = ["timestamp:ts",
         "sum:double:{detectDrops=false,delta=true}",
         "count:double:{detectDrops=false,delta=true}",
-        "tscount:double:{detectDrops=false,delta=true}"
+        "tscount:double:{detectDrops=false,delta=true}",
         "h:hist:{counter=false,delta=true}"]
       value-column = "h"
       downsample-period-marker = "time(0)"
@@ -256,13 +256,13 @@ filodb {
       columns = ["timestamp:ts",
         "sum:double:{detectDrops=false,delta=true}",
         "count:double:{detectDrops=false,delta=true}",
+        "tscount:double:{detectDrops=false,delta=true}",
+        "h:hist:{counter=false,delta=true}",
         "min:double:{detectDrops=false,delta=true}",
-        "max:double:{detectDrops=false,delta=true}",
-        "tscount:double:{detectDrops=false,delta=true}"
-        "h:hist:{counter=false,delta=true}"]
+        "max:double:{detectDrops=false,delta=true}"]
       value-column = "h"
       downsample-period-marker = "time(0)"
-      downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "dMin(3)", "dMax(4)", "dSum(5)", "hSum(6)"]
+      downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "dSum(3)", "hSum(4)", "dMin(5)", "dMax(6)"]
       downsample-schema = "preagg-otel-delta-histogram"
     }
 

--- a/core/src/main/scala/filodb.core/GlobalConfig.scala
+++ b/core/src/main/scala/filodb.core/GlobalConfig.scala
@@ -2,6 +2,7 @@ package filodb.core
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
+import scala.jdk.CollectionConverters._
 
 /**
   * Loads the overall configuration in a specific order:
@@ -40,5 +41,12 @@ object GlobalConfig extends StrictLogging {
       |  actor.provider = "remote"
       |}
       |""".stripMargin)
+
+  // Workspaces which are disabled for using min/max columns for otel histograms
+  val workspacesDisabledForMaxMin : Option[Set[String]] =
+    systemConfig.hasPath("filodb.query.workspaces-disabled-max-min") match {
+      case false => None
+      case true => Some(systemConfig.getStringList("filodb.query.workspaces-disabled-max-min").asScala.toSet)
+  }
 
 }

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -175,7 +175,7 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       lookupRes.firstSchemaId match {
         case Some(reqSchemaId) =>
           scanPartitions(ref, lookupRes, columnIDs, querySession).filter { p =>
-            if (p.schema.schemaHash != reqSchemaId)
+            if (!p.isBackCompatibleHistograms(Schemas.global.schemaName(reqSchemaId), reqSchemaId))
               throw SchemaMismatch(Schemas.global.schemaName(reqSchemaId), p.schema.name, getClass.getSimpleName)
             p.hasChunks(lookupRes.chunkMethod)
           }

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -175,7 +175,7 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       lookupRes.firstSchemaId match {
         case Some(reqSchemaId) =>
           scanPartitions(ref, lookupRes, columnIDs, querySession).filter { p =>
-            if (!p.isBackCompatibleHistograms(Schemas.global.schemaName(reqSchemaId), reqSchemaId))
+            if (!p.doesSchemaMatchOrBackCompatibleHistograms(Schemas.global.schemaName(reqSchemaId), reqSchemaId))
               throw SchemaMismatch(Schemas.global.schemaName(reqSchemaId), p.schema.name, getClass.getSimpleName)
             p.hasChunks(lookupRes.chunkMethod)
           }

--- a/core/src/main/scala/filodb.core/store/ReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/store/ReadablePartition.scala
@@ -129,5 +129,14 @@ trait ReadablePartition extends FiloPartition {
                           countInfoIterator: CountingChunkInfoIterator): RangeVectorCursor =
     new PartitionTimeRangeReader(this, method.startTime, method.endTime, countInfoIterator, columnIDs)
 
+  final def isBackCompatibleHistograms(schemaNameToCheck : String, schemaHashToCheck : Int) : Boolean = {
+    val sortedSchemas = Seq(schema.name, schemaNameToCheck).sortBy(_.length)
+    val ret = if ( (sortedSchemas(0) == "prom-histogram") && (sortedSchemas(1) == "otel-cumulative-histogram") ) true
+    else if ( (sortedSchemas(0) == "delta-histogram") && (sortedSchemas(1) == "otel-delta-histogram") ) true
+    else if (schema.schemaHash == schemaHashToCheck) true
+    else false
+    ret
+  }
+
   def publishInterval: Option[Long]
 }

--- a/core/src/main/scala/filodb.core/store/ReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/store/ReadablePartition.scala
@@ -129,13 +129,20 @@ trait ReadablePartition extends FiloPartition {
                           countInfoIterator: CountingChunkInfoIterator): RangeVectorCursor =
     new PartitionTimeRangeReader(this, method.startTime, method.endTime, countInfoIterator, columnIDs)
 
-  final def isBackCompatibleHistograms(schemaNameToCheck : String, schemaHashToCheck : Int) : Boolean = {
-    val sortedSchemas = Seq(schema.name, schemaNameToCheck).sortBy(_.length)
-    val ret = if ( (sortedSchemas(0) == "prom-histogram") && (sortedSchemas(1) == "otel-cumulative-histogram") ) true
-    else if ( (sortedSchemas(0) == "delta-histogram") && (sortedSchemas(1) == "otel-delta-histogram") ) true
-    else if (schema.schemaHash == schemaHashToCheck) true
-    else false
-    ret
+  /**
+   * @param schemaNameToCheck the schema name to check against
+   * @param schemaHashToCheck the schema hash to check against
+   * @return true if the schema name and hash match or if the schemas are back compatible histograms
+   */
+  final def doesSchemaMatchOrBackCompatibleHistograms(schemaNameToCheck : String, schemaHashToCheck : Int) : Boolean = {
+    if (schema.schemaHash == schemaHashToCheck) { true }
+    else {
+      val sortedSchemas = Seq(schema.name, schemaNameToCheck).sortBy(_.length)
+      val ret = if ((sortedSchemas(0) == "prom-histogram") && (sortedSchemas(1) == "otel-cumulative-histogram")) true
+      else if ((sortedSchemas(0) == "delta-histogram") && (sortedSchemas(1) == "otel-delta-histogram")) true
+      else false
+      ret
+    }
   }
 
   def publishInterval: Option[Long]

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -133,6 +133,7 @@ filodb {
     translate-prom-to-filodb-histogram = true
     parser = "antlr"
     enforce-result-byte-limit = true
+    workspaces-disabled-max-min = ["disabled_ws"]
     container-size-overrides {
         filodb-query-exec-aggregate-large-container                    = 65536
         filodb-query-exec-metadataexec                                 = 65536

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -358,7 +358,7 @@ object MachineMetricsData {
 
   var histBucketScheme: bv.HistogramBuckets = _
   def linearHistSeries(startTs: Long = 100000L, numSeries: Int = 10, timeStep: Int = 1000, numBuckets: Int = 8,
-                       infBucket: Boolean = false):
+                       infBucket: Boolean = false, ws: String = "demo"):
   Stream[Seq[Any]] = {
     val scheme = if (infBucket) {
                    // Custom geometric buckets, with top bucket being +Inf
@@ -379,7 +379,7 @@ object MachineMetricsData {
           buckets.sum.toLong,
           bv.LongHistogram(scheme, buckets.map(x => x)),
           "request-latency",
-          extraTags ++ Map("_ws_".utf8 -> "demo".utf8, "_ns_".utf8 -> "testapp".utf8, "dc".utf8 -> s"${n % numSeries}".utf8))
+          extraTags ++ Map("_ws_".utf8 -> ws.utf8, "_ns_".utf8 -> "testapp".utf8, "dc".utf8 -> s"${n % numSeries}".utf8))
     }
   }
 

--- a/core/src/test/scala/filodb.core/TestData.scala
+++ b/core/src/test/scala/filodb.core/TestData.scala
@@ -393,8 +393,10 @@ object MachineMetricsData {
   val schemas2h = Schemas(schema2.partition,
                         Map(schema2.name -> schema2, "histogram" -> histDataset.schema))
 
-  val histMaxMinDS = Dataset("histmaxmin", Seq("metric:string", "tags:map"),
-    Seq("timestamp:ts", "count:long", "sum:long", "min:double", "max:double", "h:hist:counter=false"))
+  val histMaxMinDS = Dataset.make("histmaxmin",
+    Seq("metric:string", "tags:map"),
+    Seq("timestamp:ts", "count:long", "sum:long", "h:hist:counter=false", "min:double", "max:double"),
+    valueColumn = Some("h")).get
 
   // Pass in the output of linearHistSeries here.
   // Adds in the max and min column before h/hist
@@ -407,7 +409,7 @@ object MachineMetricsData {
                             .lastOption.getOrElse(hist.numBuckets - 1)
       val max = hist.bucketTop(lastBucketNum) * 0.8
       val min = hist.bucketTop(lastBucketNum) * 0.1
-      ((row take 3):+ min :+ max) ++ (row drop 3)
+      ((row take 4):+ min :+ max) ++ (row drop 4)
     }
 
   val histKeyBuilder = new RecordBuilder(TestData.nativeMem, 2048)
@@ -436,7 +438,7 @@ object MachineMetricsData {
 
   private val histMaxBP = new WriteBufferPool(TestData.nativeMem, histMaxMinDS.schema.data, TestData.storeConf)
 
-  // Designed explicitly to work with histMax(linearHistSeries) records
+  // Designed explicitly to work with histMaxMin(linearHistSeries) records
   def histMaxMinRV(startTS: Long, pubFreq: Long = 10000L, numSamples: Int = 100, numBuckets: Int = 8):
   (Stream[Seq[Any]], RawDataRangeVector) = {
     val histData = histMaxMin(linearHistSeries(startTS, 1, pubFreq.toInt, numBuckets)).take(numSamples)
@@ -447,7 +449,7 @@ object MachineMetricsData {
     // Now flush and ingest the rest to ensure two separate chunks
     part.switchBuffers(histMaxMinBH, encode = true)
     // Select timestamp, hist, max, min
-    (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 5, 4, 3),
+    (histData, RawDataRangeVector(null, part, AllChunkScan, Array(0, 3, 5, 4),
       new AtomicLong, Long.MaxValue, "query-id"))
   }
 }

--- a/core/src/test/scala/filodb.core/store/ReadablePartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ReadablePartitionSpec.scala
@@ -1,0 +1,77 @@
+package filodb.core.store
+
+import filodb.core.GlobalConfig
+import filodb.core.NamesTestData.dataset
+import filodb.core.downsample.OffHeapMemory
+import filodb.core.memstore.{PagedReadablePartition, TimeSeriesPartition, TimeSeriesShardInfo, TimeSeriesShardStats}
+import filodb.core.metadata.Schemas
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+class ReadablePartitionSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
+
+  it("doesSchemaMatchOrBackCompatibleHistograms should return true for delta and otel-delta") {
+    val rawData = RawPartData(Array.empty, Seq.empty)
+    val p1 = new PagedReadablePartition(Schemas.deltaHistogram, 0, -1, rawData, 10)
+    val p2 = new PagedReadablePartition(Schemas.otelDeltaHistogram, 0, -1, rawData, 10)
+    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+  }
+
+  it("doesSchemaMatchOrBackCompatibleHistograms should return true for cumulative and otel-cumulative") {
+    val rawData = RawPartData(Array.empty, Seq.empty)
+    val p1 = new PagedReadablePartition(Schemas.promHistogram, 0, -1, rawData, 10)
+    val p2 = new PagedReadablePartition(Schemas.otelCumulativeHistogram, 0, -1, rawData, 10)
+    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+  }
+
+  it("doesSchemaMatchOrBackCompatibleHistograms should return true if schema matches paged readble partition") {
+    val rawData = RawPartData(Array.empty, Seq.empty)
+    val p1 = new PagedReadablePartition(Schemas.deltaCounter, 0, -1, rawData, 10)
+    val p2 = new PagedReadablePartition(Schemas.deltaCounter, 0, -1, rawData, 10)
+    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+
+    val p3 = new PagedReadablePartition(Schemas.gauge, 0, -1, rawData, 10)
+    val p4 = new PagedReadablePartition(Schemas.gauge, 0, -1, rawData, 10)
+    p3.doesSchemaMatchOrBackCompatibleHistograms(p4.schema.name, p4.schema.schemaHash) shouldEqual true
+
+    val p5 = new PagedReadablePartition(Schemas.promHistogram, 0, -1, rawData, 10)
+    val p6 = new PagedReadablePartition(Schemas.promHistogram, 0, -1, rawData, 10)
+    p5.doesSchemaMatchOrBackCompatibleHistograms(p6.schema.name, p6.schema.schemaHash) shouldEqual true
+
+    val p7 = new PagedReadablePartition(Schemas.promCounter, 0, -1, rawData, 10)
+    val p8 = new PagedReadablePartition(Schemas.promCounter, 0, -1, rawData, 10)
+    p7.doesSchemaMatchOrBackCompatibleHistograms(p8.schema.name, p8.schema.schemaHash) shouldEqual true
+  }
+
+  it("doesSchemaMatchOrBackCompatibleHistograms should return true if schema matches timeseries partition") {
+    val storeConfig = StoreConfig(GlobalConfig.defaultFiloConfig.getConfig("downsampler.downsample-store-config"))
+    val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram, Schemas.untyped),
+      Map.empty, 100, storeConfig)
+    val shardInfo = TimeSeriesShardInfo(
+      0, new TimeSeriesShardStats(dataset.ref, 0), offheapMem.bufferPools, offheapMem.nativeMemoryManager)
+
+    val p1 = new TimeSeriesPartition(0, Schemas.deltaHistogram, 0, shardInfo, 1)
+    val p2 = new TimeSeriesPartition(0, Schemas.otelDeltaHistogram, 0, shardInfo, 1)
+    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+
+    val p3 = new TimeSeriesPartition(0, Schemas.gauge, 0, shardInfo, 1)
+    val p4 = new TimeSeriesPartition(0, Schemas.gauge, 0, shardInfo, 1)
+    p3.doesSchemaMatchOrBackCompatibleHistograms(p4.schema.name, p4.schema.schemaHash) shouldEqual true
+  }
+
+  it("doesSchemaMatchOrBackCompatibleHistograms should return false if schema does not matches timeseries partition") {
+    val storeConfig = StoreConfig(GlobalConfig.defaultFiloConfig.getConfig("downsampler.downsample-store-config"))
+    val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram, Schemas.untyped),
+      Map.empty, 100, storeConfig)
+    val shardInfo = TimeSeriesShardInfo(
+      0, new TimeSeriesShardStats(dataset.ref, 0), offheapMem.bufferPools, offheapMem.nativeMemoryManager)
+
+    val p1 = new TimeSeriesPartition(0, Schemas.deltaHistogram, 0, shardInfo, 1)
+    val p2 = new TimeSeriesPartition(0, Schemas.promHistogram, 0, shardInfo, 1)
+    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual false
+
+    val p3 = new TimeSeriesPartition(0, Schemas.promCounter, 0, shardInfo, 1)
+    val p4 = new TimeSeriesPartition(0, Schemas.deltaCounter, 0, shardInfo, 1)
+    p3.doesSchemaMatchOrBackCompatibleHistograms(p4.schema.name, p4.schema.schemaHash) shouldEqual false
+  }
+}

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -127,9 +127,9 @@ object InputRecord {
       builder.addLong(timestamp)
       builder.addDouble(sum)
       builder.addDouble(count)
+      builder.addBlob(hist.serialize())
       builder.addDouble(min)
       builder.addDouble(max)
-      builder.addBlob(hist.serialize())
 
       builder.addString(metric)
       builder.addMap(tags.map { case (k, v) => (k.utf8, v.utf8) })
@@ -220,9 +220,9 @@ object InputRecord {
       builder.addLong(timestamp)
       builder.addDouble(sum)
       builder.addDouble(count)
+      builder.addBlob(hist.serialize())
       builder.addDouble(min)
       builder.addDouble(max)
-      builder.addBlob(hist.serialize())
 
       builder.addString(metric)
       builder.addMap(tags.map { case (k, v) => (k.utf8, v.utf8) })

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesProducer.scala
@@ -249,7 +249,7 @@ object TestTimeseriesProducer extends StrictLogging {
       if (histSchema == Schemas.otelDeltaHistogram || histSchema == Schemas.otelCumulativeHistogram) {
         val minVal = buckets.min.toDouble
         val maxVal = buckets.max.toDouble
-        new MetricTagInputRecord(Seq(timestamp, sum, count, minVal, maxVal, hist), metric, tags, histSchema)
+        new MetricTagInputRecord(Seq(timestamp, sum, count, hist, minVal, maxVal), metric, tags, histSchema)
       }
       else {
         new MetricTagInputRecord(Seq(timestamp, sum, count, hist), metric, tags, histSchema)

--- a/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
@@ -72,9 +72,9 @@ class InputRecordBuilderSpec extends AnyFunSpec with Matchers {
     builder2.allContainers.head.iterate(Schemas.otelDeltaHistogram.ingestionSchema).foreach { row =>
       row.getDouble(1) shouldEqual sum
       row.getDouble(2) shouldEqual count
-      row.getDouble(3) shouldEqual min
-      row.getDouble(4) shouldEqual max
-      row.getHistogram(5) shouldEqual expected
+      row.getDouble(4) shouldEqual min
+      row.getDouble(5) shouldEqual max
+      row.getHistogram(3) shouldEqual expected
     }
   }
 
@@ -91,9 +91,9 @@ class InputRecordBuilderSpec extends AnyFunSpec with Matchers {
     builder2.allContainers.head.iterate(Schemas.otelCumulativeHistogram.ingestionSchema).foreach { row =>
       row.getDouble(1) shouldEqual sum
       row.getDouble(2) shouldEqual count
-      row.getDouble(3) shouldEqual min
-      row.getDouble(4) shouldEqual max
-      row.getHistogram(5) shouldEqual expected
+      row.getDouble(4) shouldEqual min
+      row.getDouble(5) shouldEqual max
+      row.getHistogram(3) shouldEqual expected
     }
   }
 

--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -60,7 +60,7 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
   def isMaxMinEnabledForWorkspace(ws: Option[String]) : Boolean = {
     ws.isDefined match {
       case true => (GlobalConfig.workspacesDisabledForMaxMin.isDefined) &&
-        (!GlobalConfig.workspacesDisabledForMaxMin.contains(ws.get))
+        (!GlobalConfig.workspacesDisabledForMaxMin.get.contains(ws.get))
       case false => false
     }
   }

--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -3,12 +3,13 @@ package filodb.query.exec
 import kamon.Kamon
 import monix.execution.Scheduler
 
-import filodb.core.DatasetRef
+import filodb.core.{DatasetRef, GlobalConfig}
 import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, QueryConfig, QueryContext, QuerySession, QueryWarnings}
 import filodb.core.query.Filter.Equals
 import filodb.core.store._
 import filodb.query.Query.qLogger
+import filodb.query.TsCardinalities
 
 final case class UnknownSchemaQueryErr(id: Int) extends
   Exception(s"Unknown schema ID $id during query.  This likely means a schema config change happened and " +
@@ -56,6 +57,14 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
     (lookupRes, Some(columnName))
   }
 
+  def isMaxMinEnabledForWorkspace(ws: Option[String]) : Boolean = {
+    ws.isDefined match {
+      case true => (GlobalConfig.workspacesDisabledForMaxMin.isDefined) &&
+        (!GlobalConfig.workspacesDisabledForMaxMin.contains(ws.get))
+      case false => false
+    }
+  }
+
   // scalastyle:off method.length
   private def finalizePlan(source: ChunkSource,
                            querySession: QuerySession): SelectRawPartitionsExec = {
@@ -63,6 +72,7 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
     Kamon.currentSpan().mark("filtered-partition-scan")
     var lookupRes = source.lookupPartitions(dataset, partMethod, chunkMethod, querySession)
     val metricName = filters.find(_.column == metricColumn).map(_.filter.valuesStrings.head.toString)
+    val ws = filters.find(_.column == TsCardinalities.LABEL_WORKSPACE).map(_.filter.valuesStrings.head.toString)
     var newColName = colName
 
     /*
@@ -99,11 +109,18 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
             // Get exact column IDs needed, including max column as needed for histogram calculations.
             // This code is responsible for putting exact IDs needed by any range functions.
             val colIDs1 = getColumnIDs(sch, newColName.toSeq, rangeVectorTransformers)
-            val colIDs  = addIDsForHistMaxMin(sch, colIDs1)
+
+            val colIDs = isMaxMinEnabledForWorkspace(ws) match {
+              case true => addIDsForHistMaxMin(sch, colIDs1)
+              case _ => colIDs1
+            }
 
             // Modify transformers as needed for histogram w/ max, downsample, other schemas
             val newxformers1 = newXFormersForDownsample(sch, rangeVectorTransformers)
-            val newxformers = newXFormersForHistMaxMin(sch, colIDs, newxformers1)
+            val newxformers = isMaxMinEnabledForWorkspace(ws) match {
+              case true => newXFormersForHistMaxMin(sch, colIDs, newxformers1)
+              case _ => newxformers1
+            }
 
             val newPlan = SelectRawPartitionsExec(queryContext, dispatcher, dataset,
                                                   Some(sch), Some(lookupRes),

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -22,7 +22,7 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
                                   ColumnInfo("value", ColumnType.DoubleColumn)), 1)
   val histSchema = ResultSchema(MMD.histDataset.schema.infosFromIDs(Seq(0, 3)), 1)
   val histMaxMinSchema = ResultSchema(
-    MMD.histMaxMinDS.schema.infosFromIDs(Seq(0, 5, 4, 3)), 1, colIDs = Seq(0, 5, 4, 3))
+    MMD.histMaxMinDS.schema.infosFromIDs(Seq(0, 3, 5, 4)), 1, colIDs = Seq(0, 3, 5, 4))
 
   val qc = QueryContext()
   val queryStats = QueryStats()
@@ -633,13 +633,13 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     result(0).key shouldEqual noKey
 
     val sums = data1.zip(data2).map { case (row1, row2) =>
-      val h1 = bv.MutableHistogram(row1(5).asInstanceOf[bv.LongHistogram])
-      h1.add(row2(5).asInstanceOf[bv.LongHistogram])
+      val h1 = bv.MutableHistogram(row1(3).asInstanceOf[bv.LongHistogram])
+      h1.add(row2(3).asInstanceOf[bv.LongHistogram])
       h1
     }.toList
 
     val maxes = data1.zip(data2).map { case (row1, row2) =>
-      Math.max(row1(4).asInstanceOf[Double], row2(4).asInstanceOf[Double])
+      Math.max(row1(5).asInstanceOf[Double], row2(5).asInstanceOf[Double])
     }.toList
 
     val answers = result(0).rows.map(r => (r.getHistogram(1), r.getDouble(2))).toList

--- a/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
@@ -139,12 +139,12 @@ class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFut
     val minColId = SelectRawPartitionsExec.histMinColumn(histMaxMinDS.schema,
       histMaxMinDS.schema.allColumns.map(x => x.id))
     minColId.isDefined shouldEqual true
-    minColId.get shouldEqual 3
+    minColId.get shouldEqual 4
 
     val maxColId = SelectRawPartitionsExec.histMaxColumn(histMaxMinDS.schema,
       histMaxMinDS.schema.allColumns.map(x => x.id))
     maxColId.isDefined shouldEqual true
-    maxColId.get shouldEqual 4
+    maxColId.get shouldEqual 5
   }
 
   it("test histMinColumn and histMaxColumn should not return the colId if not present") {
@@ -159,10 +159,10 @@ class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFut
     val colIds = SelectRawPartitionsExec.getColumnIDs(histMaxMinDS.schema, Seq(),
       Seq(PeriodicSamplesMapper(100000L, 100000, 600000L, None, None, QueryContext())))
     colIds.size shouldEqual 2
-    colIds shouldEqual Seq(0, 5)
+    colIds shouldEqual Seq(0, 3)
     val colIdsWithMinMax = SelectRawPartitionsExec.addIDsForHistMaxMin(histMaxMinDS.schema, colIds)
     colIdsWithMinMax.size shouldEqual 4
-    colIdsWithMinMax shouldEqual Seq(0, 5, 4, 3)
+    colIdsWithMinMax shouldEqual Seq(0, 3, 5, 4)
   }
 
   it("test getColumnIDs returns correct colIds for prom histograms") {

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -370,7 +370,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
     info(execPlan.printTree())
     // Check that the "inner" SelectRawPartitionsExec has the right schema/columnIDs
     execPlan.finalPlan shouldBe a[SelectRawPartitionsExec]
-    execPlan.finalPlan.asInstanceOf[SelectRawPartitionsExec].colIds shouldEqual Seq(0, 5, 4, 3)
+    execPlan.finalPlan.asInstanceOf[SelectRawPartitionsExec].colIds shouldEqual Seq(0, 3, 5, 4)
     val result = resp.asInstanceOf[QueryResult]
     result.resultSchema.columns.map(_.colType) shouldEqual
       Seq(TimestampColumn, HistogramColumn, DoubleColumn, DoubleColumn)
@@ -382,7 +382,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
     // Rely on AggrOverTimeFunctionsSpec to actually validate aggregation results
     val orig = histMaxMinData.filter(_(7).asInstanceOf[Types.UTF8Map]("dc".utf8) == "0".utf8)
                        .grouped(2).map(_.head)   // Skip every other one, starting with second, since step=2x pace
-                       .zip((start to end by step).toIterator).map { case (r, t) => (t, r(5), r(4), r(3)) }
+                       .zip((start to end by step).toIterator).map { case (r, t) => (t, r(3), r(5), r(4)) }
     resultIt.zip(orig.toIterator).foreach { case (res, origData) =>
       res._3.isNaN shouldEqual false
       res._3 should be >= origData._3.asInstanceOf[Double]
@@ -424,7 +424,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
     // Rely on AggrOverTimeFunctionsSpec to actually validate aggregation results
     val orig = histMaxMinData.filter(_(7).asInstanceOf[Types.UTF8Map]("dc".utf8) == "0".utf8)
                        .grouped(2).map(_.head)   // Skip every other one, starting with second, since step=2x pace
-                       .zip((start to end by step).toIterator).map { case (r, t) => (t, r(5), r(4), r(3)) }
+                       .zip((start to end by step).toIterator).map { case (r, t) => (t, r(3), r(5), r(4)) }
     resultIt.zip(orig.toIterator).foreach { case (res, origData) =>
       res._3.isNaN shouldEqual false
       res._3 should be >= origData._3.asInstanceOf[Double]

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -1,14 +1,13 @@
 package filodb.query.exec
 
 import com.typesafe.config.ConfigFactory
-
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SchemaMismatch, SomeData, TimeSeriesMemStore}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn, LongColumn, TimestampColumn}
 import filodb.core.metadata.Schemas
 import filodb.core.query._
 import filodb.core.store.{AllChunkScan, ChunkSource, InMemoryMetaStore, NullColumnStore, TimeRangeChunkScan}
-import filodb.core.{DatasetRef, QueryTimeoutException, TestData, Types}
+import filodb.core.{DatasetRef, GlobalConfig, QueryTimeoutException, TestData, Types}
 import filodb.memory.MemFactory
 import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import filodb.query._
@@ -20,8 +19,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import monix.reactive.Observable
 
 object MultiSchemaPartitionsExecSpec {
@@ -85,6 +84,9 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
   val histData = MMD.linearHistSeries().take(100)
   val histMaxMinData = MMD.histMaxMin(histData)
 
+  val histDataDisabledWS = MMD.linearHistSeries(ws = GlobalConfig.workspacesDisabledForMaxMin.get.head).take(100)
+  val histMaxMinDataDisabledWS = MMD.histMaxMin(histDataDisabledWS)
+
   implicit val execTimeout = 5.seconds
 
   override def beforeAll(): Unit = {
@@ -99,6 +101,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
     memStore.ingest(MMD.dataset1.ref, 0, mmdSomeData)
     memStore.setup(MMD.histMaxMinDS.ref, Schemas(MMD.histMaxMinDS.schema), 0, TestData.storeConf, 1)
     memStore.ingest(MMD.histMaxMinDS.ref, 0, MMD.records(MMD.histMaxMinDS, histMaxMinData))
+    memStore.ingest(MMD.histMaxMinDS.ref, 0, MMD.records(MMD.histMaxMinDS, histMaxMinDataDisabledWS))
 
     memStore.refreshIndexForTesting(dsRef)
     memStore.refreshIndexForTesting(MMD.dataset1.ref)
@@ -355,7 +358,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
 
   // A lower-level (below coordinator) end to end histogram with max ingestion and querying test
   it("should sum Histogram records with max correctly") {
-    val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)))
+    val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)), ColumnFilter("_ws_", Filter.Equals("demo".utf8)))
     val execPlan = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher, MMD.histMaxMinDS.ref, 0,
                                              filters, AllChunkScan, "_metric_", colName = Some("h"))
 
@@ -403,7 +406,7 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
   }
 
   it("should extract Histogram with max using Last/None function correctly") {
-    val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)))
+    val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)), ColumnFilter("_ws_", Filter.Equals("demo".utf8)))
     val execPlan = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher, MMD.histMaxMinDS.ref, 0,
                                              filters, AllChunkScan, "_metric_")   // should default to h column
 
@@ -431,7 +434,33 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
       res._4.isNaN shouldEqual false
       res._4 should be <= origData._3.asInstanceOf[Double]
     }
+  }
 
+  it("should not pickup max min columns if ws is disabled") {
+    val filters = Seq(ColumnFilter("dc", Filter.Equals("0".utf8)), ColumnFilter("_ws_",
+      Filter.Equals(GlobalConfig.workspacesDisabledForMaxMin.get.head.utf8)))
+    val execPlan = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher, MMD.histMaxMinDS.ref, 0,
+      filters, AllChunkScan, "_metric_", colName = Some("h"))
+
+    val start = 105000L
+    val step = 20000L
+    val end = 185000L
+    execPlan.addRangeVectorTransformer(new PeriodicSamplesMapper(start, step, end, Some(300 * 1000), // [5m]
+      Some(InternalRangeFunction.SumOverTime), QueryContext()))
+    execPlan.addRangeVectorTransformer(AggregateMapReduce(AggregationOperator.Sum, Nil))
+    execPlan.execute(memStore, querySession).runToFuture.futureValue
+    info(execPlan.printTree())
+    execPlan.finalPlan shouldBe a[SelectRawPartitionsExec]
+    // if the ws is disabled for max min calculation, then the max min columns should not be picked up
+    execPlan.finalPlan.colIds shouldEqual Seq(0, 3)
+  }
+
+  it("test isMaxMinEnabledForWorkspace correctly returns expected values") {
+    val execPlan = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher, MMD.histMaxMinDS.ref, 0,
+      Seq(), AllChunkScan, "_metric_", colName = Some("h"))
+    execPlan.isMaxMinEnabledForWorkspace(Some("demo")) shouldEqual true
+    execPlan.isMaxMinEnabledForWorkspace(Some(GlobalConfig.workspacesDisabledForMaxMin.get.head)) shouldEqual false
+    execPlan.isMaxMinEnabledForWorkspace(None) shouldEqual false
   }
 
   it("should return chunk metadata from MemStore") {

--- a/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PeriodicSamplesMapperSpec.scala
@@ -27,7 +27,7 @@ class PeriodicSamplesMapperSpec extends AnyFunSpec with Matchers with ScalaFutur
   val rv = timeValueRVPk(samples)
 
   val histMaxMinSchema = ResultSchema(
-    MachineMetricsData.histMaxMinDS.schema.infosFromIDs(Seq(0, 5, 4, 3)), 1, colIDs = Seq(0, 5, 4, 3))
+    MachineMetricsData.histMaxMinDS.schema.infosFromIDs(Seq(0, 3, 5, 4)), 1, colIDs = Seq(0, 3, 5, 4))
 
   val rvHistMaxMin = MachineMetricsData.histMaxMinRV(100000L, numSamples = 3, numBuckets = 4)._2
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -299,14 +299,14 @@ class AggrOverTimeFunctionsSpec extends RawDataWindowingSpec {
       info(s"iteration $x windowSize=$windowSize step=$step")
 
       val row = new TransientHistMaxMinRow()
-      val chunkedIt = chunkedWindowItHist(data, rv, new SumAndMaxOverTimeFuncHD(4), windowSize, step, row)
+      val chunkedIt = chunkedWindowItHist(data, rv, new SumAndMaxOverTimeFuncHD(5), windowSize, step, row)
       chunkedIt.zip(data.sliding(windowSize, step)).foreach { case (aggRow, rawDataWindow) =>
         val aggHist = aggRow.getHistogram(1)
-        val sumRawHist = rawDataWindow.map(_(5).asInstanceOf[bv.LongHistogram])
+        val sumRawHist = rawDataWindow.map(_(3).asInstanceOf[bv.LongHistogram])
                                       .foldLeft(emptyAggHist) { case (agg, h) => agg.add(h); agg }
         aggHist shouldEqual sumRawHist
 
-        val maxMax = rawDataWindow.map(_(4).asInstanceOf[Double])
+        val maxMax = rawDataWindow.map(_(5).asInstanceOf[Double])
                                   .foldLeft(0.0) { case (agg, m) => Math.max(agg, m) }
         aggRow.getDouble(2) shouldEqual maxMax
       }

--- a/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
@@ -16,7 +16,7 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
 
   val resultSchema = ResultSchema(MetricsTestData.timeseriesSchema.infosFromIDs(0 to 1), 1)
   val histSchema = ResultSchema(MMD.histDataset.schema.infosFromIDs(Seq(0, 3)), 1)
-  val histMaxMinSchema = ResultSchema(MMD.histMaxMinDS.schema.infosFromIDs(Seq(0, 5, 4, 3)), 1, colIDs=Seq(0, 5, 4, 3))
+  val histMaxMinSchema = ResultSchema(MMD.histMaxMinDS.schema.infosFromIDs(Seq(0, 3, 5, 4)), 1, colIDs=Seq(0, 3, 5, 4))
   val ignoreKey = CustomRangeVectorKey(
     Map(ZeroCopyUTF8String("ignore") -> ZeroCopyUTF8String("ignore")))
   val sampleBase: Array[RangeVector] = Array(
@@ -329,9 +329,9 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     val (data, histRV) = MMD.histMaxMinRV(100000L, numSamples = 7)
     val expected = data.zipWithIndex.map { case (row, i) =>
       // Calculating the quantile is quite complex... sigh
-      val _max = row(4).asInstanceOf[Double]
+      val _max = row(5).asInstanceOf[Double]
       if ((i % 8) == 0) (_max * 0.9) else {
-        val _hist = row(5).asInstanceOf[bv.LongHistogram]
+        val _hist = row(3).asInstanceOf[bv.LongHistogram]
         val rank = 0.9 * _hist.bucketValue(_hist.numBuckets - 1)
         val ratio = (rank - _hist.bucketValue((i-1) % 8)) / (_hist.bucketValue(i%8) - _hist.bucketValue((i-1) % 8))
         _hist.bucketTop((i-1) % 8) + ratio * (_max -  _hist.bucketTop((i-1) % 8))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** back compatibility of queries spanning across prom-histograms and otel histograms with same metric name.

**New behavior :** supporting this behavior.

**BREAKING CHANGES**

- Changed storage schema of `otel-cumulative-histogram` and `otel-delta-histogram`. Moved histogram to column 3 from column 5.