### PR TITLE
fix(query): fix NullPointerException if shard is unassigned

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -371,7 +371,12 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
       } else {
         false
       }
-      val path = shardMapper.coordForShard(i).path.toString
+      val actorRef = shardMapper.coordForShard(i)
+      val path = if (actorRef == akka.actor.ActorRef.noSender) {
+        ""
+      } else {
+        actorRef.path.toString
+      }
       shardInfoArray(i) = filodb.core.query.ShardInfo(isActive, path)
     }
     val localActiveShardMapper = ActiveShardMapper(shardInfoArray)


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
If clustering V2 is enabled, shard level failover is enabled, and a shard is not assigned, HighAvailabilityPlanner would throw a NullPointerException while producing a plan.

**New behavior :**
HighAvailabilityPlanner produces a plan and no exception is thrown.


**BREAKING CHANGES**
n/a

**Other information**: