### PR TITLE
fix bugs caused by stitching empty and non-empty data.

### DIFF
--- a/core/src/main/scala/filodb.core/query/TransientRow.scala
+++ b/core/src/main/scala/filodb.core/query/TransientRow.scala
@@ -10,8 +10,8 @@ trait MutableRowReader extends RowReader {
   def setBlob(columnNo: Int, base: Array[Byte], offset: Int, length: Int): Unit
 }
 
-final class NaNRowRead(var timestamp: Long) extends RowReader {
-  override def isNaN(): Boolean = true
+final class NaNRowReader(var timestamp: Long) extends RowReader {
+  override def isNaN: Boolean = true
   override def notNull(columnNo: Int): Boolean = true
   override def getBoolean(columnNo: Int): Boolean = false
   override def getInt(columnNo: Int): Int = 0

--- a/core/src/main/scala/filodb.core/query/TransientRow.scala
+++ b/core/src/main/scala/filodb.core/query/TransientRow.scala
@@ -1,6 +1,7 @@
 package filodb.core.query
 
 import filodb.memory.format.{vectors => bv, RowReader, UnsafeUtils, ZeroCopyUTF8String}
+import filodb.memory.format.vectors.Histogram
 
 trait MutableRowReader extends RowReader {
   def setLong(columnNo: Int, value: Long): Unit
@@ -9,6 +10,21 @@ trait MutableRowReader extends RowReader {
   def setBlob(columnNo: Int, base: Array[Byte], offset: Int, length: Int): Unit
 }
 
+final class NaNRowRead(var timestamp: Long) extends RowReader {
+  override def isNaN(): Boolean = true
+  override def notNull(columnNo: Int): Boolean = true
+  override def getBoolean(columnNo: Int): Boolean = false
+  override def getInt(columnNo: Int): Int = 0
+  override def getLong(columnNo: Int): Long = if (columnNo == 0) timestamp else 0
+  override def getDouble(columnNo: Int): Double = Double.NaN
+  override def getFloat(columnNo: Int): Float = Float.NaN
+  override def getString(columnNo: Int): String = ""
+  override def getAny(columnNo: Int): Any = Double.NaN
+  override def getBlobBase(columnNo: Int): Any = Double.NaN
+  override def getBlobOffset(columnNo: Int): Long = 0
+  override def getBlobNumBytes(columnNo: Int): Int = 0
+  override def getHistogram(columnNo: Int): Histogram = bv.Histogram.empty
+}
 /**
   * Represents intermediate sample which will be part of a transformed RangeVector.
   * IMPORTANT: It is mutable for memory efficiency purposes. Consumers from

--- a/core/src/main/scala/filodb.core/query/TransientRow.scala
+++ b/core/src/main/scala/filodb.core/query/TransientRow.scala
@@ -11,8 +11,7 @@ trait MutableRowReader extends RowReader {
 }
 
 final class NaNRowReader(var timestamp: Long) extends RowReader {
-  override def isNaN: Boolean = true
-  override def notNull(columnNo: Int): Boolean = true
+  override def notNull(columnNo: Int): Boolean = columnNo == 0
   override def getBoolean(columnNo: Int): Boolean = false
   override def getInt(columnNo: Int): Int = 0
   override def getLong(columnNo: Int): Long = if (columnNo == 0) timestamp else 0

--- a/memory/src/main/scala/filodb.memory/format/RowReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowReader.scala
@@ -19,6 +19,7 @@ import filodb.memory.format.vectors.Histogram
  */
 // scalastyle:off
 trait RowReader {
+  def isNaN: Boolean = false
   def notNull(columnNo: Int): Boolean
   def getBoolean(columnNo: Int): Boolean
   def getInt(columnNo: Int): Int

--- a/memory/src/main/scala/filodb.memory/format/RowReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/RowReader.scala
@@ -19,7 +19,6 @@ import filodb.memory.format.vectors.Histogram
  */
 // scalastyle:off
 trait RowReader {
-  def isNaN: Boolean = false
   def notNull(columnNo: Int): Boolean
   def getBoolean(columnNo: Int): Boolean
   def getInt(columnNo: Int): Int

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -21,7 +21,7 @@ object StitchRvsExec {
     private val weight = math.pow(10, toleranceNumDecimal)
     private val bVectors = vectors.map(_.buffered)
     val mins = new mutable.ArrayBuffer[BufferedIterator[RowReader]](2)
-    val nanResult = new NaNRowRead(0)
+    val nanResult = new NaNRowReader(0)
     val tsIter: BufferedIterator[Long] = outputRange match {
       case Some(RvRange(startMs, 0, endMs)) =>
         if (startMs == endMs)

--- a/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/StitchRvsExec.scala
@@ -21,7 +21,7 @@ object StitchRvsExec {
     private val weight = math.pow(10, toleranceNumDecimal)
     private val bVectors = vectors.map(_.buffered)
     val mins = new mutable.ArrayBuffer[BufferedIterator[RowReader]](2)
-    val nanResult = new TransientRow(0, Double.NaN)
+    val nanResult = new NaNRowRead(0)
     val tsIter: BufferedIterator[Long] = outputRange match {
       case Some(RvRange(startMs, 0, endMs)) =>
         if (startMs == endMs)

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -352,6 +352,44 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     mergeAndValidate(rvs, expected)
   }
 
+  it("should merge avg correctly when there are gaps") {
+    // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
+    // The merge functionality should honor the passed RvRange and accordingly generate the rows
+    val rvs = Seq(
+      Seq(
+        (50L, 1L, 2.0),
+        (60L, 2L, 5.0),
+      ),
+      Seq(
+        (30L, 4L, 5.0)
+      )
+    )
+    val expected = Seq(
+        (30L, 4L, 5.0),
+        (40L, 0L, Double.NaN),
+        (50L, 1L, 2.0),
+        (60L, 2L, 5.0)
+      )
+    val inputSeq = rvs.map { rows =>
+      new NoCloseCursor(rows.iterator.map(r => {
+        val row = new AvgAggTransientRow()
+        row.setLong(0, r._1)
+        row.setLong(2, r._2)
+        row.setDouble(1, r._3)
+        row
+      }))
+    }
+    val (minTs, maxTs) = expected.foldLeft((Long.MaxValue, Long.MinValue)) {
+      case ((allMin, allMax), (thisTs, _, _)) => (allMin.min(thisTs), allMax.max(thisTs)) }
+    val expectedStep = expected match {
+      case (t1, _, _) :: (t2, _, _) :: _ => t2 - t1
+      case _ => 1
+    }
+    val result = StitchRvsExec.merge(inputSeq, Some(RvRange(startMs = minTs, endMs = maxTs, stepMs = expectedStep)))
+      .map(r => (r.getLong(0), r.getLong(2), r.getDouble(1)))
+    compareIterAvg(result, expected.toIterator)
+  }
+
   it("should honor the passed RvRange from planner when generating rows") {
     // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
     // The merge functionality should honor the passed RvRange and accordingly generate the rows
@@ -399,7 +437,7 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     mergeAndValidateHistogram(rvs, expected)
   }
 
-  ignore("should merge histograms correctly when there are gaps") {
+  it("should merge histograms correctly when there are gaps") {
     // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
     // The merge functionality should honor the passed RvRange and accordingly generate the rows
     val h1 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 5).toArray)
@@ -464,6 +502,22 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
         if (v1._2.isNaN) v2._2.isNaN shouldEqual true
         else Math.abs(v1._2-v2._2) should be < error
         compareIter(it1, it2)
+      case (false, false) => Unit
+      case _ => fail("Unequal lengths")
+    }
+  }
+
+  @tailrec
+  final private def compareIterAvg(it1: Iterator[(Long, Long, Double)], it2: Iterator[(Long, Long, Double)]): Unit = {
+    (it1.hasNext, it2.hasNext) match {
+      case (true, true) =>
+        val v1 = it1.next()
+        val v2 = it2.next()
+        v1._1 shouldEqual v2._1
+        v1._2 shouldEqual v2._2
+        if (v1._3.isNaN) v2._3.isNaN shouldEqual true
+        else Math.abs(v1._3 - v2._3) should be < error
+        compareIterAvg(it1, it2)
       case (false, false) => Unit
       case _ => fail("Unequal lengths")
     }

--- a/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/StitchRvsExecSpec.scala
@@ -460,6 +460,52 @@ class StitchRvsExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
       )
     mergeAndValidateHistogram(rvs, expected)
   }
+  it("should merge histograms correctly when there are gaps and empty data points1") {
+    // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
+    // The merge functionality should honor the passed RvRange and accordingly generate the rows
+    val h1 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 5).toArray)
+    val h2 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 2).toArray)
+    val rvs = Seq(
+      Seq(
+        (30L, h2),
+        (50L, h1),
+        (60L, h1),
+      ),
+      Seq()
+    )
+    val expected =
+      Seq(
+        (30L, h2),
+        (40L, HistogramWithBuckets.empty),
+        (50L, h1),
+        (60L, h1)
+      )
+    mergeAndValidateHistogram(rvs, expected)
+  }
+
+  it("should merge histograms correctly when there are gaps and empty data points2") {
+    // The test relies on mergeAndValidate to generate the expected RvRange to (40, 10, 90)
+    // The merge functionality should honor the passed RvRange and accordingly generate the rows
+    val h1 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 5).toArray)
+    val h2 = LongHistogram(CustomBuckets(Array(1.0, 2.0, Double.PositiveInfinity)), (0L to 10L by 2).toArray)
+    val rvs = Seq(
+      Seq(),
+      Seq(
+        (30L, h2),
+        (50L, h1),
+        (60L, h1),
+      )
+    )
+    val expected =
+      Seq(
+        (30L, h2),
+        (40L, HistogramWithBuckets.empty),
+        (50L, h1),
+        (60L, h1)
+      )
+    mergeAndValidateHistogram(rvs, expected)
+  }
+
 
   def mergeAndValidateHistogram(rvs: Seq[Seq[(Long, HistogramWithBuckets)]],
                                 expected: Seq[(Long, HistogramWithBuckets)]): Unit = {


### PR DESCRIPTION
The current Transient row can only handle a schema (Long, Double). However, there are different schemas for histogram, Avg and so on. Create a NaNRowReader to handle any schemas.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: