### PR TITLE
fix(downsample): apply correct export rules

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -98,13 +98,12 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
                            batchExporter: BatchExporter,
                            sparkSession: SparkSession): Unit = {
     val exportStartMs = System.currentTimeMillis()
-    val filteredRowRdd = {
-      val allTableRows = rdd.flatMap(batchExporter.getExportRows(_, exportTableConfig))
-      batchExporter.filterRdd(allTableRows, exportKeyFilters, exportTableConfig)
-    }.map { row =>
-      numRowsExported.increment()
-      row
-    }
+    val filteredRowRdd = rdd
+      .flatMap(batchExporter.getExportRows(_, exportKeyFilters, exportTableConfig))
+      .map { row =>
+        numRowsExported.increment()
+        row
+      }
 
     // write filteredRowRdd to iceberg table
     batchExporter.writeDataToIcebergTable(sparkSession, settings, exportTableConfig, filteredRowRdd)

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -9,7 +9,6 @@ import net.ceedubs.ficus.Ficus._
 import org.apache.spark.sql.types._
 
 import filodb.coordinator.{FilodbSettings, NodeClusterActor}
-import filodb.core.query.ColumnFilterMap
 import filodb.core.store.{IngestionConfig, StoreConfig}
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.ExportConstants._
@@ -145,12 +144,6 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
       keyFilters -> config
     }
-  }
-
-  @transient lazy val exportColumnFilterMap = {
-    val cfMap = new ColumnFilterMap[ExportTableConfig](exportKeyToConfig)
-    logger.info(s"Constructed data-export rule map: $cfMap")
-    cfMap
   }
 
   @transient lazy val exportFormat = downsamplerConfig.getString("data-export.format")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, the `ColumnFilterMap` used in `BatchExporter::getRuleIfShouldExport` will choose an export config arbitrarily from multiple key filter matches. For example, if the map contains:
```
{l1=foo.*} -> config1
{l1=fooA.*} -> config2
```
Then this series would technically match both keys:
```
{l1=fooABC}
```
-- and either `config1` or `config2` may be returned.

Since both contain their own `allow`/`block` rules, it's possible the series should be exported according to `config1` but no export rule is returned because it is blocked by `config2`.

Since anyways an `RDD` with _all_ rows is iterated once per table, it is both less confusing and more correct to consider exclusively the rules for one table per iteration. This PR adds a table config parameter to `getRuleIfShouldExport`, and it consolidates all row filtering logic.