### PR TITLE
bug(coord): Adding ApplyLimitFunction support for cross-partition query routing

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -16,6 +16,8 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
 
   it("should generate query from LogicalPlan") {
     parseAndAssertResult("""http_requests_total{job="app"}""") ()
+    parseAndAssertResult("""http_requests_total{job="app"} limit 1""") ()
+    parseAndAssertResult("""sum(http_requests_total{job="app"}) limit 1""") ()
     parseAndAssertResult("""sum(http_requests_total{job="app"})""") ()
     parseAndAssertResult("""sum(count(http_requests_total{job="app"}))""")()
     parseAndAssertResult("""sum(http_requests_total{job="app",instance="inst-1"}) by (instance)""")()


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

When query is routed to different partition, we see this type of error

```
invalid_query: Logical plan to query not supported for ApplyLimitFunction(PeriodicSeries(RawSeries(IntervalSelector(1723149600000,1723149900000),List(ColumnFilter(service_namespace,Equals(servicens)), ColumnFilter(service_name,Equals(svcname)), ColumnFilter(environment,EqualsRegex(PROD)), ColumnFilter(__name__,Equals(http_server_request_duration_bucket)), ColumnFilter(_ws_,Equals(myws)), ColumnFilter(_ns_,Equals(myNs))),List(),Some(300000),None,false),1723149600000,60000,1723149900000,None,None),..
```

This PR fixes the logical plan to query translation and also removes the default handler.

