### PR TITLE
misc(core): Adding unit tests for histograms for StitchRvsExec

### DIFF
--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -1,19 +1,18 @@
 package filodb.query.exec
 
 import scala.annotation.tailrec
-
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
 import filodb.core.query._
 import filodb.core.query.NoCloseCursor.NoCloseCursor
 import filodb.core.MetricsTestData
 import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.vectors.{CustomBuckets, HistogramWithBuckets, LongHistogram}
 import filodb.query.QueryResult
 
 // scalastyle:off null
@@ -351,13 +350,10 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     mergeAndValidate(rvs, expected)
   }
 
-
-
-
-  it ("should honor the passed RvRange from planner when generating rows") {
+  it("should honor the passed RvRange from planner when generating rows") {
     // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
     // The merge functionality should honor the passed RvRange and accordingly generate the rows
-    val rvs = Seq (
+    val rvs = Seq(
       Seq(
         (60L, 3d),
         (70L, 3d)
@@ -374,6 +370,71 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         (90L, Double.NaN)
       )
     mergeAndValidate(rvs, expected)
+  }
+
+  it("should merge histograms correctly when there are no gaps") {
+    // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
+    // The merge functionality should honor the passed RvRange and accordingly generate the rows
+    val h1 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 5).toArray)
+    val h2 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 2).toArray)
+    val rvs = Seq(
+      Seq(
+        (50L, h1),
+        (60L, h1),
+      ),
+      Seq(
+        (30L, h2),
+        (40L, h2)
+      )
+    )
+    val expected =
+      Seq(
+        (30L, h2),
+        (40L, h2),
+        (50L, h1),
+        (60L, h1)
+      )
+    mergeAndValidateHistogram(rvs, expected)
+  }
+
+  ignore("should merge histograms correctly when there are gaps") {
+    // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
+    // The merge functionality should honor the passed RvRange and accordingly generate the rows
+    val h1 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 5).toArray)
+    val h2 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 2).toArray)
+    val rvs = Seq(
+      Seq(
+        (50L, h1),
+        (60L, h1),
+      ),
+      Seq(
+        (30L, h2)
+      )
+    )
+    val expected =
+      Seq(
+        (30L, h2),
+        (40L, HistogramWithBuckets.empty),
+        (50L, h1),
+        (60L, h1)
+      )
+    mergeAndValidateHistogram(rvs, expected)
+  }
+
+  def mergeAndValidateHistogram(rvs: Seq[Seq[(Long, HistogramWithBuckets)]],
+                                expected: Seq[(Long, HistogramWithBuckets)]): Unit = {
+    val inputSeq = rvs.map { rows =>
+      new NoCloseCursor(rows.iterator.map(r => new TransientHistRow(r._1, r._2)))
+    }
+    val (minTs, maxTs) = expected.foldLeft((Long.MaxValue, Long.MinValue)) { case ((allMin, allMax), (thisTs, _)) => (allMin.min(thisTs), allMax.max(thisTs)) }
+    val expectedStep = expected match {
+      case (t1, _) :: (t2, _) :: _ => t2 - t1
+      case _ => 1
+    }
+    val result = StitchRvsExec.merge(inputSeq, Some(RvRange(startMs = minTs, endMs = maxTs, stepMs = expectedStep)))
+      .map(r => (r.getLong(0), r.getHistogram(1).asInstanceOf[HistogramWithBuckets]))
+
+    compareIterHist(result, expected.toIterator)
   }
 
   def mergeAndValidate(rvs: Seq[Seq[(Long, Double)]], expected: Seq[(Long, Double)]): Unit = {
@@ -401,6 +462,30 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         if (v1._2.isNaN) v2._2.isNaN shouldEqual true
         else Math.abs(v1._2-v2._2) should be < error
         compareIter(it1, it2)
+      case (false, false) => Unit
+      case _ => fail("Unequal lengths")
+    }
+  }
+
+  def arraysEqual(arr1: Array[Double], arr2: Array[Double]): Boolean = {
+    if (arr1.length != arr2.length) return false
+    for (i <- arr1.indices) {
+      if (arr1(i) != arr2(i)) return false
+    }
+    true
+  }
+
+  @tailrec
+  final private def compareIterHist(it1: Iterator[(Long, HistogramWithBuckets)],
+                                    it2: Iterator[(Long, HistogramWithBuckets)]): Unit = {
+    (it1.hasNext, it2.hasNext) match {
+      case (true, true) =>
+        val v1 = it1.next()
+        val v2 = it2.next()
+        v1._1 shouldEqual v2._1
+        v1._2.buckets.equals(v2._2.buckets) shouldEqual true
+        arraysEqual(v1._2.valueArray, v2._2.valueArray) shouldEqual true
+        compareIterHist(it1, it2)
       case (false, false) => Unit
       case _ => fail("Unequal lengths")
     }

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -1,12 +1,14 @@
 package filodb.query.exec
 
 import scala.annotation.tailrec
+
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, TimestampColumn}
 import filodb.core.query._
 import filodb.core.query.NoCloseCursor.NoCloseCursor


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** We don't have unit tests for StitchRvsExec which uses Histogram values.


**New behavior :** Adding unit tests for `StitchRvsExec` with histogram values.