### PR TITLE
perf(query): add FastColumnFilterMap

### DIFF
--- a/core/src/main/scala/filodb.core/TargetSchemaProvider.scala
+++ b/core/src/main/scala/filodb.core/TargetSchemaProvider.scala
@@ -39,23 +39,4 @@ final case class ColumnFilterMapTargetSchemaProvider(columnFilterMap: ColumnFilt
   }
 }
 
-object ColumnFilterMapTargetSchemaProvider {
-  /**
-   * @param filterChangePairs (filters,changes) pairs used to populate the backing ColumnFilterMap;
-   *                          at most one of 'filters' can be a non-Equals filter.
-   */
-  def apply(filterChangePairs: Iterable[(
-      Iterable[ColumnFilter],
-      Iterable[TargetSchemaChange]
-    )]): ColumnFilterMapTargetSchemaProvider = {
-    val columnFilterMap = {
-      val sortedFilterChangePairs = filterChangePairs.map { case (filters, changes) =>
-        (filters, changes.toSeq.sortBy(_.time))
-      }
-      new ColumnFilterMap[Seq[TargetSchemaChange]](sortedFilterChangePairs)
-    }
-    new ColumnFilterMapTargetSchemaProvider(columnFilterMap)
-  }
-}
-
 final case class TargetSchemaChange(time: Long = 0L, schema: Seq[String])

--- a/core/src/test/scala/filodb.core/query/ColumnFilterMapSpec.scala
+++ b/core/src/test/scala/filodb.core/query/ColumnFilterMapSpec.scala
@@ -110,8 +110,8 @@ class ColumnFilterMapSpec extends AnyFunSpec with Matchers {
           regex("b", "bbb.*"),
           regex("c", "ccc.*")), "3r"),
         (Seq(
-          regex("b", "bbb.*"),
-          regex("c", "ccc.*")), "4r"),
+          regex("b", "bbb.*123.*"),
+          regex("c", "ccc.*123.*")), "4r"),
       )
       val cfMap = new DefaultColumnFilterMap[String](entries)
       cfMap.get(Map()) shouldEqual None
@@ -124,7 +124,7 @@ class ColumnFilterMapSpec extends AnyFunSpec with Matchers {
       cfMap.get(Map("a" -> "aaa123")).get shouldEqual "1r"
       cfMap.get(Map("a" -> "aaa123", "b" -> "bbb123")).isDefined shouldEqual true
       cfMap.get(Map("a" -> "aaa123", "b" -> "bbb123", "c" -> "ccc123")).isDefined shouldEqual true
-      cfMap.get(Map("b" -> "bbb123", "c" -> "ccc123")).get shouldEqual "4r"
+      cfMap.get(Map("b" -> "bbbXYZ123", "c" -> "cccXYZ123")).get shouldEqual "4r"
     }
   }
 
@@ -184,7 +184,8 @@ class ColumnFilterMapSpec extends AnyFunSpec with Matchers {
     val equalsValues = Map(
       "foo" -> "equalsFooVal",
       "bar" -> "equalsBarVal",
-      "baz" -> "equalsBazVal"
+      "baz" -> "equalsBazVal",
+      "bat" -> "equalsBatVal",
     )
     val filterEltPairs = Seq(
       (Filter.EqualsRegex("foo.*"), "filterFooVal"), // Prefix regex!
@@ -193,6 +194,7 @@ class ColumnFilterMapSpec extends AnyFunSpec with Matchers {
       (Filter.EqualsRegex("bar.123.*"), "filterBarVal2"),
       (Filter.Equals("baz"), "filterBazVal"),
       (Filter.Equals("baz"), "filterBazVal2"),
+      (Filter.EqualsRegex("bat.*123.*"), "filterBatVal"),
     )
     val cfMap = new FastColumnFilterMap[String](
       "equals",
@@ -213,6 +215,7 @@ class ColumnFilterMapSpec extends AnyFunSpec with Matchers {
     cfMap.get(Map("equals" -> "DNE", "filter" -> "foo123", "DNE" -> "DNE")).get shouldEqual "filterFooVal"
     cfMap.get(Map("equals" -> "DNE", "filter" -> "barA123456")).get shouldEqual "filterBarVal"
     cfMap.get(Map("equals" -> "DNE", "filter" -> "baz")).get shouldEqual "filterBazVal"
+    cfMap.get(Map("equals" -> "DNE", "filter" -> "bat123")).get shouldEqual "filterBatVal"
 
     // Make sure equals label is matched after filtered label
     cfMap.get(Map("equals" -> "baz", "filter" -> "foo123")).get shouldEqual "filterFooVal"

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -9,7 +9,7 @@ import net.ceedubs.ficus.Ficus._
 import org.apache.spark.sql.types._
 
 import filodb.coordinator.{FilodbSettings, NodeClusterActor}
-import filodb.core.query.ColumnFilterMap
+import filodb.core.query.DefaultColumnFilterMap
 import filodb.core.store.{IngestionConfig, StoreConfig}
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.ExportConstants._
@@ -148,7 +148,7 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
   }
 
   @transient lazy val exportColumnFilterMap = {
-    val cfMap = new ColumnFilterMap[ExportTableConfig](exportKeyToConfig)
+    val cfMap = new DefaultColumnFilterMap[ExportTableConfig](exportKeyToConfig)
     logger.info(s"Constructed data-export rule map: $cfMap")
     cfMap
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Adds `FastColumnFilterMap`. Snippet from the javadoc:
```
 * Bare-bones but (in some cases) ultra-fast ColumnFilterMap.
 * At most two label-values are read during a get() call:
 *   - One to be matched by equality.
 *   - One to be matched by any arbitrary filter.
 * Useful for performance-critical use-cases where this minimal functionality is sufficient:
 *   at most two labels are filtered, and only one supports non-equals filters.
```

Local tests demonstrate that-- although it is significantly more constrained--  `FastColumnFilterMap`  is about 4x faster than `DefaultColumnFilterMap` in these limited-filtering scenarios.