### PR TITLE
refactor(core): Move common index logic to abstract base class

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/OnDemandPagingShard.scala
@@ -263,7 +263,7 @@ TimeSeriesShard(ref, schemas, storeConfig, numShards, quotaSource, shardNum, buf
           logger.debug(s"Creating TSPartition for ODP from part ID $id in dataset=$ref shard=$shardNum")
           // If not there, then look up in Lucene and get the details
           for { partKeyBytesRef <- partKeyIndex.partKeyFromPartId(id)
-                unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(partKeyBytesRef.offset)
+                unsafeKeyOffset = PartKeyIndexRaw.bytesRefToUnsafeOffset(partKeyBytesRef.offset)
                 group = partKeyGroup(schemas.part.binSchema, partKeyBytesRef.bytes, unsafeKeyOffset, numGroups)
                 sch  <- Option(schemas(RecordSchema.schemaID(partKeyBytesRef.bytes, unsafeKeyOffset)))
                           } yield {

--- a/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
@@ -1,12 +1,228 @@
 package filodb.core.memstore
 
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.regex.Pattern
+
+import scala.collection.immutable.HashSet
+import scala.util.{Failure, Success}
+
+import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
+import kamon.metric.MeasurementUnit
 import org.apache.lucene.util.BytesRef
 
+import filodb.core.{concurrentCache, DatasetRef, Utils}
+import filodb.core.Types.PartitionKey
+import filodb.core.binaryrecord2.MapItemConsumer
+import filodb.core.memstore.PartKeyIndexRaw.{bytesRefToUnsafeOffset, createTempDir, END_TIME, START_TIME}
+import filodb.core.memstore.PartKeyLuceneIndex.unsafeOffsetToBytesRefOffset
+import filodb.core.memstore.PartKeyQueryBuilder.removeRegexAnchors
 import filodb.core.memstore.ratelimit.CardinalityTracker
+import filodb.core.metadata.Column.ColumnType.{MapColumn, StringColumn}
 import filodb.core.metadata.PartitionSchema
-import filodb.core.query.ColumnFilter
+import filodb.core.query.{ColumnFilter, Filter, QueryUtils}
+import filodb.core.query.Filter.{And, Equals, EqualsRegex, In, NotEquals, NotEqualsRegex}
+import filodb.memory.{UTF8StringMedium, UTF8StringShort}
+import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String => UTF8Str}
 
-trait PartKeyIndexRaw {
+object PartKeyIndexRaw {
+  // NOTE: these partId fields need to be separate because Lucene 9.7.0 enforces consistent types for document
+  //   field values (i.e. a field cannot have both numeric and string values). Additional details can be found
+  //   here: https://github.com/apache/lucene/pull/11
+  final val PART_ID_DV = "__partIdDv__"
+  final val PART_ID_FIELD = "__partIdField__"
+  final val START_TIME = "__startTime__"
+  final val END_TIME = "__endTime__"
+  final val PART_KEY = "__partKey__"
+  final val LABEL_LIST = s"__labelList__"
+  final val FACET_FIELD_PREFIX = "$facet_"
+  final val LABEL_LIST_FACET = FACET_FIELD_PREFIX + LABEL_LIST
+
+  final val ignoreIndexNames = HashSet(START_TIME, PART_KEY, END_TIME, PART_ID_FIELD, PART_ID_DV)
+
+  def bytesRefToUnsafeOffset(bytesRefOffset: Int): Int = bytesRefOffset + UnsafeUtils.arayOffset
+
+  private def defaultTempDir(ref: DatasetRef, shardNum: Int): File = {
+    val baseDir = new File(System.getProperty("java.io.tmpdir"))
+    val baseName = s"partKeyIndex-$ref-$shardNum-${System.currentTimeMillis()}-"
+    val tempDir = new File(baseDir, baseName)
+    tempDir
+  }
+
+  private def createTempDir(ref: DatasetRef, shardNum: Int): File = {
+    val tempDir = defaultTempDir(ref, shardNum)
+    tempDir.mkdir()
+    tempDir
+  }
+}
+
+abstract class PartKeyIndexRaw(ref: DatasetRef,
+                               shardNum: Int,
+                               schema: PartitionSchema,
+                               diskLocation: Option[File] = None,
+                               protected val lifecycleManager: Option[IndexMetadataStore] = None)
+  extends StrictLogging {
+
+  protected val queryIndexLookupLatency = Kamon.histogram("index-partition-lookup-latency",
+      MeasurementUnit.time.nanoseconds)
+    .withTag("dataset", ref.dataset)
+    .withTag("shard", shardNum)
+
+  protected val indexDiskLocation = diskLocation.map(new File(_, ref.dataset + File.separator + shardNum))
+    .getOrElse(createTempDir(ref, shardNum)).toPath
+
+  // If index rebuild is triggered or the state is Building, simply clean up the index directory and start
+  // index rebuild
+  if (
+    lifecycleManager.forall(_.shouldTriggerRebuild(ref, shardNum))
+  ) {
+    logger.info(s"Cleaning up indexDirectory=$indexDiskLocation for  dataset=$ref, shard=$shardNum")
+    Utils.deleteRecursively(indexDiskLocation.toFile) match {
+      case Success(_) => // Notify the handler that the directory is now empty
+        logger.info(s"Cleaned directory for dataset=$ref, shard=$shardNum and index directory=$indexDiskLocation")
+        notifyLifecycleListener(IndexState.Empty, System.currentTimeMillis)
+
+      case Failure(t) => // Update index state as TriggerRebuild again and rethrow the exception
+        logger.warn(s"Exception while deleting directory for dataset=$ref, shard=$shardNum " +
+          s"and index directory=$indexDiskLocation with stack trace", t)
+        notifyLifecycleListener(IndexState.TriggerRebuild, System.currentTimeMillis)
+        throw new IllegalStateException("Unable to clean up index directory", t)
+    }
+  }
+  //else {
+  // TODO here we assume there is non-empty index which we need to validate
+  //}
+
+  protected def loadIndexData[T](ctor: () => T): T = try {
+    ctor()
+  } catch {
+    case e: Exception =>
+      // If an exception is thrown here there is something wrong with the index or the directory
+      // We will attempt once by cleaning the directory and try instantiating the index again
+      logger.warn(s"Index for dataset:${ref.dataset} and shard: $shardNum possibly corrupt," +
+        s"index directory will be cleaned up and index rebuilt", e)
+      Utils.deleteRecursively(indexDiskLocation.toFile) match {
+        case Success(_)       => // Notify the handler that the directory is now empty
+          logger.info(s"Cleaned directory for dataset=$ref," +
+            s"shard=$shardNum and index directory=$indexDiskLocation")
+          notifyLifecycleListener(IndexState.Empty, System.currentTimeMillis)
+        case Failure(t)       => logger.warn(s"Exception while deleting directory for dataset=$ref," +
+          s"shard=$shardNum and index directory=$indexDiskLocation with stack trace", t)
+          // If we still see failure, set the TriggerRebuild and rethrow the exception
+          notifyLifecycleListener(IndexState.TriggerRebuild, System.currentTimeMillis)
+          throw new IllegalStateException("Unable to clean up index directory", t)
+      }
+      // Retry again after cleaning up the index directory, if it fails again, something needs to be looked into.
+      ctor()
+  }
+
+
+  def notifyLifecycleListener(state: IndexState.Value, time: Long): Unit =
+    lifecycleManager.foreach(_.updateState(ref, shardNum, state, time))
+
+
+
+  protected def partKeyString(docId: String,
+                            partKeyOnHeapBytes: Array[Byte],
+                            partKeyBytesRefOffset: Int = 0): String = {
+    val partHash = schema.binSchema.partitionHash(partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset))
+    //scalastyle:off
+    s"shard=$shardNum partId=$docId partHash=$partHash [${
+      TimeSeriesPartition
+        .partKeyString(schema, partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset))
+    }]"
+    //scalastyle:on
+  }
+
+  private val utf8ToStrCache = concurrentCache[UTF8Str, String](PartKeyLuceneIndex.MAX_STR_INTERN_ENTRIES)
+
+  /**
+   * Map of partKey column to the logic for indexing the column (aka Indexer).
+   * Optimization to avoid match logic while iterating through each column of the partKey
+   */
+  protected final val indexers = schema.columns.zipWithIndex.map { case (c, pos) =>
+    c.columnType match {
+      case StringColumn => new Indexer {
+        val colName = UTF8Str(c.name)
+        def fromPartKey(base: Any, offset: Long, partIndex: Int): Unit = {
+          val strOffset = schema.binSchema.blobOffset(base, offset, pos)
+          val numBytes = schema.binSchema.blobNumBytes(base, offset, pos)
+          val value = new String(base.asInstanceOf[Array[Byte]], strOffset.toInt - UnsafeUtils.arayOffset,
+            numBytes, StandardCharsets.UTF_8)
+          addIndexedField(colName.toString, value)
+        }
+        def getNamesValues(key: PartitionKey): Seq[(UTF8Str, UTF8Str)] = ??? // not used
+      }
+      case MapColumn => new Indexer {
+        private val colName = c.name
+
+        private val mapConsumer = new MapItemConsumer {
+          def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
+            import filodb.core._
+            val key = utf8ToStrCache.getOrElseUpdate(new UTF8Str(keyBase, keyOffset + 1,
+              UTF8StringShort.numBytes(keyBase, keyOffset)),
+              _.toString)
+            val value = new String(valueBase.asInstanceOf[Array[Byte]],
+              unsafeOffsetToBytesRefOffset(valueOffset + 2), // add 2 to move past numBytes
+              UTF8StringMedium.numBytes(valueBase, valueOffset), StandardCharsets.UTF_8)
+            addIndexedMapField(colName, key, value)
+          }
+        }
+
+        def fromPartKey(base: Any, offset: Long, partIndex: Int): Unit = {
+          schema.binSchema.consumeMapItems(base, offset, pos, mapConsumer)
+        }
+        def getNamesValues(key: PartitionKey): Seq[(UTF8Str, UTF8Str)] = ??? // not used
+      }
+      case other: Any =>
+        logger.warn(s"Column $c has type that cannot be indexed and will be ignored right now")
+        NoOpIndexer
+    }
+  }.toArray
+
+  protected val numPartColumns = schema.columns.length
+
+  private final val emptyStr = ""
+  // Multi-column facets to be created on "partition-schema" columns
+  protected def createMultiColumnFacets(partKeyOnHeapBytes: Array[Byte], partKeyBytesRefOffset: Int): Unit = {
+    schema.options.multiColumnFacets.foreach(facetCols => {
+      facetCols match {
+        case (name, cols) => {
+          val concatFacetValue = cols.map { col =>
+            val colInfoOpt = schema.columnIdxLookup.get(col)
+            colInfoOpt match {
+              case Some((columnInfo, pos)) if columnInfo.columnType == StringColumn =>
+                val base = partKeyOnHeapBytes
+                val offset = bytesRefToUnsafeOffset(partKeyBytesRefOffset)
+                val strOffset = schema.binSchema.blobOffset(base, offset, pos)
+                val numBytes = schema.binSchema.blobNumBytes(base, offset, pos)
+                new String(base, strOffset.toInt - UnsafeUtils.arayOffset,
+                  numBytes, StandardCharsets.UTF_8)
+              case _ => emptyStr
+            }
+          }.mkString("\u03C0")
+          addMultiColumnFacet(name, concatFacetValue)
+        }
+      }
+    })
+  }
+
+
+  /**
+   * Add an indexed field + value to the document being prepared
+   */
+  protected def addIndexedField(key: String, value: String): Unit
+
+  /**
+   * Add an indexed field + value defined in a map field to the document being prepared
+   */
+  protected def addIndexedMapField(mapColumn: String, key: String, value: String): Unit
+
+  /**
+   * Add a facet for a computed multi-column facet
+   */
+  protected def addMultiColumnFacet(key: String, value: String): Unit
 
   /**
    * Clear the index by deleting all documents and commit
@@ -48,11 +264,6 @@ trait PartKeyIndexRaw {
    * Number of documents in flushed index, excludes tombstones for deletes
    */
   def indexNumEntries: Long
-
-  /**
-   * Number of documents in flushed index, includes tombstones for deletes
-   */
-  def indexNumEntriesWithTombstones: Long
 
   /**
    * Closes the index for read by other clients. Check for implementation if commit would be done
@@ -132,7 +343,7 @@ trait PartKeyIndexRaw {
   /**
    * Commit index contents to disk
    */
-  def commit(): Long
+  def commit(): Unit
 
   /**
    * Update existing part key document with new endTime.
@@ -181,11 +392,14 @@ trait PartKeyIndexRaw {
 
 }
 
-trait PartKeyIndexDownsampled extends PartKeyIndexRaw {
+abstract class PartKeyIndexDownsampled(ref: DatasetRef,
+                                       shardNum: Int,
+                                       schema: PartitionSchema,
+                                       diskLocation: Option[File] = None,
+                                       lifecycleManager: Option[IndexMetadataStore] = None)
+  extends PartKeyIndexRaw(ref, shardNum, schema, diskLocation, lifecycleManager) {
 
   def getCurrentIndexState(): (IndexState.Value, Option[Long])
-
-  def  notifyLifecycleListener(state: IndexState.Value, time: Long): Unit
 
   /**
    * Iterate through the LuceneIndex and calculate cardinality count
@@ -205,3 +419,209 @@ trait PartKeyIndexDownsampled extends PartKeyIndexRaw {
                                    endTime: Long, func: (BytesRef) => Unit): Int
 
 }
+
+/**
+ * Base class to convert incoming FiloDB ColumnFilters into the index native
+ * query format.  Uses a visitor pattern to allow the implementation to build
+ * different query object patterns.
+ *
+ * The query language supports the following:
+ * * Boolean queries (many subqueries with MUST / MUST_NOT).  These may be nested.
+ * * Equals queries (term match)
+ * * Regex queries (regex term match)
+ * * TermIn queries (term presence in list)
+ * * Prefix queries (term starts with)
+ * * MatchAll queries (match all values)
+ * * Range queries (start to end on a long value)
+ *
+ * This list may expand over time.
+ *
+ * The top level is always a Boolean query, even if it only has one child query.  A
+ * Boolean query will never have zero child queries.  Leaf nodes are always non-Boolean
+ * queries.
+ *
+ * For example:
+ *   + represents MUST, - represents MUST_NOT
+ *   Input query -> ((+Equals(Col, A) -Equals(Col, B)) +Regex(Col2, C.*))
+ *
+ *   The visitor call pattern would be:
+ *    * visitStartBooleanQuery
+ *    * visitStartBooleanQuery
+ *    * visitEqualsQuery(Col, A, MUST)
+ *    * visitEqualsQuery(Col, B, MUST_NOT)
+ *    * visitEndBooleanQuery
+ *    * visitRegexQuery(Col2, C.*, MUST)
+ *    * visitEndBooleanQuery
+ *
+ * This class should be used instead of putting query parsing code in each
+ * implementation so that common optimizations, such as query rewriting,
+ * can occur in one place.
+ */
+abstract class PartKeyQueryBuilder {
+  /**
+   * Start a new boolean query
+   */
+  protected def visitStartBooleanQuery(): Unit
+
+  /**
+   * Indicate the current boolean query has ended
+   */
+  protected def visitEndBooleanQuery(): Unit
+
+  /**
+   * Add a new equals query to the current boolean query
+   */
+  protected def visitEqualsQuery(column: String, term: String, occur: PartKeyQueryOccur): Unit
+
+  /**
+   * Add a new Regex query to the current boolean query
+   */
+  protected def visitRegexQuery(column: String, pattern: String, occur: PartKeyQueryOccur): Unit
+
+  /**
+   * Add a TermsIn query to the current boolean query
+   */
+  protected def visitTermInQuery(column: String, terms: Seq[String], occur: PartKeyQueryOccur): Unit
+
+  /**
+   * Add a prefix query to the current boolean query
+   */
+  protected def visitPrefixQuery(column: String, prefix: String, occur: PartKeyQueryOccur): Unit
+
+  /**
+   * Add a match all query to the current boolean query
+   */
+  protected def visitMatchAllQuery(): Unit
+
+  /**
+   * Add a range match to the current boolean query
+   */
+  protected def visitRangeQuery(column: String, start: Long, end: Long, occur: PartKeyQueryOccur): Unit
+
+  protected def visitQuery(columnFilters: Seq[ColumnFilter]): Unit = {
+    visitStartBooleanQuery()
+    columnFilters.foreach { filter =>
+      visitFilter(filter.column, filter.filter)
+    }
+    visitEndBooleanQuery()
+  }
+
+  protected def visitQueryWithStartAndEnd(columnFilters: Seq[ColumnFilter], startTime: PartitionKey,
+                                          endTime: PartitionKey): Unit = {
+    visitStartBooleanQuery()
+    columnFilters.foreach { filter =>
+      visitFilter(filter.column, filter.filter)
+    }
+    visitRangeQuery(START_TIME, 0, endTime, OccurMust)
+    visitRangeQuery(END_TIME, startTime, Long.MaxValue, OccurMust)
+    visitEndBooleanQuery()
+  }
+
+  // scalastyle:off method.length
+  private def visitFilter(column: String, filter: Filter): Unit = {
+    def equalsQuery(value: String): Unit = {
+      if (value.nonEmpty) visitEqualsQuery(column, value, OccurMust)
+      else visitFilter(column, NotEqualsRegex(".+")) // value="" means the label is absent or has an empty value.
+    }
+
+    filter match {
+      case EqualsRegex(value) =>
+        val regex = removeRegexAnchors(value.toString)
+        if (regex == "") {
+          // if label=~"" then match empty string or label not present condition too
+          visitFilter(column, NotEqualsRegex(".+"))
+        } else if (regex.replaceAll("\\.\\*", "") == "") {
+          // if label=~".*" then match all docs since promQL matches .* with absent label too
+          visitMatchAllQuery()
+        } else if (!QueryUtils.containsRegexChars(regex)) {
+          // if all regex special chars absent, then treat like Equals
+          equalsQuery(regex)
+        } else if (QueryUtils.containsPipeOnlyRegex(regex)) {
+          // if pipe is only regex special char present, then convert to IN query
+          visitTermInQuery(column, regex.split('|'), OccurMust)
+        } else if (regex.endsWith(".*") && regex.length > 2 &&
+          !QueryUtils.containsRegexChars(regex.dropRight(2))) {
+          // if suffix is .* and no regex special chars present in non-empty prefix, then use prefix query
+          visitPrefixQuery(column, regex.dropRight(2), OccurMust)
+        } else {
+          // regular non-empty regex query
+          visitRegexQuery(column, regex, OccurMust)
+        }
+
+      case NotEqualsRegex(value) =>
+        val term = removeRegexAnchors(value.toString)
+        visitStartBooleanQuery()
+        visitMatchAllQuery()
+        visitRegexQuery(column, term, OccurMustNot)
+        visitEndBooleanQuery()
+
+      case Equals(value) =>
+        equalsQuery(value.toString)
+
+      case NotEquals(value) =>
+        val str = value.toString
+        visitStartBooleanQuery()
+        str.isEmpty match {
+          case true =>
+            visitRegexQuery(column, ".*", OccurMust)
+          case false =>
+            visitMatchAllQuery()
+        }
+        visitEqualsQuery(column, str, OccurMustNot)
+        visitEndBooleanQuery()
+
+      case In(values) =>
+        visitTermInQuery(column, values.toArray.map(t => t.toString), OccurMust)
+
+      case And(lhs, rhs) =>
+        visitStartBooleanQuery()
+        visitFilter(column, lhs)
+        visitFilter(column, rhs)
+        visitEndBooleanQuery()
+
+      case _ => throw new UnsupportedOperationException
+    }
+  }
+  //scalastyle:on method.length
+}
+
+object PartKeyQueryBuilder {
+
+  /**
+   * Remove leading anchor &#94; and ending anchor $.
+   *
+   * @param regex the orignal regex string.
+   * @return the regex string without anchors.
+   */
+  def removeRegexAnchors(regex: String): String = {
+    removeRegexTailDollarSign(regex.stripPrefix("^"))
+  }
+
+  private def removeRegexTailDollarSign(regex: String): String = {
+    // avoid unnecessary calculation when $ is not present at the end of the regex.
+    if (regex.nonEmpty && regex.last == '$' && Pattern.matches("""^(|.*[^\\])(\\\\)*\$$""", regex)) {
+      // (|.*[^\\]) means either empty or a sequence end with a character not \.
+      // (\\\\)* means any number of \\.
+      // remove the last $ if it is not \$.
+      // $ at locations other than the end will not be removed.
+      regex.substring(0, regex.length - 1)
+    } else {
+      regex
+    }
+  }
+}
+
+/**
+ * Enumeration of occur values for a query - MUST vs MUST_NOT
+ */
+sealed trait PartKeyQueryOccur
+
+/**
+ * Query must match
+ */
+case object OccurMust extends PartKeyQueryOccur
+
+/**
+ * Query must not match
+ */
+case object OccurMustNot extends PartKeyQueryOccur

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -1,19 +1,13 @@
 package filodb.core.memstore
 
 import java.io.File
-import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.util
 import java.util.{Base64, PriorityQueue}
-import java.util.regex.Pattern
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.HashSet
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
 import com.github.benmanes.caffeine.cache.{Caffeine, LoadingCache}
 import com.googlecode.javaewah.{EWAHCompressedBitmap, IntIterator}
@@ -35,39 +29,20 @@ import org.apache.lucene.util.{BytesRef, InfoStream}
 import org.apache.lucene.util.automaton.RegExp
 import spire.syntax.cfor._
 
-import filodb.core.{concurrentCache, DatasetRef}
+import filodb.core.DatasetRef
 import filodb.core.Types.PartitionKey
-import filodb.core.binaryrecord2.MapItemConsumer
 import filodb.core.memstore.ratelimit.CardinalityTracker
-import filodb.core.metadata.Column.ColumnType.{MapColumn, StringColumn}
 import filodb.core.metadata.PartitionSchema
-import filodb.core.query.{ColumnFilter, Filter, QueryUtils}
-import filodb.core.query.Filter._
-import filodb.memory.{BinaryRegionLarge, UTF8StringMedium, UTF8StringShort}
+import filodb.core.query.{ColumnFilter, Filter}
+import filodb.memory.BinaryRegionLarge
 import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String => UTF8Str}
 
 object PartKeyLuceneIndex {
-  // NOTE: these partId fields need to be separate because Lucene 9.7.0 enforces consistent types for document
-  //   field values (i.e. a field cannot have both numeric and string values). Additional details can be found
-  //   here: https://github.com/apache/lucene/pull/11
-  final val PART_ID_DV = "__partIdDv__"
-  final val PART_ID_FIELD = "__partIdField__"
-  final val START_TIME = "__startTime__"
-  final val END_TIME = "__endTime__"
-  final val PART_KEY = "__partKey__"
-  final val LABEL_LIST = s"__labelList__"
-  final val FACET_FIELD_PREFIX = "$facet_"
-  final val LABEL_LIST_FACET = FACET_FIELD_PREFIX + LABEL_LIST
-
-  final val ignoreIndexNames = HashSet(START_TIME, PART_KEY, END_TIME, PART_ID_FIELD, PART_ID_DV)
-
   val MAX_STR_INTERN_ENTRIES = 10000
   val MAX_TERMS_TO_ITERATE = 10000
   val FACET_FIELD_MAX_LEN = 1000
 
   val NOT_FOUND = -1
-
-  def bytesRefToUnsafeOffset(bytesRefOffset: Int): Int = bytesRefOffset + UnsafeUtils.arayOffset
 
   def unsafeOffsetToBytesRefOffset(offset: Long): Int = offset.toInt - UnsafeUtils.arayOffset
 
@@ -76,48 +51,12 @@ object PartKeyLuceneIndex {
       BinaryRegionLarge.numBytes(partKeyBase, partKeyOffset))
   }
 
-  def defaultTempDir(ref: DatasetRef, shardNum: Int): File = {
-    val baseDir = new File(System.getProperty("java.io.tmpdir"))
-    val baseName = s"partKeyIndex-$ref-$shardNum-${System.currentTimeMillis()}-"
-    val tempDir = new File(baseDir, baseName)
-    tempDir
-  }
-
-  private def createTempDir(ref: DatasetRef, shardNum: Int): File = {
-    val tempDir = defaultTempDir(ref, shardNum)
-    tempDir.mkdir()
-    tempDir
-  }
-
   def partKeyByteRefToSHA256Digest(bytes: Array[Byte], offset: Int, length: Int): String = {
     import java.security.MessageDigest
     val md: MessageDigest = MessageDigest.getInstance("SHA-256")
     md.update(bytes, offset, length)
     val strDigest = Base64.getEncoder.encodeToString(md.digest())
     strDigest
-  }
-
-   private def removeRegexTailDollarSign(regex: String): String = {
-    // avoid unnecessary calculation when $ is not present at the end of the regex.
-    if (regex.nonEmpty && regex.last == '$' && Pattern.matches("""^(|.*[^\\])(\\\\)*\$$""", regex)) {
-      // (|.*[^\\]) means either empty or a sequence end with a character not \.
-      // (\\\\)* means any number of \\.
-      // remove the last $ if it is not \$.
-      // $ at locations other than the end will not be removed.
-      regex.substring(0, regex.length - 1)
-    } else {
-      regex
-    }
-  }
-
-  /**
-   * Remove leading anchor &#94; and ending anchor $.
-   *
-   * @param regex the orignal regex string.
-   * @return the regex string without anchors.
-   */
-  def removeRegexAnchors(regex: String): String = {
-    removeRegexTailDollarSign(regex.stripPrefix("^"))
   }
 }
 
@@ -132,19 +71,15 @@ class PartKeyLuceneIndex(ref: DatasetRef,
                          shardNum: Int,
                          retentionMillis: Long, // only used to calculate fallback startTime
                          diskLocation: Option[File] = None,
-                         val lifecycleManager: Option[IndexMetadataStore] = None,
+                         lifecycleManager: Option[IndexMetadataStore] = None,
                          useMemoryMappedImpl: Boolean = true,
                          disableIndexCaching: Boolean = false
-                        ) extends StrictLogging with PartKeyIndexDownsampled {
+                        ) extends PartKeyIndexDownsampled(ref, shardNum, schema, diskLocation, lifecycleManager) {
 
   import PartKeyLuceneIndex._
+  import PartKeyIndexRaw._
 
   val startTimeLookupLatency = Kamon.histogram("index-startTimes-for-odp-lookup-latency",
-    MeasurementUnit.time.nanoseconds)
-    .withTag("dataset", ref.dataset)
-    .withTag("shard", shardNum)
-
-  val queryIndexLookupLatency = Kamon.histogram("index-partition-lookup-latency",
     MeasurementUnit.time.nanoseconds)
     .withTag("dataset", ref.dataset)
     .withTag("shard", shardNum)
@@ -162,38 +97,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   val readerStateCacheHitRate = Kamon.gauge("index-reader-state-cache-hit-rate")
     .withTag("dataset", ref.dataset)
     .withTag("shard", shardNum)
-
-  private val numPartColumns = schema.columns.length
-
-
-  val indexDiskLocation = diskLocation.map(new File(_, ref.dataset + File.separator + shardNum))
-    .getOrElse(createTempDir(ref, shardNum)).toPath
-
-  // If index rebuild is triggered or the state is Building, simply clean up the index directory and start
-  // index rebuild
-  if (
-    lifecycleManager.forall(_.shouldTriggerRebuild(ref, shardNum))
-  ) {
-    logger.info(s"Cleaning up indexDirectory=$indexDiskLocation for  dataset=$ref, shard=$shardNum")
-    deleteRecursively(indexDiskLocation.toFile) match {
-      case Success(_) => // Notify the handler that the directory is now empty
-        logger.info(s"Cleaned directory for dataset=$ref, shard=$shardNum and index directory=$indexDiskLocation")
-        notifyLifecycleListener(IndexState.Empty, System.currentTimeMillis)
-
-      case Failure(t) => // Update index state as TriggerRebuild again and rethrow the exception
-        logger.warn(s"Exception while deleting directory for dataset=$ref, shard=$shardNum " +
-          s"and index directory=$indexDiskLocation with stack trace", t)
-        notifyLifecycleListener(IndexState.TriggerRebuild, System.currentTimeMillis)
-        throw new IllegalStateException("Unable to clean up index directory", t)
-    }
-  }
-  //else {
-  // TODO here we assume there is non-empty index which we need to validate
-  //}
-
-  def  notifyLifecycleListener(state: IndexState.Value, time: Long): Unit =
-    lifecycleManager.foreach(_.updateState(ref, shardNum, state, time))
-
 
   val fsDirectory = if (useMemoryMappedImpl)
     new MMapDirectory(indexDiskLocation)
@@ -215,30 +118,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   }
 
   private val indexWriter =
-    try {
-      new IndexWriterPlus(fsDirectory, createIndexWriterConfig(), ref, shardNum)
-    } catch {
-      case e: Exception =>
-        // If an exception is thrown here there is something wrong with the index or the directory
-        // We will attempt once by cleaning the directory and try instantiating the index again
-        logger.warn(s"Index for dataset:${ref.dataset} and shard: $shardNum possibly corrupt," +
-          s"index directory will be cleaned up and index rebuilt", e)
-        deleteRecursively(indexDiskLocation.toFile) match {
-          case Success(_)       => // Notify the handler that the directory is now empty
-            logger.info(s"Cleaned directory for dataset=$ref," +
-              s"shard=$shardNum and index directory=$indexDiskLocation")
-            notifyLifecycleListener(IndexState.Empty, System.currentTimeMillis)
-          case Failure(t)       => logger.warn(s"Exception while deleting directory for dataset=$ref," +
-            s"shard=$shardNum and index directory=$indexDiskLocation with stack trace", t)
-            // If we still see failure, set the TriggerRebuild and rethrow the exception
-            notifyLifecycleListener(IndexState.TriggerRebuild, System.currentTimeMillis)
-            throw new IllegalStateException("Unable to clean up index directory", t)
-        }
-        // Retry again after cleaning up the index directory, if it fails again, something needs to be looked into.
-        new IndexWriterPlus(fsDirectory, createIndexWriterConfig(), ref, shardNum)
-    }
-
-  private val utf8ToStrCache = concurrentCache[UTF8Str, String](PartKeyLuceneIndex.MAX_STR_INTERN_ENTRIES)
+    loadIndexData(() => new IndexWriterPlus(fsDirectory, createIndexWriterConfig(), ref, shardNum))
 
   //scalastyle:off
   private val searcherManager =
@@ -268,35 +148,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
 
   private def facetEnabledForLabel(label: String) = {
     facetEnabledAllLabels || (facetEnabledShardKeyLabels && schema.options.shardKeyColumns.contains(label))
-  }
-
-  private def deleteRecursively(f: File, deleteRoot: Boolean = false): Try[Boolean] = {
-    val subDirDeletion: Try[Boolean] =
-      if (f.isDirectory)
-        f.listFiles match {
-          case xs: Array[File] if xs != null  && !xs.isEmpty  =>
-            val subDirDeletions: Array[Try[Boolean]] = xs map (f => deleteRecursively(f, true))
-              subDirDeletions reduce((reduced, thisOne) => {
-                thisOne match {
-                  // Ensures even if one Right(_) is found, thr response will be Right(Throwable)
-                  case Success(_) if reduced == Success(true)    => thisOne
-                  case Failure(_)                                => thisOne
-                  case _                                         => reduced
-                }
-              })
-          case _                               => Success(true)
-        }
-      else
-        Success(true)
-
-    subDirDeletion match  {
-      case Success(_)        =>
-        if (deleteRoot) {
-          if (f.delete()) Success(true) else Failure(new IOException(s"Unable to delete $f"))
-        } else Success(true)
-      case right @ Failure(_)  => right
-    }
-
   }
 
   case class ReusableLuceneDocument() {
@@ -384,49 +235,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     override def initialValue(): ReusableLuceneDocument = new ReusableLuceneDocument
   }
 
-  private val mapConsumer = new MapItemConsumer {
-    def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
-      import filodb.core._
-      val key = utf8ToStrCache.getOrElseUpdate(new UTF8Str(keyBase, keyOffset + 1,
-        UTF8StringShort.numBytes(keyBase, keyOffset)),
-        _.toString)
-      val value = new String(valueBase.asInstanceOf[Array[Byte]],
-        unsafeOffsetToBytesRefOffset(valueOffset + 2), // add 2 to move past numBytes
-        UTF8StringMedium.numBytes(valueBase, valueOffset), StandardCharsets.UTF_8)
-      addIndexedField(key, value)
-    }
-  }
-
-  /**
-   * Map of partKey column to the logic for indexing the column (aka Indexer).
-   * Optimization to avoid match logic while iterating through each column of the partKey
-   */
-  private final val indexers = schema.columns.zipWithIndex.map { case (c, pos) =>
-    c.columnType match {
-      case StringColumn => new Indexer {
-        val colName = UTF8Str(c.name)
-        def fromPartKey(base: Any, offset: Long, partIndex: Int): Unit = {
-          val strOffset = schema.binSchema.blobOffset(base, offset, pos)
-          val numBytes = schema.binSchema.blobNumBytes(base, offset, pos)
-          val value = new String(base.asInstanceOf[Array[Byte]], strOffset.toInt - UnsafeUtils.arayOffset,
-            numBytes, StandardCharsets.UTF_8)
-          addIndexedField(colName.toString, value)
-        }
-        def getNamesValues(key: PartitionKey): Seq[(UTF8Str, UTF8Str)] = ??? // not used
-      }
-      case MapColumn => new Indexer {
-        def fromPartKey(base: Any, offset: Long, partIndex: Int): Unit = {
-          schema.binSchema.consumeMapItems(base, offset, pos, mapConsumer)
-        }
-        def getNamesValues(key: PartitionKey): Seq[(UTF8Str, UTF8Str)] = ??? // not used
-      }
-      case other: Any =>
-        logger.warn(s"Column $c has type that cannot be indexed and will be ignored right now")
-        NoOpIndexer
-    }
-  }.toArray
-
-
   def getCurrentIndexState(): (IndexState.Value, Option[Long]) =
     lifecycleManager.map(_.currentState(this.ref, this.shardNum)).getOrElse((IndexState.Empty, None))
 
@@ -447,14 +255,14 @@ class PartKeyLuceneIndex(ref: DatasetRef,
 
   def partIdsEndedBefore(endedBefore: Long): debox.Buffer[Int] = {
     val collector = new PartIdCollector(Int.MaxValue)
-    val deleteQuery = LongPoint.newRangeQuery(PartKeyLuceneIndex.END_TIME, 0, endedBefore)
+    val deleteQuery = LongPoint.newRangeQuery(END_TIME, 0, endedBefore)
 
     withNewSearcher(s => s.search(deleteQuery, collector))
     collector.result
   }
 
   def removePartitionsEndedBefore(endedBefore: Long, returnApproxDeletedCount: Boolean = true): Int = {
-    val deleteQuery = LongPoint.newRangeQuery(PartKeyLuceneIndex.END_TIME, 0, endedBefore)
+    val deleteQuery = LongPoint.newRangeQuery(END_TIME, 0, endedBefore)
     // SInce delete does not return the deleted document count, we query to get the count that match the filter criteria
     // and then delete the documents
     val approxDeletedCount = if (returnApproxDeletedCount) {
@@ -493,8 +301,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   def indexRamBytes: Long = indexWriter.ramBytesUsed()
 
   def indexNumEntries: Long = indexWriter.getDocStats().numDocs
-
-  def indexNumEntriesWithTombstones: Long = indexWriter.getDocStats().maxDoc
 
   def closeIndex(): Unit = {
     logger.info(s"Closing index on dataset=$ref shard=$shardNum")
@@ -620,8 +426,12 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     ret
   }
 
-  private def addIndexedField(labelName: String, value: String): Unit = {
+  protected def addIndexedField(labelName: String, value: String): Unit = {
     luceneDocument.get().addField(labelName, value)
+  }
+
+  protected def addIndexedMapField(mapColumn: String, key: String, value: String): Unit = {
+    luceneDocument.get().addField(key, value)
   }
 
   def addPartKey(partKeyOnHeapBytes: Array[Byte],
@@ -655,19 +465,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     indexWriter.updateDocument(term, docToAdd)
   }
 
-
-  private def partKeyString(docId: String,
-                            partKeyOnHeapBytes: Array[Byte],
-                            partKeyBytesRefOffset: Int = 0): String = {
-    val partHash = schema.binSchema.partitionHash(partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset))
-    //scalastyle:off
-    s"shard=$shardNum partId=$docId partHash=$partHash [${
-      TimeSeriesPartition
-        .partKeyString(schema, partKeyOnHeapBytes, bytesRefToUnsafeOffset(partKeyBytesRefOffset))
-    }]"
-    //scalastyle:on
-  }
-
   private def makeDocument(partKeyOnHeapBytes: Array[Byte],
                            partKeyBytesRefOffset: Int,
                            partKeyNumBytes: Int,
@@ -685,29 +482,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     luceneDocument.get().document
   }
 
-  private final val emptyStr = ""
-  // Multi-column facets to be created on "partition-schema" columns
-  private def createMultiColumnFacets(partKeyOnHeapBytes: Array[Byte], partKeyBytesRefOffset: Int): Unit = {
-    schema.options.multiColumnFacets.foreach(facetCols => {
-      facetCols match {
-        case (name, cols) => {
-          val concatFacetValue = cols.map { col =>
-            val colInfoOpt = schema.columnIdxLookup.get(col)
-            colInfoOpt match {
-              case Some((columnInfo, pos)) if columnInfo.columnType == StringColumn =>
-                val base = partKeyOnHeapBytes
-                val offset = bytesRefToUnsafeOffset(partKeyBytesRefOffset)
-                val strOffset = schema.binSchema.blobOffset(base, offset, pos)
-                val numBytes = schema.binSchema.blobNumBytes(base, offset, pos)
-                new String(base, strOffset.toInt - UnsafeUtils.arayOffset,
-                  numBytes, StandardCharsets.UTF_8)
-              case _ => emptyStr
-            }
-          }.mkString("\u03C0")
-          luceneDocument.get().addFacet(name, concatFacetValue, false)
-        }
-      }
-    })
+  protected override def addMultiColumnFacet(key: String, value: String): Unit = {
+    luceneDocument.get().addFacet(key, value, false)
   }
 
   def partKeyFromPartId(partId: Int): Option[BytesRef] = {
@@ -717,7 +493,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   }
 
   def startTimeFromPartId(partId: Int): Long = {
-    val collector = new NumericDocValueCollector(PartKeyLuceneIndex.START_TIME)
+    val collector = new NumericDocValueCollector(START_TIME)
     withNewSearcher(s => s.search(new TermQuery(new Term(PART_ID_FIELD, partId.toString)), collector))
     collector.singleResult
   }
@@ -741,10 +517,10 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     collector.startTimes
   }
 
-  def commit(): Long = indexWriter.commit()
+  def commit(): Unit = indexWriter.commit()
 
   def endTimeFromPartId(partId: Int): Long = {
-    val collector = new NumericDocValueCollector(PartKeyLuceneIndex.END_TIME)
+    val collector = new NumericDocValueCollector(END_TIME)
     withNewSearcher(s => s.search(new TermQuery(new Term(PART_ID_FIELD, partId.toString)), collector))
     collector.singleResult
   }
@@ -804,78 +580,6 @@ class PartKeyLuceneIndex(ref: DatasetRef,
     logger.info(s"Refreshed index searchers to make reads consistent for dataset=$ref shard=$shardNum")
   }
 
-  // scalastyle:off method.length
-  private def leafFilter(column: String, filter: Filter): Query = {
-
-    def equalsQuery(value: String): Query = {
-      if (value.nonEmpty) new TermQuery(new Term(column, value))
-      else leafFilter(column, NotEqualsRegex(".+")) // value="" means the label is absent or has an empty value.
-    }
-
-    filter match {
-      case EqualsRegex(value) =>
-        val regex = removeRegexAnchors(value.toString)
-        if (regex == "") {
-          // if label=~"" then match empty string or label not present condition too
-          leafFilter(column, NotEqualsRegex(".+"))
-        } else if (regex.replaceAll("\\.\\*", "") == "") {
-          // if label=~".*" then match all docs since promQL matches .* with absent label too
-          new MatchAllDocsQuery
-        } else if (!QueryUtils.containsRegexChars(regex)) {
-          // if all regex special chars absent, then treat like Equals
-          equalsQuery(regex)
-        } else if (QueryUtils.containsPipeOnlyRegex(regex)) {
-          // if pipe is only regex special char present, then convert to IN query
-          new TermInSetQuery(column, regex.split('|').map(t => new BytesRef(t)): _*)
-        } else if (regex.endsWith(".*") && regex.length > 2 &&
-                   !QueryUtils.containsRegexChars(regex.dropRight(2))) {
-          // if suffix is .* and no regex special chars present in non-empty prefix, then use prefix query
-          new PrefixQuery(new Term(column, regex.dropRight(2)))
-        } else {
-          // regular non-empty regex query
-          new RegexpQuery(new Term(column, regex), RegExp.NONE)
-        }
-
-      case NotEqualsRegex(value) =>
-        val term = new Term(column, removeRegexAnchors(value.toString))
-        val allDocs = new MatchAllDocsQuery
-        val booleanQuery = new BooleanQuery.Builder
-        booleanQuery.add(allDocs, Occur.FILTER)
-        booleanQuery.add(new RegexpQuery(term, RegExp.NONE), Occur.MUST_NOT)
-        booleanQuery.build()
-
-      case Equals(value) =>
-        equalsQuery(value.toString)
-
-      case NotEquals(value) =>
-        val str = value.toString
-        val term = new Term(column, str)
-        val booleanQuery = new BooleanQuery.Builder
-        str.isEmpty match {
-          case true =>
-            val termAll = new Term(column, ".*")
-            booleanQuery.add(new RegexpQuery(termAll, RegExp.NONE), Occur.FILTER)
-          case false =>
-            val allDocs = new MatchAllDocsQuery
-            booleanQuery.add(allDocs, Occur.FILTER)
-        }
-        booleanQuery.add(new TermQuery(term), Occur.MUST_NOT)
-        booleanQuery.build()
-
-      case In(values) =>
-        new TermInSetQuery(column, values.toArray.map(t => new BytesRef(t.toString)): _*)
-
-      case And(lhs, rhs) =>
-        val andQuery = new BooleanQuery.Builder
-        andQuery.add(leafFilter(column, lhs), Occur.FILTER)
-        andQuery.add(leafFilter(column, rhs), Occur.FILTER)
-        andQuery.build()
-
-      case _ => throw new UnsupportedOperationException
-    }
-  }
-  //scalastyle:on method.length
-
   def partIdsFromFilters(columnFilters: Seq[ColumnFilter],
                          startTime: Long,
                          endTime: Long,
@@ -932,15 +636,8 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   }
 
   private def colFiltersToQuery(columnFilters: Seq[ColumnFilter], startTime: PartitionKey, endTime: PartitionKey) = {
-    val booleanQuery = new BooleanQuery.Builder
-    columnFilters.foreach { filter =>
-      val q = leafFilter(filter.column, filter.filter)
-      booleanQuery.add(q, Occur.FILTER)
-    }
-    booleanQuery.add(LongPoint.newRangeQuery(START_TIME, 0, endTime), Occur.FILTER)
-    booleanQuery.add(LongPoint.newRangeQuery(END_TIME, startTime, Long.MaxValue), Occur.FILTER)
-    val query = booleanQuery.build()
-    new ConstantScoreQuery(query) // disable scoring
+    val queryBuilder = new LuceneQueryBuilder()
+    queryBuilder.buildQueryWithStartAndEnd(columnFilters, startTime, endTime)
   }
 
   def partIdFromPartKeySlow(partKeyBase: Any,
@@ -950,18 +647,15 @@ class PartKeyLuceneIndex(ref: DatasetRef,
       .map { pair => ColumnFilter(pair._1, Filter.Equals(pair._2)) }
 
     val startExecute = System.nanoTime()
-    val booleanQuery = new BooleanQuery.Builder
-    columnFilters.foreach { filter =>
-      val q = leafFilter(filter.column, filter.filter)
-      booleanQuery.add(q, Occur.FILTER)
-    }
-    val query = booleanQuery.build()
+    val queryBuilder = new LuceneQueryBuilder()
+    val query = queryBuilder.buildQuery(columnFilters)
+
     logger.debug(s"Querying dataset=$ref shard=$shardNum partKeyIndex with: $query")
     var chosenPartId: Option[Int] = None
     def handleMatch(partId: Int, candidate: BytesRef): Unit = {
       // we need an equals check because there can potentially be another partKey with additional tags
       if (schema.binSchema.equals(partKeyBase, partKeyOffset,
-        candidate.bytes, PartKeyLuceneIndex.bytesRefToUnsafeOffset(candidate.offset))) {
+        candidate.bytes, PartKeyIndexRaw.bytesRefToUnsafeOffset(candidate.offset))) {
         logger.debug(s"There is already a partId=$partId assigned for " +
           s"${schema.binSchema.stringify(partKeyBase, partKeyOffset)} in" +
           s" dataset=$ref shard=$shardNum")
@@ -982,6 +676,100 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   }
 }
 
+protected class LuceneQueryBuilder extends PartKeyQueryBuilder {
+
+  private val stack: mutable.ArrayStack[BooleanQuery.Builder] = mutable.ArrayStack()
+
+  private def toLuceneOccur(occur: PartKeyQueryOccur): Occur = {
+    occur match {
+      case OccurMust => Occur.MUST
+      case OccurMustNot => Occur.MUST_NOT
+    }
+  }
+
+  override protected def visitStartBooleanQuery(): Unit = {
+    stack.push(new BooleanQuery.Builder)
+  }
+
+  override protected def visitEndBooleanQuery(): Unit = {
+    val builder = stack.pop()
+    val query = builder.build()
+
+    val parent = stack.top
+    parent.add(query, Occur.FILTER)
+  }
+
+  override protected def visitEqualsQuery(column: String, term: String, occur: PartKeyQueryOccur): Unit = {
+    val query = new TermQuery(new Term(column, term))
+
+    val parent = stack.top
+    parent.add(query, toLuceneOccur(occur))
+  }
+
+  override protected def visitRegexQuery(column: String, pattern: String, occur: PartKeyQueryOccur): Unit = {
+    val query = new RegexpQuery(new Term(column, pattern), RegExp.NONE)
+
+    val parent = stack.top
+    parent.add(query, toLuceneOccur(occur))
+  }
+
+  override protected def visitTermInQuery(column: String, terms: Seq[String], occur: PartKeyQueryOccur): Unit = {
+    val query = new TermInSetQuery(column, terms.toArray.map(t => new BytesRef(t)): _*)
+
+    val parent = stack.top
+    parent.add(query, toLuceneOccur(occur))
+  }
+
+  override protected def visitPrefixQuery(column: String, prefix: String, occur: PartKeyQueryOccur): Unit = {
+    val query = new PrefixQuery(new Term(column, prefix))
+
+    val parent = stack.top
+    parent.add(query, toLuceneOccur(occur))
+  }
+
+  override protected def visitMatchAllQuery(): Unit = {
+    val query = new MatchAllDocsQuery
+
+    val parent = stack.top
+    parent.add(query, Occur.MUST)
+  }
+
+  override protected def visitRangeQuery(column: String, start: Long, end: Long,
+                                         occur: PartKeyQueryOccur): Unit = {
+    val query = LongPoint.newRangeQuery(column, start, end)
+
+    val parent = stack.top
+    parent.add(query, toLuceneOccur(occur))
+  }
+
+  def buildQuery(columnFilters: Seq[ColumnFilter]): Query = {
+    visitStartBooleanQuery()
+    visitQuery(columnFilters)
+
+    val builder = stack.pop()
+    if (stack.nonEmpty) {
+      // Should never happen given inputs, sanity check on invalid queries
+      throw new RuntimeException("Query stack not empty after processing")
+    }
+    val query = builder.build()
+    new ConstantScoreQuery(query) // disable scoring
+  }
+
+  def buildQueryWithStartAndEnd(columnFilters: Seq[ColumnFilter], startTime: PartitionKey,
+                                endTime: PartitionKey): Query = {
+    visitStartBooleanQuery()
+    visitQueryWithStartAndEnd(columnFilters, startTime, endTime)
+
+    val builder = stack.pop()
+    if (stack.nonEmpty) {
+      // Should never happen given inputs, sanity check on invalid queries
+      throw new RuntimeException("Query stack not empty after processing")
+    }
+    val query = builder.build()
+    new ConstantScoreQuery(query) // disable scoring
+  }
+}
+
 /**
  * In this lucene index collector, we read through the entire lucene index periodically and re-calculate
  * the cardinality count from scratch. This class iterates through each document in lucene, extracts a shard-key
@@ -994,14 +782,14 @@ class CardinalityCountBuilder(partSchema: PartitionSchema, cardTracker: Cardinal
 
   // gets called for each segment
   override def doSetNextReader(context: LeafReaderContext): Unit = {
-    partKeyDv = context.reader().getBinaryDocValues(PartKeyLuceneIndex.PART_KEY)
+    partKeyDv = context.reader().getBinaryDocValues(PartKeyIndexRaw.PART_KEY)
   }
 
   // gets called for each matching document in current segment
   override def collect(doc: Int): Unit = {
     if (partKeyDv.advanceExact(doc)) {
       val binaryValue = partKeyDv.binaryValue()
-      val unsafePkOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(binaryValue.offset)
+      val unsafePkOffset = PartKeyIndexRaw.bytesRefToUnsafeOffset(binaryValue.offset)
       val shardKey = partSchema.binSchema.colValues(
         binaryValue.bytes, unsafePkOffset, partSchema.options.shardKeyColumns)
 
@@ -1049,7 +837,7 @@ class SinglePartKeyCollector extends SimpleCollector {
 
   // gets called for each segment
   override def doSetNextReader(context: LeafReaderContext): Unit = {
-    partKeyDv = context.reader().getBinaryDocValues(PartKeyLuceneIndex.PART_KEY)
+    partKeyDv = context.reader().getBinaryDocValues(PartKeyIndexRaw.PART_KEY)
   }
 
   // gets called for each matching document in current segment
@@ -1073,7 +861,7 @@ class SinglePartIdCollector extends SimpleCollector {
 
   // gets called for each segment
   override def doSetNextReader(context: LeafReaderContext): Unit = {
-    partIdDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.PART_ID_DV)
+    partIdDv = context.reader().getNumericDocValues(PartKeyIndexRaw.PART_ID_DV)
   }
 
   // gets called for each matching document in current segment
@@ -1100,7 +888,7 @@ class SinglePartIdCollector extends SimpleCollector {
  */
 class TopKPartIdsCollector(limit: Int) extends Collector with StrictLogging {
 
-  import PartKeyLuceneIndex._
+  import PartKeyIndexRaw._
 
   var endTimeDv: NumericDocValues = _
   var partIdDv: NumericDocValues = _
@@ -1160,7 +948,7 @@ class PartIdCollector(limit: Int) extends SimpleCollector {
 
   override def doSetNextReader(context: LeafReaderContext): Unit = {
     //set the subarray of the numeric values for all documents in the context
-    partIdDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.PART_ID_DV)
+    partIdDv = context.reader().getNumericDocValues(PartKeyIndexRaw.PART_ID_DV)
   }
 
   override def collect(doc: Int): Unit = {
@@ -1183,8 +971,8 @@ class PartIdStartTimeCollector extends SimpleCollector {
 
   override def doSetNextReader(context: LeafReaderContext): Unit = {
     //set the subarray of the numeric values for all documents in the context
-    partIdDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.PART_ID_DV)
-    startTimeDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.START_TIME)
+    partIdDv = context.reader().getNumericDocValues(PartKeyIndexRaw.PART_ID_DV)
+    startTimeDv = context.reader().getNumericDocValues(PartKeyIndexRaw.START_TIME)
   }
 
   override def collect(doc: Int): Unit = {
@@ -1207,9 +995,9 @@ class PartKeyRecordCollector(limit: Int) extends SimpleCollector {
   override def scoreMode(): ScoreMode = ScoreMode.COMPLETE_NO_SCORES
 
   override def doSetNextReader(context: LeafReaderContext): Unit = {
-    partKeyDv = context.reader().getBinaryDocValues(PartKeyLuceneIndex.PART_KEY)
-    startTimeDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.START_TIME)
-    endTimeDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.END_TIME)
+    partKeyDv = context.reader().getBinaryDocValues(PartKeyIndexRaw.PART_KEY)
+    startTimeDv = context.reader().getNumericDocValues(PartKeyIndexRaw.START_TIME)
+    endTimeDv = context.reader().getNumericDocValues(PartKeyIndexRaw.END_TIME)
   }
 
   override def collect(doc: Int): Unit = {
@@ -1234,8 +1022,8 @@ class ActionCollector(action: (Int, BytesRef) => Unit) extends SimpleCollector {
   override def scoreMode(): ScoreMode = ScoreMode.COMPLETE_NO_SCORES
 
   override def doSetNextReader(context: LeafReaderContext): Unit = {
-    partIdDv = context.reader().getNumericDocValues(PartKeyLuceneIndex.PART_ID_DV)
-    partKeyDv = context.reader().getBinaryDocValues(PartKeyLuceneIndex.PART_KEY)
+    partIdDv = context.reader().getNumericDocValues(PartKeyIndexRaw.PART_ID_DV)
+    partKeyDv = context.reader().getBinaryDocValues(PartKeyIndexRaw.PART_KEY)
   }
 
   override def collect(doc: Int): Unit = {
@@ -1259,7 +1047,7 @@ class PartKeyActionCollector(action: (BytesRef) => Unit) extends SimpleCollector
   override def scoreMode(): ScoreMode = ScoreMode.COMPLETE_NO_SCORES
 
   override def doSetNextReader(context: LeafReaderContext): Unit = {
-    partKeyDv = context.reader().getBinaryDocValues(PartKeyLuceneIndex.PART_KEY)
+    partKeyDv = context.reader().getBinaryDocValues(PartKeyIndexRaw.PART_KEY)
   }
 
   override def collect(doc: Int): Unit = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1220,7 +1220,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     }
     partIter.skippedPartIDs.foreach { pId =>
       partKeyIndex.partKeyFromPartId(pId).foreach { pk =>
-        val unsafePkOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(pk.offset)
+        val unsafePkOffset = PartKeyIndexRaw.bytesRefToUnsafeOffset(pk.offset)
         val schema = schemas(RecordSchema.schemaID(pk.bytes, unsafePkOffset))
         val shardKey = schema.partKeySchema.colValues(pk.bytes, unsafePkOffset,
           schemas.part.options.shardKeyColumns)
@@ -1899,7 +1899,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     partitions.get(partID) match {
       case TimeSeriesShard.OutOfMemPartition =>
         partKeyIndex.partKeyFromPartId(partID).map { pkBytesRef =>
-          val unsafeKeyOffset = PartKeyLuceneIndex.bytesRefToUnsafeOffset(pkBytesRef.offset)
+          val unsafeKeyOffset = PartKeyIndexRaw.bytesRefToUnsafeOffset(pkBytesRef.offset)
           RecordSchema.schemaID(pkBytesRef.bytes, unsafeKeyOffset)
         }.getOrElse(-1)
       case p: TimeSeriesPartition => p.schema.schemaHash

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -900,27 +900,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     }
   }
 
-  it("should match the regex after anchors stripped") {
-    for ((regex, regexNoAnchors) <- Map(
-      """^.*$""" -> """.*""", // both anchor are stripped.
-      """\$""" -> """\$""", // \$ is not removed.
-      """\\\$""" -> """\\\$""", // \$ is not removed.
-      """\\$""" -> """\\""", // $ is removed.
-      """$""" -> """""", // $ is removed.
-      """\^.*$""" -> """\^.*""", // do not remove \^.
-      """^ ^.*$""" -> """ ^.*""", // only remove the first ^.
-      """^.*\$""" -> """.*\$""",  // do not remove \$
-      """^ $foo""" -> """ $foo""",  // the $ is not at the end, keep it.
-      """.* $ \ $$""" -> """.* $ \ $""",  // only remove the last $
-      """foo.*\\\ $""" -> """foo.*\\\ """, // remove $ for it at the end and not escaped.
-      """foo.*\\\$""" -> """foo.*\\\$""", // keep \$.
-      """foo.*\\$""" -> """foo.*\\""",  // remove $ for it at the end and not escaped.
-      """foo.*$\\\\$""" -> """foo.*$\\\\""",  // keep the first $ since it not at the end.
-    )) {
-      PartKeyLuceneIndex.removeRegexAnchors(regex) shouldEqual regexNoAnchors
-    }
-  }
-
   it("should get a single match for part keys through a field with empty value") {
     val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.slice(95, 96)), Some(partBuilder))
       .zipWithIndex.map { case (addr, i) =>

--- a/core/src/test/scala/filodb.core/memstore/PartKeyQueryBuilderSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyQueryBuilderSpec.scala
@@ -1,0 +1,27 @@
+package filodb.core.memstore
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PartKeyQueryBuilderSpec extends AnyFunSpec with Matchers {
+  it("should match the regex after anchors stripped") {
+    for ((regex, regexNoAnchors) <- Map(
+      """^.*$""" -> """.*""", // both anchor are stripped.
+      """\$""" -> """\$""", // \$ is not removed.
+      """\\\$""" -> """\\\$""", // \$ is not removed.
+      """\\$""" -> """\\""", // $ is removed.
+      """$""" -> """""", // $ is removed.
+      """\^.*$""" -> """\^.*""", // do not remove \^.
+      """^ ^.*$""" -> """ ^.*""", // only remove the first ^.
+      """^.*\$""" -> """.*\$""",  // do not remove \$
+      """^ $foo""" -> """ $foo""",  // the $ is not at the end, keep it.
+      """.* $ \ $$""" -> """.* $ \ $""",  // only remove the last $
+      """foo.*\\\ $""" -> """foo.*\\\ """, // remove $ for it at the end and not escaped.
+      """foo.*\\\$""" -> """foo.*\\\$""", // keep \$.
+      """foo.*\\$""" -> """foo.*\\""",  // remove $ for it at the end and not escaped.
+      """foo.*$\\\\$""" -> """foo.*$\\\\""",  // keep the first $ since it not at the end.
+    )) {
+      PartKeyQueryBuilder.removeRegexAnchors(regex) shouldEqual regexNoAnchors
+    }
+  }
+}


### PR DESCRIPTION
In preparation for new index types separate common logic from Lucene specific logic.  No functional changes are made as part of this commit, just moving code around and refactoring to accept multiple index implementations.

In most cases this amounts to moving code out of PartKeyLuceneIndex and into PartKeyIndexRaw without further changes.  In a few cases things that were instaniating Lucene specific types now use callbacks or other approaches to allow instantiating index specific types.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
