### PR TITLE
feat(core): Add Scala side of Tantivy query support

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -800,6 +800,11 @@ filodb {
         # of the number of documents each segment searches over, estimated to 250k docs.
         # This is a hint to the cache only and does not bound the max number of items.
         query-cache-estimated-item-size = 31250
+
+        # Percentage of deleted docs in a segment that will flag this to be considered
+        # for a merge.  Setting this too high will leave too many documents around
+        # and increase query time.
+        deleted-doc-merge-threshold = 0.1
     }
 
     # At the cost of some extra heap memory, we can track queries holding shared lock for a long time

--- a/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
@@ -313,11 +313,13 @@ abstract class PartKeyIndexRaw(ref: DatasetRef,
    */
   def labelNamesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long): Seq[String]
 
+  protected final val LABEL_NAMES_AND_VALUES_DEFAULT_LIMIT = 100
+
   /**
    * Use faceting to get field/index values given a column filter and time range
    */
   def labelValuesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
-                           colName: String, limit: Int = 100): Seq[String]
+                           colName: String, limit: Int = LABEL_NAMES_AND_VALUES_DEFAULT_LIMIT): Seq[String]
 
   /**
    * Add new part key to index

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -327,7 +327,7 @@ class PartKeyLuceneIndex(ref: DatasetRef,
   }
 
   def labelValuesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
-                           colName: String, limit: Int = 100): Seq[String] = {
+                           colName: String, limit: Int = LABEL_NAMES_AND_VALUES_DEFAULT_LIMIT): Seq[String] = {
     require(facetEnabledForLabel(colName),
       s"Faceting not enabled for label $colName; labelValuesEfficient should not have been called")
 

--- a/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
@@ -41,7 +41,8 @@ class PartKeyTantivyIndex(ref: DatasetRef,
                           lifecycleManager: Option[IndexMetadataStore] = None,
                           columnCacheCount: Long = 1000,
                           queryCacheMaxSize: Long = 50 * 1000 * 1000,
-                          queryCacheEstimatedItemSize: Long = 31250
+                          queryCacheEstimatedItemSize: Long = 31250,
+                          deletedDocMergeThreshold: Float = 0.1f
                          ) extends PartKeyIndexRaw(ref, shardNum, schema, diskLocation, lifecycleManager) {
 
   // Compute field names for native schema code
@@ -62,7 +63,7 @@ class PartKeyTantivyIndex(ref: DatasetRef,
   // Native handle for cross JNI operations
   private var indexHandle: Long = loadIndexData(() => TantivyNativeMethods.newIndexHandle(indexDiskLocation.toString,
     schemaFields, schemaMapFields, schemaMultiColumnFacets, columnCacheCount, queryCacheMaxSize,
-    queryCacheEstimatedItemSize))
+    queryCacheEstimatedItemSize, deletedDocMergeThreshold))
 
   logger.info(s"Created tantivy index for dataset=$ref shard=$shardNum at $indexDiskLocation")
 
@@ -569,7 +570,8 @@ protected object TantivyNativeMethods {
   @native
   def newIndexHandle(diskLocation: String, schemaFields: Array[String],
                      schemaMapFields: Array[String], schemaMultiColumnFacets: Array[String],
-                     columnCacheSize: Long, queryCacheMaxSize: Long, queryCacheItemSize: Long): Long
+                     columnCacheSize: Long, queryCacheMaxSize: Long, queryCacheItemSize: Long,
+                     deletedDocMergeThreshold: Float): Long
 
   // Free memory used by an index handle
   @native

--- a/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
@@ -146,7 +146,8 @@ class PartKeyTantivyIndex(ref: DatasetRef,
     val queryBuilder = new TantivyQueryBuilder()
     val query = queryBuilder.buildQuery(colFilters)
 
-    val results = TantivyNativeMethods.labelNames(indexHandle, query, 100, startTime, endTime)
+    val results = TantivyNativeMethods.labelNames(indexHandle, query, LABEL_NAMES_AND_VALUES_DEFAULT_LIMIT,
+      startTime, endTime)
 
     labelValuesQueryLatency.record(System.nanoTime() - start)
 
@@ -521,6 +522,12 @@ class TantivyQueryBuilder extends PartKeyQueryBuilder with StrictLogging {
 
   def buildQuery(columnFilters: Seq[ColumnFilter]): Array[Byte] = {
     visitQuery(columnFilters)
+
+    buffer.toArray
+  }
+
+  def buildQueryWithStartAndEnd(columnFilters: Seq[ColumnFilter], start: Long, end: Long): Array[Byte] = {
+    visitQueryWithStartAndEnd(columnFilters, start, end)
 
     buffer.toArray
   }

--- a/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
@@ -1,23 +1,37 @@
 package filodb.core.memstore
 
 import java.io.File
+import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.file.Files
 import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
 
 import scala.collection.mutable.ArrayBuffer
 
+import com.typesafe.scalalogging.StrictLogging
 import debox.Buffer
+import kamon.Kamon
 import org.apache.commons.lang3.SystemUtils
 import org.apache.lucene.util.BytesRef
 import spire.implicits.cforRange
 
 import filodb.core.DatasetRef
 import filodb.core.binaryrecord2.RecordSchema
-import filodb.core.memstore.PartKeyIndexRaw.bytesRefToUnsafeOffset
+import filodb.core.memstore.PartKeyIndexRaw.{bytesRefToUnsafeOffset, ignoreIndexNames, FACET_FIELD_PREFIX,
+  PART_ID_FIELD}
 import filodb.core.metadata.{PartitionSchema, Schemas}
 import filodb.core.metadata.Column.ColumnType.{MapColumn, StringColumn}
-import filodb.core.query.ColumnFilter
+import filodb.core.query.{ColumnFilter, Filter}
 import filodb.memory.format.UnsafeUtils
+
+object PartKeyTantivyIndex {
+  def startMemoryProfiling(): Unit = {
+    TantivyNativeMethods.startMemoryProfiling()
+  }
+
+  def stopMemoryProfiling(): Unit = {
+    TantivyNativeMethods.stopMemoryProfiling()
+  }
+}
 
 class PartKeyTantivyIndex(ref: DatasetRef,
                           schema: PartitionSchema,
@@ -72,7 +86,12 @@ class PartKeyTantivyIndex(ref: DatasetRef,
   }
 
   override def partIdsEndedBefore(endedBefore: Long): Buffer[Int] = {
-    ???
+    val result: debox.Buffer[Int] = debox.Buffer.empty[Int]
+    val partIds = TantivyNativeMethods.partIdsEndedBefore(indexHandle, endedBefore)
+
+    result.extend(partIds)
+
+    result
   }
 
   override def removePartitionsEndedBefore(endedBefore: Long, returnApproxDeletedCount: Boolean): Int = {
@@ -86,11 +105,15 @@ class PartKeyTantivyIndex(ref: DatasetRef,
   }
 
   override def indexRamBytes: Long = {
-    ???
+    TantivyNativeMethods.indexRamBytes(indexHandle)
   }
 
   override def indexNumEntries: Long = {
-    ???
+    TantivyNativeMethods.indexNumEntries(indexHandle)
+  }
+
+  override def indexMmapBytes: Long = {
+    TantivyNativeMethods.indexMmapBytes(indexHandle)
   }
 
   override def closeIndex(): Unit = {
@@ -107,20 +130,40 @@ class PartKeyTantivyIndex(ref: DatasetRef,
   }
 
   override def indexNames(limit: Int): Seq[String] = {
-    ???
+    TantivyNativeMethods.indexNames(indexHandle).filterNot {
+      n => ignoreIndexNames.contains(n) || n.startsWith(FACET_FIELD_PREFIX)
+    }
   }
 
   override def indexValues(fieldName: String, topK: Int): Seq[TermInfo] = {
-    ???
+    val results = TantivyNativeMethods.indexValues(indexHandle, fieldName, topK)
+
+    results.toSeq
   }
 
   override def labelNamesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long): Seq[String] = {
-    ???
+    val start = System.nanoTime()
+    val queryBuilder = new TantivyQueryBuilder()
+    val query = queryBuilder.buildQuery(colFilters)
+
+    val results = TantivyNativeMethods.labelNames(indexHandle, query, 100, startTime, endTime)
+
+    labelValuesQueryLatency.record(System.nanoTime() - start)
+
+    results.toSeq
   }
 
   override def labelValuesEfficient(colFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
                                     colName: String, limit: Int): Seq[String] = {
-    ???
+    val start = System.nanoTime()
+    val queryBuilder = new TantivyQueryBuilder()
+    val query = queryBuilder.buildQuery(colFilters)
+
+    val results = TantivyNativeMethods.labelValues(indexHandle, query, colName, limit, startTime, endTime)
+
+    labelValuesQueryLatency.record(System.nanoTime() - start)
+
+    results.toSeq
   }
 
   override def addPartKey(partKeyOnHeapBytes: Array[Byte], partId: Int, startTime: Long, endTime: Long,
@@ -140,21 +183,51 @@ class PartKeyTantivyIndex(ref: DatasetRef,
   }
 
   override def partKeyFromPartId(partId: Int): Option[BytesRef] = {
-    ???
+    val results = searchFromFilters(Seq(ColumnFilter(PART_ID_FIELD, Filter.Equals(partId.toString))),
+      0, Long.MaxValue, 1, TantivyNativeMethods.queryPartKey)
+
+    if (results == null) {
+      None
+    } else {
+      Some(new BytesRef(results, 0, results.length))
+    }
   }
 
   private val NOT_FOUND = -1
 
   override def startTimeFromPartId(partId: Int): Long = {
-    ???
+    val rawResult = TantivyNativeMethods.startTimeFromPartIds(indexHandle, Seq(partId).toArray)
+
+    if (rawResult.length == 0) {
+      NOT_FOUND
+    } else {
+      rawResult(1)
+    }
   }
 
   override def endTimeFromPartId(partId: Int): Long = {
-    ???
+    TantivyNativeMethods.endTimeFromPartId(indexHandle, partId)
   }
 
   override def startTimeFromPartIds(partIds: Iterator[Int]): debox.Map[Int, Long] = {
-    ???
+    val startExecute = System.nanoTime()
+    val span = Kamon.currentSpan()
+    val partIdsArray = partIds.toArray
+
+    val result = debox.Map.empty[Int, Long]
+    val rawResult = TantivyNativeMethods.startTimeFromPartIds(indexHandle, partIdsArray)
+    var idx = 0
+    while (idx < rawResult.length) {
+      result.update(rawResult(idx).toInt, rawResult(idx + 1))
+      idx += 2
+    }
+
+    span.tag(s"num-partitions-to-page", partIdsArray.length)
+    val latency = System.nanoTime - startExecute
+    span.mark(s"index-startTimes-for-odp-lookup-latency=${latency}ns")
+    startTimeLookupLatency.record(latency)
+
+    result
   }
 
   override def commit(): Unit = {
@@ -177,26 +250,75 @@ class PartKeyTantivyIndex(ref: DatasetRef,
   }
 
   override def refreshReadersBlocking(): Unit = {
-    ???
+    TantivyNativeMethods.refreshReaders(indexHandle)
+  }
+
+  private def searchFromFilters[T](columnFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
+                                   limit: Int,
+                                   searchFunc: (Long, Array[Byte], Long, Long, Long) => Array[T]): Array[T] = {
+    val startExecute = System.nanoTime()
+    val span = Kamon.currentSpan()
+    val queryBuilder = new TantivyQueryBuilder()
+    val query = queryBuilder.buildQuery(columnFilters)
+    val results = searchFunc(indexHandle, query, limit, startTime, endTime)
+    val latency = System.nanoTime - startExecute
+    span.mark(s"index-partition-lookup-latency=${latency}ns")
+    queryIndexLookupLatency.record(latency)
+
+    results
   }
 
   override def partIdsFromFilters(columnFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
                                   limit: Int): Buffer[Int] = {
-    ???
+    val results = searchFromFilters(columnFilters, startTime, endTime, limit, TantivyNativeMethods.queryPartIds)
+
+    // "unsafe" means you must not modify the array you're passing in after creating the buffer
+    // We don't, so this is more performant
+    debox.Buffer.unsafe(results)
   }
 
   override def partKeyRecordsFromFilters(columnFilters: Seq[ColumnFilter], startTime: Long, endTime: Long,
                                          limit: Int): Seq[PartKeyLuceneIndexRecord] = {
-    ???
+    val results = searchFromFilters(columnFilters, startTime, endTime, limit, TantivyNativeMethods.queryPartKeyRecords)
+
+    val buffer = ByteBuffer.wrap(results)
+    buffer.order(ByteOrder.LITTLE_ENDIAN)
+
+    val parsedResults = new ArrayBuffer[PartKeyLuceneIndexRecord]()
+
+    while (buffer.hasRemaining) {
+      val start = buffer.getLong
+      val end = buffer.getLong
+      val pkLen = buffer.getInt
+      val pk = new Array[Byte](pkLen)
+      buffer.get(pk)
+
+      parsedResults += PartKeyLuceneIndexRecord(pk, start, end)
+    }
+
+    parsedResults
   }
 
   override def partIdFromPartKeySlow(partKeyBase: Any, partKeyOffset: Long): Option[Int] = {
-    ???
+    val partKey = schema.binSchema.asByteArray(partKeyBase, partKeyOffset)
+    val startExecute = System.nanoTime()
+
+    val id = TantivyNativeMethods.partIdFromPartKey(indexHandle, partKey)
+
+    partIdFromPartKeyLookupLatency.record(System.nanoTime - startExecute)
+
+    if (id == -1) {
+      None
+    } else {
+      Some(id)
+    }
   }
 
   override def singlePartKeyFromFilters(columnFilters: Seq[ColumnFilter], startTime: Long,
                                         endTime: Long): Option[Array[Byte]] = {
-    ???
+    val results = searchFromFilters(columnFilters, 0, Long.MaxValue, 1, TantivyNativeMethods.queryPartKey)
+
+    Option(results)
   }
 
   override protected def addIndexedField(key: String, value: String): Unit = {
@@ -263,6 +385,10 @@ class PartKeyTantivyIndex(ref: DatasetRef,
     TantivyNativeMethods.ingestDocument(indexHandle, partKeyOnHeapBytes, partKeyBytesRefOffset, partKeyNumBytes,
       partId, documentId, startTime, endTime, docBufferLocal.get().toArray, upsert)
   }
+
+  def dumpCacheStats(): String = {
+    TantivyNativeMethods.dumpCacheStats(indexHandle)
+  }
 }
 
 object ByteBufferEncodingUtils {
@@ -272,9 +398,131 @@ object ByteBufferEncodingUtils {
     buffer ++= bytes
   }
 
-  private def writeLengthToBuffer(len: Int, buffer: ArrayBuffer[Byte]): Unit = {
+  def writeLengthToBuffer(len: Int, buffer: ArrayBuffer[Byte]): Unit = {
     buffer += len.toByte
     buffer += (len >> 8).toByte
+  }
+}
+
+object TantivyQueryBuilder {
+  private val bufferLocal = new ThreadLocal[ArrayBuffer[Byte]]() {
+    override def initialValue(): ArrayBuffer[Byte] = new ArrayBuffer[Byte](4096)
+  }
+}
+
+class TantivyQueryBuilder extends PartKeyQueryBuilder with StrictLogging {
+  private final val TERMINATOR_BYTE: Byte = 0
+  private final val BOOLEAN_TYPE_BYTE: Byte = 1
+  private final val EQUALS_TYPE_BYTE: Byte = 2
+  private final val REGEX_TYPE_BYTE: Byte = 3
+  private final val TERM_IN_TYPE_BYTE: Byte = 4
+  private final val PREFIX_TYPE_BYTE: Byte = 5
+  private final val MATCH_ALL_TYPE_BYTE: Byte = 6
+  private final val LONG_RANGE_TYPE_BYTE: Byte = 7
+
+  private final val OCCUR_MUST: Byte = 1
+  private final val OCCUR_MUST_NOT: Byte = 2
+
+  private val buffer = {
+    val buffer = TantivyQueryBuilder.bufferLocal.get()
+    buffer.clear()
+
+    buffer
+  }
+
+  private def writeString(s: String): Unit = {
+    ByteBufferEncodingUtils.writeStringToBuffer(s, buffer)
+  }
+
+  private def writeLong(v: Long): Unit = {
+    buffer += v.toByte
+    buffer += (v >> 8).toByte
+    buffer += (v >> 16).toByte
+    buffer += (v >> 24).toByte
+    buffer += (v >> 32).toByte
+    buffer += (v >> 40).toByte
+    buffer += (v >> 48).toByte
+    buffer += (v >> 56).toByte
+  }
+
+  private def writeOccur(occur: PartKeyQueryOccur): Unit = {
+    occur match {
+      case OccurMust => buffer += OCCUR_MUST
+      case OccurMustNot => buffer += OCCUR_MUST_NOT
+    }
+  }
+
+  override protected def visitStartBooleanQuery(): Unit = {
+    if (buffer.nonEmpty) {
+      // Nested, add occur byte
+      buffer += OCCUR_MUST
+    }
+    buffer += BOOLEAN_TYPE_BYTE
+  }
+
+  override protected def visitEndBooleanQuery(): Unit = {
+    buffer += TERMINATOR_BYTE
+  }
+
+  override protected def visitEqualsQuery(column: String, term: String, occur: PartKeyQueryOccur): Unit = {
+    writeOccur(occur)
+
+    // Type byte, col len, col, term len, term
+    buffer += EQUALS_TYPE_BYTE
+    writeString(column)
+    writeString(term)
+  }
+
+  override protected def visitRegexQuery(column: String, pattern: String, occur: PartKeyQueryOccur): Unit = {
+    writeOccur(occur)
+
+    // Type byte, col len, col, pattern len, pattern
+    buffer += REGEX_TYPE_BYTE
+    writeString(column)
+    writeString(pattern)
+  }
+
+  override protected def visitTermInQuery(column: String, terms: Seq[String], occur: PartKeyQueryOccur): Unit = {
+    writeOccur(occur)
+
+    // Type byte, column len, column bytes, (for each term -> term len, term), 0 length
+    buffer += TERM_IN_TYPE_BYTE
+    writeString(column)
+
+    ByteBufferEncodingUtils.writeLengthToBuffer(terms.length, buffer)
+    for (term <- terms) {
+      writeString(term)
+    }
+  }
+
+  override protected def visitPrefixQuery(column: String, prefix: String, occur: PartKeyQueryOccur): Unit = {
+    writeOccur(occur)
+
+    // Type byte, col len, col, prefix len, prefix
+    buffer += PREFIX_TYPE_BYTE
+    writeString(column)
+    writeString(prefix)
+  }
+
+  override protected def visitMatchAllQuery(): Unit = {
+    buffer += OCCUR_MUST
+    buffer += MATCH_ALL_TYPE_BYTE
+  }
+
+  override protected def visitRangeQuery(column: String, start: Long, end: Long, occur: PartKeyQueryOccur): Unit = {
+    writeOccur(occur)
+
+    // Type byte, col len, col, start, end
+    buffer += LONG_RANGE_TYPE_BYTE
+    writeString(column)
+    writeLong(start)
+    writeLong(end)
+  }
+
+  def buildQuery(columnFilters: Seq[ColumnFilter]): Array[Byte] = {
+    visitQuery(columnFilters)
+
+    buffer.toArray
   }
 }
 
@@ -341,11 +589,80 @@ protected object TantivyNativeMethods {
                         upsert: Boolean): Unit
   // scalastyle:on parameter.number
 
+  // Get the estimated amount of RAM being used by this index
+  @native
+  def indexRamBytes(handle: Long): Long
+
+  // Get the estimated amount of Mmap space being used by this index
+  @native
+  def indexMmapBytes(handle: Long): Long
+
+  // Get the number of entries (docs) in the index
+  @native
+  def indexNumEntries(handle: Long): Long
+
+  // Get part IDs that ended before a given time
+  @native
+  def partIdsEndedBefore(handle: Long, endedBefore: Long): Array[Int]
+
   // Remove docs with given part keys
   @native
   def removePartKeys(handle: Long, keys: Array[Int]): Unit
 
+  // Get the list of unique indexed field names
+  @native
+  def indexNames(handle: Long): Array[String]
+
+  // Get the list of unique values for a field
+  @native
+  def indexValues(handle: Long, fieldName: String, topK: Int): Array[TermInfo]
+
+  // Get the list of unique indexed field names
+  @native
+  def labelNames(handle: Long, query: Array[Byte], limit: Int, start: Long, end: Long): Array[String]
+
+  // Get the list of unique values for a field
+  @native
+  def labelValues(handle: Long, query: Array[Byte], colName: String, limit: Int, start: Long, end: Long): Array[String]
+
+  // Get the list of part IDs given a query
+  @native
+  def queryPartIds(handle: Long, query: Array[Byte], limit: Long, start: Long, end: Long): Array[Int]
+
+  // Get the list of part IDs given a query
+  @native
+  def queryPartKeyRecords(handle: Long, query: Array[Byte], limit: Long, start: Long,
+                          end: Long): Array[Byte]
+
+  // Get a part key by query
+  @native
+  def queryPartKey(handle: Long, query: Array[Byte], limit: Long, start: Long, end: Long): Array[Byte]
+
+  /// Get a part ID from a part key
+  @native
+  def partIdFromPartKey(handle: Long, partKey : Array[Byte]): Int
+
+  // Get map of start times from partition ID list
+  @native
+  def startTimeFromPartIds(handle: Long, partIds: Array[Int]): Array[Long]
+
+  // Get end time from part ID
+  @native
+  def endTimeFromPartId(handle: Long, partId: Int): Long
+
   // Remove partition IDs and return approximate deleted count
   @native
   def removePartitionsEndedBefore(handle: Long, endedBefore: Long, returnApproxDeletedCount: Boolean): Int
+
+  // Dump stats - mainly meant for testing
+  @native
+  def dumpCacheStats(handle: Long): String
+
+  // Start memory profiling if enabled for this build, or no-op
+  @native
+  def startMemoryProfiling(): Unit
+
+  // Start memory profiling if enabled for this build, or no-op
+  @native
+  def stopMemoryProfiling(): Unit
 }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -290,7 +290,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   private val tantivyQueryCacheSize = filodbConfig.getMemorySize("memstore.tantivy.query-cache-max-bytes")
   private val tantivyQueryCacheEstimatedItemSize =
     filodbConfig.getMemorySize("memstore.tantivy.query-cache-estimated-item-size")
-
+  private val tantivyDeletedDocMergeThreshold = filodbConfig.getDouble("memstore.tantivy.deleted-doc-merge-threshold")
 
   /////// END CONFIGURATION FIELDS ///////////////////
 
@@ -323,7 +323,8 @@ class TimeSeriesShard(val ref: DatasetRef,
     case "tantivy" => new PartKeyTantivyIndex(ref, schemas.part,
       shardNum, storeConfig.diskTTLSeconds * 1000, columnCacheCount = tantivyColumnCacheCount,
       queryCacheMaxSize = tantivyQueryCacheSize.toBytes,
-      queryCacheEstimatedItemSize = tantivyQueryCacheEstimatedItemSize.toBytes)
+      queryCacheEstimatedItemSize = tantivyQueryCacheEstimatedItemSize.toBytes,
+      deletedDocMergeThreshold = tantivyDeletedDocMergeThreshold.toFloat)
     case x => sys.error(s"Unsupported part key index type: '$x'")
   }
 

--- a/core/src/rust/filodb_core/src/index.rs
+++ b/core/src/rust/filodb_core/src/index.rs
@@ -40,6 +40,8 @@ pub extern "system" fn Java_filodb_core_memstore_TantivyNativeMethods_00024_newI
 ) -> jlong {
     jni_exec(&mut env, |env| {
         let disk_location: String = env.get_string(&disk_location)?.into();
+        std::fs::create_dir_all(&disk_location)?;
+
         let directory = MmapDirectory::open(disk_location)?;
 
         // Build the schema for documents

--- a/core/src/rust/filodb_core/src/index.rs
+++ b/core/src/rust/filodb_core/src/index.rs
@@ -2,7 +2,7 @@
 
 use jni::{
     objects::{JClass, JObjectArray, JString},
-    sys::jlong,
+    sys::{jfloat, jlong},
     JNIEnv,
 };
 use tantivy::{
@@ -37,6 +37,7 @@ pub extern "system" fn Java_filodb_core_memstore_TantivyNativeMethods_00024_newI
     column_cache_size: jlong,
     query_cache_max_size: jlong,
     query_cache_estimated_item_size: jlong,
+    deleted_doc_merge_threshold: jfloat,
 ) -> jlong {
     jni_exec(&mut env, |env| {
         let disk_location: String = env.get_string(&disk_location)?.into();
@@ -61,7 +62,7 @@ pub extern "system" fn Java_filodb_core_memstore_TantivyNativeMethods_00024_newI
         let writer = index.writer::<TantivyDocument>(WRITER_MEM_BUDGET)?;
 
         let mut merge_policy = LogMergePolicy::default();
-        merge_policy.set_del_docs_ratio_before_merge(0.1);
+        merge_policy.set_del_docs_ratio_before_merge(deleted_doc_merge_threshold);
 
         writer.set_merge_policy(Box::new(merge_policy));
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -103,6 +103,7 @@ filodb {
       column-cache-count = 1000
       query-cache-max-bytes = 50MB
       query-cache-estimated-item-size = 31250
+      deleted-doc-merge-threshold = 0.1
     }
 
     flush-task-parallelism = 1

--- a/core/src/test/scala/filodb.core/memstore/PartKeyIndexRawSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyIndexRawSpec.scala
@@ -1,0 +1,926 @@
+package filodb.core.memstore
+
+import filodb.core.query.ColumnFilter
+import filodb.core.query.Filter.{Equals, EqualsRegex, NotEquals, NotEqualsRegex}
+import filodb.core.GdeltTestData.{dataset1, dataset6, dataset7, partKeyFromRecords, readers, records, uniqueReader}
+import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
+import filodb.core.DatasetRef
+import filodb.core.metadata.{PartitionSchema, Schemas}
+import filodb.memory.format.UnsafeUtils.ZeroPointer
+import filodb.memory.format.{UnsafeUtils, UTF8Wrapper}
+import filodb.memory.format.ZeroCopyUTF8String.StringToUTF8
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers.{contain, not}
+import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
+
+import java.io.{File, FileFilter}
+import java.nio.file.{Files, StandardOpenOption}
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.DurationInt
+import scala.util.Random
+
+trait PartKeyIndexRawSpec {
+  this: AnyFunSpec =>
+
+  def partKeyOnHeap(partKeySchema: RecordSchema,
+                    base: Any,
+                    offset: Long): Array[Byte] = partKeySchema.asByteArray(base, offset)
+
+  protected def createNewIndex(ref: DatasetRef,
+                               schema: PartitionSchema,
+                               facetEnabledAllLabels: Boolean,
+                               facetEnabledShardKeyLabels: Boolean,
+                               shardNum: Int,
+                               retentionMillis: Long,
+                               diskLocation: Option[File] = None,
+                               lifecycleManager: Option[IndexMetadataStore] = None): PartKeyIndexRaw
+
+  // scalastyle:off method.length
+  // scalastyle:off cyclomatic.complexity
+  def commonPartKeyTests(keyIndex: PartKeyIndexRaw, partBuilder: RecordBuilder): Unit = {
+    it("should add part keys and parse filters correctly") {
+      val start = System.currentTimeMillis()
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+        }
+      val end = System.currentTimeMillis()
+      keyIndex.refreshReadersBlocking()
+
+      // Should get empty iterator when passing no filters
+      val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
+      partNums1.toIterable() should contain theSameElementsAs List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+      // return only 4 partIds - empty filter
+      val partNumsLimit = keyIndex.partIdsFromFilters(Nil, start, end, 4)
+      partNumsLimit.length shouldEqual 4
+      // It's not deterministic which 4 docs are returned, but we can check that a valid part ID is in the list
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9) should contain allElementsOf partNumsLimit.toIterable()
+
+      val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), start, end)
+      partNums2.toIterable() should contain theSameElementsAs List(7, 8, 9)
+
+      // return only 2 partIds - with filter
+      val partNumsLimitFilter = keyIndex.partIdsFromFilters(Seq(filter2), start, end, 2)
+      partNumsLimitFilter.length shouldEqual  2
+      List(7,8,9) should contain allElementsOf partNumsLimitFilter.toIterable()
+
+      val filter3 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), start, end)
+      partNums3.toIterable() should contain theSameElementsAs List(8, 9)
+
+      val filter4 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums4 = keyIndex.partIdsFromFilters(Seq(filter4), 10, start-1)
+      partNums4 shouldEqual debox.Buffer.empty[Int]
+
+      val filter5 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums5 = keyIndex.partIdsFromFilters(Seq(filter5), end + 100, end + 100000)
+      partNums5 should not equal debox.Buffer.empty[Int]
+
+      val filter6 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums6 = keyIndex.partIdsFromFilters(Seq(filter6), start - 10000, end )
+      partNums6 should not equal debox.Buffer.empty[Int]
+
+      val filter7 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums7 = keyIndex.partIdsFromFilters(Seq(filter7), (start + end)/2, end + 1000 )
+      partNums7 should not equal debox.Buffer.empty[Int]
+
+      // tests to validate schema ID filter
+      val filter8 = Seq( ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+        ColumnFilter("_type_", Equals("schemaID:46894".utf8)))
+      val partNums8 = keyIndex.partIdsFromFilters(filter8, start, end)
+      partNums8.toIterable() should contain theSameElementsAs List(7, 8, 9)
+
+      val filter9 = Seq( ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+        ColumnFilter("_type_", Equals("prom-counter".utf8)))
+      val partNums9 = keyIndex.partIdsFromFilters(filter9, start, end)
+      partNums9.length shouldEqual 0
+    }
+
+    it("should parse filters with UTF8Wrapper and string correctly") {
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+        }
+
+      keyIndex.refreshReadersBlocking()
+
+      val filter2 = ColumnFilter("Actor2Name", Equals(UTF8Wrapper("REGIME".utf8)))
+      val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), 0, Long.MaxValue)
+      partNums2.toIterable() should contain theSameElementsAs List(8, 9)
+
+      val filter3 = ColumnFilter("Actor2Name", Equals("REGIME"))
+      val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), 0, Long.MaxValue)
+      partNums3.toIterable() should contain theSameElementsAs List(8, 9)
+    }
+
+    it("should fetch part key records from filters correctly") {
+      // Add the first ten keys and row numbers
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, i, i, i + 10)()
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result = keyIndex.partKeyRecordsFromFilters(Seq(filter2), 0, Long.MaxValue)
+      val expected = Seq(pkrs(7), pkrs(8), pkrs(9))
+
+      result.map(_.partKey.toSeq) should contain theSameElementsAs expected.map(_.partKey.toSeq)
+      result.map( p => (p.startTime, p.endTime)) should contain theSameElementsAs expected.map( p => (p.startTime, p.endTime))
+    }
+
+    it("should fetch only two part key records from filters") {
+      // Add the first ten keys and row numbers
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, i, i, i + 10)()
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result = keyIndex.partKeyRecordsFromFilters(Seq(filter2), 0, Long.MaxValue, 2)
+      val expected = Seq(pkrs(7), pkrs(8), pkrs(9))
+
+      result.length shouldEqual 2
+      // Which two elements are chosen aren't deterministic - any of 7,8,9 may come back
+      expected.map(_.partKey.toSeq) should contain allElementsOf result.map(_.partKey.toSeq)
+      expected.map(p => (p.startTime, p.endTime)) should contain allElementsOf result.map(p => (p.startTime, p.endTime))
+    }
+
+    it("should fetch records from filters correctly with a missing label != with a non empty value") {
+      // Weird case in prometheus where if a non existent label is used with != check with an empty value,
+      // the returned result includes all results where the label is missing and those where the label exists
+      // and the value is not equal to the provided value.
+      // Check next test case for the check for empty value
+
+      // Add the first ten keys and row numbers
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, i, i, i + 10)()
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      // Filter != condition on a field that doesn't exist must not affect the result
+
+      val filter1 = ColumnFilter("some", NotEquals("t".utf8))
+      val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result = keyIndex.partKeyRecordsFromFilters(Seq(filter1, filter2), 0, Long.MaxValue)
+      val expected = Seq(pkrs(7), pkrs(8), pkrs(9))
+
+      result.map(_.partKey.toSeq) should contain theSameElementsAs expected.map(_.partKey.toSeq)
+      result.map( p => (p.startTime, p.endTime)) should contain theSameElementsAs expected.map( p => (p.startTime, p.endTime))
+    }
+
+    it("should not fetch records from filters correctly with a missing label != with an empty value") {
+
+      // Weird case in prometheus where if a non existent label is used with != check with an empty value,
+      // the returned result is empty
+
+      // Add the first ten keys and row numbers
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, i, i, i + 10)()
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      // Filter != condition on a field that doesn't exist must not affect the result
+
+      val filter1 = ColumnFilter("some", NotEquals("".utf8))
+      val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result = keyIndex.partKeyRecordsFromFilters(Seq(filter1, filter2), 0, Long.MaxValue)
+      result.isEmpty shouldBe true
+    }
+
+    it("should add part keys and fetch startTimes correctly for more than 1024 keys") {
+      val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
+      val start = System.currentTimeMillis()
+      // we dont care much about the partKey here, but the startTime against partId.
+      val partKeys = Stream.continually(readers.head).take(numPartIds).toList
+      partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i)()
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val startTimes = keyIndex.startTimeFromPartIds((0 until numPartIds).iterator)
+      for { i <- 0 until numPartIds} {
+        startTimes(i) shouldEqual start + i
+      }
+    }
+
+    it("should upsert part keys with endtime by partKey should work and return only active partkeys") {
+      // Add the first ten keys and row numbers
+      val expectedSHA256PartIds = ArrayBuffer.empty[String]
+      partKeyFromRecords(dataset6, records(dataset6, uniqueReader.take(10)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          val time = System.currentTimeMillis()
+          val pkOnHeap = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pkOnHeap, -1, time)(
+            pkOnHeap.length,
+            PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pkOnHeap, 0, pkOnHeap.length))
+          if (i % 2 == 0) {
+            keyIndex.upsertPartKey(pkOnHeap, -1, time, time + 300)(pkOnHeap.length,
+              PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pkOnHeap, 0, pkOnHeap.length))
+          } else {
+            expectedSHA256PartIds.append(PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pkOnHeap, 0, pkOnHeap.length))
+          }
+        }
+      keyIndex.refreshReadersBlocking()
+
+      keyIndex.indexNumEntries shouldEqual 10
+
+      val activelyIngestingParts =
+        keyIndex.partKeyRecordsFromFilters(Nil, System.currentTimeMillis() + 500, Long.MaxValue)
+      activelyIngestingParts.size shouldBe 5
+
+
+      val actualSha256PartIds = activelyIngestingParts.map(r => {
+        PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(r.partKey, 0, r.partKey.length)
+      })
+
+      expectedSHA256PartIds.toSet shouldEqual actualSha256PartIds.toSet
+    }
+
+    it("should add part keys and fetch partIdsEndedBefore and removePartKeys correctly for more than 1024 keys") {
+      val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
+      val start = 1000
+      // we dont care much about the partKey here, but the startTime against partId.
+      val partKeys = Stream.continually(readers.head).take(numPartIds).toList
+      partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i, start + i + 100)()
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val pIds = keyIndex.partIdsEndedBefore(start + 200)
+      val pIdsList = pIds.toList()
+      for { i <- 0 until numPartIds} {
+        pIdsList.contains(i) shouldEqual (if (i <= 100) true else false)
+      }
+
+      keyIndex.removePartKeys(pIds)
+      keyIndex.refreshReadersBlocking()
+
+      for { i <- 0 until numPartIds} {
+        keyIndex.partKeyFromPartId(i).isDefined shouldEqual (if (i <= 100) false else true)
+      }
+
+    }
+
+    it("should add part keys and removePartKeys (without partIds) correctly for more than 1024 keys with del count") {
+      // Identical to test
+      // it("should add part keys and fetch partIdsEndedBefore and removePartKeys correctly for more than 1024 keys")
+      // However, combines them not requiring us to get partIds and pass them tpo remove
+      val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
+      val start = 1000
+      // we dont care much about the partKey here, but the startTime against partId.
+      val partKeys = Stream.continually(readers.head).take(numPartIds).toList
+      partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i, start + i + 100)()
+        }
+      keyIndex.refreshReadersBlocking()
+      val pIdsList = keyIndex.partIdsEndedBefore(start + 200).toList()
+      for { i <- 0 until numPartIds} {
+        pIdsList.contains(i) shouldEqual (i <= 100)
+      }
+      val numDeleted = keyIndex.removePartitionsEndedBefore(start + 200)
+      numDeleted shouldEqual pIdsList.size
+      keyIndex.refreshReadersBlocking()
+
+      // Ensure everything expected is present or deleted
+      for { i <- 0 until numPartIds} {
+        // Everything with partId > 100 should be present
+        keyIndex.partKeyFromPartId(i).isDefined shouldEqual (i > 100)
+      }
+
+      // Important, while the unit test uses partIds to assert the presence or absence before and after deletion
+      // it is no longer required to have partIds in the index on non unit test setup
+    }
+
+    it("should add part keys and removePartKeys (without partIds) correctly for more than 1024 keys w/o del count") {
+      // identical
+      // to should add part keys and removePartKeys (without partIds) correctly for more than 1024 keys w/o del count
+      // except that this one returns 0 for numDocuments deleted
+
+      val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
+      val start = 1000
+      val partKeys = Stream.continually(readers.head).take(numPartIds).toList
+      partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i, start + i + 100)()
+        }
+      keyIndex.refreshReadersBlocking()
+      val pIdsList = keyIndex.partIdsEndedBefore(start + 200).toList()
+      for { i <- 0 until numPartIds} {
+        pIdsList.contains(i) shouldEqual (i <= 100)
+      }
+      val numDeleted = keyIndex.removePartitionsEndedBefore(start + 200, false)
+      numDeleted shouldEqual 0
+      keyIndex.refreshReadersBlocking()
+
+      // Ensure everything expected is present or deleted
+      for { i <- 0 until numPartIds} {
+        // Everything with partId > 100 should be present
+        keyIndex.partKeyFromPartId(i).isDefined shouldEqual (i > 100)
+      }
+
+      // Important, while the unit test uses partIds to assert the presence or absence before and after deletion
+      // it is no longer required to have partIds in the index on non unit test setup
+    }
+
+    it("should update part keys with endtime and parse filters correctly") {
+      val start = System.currentTimeMillis()
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          val time = System.currentTimeMillis()
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, time)()
+          keyIndex.refreshReadersBlocking() // updates need to be able to read startTime from index, so commit
+          keyIndex.updatePartKeyWithEndTime(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, time + 10000)()
+        }
+      val end = System.currentTimeMillis()
+      keyIndex.refreshReadersBlocking()
+
+      // Should get empty iterator when passing no filters
+      val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
+      partNums1.toIterable() should contain theSameElementsAs List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+      val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), start, end)
+      partNums2.toIterable() should contain theSameElementsAs  List(7, 8, 9)
+
+      val filter3 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), start, end)
+      partNums3.toIterable() should contain theSameElementsAs List(8, 9)
+
+      val filter4 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums4 = keyIndex.partIdsFromFilters(Seq(filter4), 10, start-1)
+      partNums4 shouldEqual debox.Buffer.empty[Int]
+
+      val filter5 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums5 = keyIndex.partIdsFromFilters(Seq(filter5), end + 20000, end + 100000)
+      partNums5 shouldEqual debox.Buffer.empty[Int]
+
+      val filter6 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums6 = keyIndex.partIdsFromFilters(Seq(filter6), start - 10000, end-1 )
+      partNums6 should not equal debox.Buffer.empty[Int]
+
+      val filter7 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
+      val partNums7 = keyIndex.partIdsFromFilters(Seq(filter7), (start + end)/2, end + 1000 )
+      partNums7 should not equal debox.Buffer.empty[Int]
+    }
+
+    it("should obtain indexed names and values") {
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+        }
+
+      keyIndex.refreshReadersBlocking()
+
+      keyIndex.indexNames(10).toList should contain theSameElementsAs Seq("_type_", "Actor2Code", "Actor2Name")
+      keyIndex.indexValues("not_found").toSeq should equal (Nil)
+
+      val infos = Seq("AFR", "CHN", "COP", "CVL", "EGYEDU").map(_.utf8).map(TermInfo(_, 1))
+      val top2infos = Seq(TermInfo("GOV".utf8, 3), TermInfo("AGR".utf8, 2))
+      // top 2 items by frequency
+      keyIndex.indexValues("Actor2Code", 2) shouldEqual top2infos
+      val allValues = keyIndex.indexValues("Actor2Code")
+      allValues take 2 shouldEqual top2infos
+      allValues.drop(2).toSet shouldEqual infos.toSet
+    }
+
+    it("should be able to AND multiple filters together") {
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+        }
+
+      keyIndex.refreshReadersBlocking()
+
+      val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+        ColumnFilter("Actor2Name", Equals("REGIME".utf8)))
+      val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+      partNums1.toIterable() should contain theSameElementsAs List(8, 9)
+
+      val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
+        ColumnFilter("Actor2Name", Equals("CHINA".utf8)))
+      val partNums2 = keyIndex.partIdsFromFilters(filters2, 0, Long.MaxValue)
+      partNums2 shouldEqual debox.Buffer.empty[Int]
+    }
+
+    it("should be able to convert pipe regex to TermInSetQuery") {
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(99)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filters1 = Seq(ColumnFilter("Actor2Code", EqualsRegex("GOV|KHM|LAB|MED".utf8)))
+      val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+      partNums1.toIterable() should contain theSameElementsAs List(7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 22, 23, 24, 25, 26, 28, 29, 73, 81, 90)
+    }
+
+    it("should be able to convert prefix regex to PrefixQuery") {
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(99)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filters1 = Seq(ColumnFilter("Actor2Name", EqualsRegex("C.*".utf8)))
+      val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+      partNums1.toIterable() should contain theSameElementsAs List(3, 12, 22, 23, 24, 31, 59, 60, 66, 69, 72, 78, 79, 80, 88, 89)
+    }
+
+
+    it("should ignore unsupported columns and return empty filter") {
+      val index2 = createNewIndex(dataset1.ref, dataset1.schema.partition, true, true, 0, 1.hour.toMillis)
+      partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
+        index2.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
+      }
+      keyIndex.refreshReadersBlocking()
+
+      val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)), ColumnFilter("Year", Equals(1979)))
+      val partNums1 = index2.partIdsFromFilters(filters1, 0, Long.MaxValue)
+      partNums1 shouldEqual debox.Buffer.empty[Int]
+    }
+
+    it("should be able to fetch partKey from partId and partId from partKey") {
+      // Add the first ten keys and row numbers
+      partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.foreach { case (addr, i) =>
+          val partKeyBytes = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(partKeyBytes, i, System.currentTimeMillis())()
+          keyIndex.refreshReadersBlocking()
+          keyIndex.partKeyFromPartId(i).get.bytes shouldEqual partKeyBytes
+          //      keyIndex.partIdFromPartKey(new BytesRef(partKeyBytes)) shouldEqual i
+        }
+    }
+
+    it("should be able to fetch label names efficiently using facets") {
+
+      val index3 = createNewIndex(DatasetRef("prometheus"), Schemas.promCounter.partition,
+        true, true, 0, 1.hour.toMillis)
+      val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+        "_ns_".utf8 -> "my_ns".utf8)
+
+      // create 1000 time series with 10 metric names
+      for { i <- 0 until 1000} {
+        val dynamicLabelNum = i % 5
+        val infoLabelNum = i % 10
+        val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, s"counter",
+          seriesTags + (s"dynamicLabel$dynamicLabelNum".utf8 -> s"dynamicLabelValue".utf8)
+            + (s"infoLabel$infoLabelNum".utf8 -> s"infoLabelValue".utf8)
+        )
+        index3.addPartKey(partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), i, 5)()
+      }
+      index3.refreshReadersBlocking()
+
+      val filters1 = Seq(ColumnFilter("_ws_", Equals("my_ws")), ColumnFilter("_metric_", Equals("counter")))
+
+      val partNums1 = index3.partIdsFromFilters(filters1, 0, Long.MaxValue)
+      partNums1.length shouldEqual 1000
+
+      val labelValues1 = index3.labelNamesEfficient(filters1, 0, Long.MaxValue)
+      labelValues1.toSet shouldEqual (0 until 5).map(c => s"dynamicLabel$c").toSet ++
+        (0 until 10).map(c => s"infoLabel$c").toSet ++
+        Set("_ns_", "_ws_", "_metric_", "_type_")
+    }
+
+    it("should be able to fetch label values efficiently using facets") {
+      val index3 = createNewIndex(DatasetRef("prometheus"), Schemas.promCounter.partition,
+        true, true, 0, 1.hour.toMillis)
+      val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+        "_ns_".utf8 -> "my_ns".utf8)
+
+      // create 1000 time series with 10 metric names
+      for { i <- 0 until 1000} {
+        val counterNum = i % 10
+        val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, s"counter$counterNum",
+          seriesTags + ("instance".utf8 -> s"instance$i".utf8))
+        index3.addPartKey(partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), i, 5)()
+      }
+      index3.refreshReadersBlocking()
+      val filters1 = Seq(ColumnFilter("_ws_", Equals("my_ws")))
+
+      val partNums1 = index3.partIdsFromFilters(filters1, 0, Long.MaxValue)
+      partNums1.length shouldEqual 1000
+
+      val labelValues1 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "_metric_")
+      labelValues1.toSet shouldEqual (0 until 10).map(c => s"counter$c").toSet
+
+      val filters2 = Seq(ColumnFilter("_ws_", Equals("NotExist")))
+      val labelValues2 = index3.labelValuesEfficient(filters2, 0, Long.MaxValue, "_metric_")
+      labelValues2.size shouldEqual 0
+
+      val filters3 = Seq(ColumnFilter("_metric_", Equals("counter1")))
+      val labelValues3 = index3.labelValuesEfficient(filters3, 0, Long.MaxValue, "_metric_")
+      labelValues3 shouldEqual Seq("counter1")
+
+      val labelValues4 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "instance", 1000)
+      labelValues4.toSet shouldEqual (0 until 1000).map(c => s"instance$c").toSet
+    }
+
+    // Testcases to test additionalFacet config
+
+    it("should be able to fetch label values efficiently using additonal facets") {
+      val facetIndex = createNewIndex(dataset7.ref, dataset7.schema.partition,
+        true, true, 0, 1.hour.toMillis)
+      val addedKeys = partKeyFromRecords(dataset7, records(dataset7, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val start = Math.abs(Random.nextLong())
+          facetIndex.addPartKey(partKeyOnHeap(dataset7.partKeySchema, ZeroPointer, addr), i, start)()
+        }
+      facetIndex.refreshReadersBlocking()
+      val filters1 = Seq.empty
+
+      val partNums1 = facetIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
+      partNums1.length shouldEqual 10
+
+      val labelValues1 = facetIndex.labelValuesEfficient(filters1, 0, Long.MaxValue, "Actor2Code")
+      labelValues1.length shouldEqual 7
+
+      val labelValues2 = facetIndex.labelValuesEfficient(filters1, 0, Long.MaxValue, "Actor2Code-Actor2Name")
+      labelValues2.length shouldEqual 8
+
+      val labelValues3 = facetIndex.labelValuesEfficient(filters1, 0, Long.MaxValue, "Actor2Name-Actor2Code")
+      labelValues3.length shouldEqual 8
+
+      labelValues1.sorted.toSet shouldEqual labelValues2.map(_.split("\u03C0")(0)).sorted.toSet
+      labelValues1.sorted.toSet shouldEqual labelValues3.map(_.split("\u03C0")(1)).sorted.toSet
+
+      val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV")))
+
+      val labelValues12 = facetIndex.labelValuesEfficient(filters2, 0, Long.MaxValue, "Actor2Name")
+      labelValues12.length shouldEqual 2
+
+      val labelValues22 = facetIndex.labelValuesEfficient(filters2, 0, Long.MaxValue, "Actor2Code-Actor2Name")
+      labelValues22.length shouldEqual 2
+
+      val labelValues32 = facetIndex.labelValuesEfficient(filters2, 0, Long.MaxValue, "Actor2Name-Actor2Code")
+      labelValues32.length shouldEqual 2
+
+      labelValues12.sorted shouldEqual labelValues22.map(_.split("\u03C0")(1)).sorted
+      labelValues12.sorted shouldEqual labelValues32.map(_.split("\u03C0")(0)).sorted
+
+    }
+
+
+    it("must clean the input directory for Index state apart from Synced and Refreshing") {
+      val events = ArrayBuffer.empty[(IndexState.Value, Long)]
+      IndexState.values.foreach {
+        indexState =>
+          val indexDirectory = new File(
+            System.getProperty("java.io.tmpdir"), "part-key-lucene-index-event")
+          val shardDirectory = new File(indexDirectory, dataset6.ref + File.separator + "0")
+          shardDirectory.mkdirs()
+          new File(shardDirectory, "empty").createNewFile()
+          // Validate the file named empty exists
+          assert(shardDirectory.list().exists(_.equals("empty")))
+          val index = createNewIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
+            Some(indexDirectory),
+            Some(new IndexMetadataStore {
+              def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
+                (indexState, None)
+
+              def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {
+                events.append((state, time))
+              }
+
+              override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
+                currentState(datasetRef: DatasetRef, shard: Int)
+
+              override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit
+              = {
+
+              }
+            }))
+          index.closeIndex()
+          events.toList match {
+            case (IndexState.Empty, _) :: Nil if indexState != IndexState.Synced && indexState != IndexState.Refreshing =>
+              // The file originally present must not be available
+              assert(!shardDirectory.list().exists(_.equals("empty")))
+              events.clear()
+            case Nil  if indexState == IndexState.Synced
+              || indexState == IndexState.Refreshing
+              || indexState == IndexState.Empty     =>
+              // Empty state denotes the FS is empty, it is not cleaned up again to ensure its empty
+              // The file originally present "must" be available, which means no cleanup was done
+              assert(shardDirectory.list().exists(_.equals("empty")))
+            case _                                                                                                      =>
+              fail("Expected an index state Empty after directory cleanup")
+          }
+      }
+    }
+
+    it("Should update the state as empty after the cleanup is from a corrupt index") {
+      val events = ArrayBuffer.empty[(IndexState.Value, Long)]
+      IndexState.values.foreach {
+        indexState =>
+          val indexDirectory = new File(
+            System.getProperty("java.io.tmpdir"), "part-key-lucene-index-event")
+          val shardDirectory = new File(indexDirectory, dataset6.ref + File.separator + "0")
+          // Delete directory to create an index from scratch
+          scala.reflect.io.Directory(shardDirectory).deleteRecursively()
+          shardDirectory.mkdirs()
+          // Validate the file named empty exists
+          val index = createNewIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
+            Some(indexDirectory),None)
+          // Add some index entries
+          val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
+            "_ns_".utf8 -> "my_ns".utf8)
+          for { i <- 0 until 1000} {
+            val counterNum = i % 10
+            val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, s"counter$counterNum",
+              seriesTags + ("instance".utf8 -> s"instance$i".utf8))
+            index.addPartKey(partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), i, 5)()
+          }
+
+          index.closeIndex()
+          // Garble some index files to force a index corruption
+          // Just add some junk to the end of the segment files
+
+          shardDirectory.listFiles(new FileFilter {
+            override def accept(pathname: File): Boolean = {
+              pathname.toString.contains("segment") || pathname.toString.contains(".term")
+            }
+          }).foreach( file => {
+            Files.writeString(file.toPath, "Hello", StandardOpenOption.APPEND)
+          })
+
+          createNewIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
+            Some(indexDirectory),
+            Some( new IndexMetadataStore {
+              def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
+                (indexState, None)
+
+              def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {
+                assert(shardDirectory.list().length == 0)
+                events.append((state, time))
+              }
+
+              override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
+                currentState(datasetRef: DatasetRef, shard: Int)
+
+              override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit
+              = {
+
+              }
+
+            })).closeIndex()
+          // For all states, including states where Index is Synced because the index is corrupt,
+          // the shard directory should be cleared and the new state should be Empty
+          events.toList match {
+            case (IndexState.Empty, _) :: Nil =>
+              // The file originally present must not be available
+              assert(!shardDirectory.list().exists(_.equals("empty")))
+              events.clear()
+            case other                                                               =>
+              fail(s"Expected an index state Empty after directory cleanup, got ${other}")
+          }
+      }
+    }
+
+    it("should get a single match for part keys by a filter") {
+
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, -1, i, i + 10)(
+            pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filter1 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1), 4, 10)
+
+      partKeyOpt.isDefined shouldBe true
+      partKeyOpt.get shouldEqual pkrs(7).partKey
+
+      val filter2 = ColumnFilter("Actor2Code", Equals("NonExist".utf8))
+      keyIndex.singlePartKeyFromFilters(Seq(filter2), 4, 10) shouldBe None
+    }
+
+    it("should get a single match for part keys through a field with empty value") {
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.slice(95, 96)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, -1, i, i + 10)(
+            pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filter1_found = ColumnFilter("Actor2Code", Equals(""))
+      val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
+      partKeyOpt.isDefined shouldBe true
+      partKeyOpt.get shouldEqual pkrs.head.partKey
+
+      val filter2_found = ColumnFilter("Actor2Code", EqualsRegex(""))
+      val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
+      partKeyOpt2.isDefined shouldBe true
+      partKeyOpt2.get shouldEqual pkrs.head.partKey
+
+      val filter3_found = ColumnFilter("Actor2Code", EqualsRegex("^$"))
+      val partKeyOpt3 = keyIndex.singlePartKeyFromFilters(Seq(filter3_found), 4, 10)
+      partKeyOpt3.isDefined shouldBe true
+      partKeyOpt3.get shouldEqual pkrs.head.partKey
+    }
+
+    it("should get a single match for part keys through a non-existing field") {
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, -1, i, i + 10)(
+            pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filter1_found = ColumnFilter("NonExistingField", Equals(""))
+      val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
+      partKeyOpt.isDefined shouldBe true
+      partKeyOpt.get shouldEqual pkrs.head.partKey
+
+      val filter2_found = ColumnFilter("NonExistingField", EqualsRegex(""))
+      val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
+      partKeyOpt2.isDefined shouldBe true
+      partKeyOpt2.get shouldEqual pkrs.head.partKey
+
+      val filter3_found = ColumnFilter("NonExistingField", EqualsRegex("^$"))
+      val partKeyOpt3 = keyIndex.singlePartKeyFromFilters(Seq(filter3_found), 4, 10)
+      partKeyOpt3.isDefined shouldBe true
+      partKeyOpt3.get shouldEqual pkrs.head.partKey
+    }
+
+    it("should get a single match for part keys by a regex filter") {
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, -1, i, i + 10)(
+            pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val filter1_found = ColumnFilter("Actor2Code", EqualsRegex("""^GO.*$"""))
+      val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
+      partKeyOpt.isDefined shouldBe true
+      partKeyOpt.get shouldEqual pkrs(7).partKey
+
+      val filter1_not_found = ColumnFilter("Actor2Code", EqualsRegex("""^GO.*\$"""))
+      keyIndex.singlePartKeyFromFilters(Seq(filter1_not_found), 4, 10) shouldBe None
+
+      val filter2 = ColumnFilter("Actor2Code", NotEqualsRegex("^.*".utf8))
+      keyIndex.singlePartKeyFromFilters(Seq(filter2), 4, 10) shouldBe None
+    }
+
+    it("Should update the state as TriggerRebuild and throw an exception for any error other than CorruptIndexException")
+    {
+      val events = ArrayBuffer.empty[(IndexState.Value, Long)]
+      IndexState.values.foreach {
+        indexState =>
+          val indexDirectory = new File(
+            System.getProperty("java.io.tmpdir"), "part-key-lucene-index-event")
+          val shardDirectory = new File(indexDirectory, dataset6.ref + File.separator + "0")
+          shardDirectory.mkdirs()
+          new File(shardDirectory, "empty").createNewFile()
+          Files.writeString(new File(shardDirectory, "meta.json").toPath, "Hello", StandardOpenOption.CREATE)
+          // Make directory readonly to for an IOException when attempting to write
+          shardDirectory.setWritable(false)
+          // Validate the file named empty exists
+          assert(shardDirectory.list().exists(_.equals("empty")))
+          try {
+            val index = createNewIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
+              Some(indexDirectory),
+              Some( new IndexMetadataStore {
+                def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
+                  (indexState, None)
+
+                def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {
+                  events.append((state, time))
+                }
+
+                override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
+                  currentState(datasetRef: DatasetRef, shard: Int)
+
+                override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long)
+                :Unit = {
+
+                }
+              }))
+            index.closeIndex()
+          } catch {
+            case is: IllegalStateException =>
+              assert(is.getMessage.equals("Unable to clean up index directory"))
+
+              events.toList match {
+                case (IndexState.TriggerRebuild, _) :: Nil =>
+                  // The file originally present would still be there as the directory
+                  // is made readonly
+                  assert(shardDirectory.list().exists(_.equals("empty")))
+                  events.clear()
+                case other                                                               =>
+                  fail(s"Expected an index state Empty after directory cleanup - got ${other}")
+              }
+          } finally {
+            shardDirectory.setWritable(true)
+          }
+
+      }
+    }
+
+    it("should match records without label when .* is provided on a non existent label") {
+
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.schema.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, i, i, i + 10)()
+          PartKeyLuceneIndexRecord(pk, i, i + 10)
+        }
+      keyIndex.refreshReadersBlocking()
+
+
+      // Query with just the existing Label name
+      val filter1 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result1 = keyIndex.partKeyRecordsFromFilters(Seq(filter1), 0, Long.MaxValue)
+      val expected1 = Seq(pkrs(7), pkrs(8), pkrs(9))
+
+      result1.map(_.partKey.toSeq) should contain theSameElementsAs expected1.map(_.partKey.toSeq)
+      result1.map(p => (p.startTime, p.endTime)) should contain theSameElementsAs expected1.map(p => (p.startTime, p.endTime))
+
+      // Query with non existent label name with an empty regex
+      val filter2 = ColumnFilter("dummy", EqualsRegex(".*".utf8))
+      val filter3 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result2 = keyIndex.partKeyRecordsFromFilters(Seq(filter2, filter3), 0, Long.MaxValue)
+      val expected2 = Seq(pkrs(7), pkrs(8), pkrs(9))
+
+      result2.map(_.partKey.toSeq) should contain theSameElementsAs expected2.map(_.partKey.toSeq)
+      result2.map(p => (p.startTime, p.endTime)) should contain theSameElementsAs expected2.map(p => (p.startTime, p.endTime))
+
+      // Query with non existent label name with an regex matching at least 1 character
+      val filter4 = ColumnFilter("dummy", EqualsRegex(".+".utf8))
+      val filter5 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result3 = keyIndex.partKeyRecordsFromFilters(Seq(filter4, filter5), 0, Long.MaxValue)
+      result3 shouldEqual Seq()
+
+      // Query with non existent label name with an empty regex
+      val filter6 = ColumnFilter("dummy", EqualsRegex("".utf8))
+      val filter7 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result4 = keyIndex.partKeyRecordsFromFilters(Seq(filter6, filter7), 0, Long.MaxValue)
+      val expected4 = Seq(pkrs(7), pkrs(8), pkrs(9))
+      result4.map(_.partKey.toSeq) should contain theSameElementsAs expected4.map(_.partKey.toSeq)
+      result4.map(p => (p.startTime, p.endTime)) should contain theSameElementsAs expected4.map(p => (p.startTime, p.endTime))
+
+      // Query with non existent label name with an empty equals
+      val filter8 = ColumnFilter("dummy", Equals("".utf8))
+      val filter9 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
+      val result5 = keyIndex.partKeyRecordsFromFilters(Seq(filter8, filter9), 0, Long.MaxValue)
+      val expected5 = Seq(pkrs(7), pkrs(8), pkrs(9))
+      result5.map(_.partKey.toSeq) should contain theSameElementsAs expected5.map(_.partKey.toSeq)
+      result5.map(p => (p.startTime, p.endTime)) should contain theSameElementsAs expected5.map(p => (p.startTime, p.endTime))
+
+
+      val filter10 = ColumnFilter("Actor2Code", EqualsRegex(".*".utf8))
+      val result10= keyIndex.partKeyRecordsFromFilters(Seq(filter10), 0, Long.MaxValue)
+      result10.map(_.partKey.toSeq) should contain theSameElementsAs pkrs.map(_.partKey.toSeq)
+      result10.map(p => (p.startTime, p.endTime)) should contain theSameElementsAs pkrs.map(p => (p.startTime, p.endTime))
+    }
+
+    it("should translate a part key to a part ID") {
+      val pks = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+        .zipWithIndex.map { case (addr, i) =>
+          val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
+          keyIndex.addPartKey(pk, i, System.currentTimeMillis())()
+
+          pk
+        }
+      keyIndex.refreshReadersBlocking()
+
+      val partKeyOpt = keyIndex.partIdFromPartKeySlow(pks(0), UnsafeUtils.arayOffset)
+      partKeyOpt.isDefined shouldBe true
+      partKeyOpt.get shouldEqual 0
+    }
+  }
+  // scalastyle:on cyclomatic.complexity
+  // scalastyle:on method.length
+}

--- a/core/src/test/scala/filodb.core/memstore/PartKeyIndexRawSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyIndexRawSpec.scala
@@ -747,7 +747,7 @@ trait PartKeyIndexRawSpec {
     }
 
     it("should get a single match for part keys through a non-existing field") {
-      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
+      val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(1)), Some(partBuilder))
         .zipWithIndex.map { case (addr, i) =>
           val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
           keyIndex.addPartKey(pk, -1, i, i + 10)(

--- a/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyLuceneIndexSpec.scala
@@ -2,26 +2,24 @@ package filodb.core.memstore
 
 import com.googlecode.javaewah.IntIterator
 import filodb.core._
-import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
+import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.memstore.ratelimit.{CardinalityTracker, RocksDbCardinalityStore}
-import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
+import filodb.core.metadata.{Dataset, DatasetOptions, PartitionSchema, Schemas}
 import filodb.core.query.{ColumnFilter, Filter}
 import filodb.memory.{BinaryRegionConsumer, MemFactory}
 import filodb.memory.format.UnsafeUtils.ZeroPointer
-import filodb.memory.format.UTF8Wrapper
 import filodb.memory.format.ZeroCopyUTF8String._
 import org.apache.lucene.util.BytesRef
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.io.{File, FileFilter}
-import java.nio.file.{Files, StandardOpenOption}
+import java.io.File
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.util.Random
 
-class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
+class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfter with PartKeyIndexRawSpec {
   import Filter._
   import GdeltTestData._
 
@@ -29,10 +27,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     Some(new java.io.File(System.getProperty("java.io.tmpdir"), "part-key-lucene-index")))
 
   val partBuilder = new RecordBuilder(TestData.nativeMem)
-
-  def partKeyOnHeap(partKeySchema: RecordSchema,
-                    base: Any,
-                    offset: Long): Array[Byte] = partKeySchema.asByteArray(base, offset)
 
   before {
     keyIndex.reset()
@@ -51,83 +45,19 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     }
   }
 
-  it("should add part keys and parse filters correctly") {
-    val start = System.currentTimeMillis()
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-    val end = System.currentTimeMillis()
-    keyIndex.refreshReadersBlocking()
-
-    // Should get empty iterator when passing no filters
-    val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
-    partNums1 shouldEqual debox.Buffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-
-    // return only 4 partIds - empty filter
-    val partNumsLimit = keyIndex.partIdsFromFilters(Nil, start, end, 4)
-    partNumsLimit shouldEqual debox.Buffer(0, 1, 2, 3)
-
-    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), start, end)
-    partNums2 shouldEqual debox.Buffer(7, 8, 9)
-
-    // return only 2 partIds - with filter
-    val partNumsLimitFilter = keyIndex.partIdsFromFilters(Seq(filter2), start, end, 2)
-    partNumsLimitFilter shouldEqual debox.Buffer(7, 8)
-
-    val filter3 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), start, end)
-    partNums3 shouldEqual debox.Buffer(8, 9)
-
-    val filter4 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums4 = keyIndex.partIdsFromFilters(Seq(filter4), 10, start-1)
-    partNums4 shouldEqual debox.Buffer.empty[Int]
-
-    val filter5 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums5 = keyIndex.partIdsFromFilters(Seq(filter5), end + 100, end + 100000)
-    partNums5 should not equal debox.Buffer.empty[Int]
-
-    val filter6 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums6 = keyIndex.partIdsFromFilters(Seq(filter6), start - 10000, end )
-    partNums6 should not equal debox.Buffer.empty[Int]
-
-    val filter7 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums7 = keyIndex.partIdsFromFilters(Seq(filter7), (start + end)/2, end + 1000 )
-    partNums7 should not equal debox.Buffer.empty[Int]
-
-    // tests to validate schema ID filter
-    val filter8 = Seq( ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-      ColumnFilter("_type_", Equals("schemaID:46894".utf8)))
-    val partNums8 = keyIndex.partIdsFromFilters(filter8, start, end)
-    partNums8 shouldEqual debox.Buffer(7, 8, 9)
-
-    val filter9 = Seq( ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-      ColumnFilter("_type_", Equals("prom-counter".utf8)))
-    val partNums9 = keyIndex.partIdsFromFilters(filter9, start, end)
-    partNums9.length shouldEqual 0
-
+  protected def createNewIndex(ref: DatasetRef,
+                               schema: PartitionSchema,
+                               facetEnabledAllLabels: Boolean,
+                               facetEnabledShardKeyLabels: Boolean,
+                               shardNum: Int,
+                               retentionMillis: Long,
+                               diskLocation: Option[File],
+                               lifecycleManager: Option[IndexMetadataStore]): PartKeyIndexRaw = {
+    new PartKeyLuceneIndex(ref, schema, facetEnabledAllLabels, facetEnabledShardKeyLabels, shardNum, retentionMillis,
+      diskLocation, lifecycleManager)
   }
 
-  it("should fetch part key records from filters correctly") {
-    // Add the first ten keys and row numbers
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, i, i, i + 10)()
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result = keyIndex.partKeyRecordsFromFilters(Seq(filter2), 0, Long.MaxValue)
-    val expected = Seq(pkrs(7), pkrs(8), pkrs(9))
-
-    result.map(_.partKey.toSeq) shouldEqual expected.map(_.partKey.toSeq)
-    result.map( p => (p.startTime, p.endTime)) shouldEqual expected.map( p => (p.startTime, p.endTime))
-  }
-
+  it should behave like commonPartKeyTests(keyIndex, partBuilder)
 
   it("should fetch part key records from filters correctly with index caching disabled") {
     // Add the first ten keys and row numbers
@@ -157,25 +87,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
   }
 
-  it("should fetch only two part key records from filters") {
-    // Add the first ten keys and row numbers
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, i, i, i + 10)()
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result = keyIndex.partKeyRecordsFromFilters(Seq(filter2), 0, Long.MaxValue, 2)
-    val expected = Seq(pkrs(7), pkrs(8))
-
-    result.map(_.partKey.toSeq) shouldEqual expected.map(_.partKey.toSeq)
-    result.map(p => (p.startTime, p.endTime)) shouldEqual expected.map(p => (p.startTime, p.endTime))
-  }
-
-
   it("should fetch part key iterator records from filters correctly") {
     // Add the first ten keys and row numbers
     val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
@@ -201,54 +112,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     }
   }
 
-  it("should fetch records from filters correctly with a missing label != with a non empty value") {
-    // Weird case in prometheus where if a non existent label is used with != check with an empty value,
-    // the returned result includes all results where the label is missing and those where the label exists
-    // and the value is not equal to the provided value.
-    // Check next test case for the check for empty value
-
-    // Add the first ten keys and row numbers
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, i, i, i + 10)()
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    // Filter != condition on a field that doesn't exist must not affect the result
-
-    val filter1 = ColumnFilter("some", NotEquals("t".utf8))
-    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result = keyIndex.partKeyRecordsFromFilters(Seq(filter1, filter2), 0, Long.MaxValue)
-    val expected = Seq(pkrs(7), pkrs(8), pkrs(9))
-
-    result.map(_.partKey.toSeq) shouldEqual expected.map(_.partKey.toSeq)
-    result.map( p => (p.startTime, p.endTime)) shouldEqual expected.map( p => (p.startTime, p.endTime))
-  }
-
-  it("should not fetch records from filters correctly with a missing label != with an empty value") {
-
-    // Weird case in prometheus where if a non existent label is used with != check with an empty value,
-    // the returned result is empty
-
-    // Add the first ten keys and row numbers
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, i, i, i + 10)()
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    // Filter != condition on a field that doesn't exist must not affect the result
-
-    val filter1 = ColumnFilter("some", NotEquals("".utf8))
-    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result = keyIndex.partKeyRecordsFromFilters(Seq(filter1, filter2), 0, Long.MaxValue)
-    result.isEmpty shouldBe true
-  }
-
   it("should upsert part keys with endtime and foreachPartKeyStillIngesting should work") {
     // Add the first ten keys and row numbers
     partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
@@ -268,297 +131,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     numHits shouldEqual 5
     partIdsIngesting shouldEqual Seq(1, 3, 5, 7, 9)
 
-  }
-
-  it("should upsert part keys with endtime by partKey should work and return only active partkeys") {
-    // Add the first ten keys and row numbers
-    val expectedSHA256PartIds = ArrayBuffer.empty[String]
-    partKeyFromRecords(dataset6, records(dataset6, uniqueReader.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      val time = System.currentTimeMillis()
-      val pkOnHeap = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pkOnHeap, -1, time)(
-        pkOnHeap.length,
-        PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pkOnHeap, 0, pkOnHeap.length))
-      if (i % 2 == 0) {
-        keyIndex.upsertPartKey(pkOnHeap, -1, time, time + 300)(pkOnHeap.length,
-          PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pkOnHeap, 0, pkOnHeap.length))
-      } else {
-        expectedSHA256PartIds.append(PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pkOnHeap, 0, pkOnHeap.length))
-      }
-    }
-    keyIndex.refreshReadersBlocking()
-
-    keyIndex.indexNumEntries shouldEqual 10
-
-    val activelyIngestingParts =
-      keyIndex.partKeyRecordsFromFilters(Nil, System.currentTimeMillis() + 500, Long.MaxValue)
-    activelyIngestingParts.size shouldBe 5
-
-
-    val actualSha256PartIds = activelyIngestingParts.map(r => {
-      PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(r.partKey, 0, r.partKey.length)
-    })
-
-    expectedSHA256PartIds.toSet shouldEqual actualSha256PartIds.toSet
-  }
-
-
-
-  it("should add part keys and fetch startTimes correctly for more than 1024 keys") {
-    val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
-    val start = System.currentTimeMillis()
-    // we dont care much about the partKey here, but the startTime against partId.
-    val partKeys = Stream.continually(readers.head).take(numPartIds).toList
-    partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i)()
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val startTimes = keyIndex.startTimeFromPartIds((0 until numPartIds).iterator)
-    for { i <- 0 until numPartIds} {
-      startTimes(i) shouldEqual start + i
-    }
-  }
-
-  it("should add part keys and fetch partIdsEndedBefore and removePartKeys correctly for more than 1024 keys") {
-    val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
-    val start = 1000
-    // we dont care much about the partKey here, but the startTime against partId.
-    val partKeys = Stream.continually(readers.head).take(numPartIds).toList
-    partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i, start + i + 100)()
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val pIds = keyIndex.partIdsEndedBefore(start + 200)
-    val pIdsList = pIds.toList()
-    for { i <- 0 until numPartIds} {
-      pIdsList.contains(i) shouldEqual (if (i <= 100) true else false)
-    }
-
-    keyIndex.removePartKeys(pIds)
-    keyIndex.refreshReadersBlocking()
-
-    for { i <- 0 until numPartIds} {
-      keyIndex.partKeyFromPartId(i).isDefined shouldEqual (if (i <= 100) false else true)
-    }
-
-  }
-
-  it("should add part keys and removePartKeys (without partIds) correctly for more than 1024 keys with del count") {
-    // Identical to test
-    // it("should add part keys and fetch partIdsEndedBefore and removePartKeys correctly for more than 1024 keys")
-    // However, combines them not requiring us to get partIds and pass them tpo remove
-    val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
-    val start = 1000
-    // we dont care much about the partKey here, but the startTime against partId.
-    val partKeys = Stream.continually(readers.head).take(numPartIds).toList
-    partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i, start + i + 100)()
-    }
-    keyIndex.refreshReadersBlocking()
-    val pIdsList = keyIndex.partIdsEndedBefore(start + 200).toList()
-    for { i <- 0 until numPartIds} {
-      pIdsList.contains(i) shouldEqual (i <= 100)
-    }
-    val numDeleted = keyIndex.removePartitionsEndedBefore(start + 200)
-    numDeleted shouldEqual pIdsList.size
-    keyIndex.refreshReadersBlocking()
-
-    // Ensure everything expected is present or deleted
-    for { i <- 0 until numPartIds} {
-      // Everything with partId > 100 should be present
-      keyIndex.partKeyFromPartId(i).isDefined shouldEqual (i > 100)
-    }
-
-    // Important, while the unit test uses partIds to assert the presence or absence before and after deletion
-    // it is no longer required to have partIds in the index on non unit test setup
-  }
-
-  it("should add part keys and removePartKeys (without partIds) correctly for more than 1024 keys w/o del count") {
-    // identical
-    // to should add part keys and removePartKeys (without partIds) correctly for more than 1024 keys w/o del count
-    // except that this one returns 0 for numDocuments deleted
-
-    val numPartIds = 3000 // needs to be more than 1024 to test the lucene term limit
-    val start = 1000
-    val partKeys = Stream.continually(readers.head).take(numPartIds).toList
-    partKeyFromRecords(dataset6, records(dataset6, partKeys), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, start + i, start + i + 100)()
-    }
-    keyIndex.refreshReadersBlocking()
-    val pIdsList = keyIndex.partIdsEndedBefore(start + 200).toList()
-    for { i <- 0 until numPartIds} {
-      pIdsList.contains(i) shouldEqual (i <= 100)
-    }
-    val numDeleted = keyIndex.removePartitionsEndedBefore(start + 200, false)
-    numDeleted shouldEqual 0
-    keyIndex.refreshReadersBlocking()
-
-    // Ensure everything expected is present or deleted
-    for { i <- 0 until numPartIds} {
-      // Everything with partId > 100 should be present
-      keyIndex.partKeyFromPartId(i).isDefined shouldEqual (i > 100)
-    }
-
-    // Important, while the unit test uses partIds to assert the presence or absence before and after deletion
-    // it is no longer required to have partIds in the index on non unit test setup
-  }
-
-  it("should update part keys with endtime and parse filters correctly") {
-    val start = System.currentTimeMillis()
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      val time = System.currentTimeMillis()
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, time)()
-      keyIndex.refreshReadersBlocking() // updates need to be able to read startTime from index, so commit
-      keyIndex.updatePartKeyWithEndTime(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, time + 10000)()
-    }
-    val end = System.currentTimeMillis()
-    keyIndex.refreshReadersBlocking()
-
-    // Should get empty iterator when passing no filters
-    val partNums1 = keyIndex.partIdsFromFilters(Nil, start, end)
-    partNums1 shouldEqual debox.Buffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-
-    val filter2 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), start, end)
-    partNums2 shouldEqual debox.Buffer(7, 8, 9)
-
-    val filter3 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), start, end)
-    partNums3 shouldEqual debox.Buffer(8, 9)
-
-    val filter4 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums4 = keyIndex.partIdsFromFilters(Seq(filter4), 10, start-1)
-    partNums4 shouldEqual debox.Buffer.empty[Int]
-
-    val filter5 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums5 = keyIndex.partIdsFromFilters(Seq(filter5), end + 20000, end + 100000)
-    partNums5 shouldEqual debox.Buffer.empty[Int]
-
-    val filter6 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums6 = keyIndex.partIdsFromFilters(Seq(filter6), start - 10000, end-1 )
-    partNums6 should not equal debox.Buffer.empty[Int]
-
-    val filter7 = ColumnFilter("Actor2Name", Equals("REGIME".utf8))
-    val partNums7 = keyIndex.partIdsFromFilters(Seq(filter7), (start + end)/2, end + 1000 )
-    partNums7 should not equal debox.Buffer.empty[Int]
-  }
-
-  it("should parse filters with UTF8Wrapper and string correctly") {
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-
-    keyIndex.refreshReadersBlocking()
-
-    val filter2 = ColumnFilter("Actor2Name", Equals(UTF8Wrapper("REGIME".utf8)))
-    val partNums2 = keyIndex.partIdsFromFilters(Seq(filter2), 0, Long.MaxValue)
-    partNums2 shouldEqual debox.Buffer(8, 9)
-
-    val filter3 = ColumnFilter("Actor2Name", Equals("REGIME"))
-    val partNums3 = keyIndex.partIdsFromFilters(Seq(filter3), 0, Long.MaxValue)
-    partNums3 shouldEqual debox.Buffer(8, 9)
-  }
-
-  it("should obtain indexed names and values") {
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-
-    keyIndex.refreshReadersBlocking()
-
-    keyIndex.indexNames(10).toList shouldEqual Seq("_type_", "Actor2Code", "Actor2Name")
-    keyIndex.indexValues("not_found").toSeq should equal (Nil)
-
-    val infos = Seq("AFR", "CHN", "COP", "CVL", "EGYEDU").map(_.utf8).map(TermInfo(_, 1))
-    val top2infos = Seq(TermInfo("GOV".utf8, 3), TermInfo("AGR".utf8, 2))
-    // top 2 items by frequency
-    keyIndex.indexValues("Actor2Code", 2) shouldEqual top2infos
-    val allValues = keyIndex.indexValues("Actor2Code")
-    allValues take 2 shouldEqual top2infos
-    allValues.drop(2).toSet shouldEqual infos.toSet
-  }
-
-  it("should be able to AND multiple filters together") {
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-
-    keyIndex.refreshReadersBlocking()
-
-    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-      ColumnFilter("Actor2Name", Equals("REGIME".utf8)))
-    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1 shouldEqual debox.Buffer(8, 9)
-
-    val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)),
-      ColumnFilter("Actor2Name", Equals("CHINA".utf8)))
-    val partNums2 = keyIndex.partIdsFromFilters(filters2, 0, Long.MaxValue)
-    partNums2 shouldEqual debox.Buffer.empty[Int]
-  }
-
-  it("should be able to convert pipe regex to TermInSetQuery") {
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(99)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filters1 = Seq(ColumnFilter("Actor2Code", EqualsRegex("GOV|KHM|LAB|MED".utf8)))
-    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1 shouldEqual debox.Buffer(7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 22, 23, 24, 25, 26, 28, 29, 73, 81, 90)
-  }
-
-  it("should be able to convert prefix regex to PrefixQuery") {
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(99)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      keyIndex.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filters1 = Seq(ColumnFilter("Actor2Name", EqualsRegex("C.*".utf8)))
-    val partNums1 = keyIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1 shouldEqual debox.Buffer(3, 12, 22, 23, 24, 31, 59, 60, 66, 69, 72, 78, 79, 80, 88, 89)
-  }
-
-  it("should ignore unsupported columns and return empty filter") {
-    val index2 = new PartKeyLuceneIndex(dataset1.ref, dataset1.schema.partition, true, true, 0, 1.hour.toMillis)
-    partKeyFromRecords(dataset1, records(dataset1, readers.take(10))).zipWithIndex.foreach { case (addr, i) =>
-      index2.addPartKey(partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr), i, System.currentTimeMillis())()
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filters1 = Seq(ColumnFilter("Actor2Code", Equals("GOV".utf8)), ColumnFilter("Year", Equals(1979)))
-    val partNums1 = index2.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1 shouldEqual debox.Buffer.empty[Int]
-  }
-
-  it("should be able to fetch partKey from partId and partId from partKey") {
-    // Add the first ten keys and row numbers
-    partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.foreach { case (addr, i) =>
-      val partKeyBytes = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(partKeyBytes, i, System.currentTimeMillis())()
-      keyIndex.refreshReadersBlocking()
-      keyIndex.partKeyFromPartId(i).get.bytes shouldEqual partKeyBytes
-      //      keyIndex.partIdFromPartKey(new BytesRef(partKeyBytes)) shouldEqual i
-    }
   }
 
   it("should be able to sort results by endTime, startTime") {
@@ -585,70 +157,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
       val untilTimePartIds = keyIndex.partIdsOrderedByEndTime(10, toEndTime = dropFrom(0)._1 - 1)
       untilTimePartIds.toArray.toSeq shouldEqual sortedKeys.take(from).map(_._3).take(10).sorted
     }
-  }
-
-  it("should be able to fetch label names efficiently using facets") {
-
-    val index3 = new PartKeyLuceneIndex(DatasetRef("prometheus"), Schemas.promCounter.partition,
-      true, true, 0, 1.hour.toMillis)
-    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
-      "_ns_".utf8 -> "my_ns".utf8)
-
-    // create 1000 time series with 10 metric names
-    for { i <- 0 until 1000} {
-      val dynamicLabelNum = i % 5
-      val infoLabelNum = i % 10
-      val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, s"counter",
-        seriesTags + (s"dynamicLabel$dynamicLabelNum".utf8 -> s"dynamicLabelValue".utf8)
-                   + (s"infoLabel$infoLabelNum".utf8 -> s"infoLabelValue".utf8)
-      )
-      index3.addPartKey(partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), i, 5)()
-    }
-    index3.refreshReadersBlocking()
-
-    val filters1 = Seq(ColumnFilter("_ws_", Equals("my_ws")), ColumnFilter("_metric_", Equals("counter")))
-
-    val partNums1 = index3.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1.length shouldEqual 1000
-
-    val labelValues1 = index3.labelNamesEfficient(filters1, 0, Long.MaxValue)
-    labelValues1.toSet shouldEqual (0 until 5).map(c => s"dynamicLabel$c").toSet ++
-                                   (0 until 10).map(c => s"infoLabel$c").toSet ++
-                                   Set("_ns_", "_ws_", "_metric_", "_type_")
-  }
-
-  it("should be able to fetch label values efficiently using facets") {
-    val index3 = new PartKeyLuceneIndex(DatasetRef("prometheus"), Schemas.promCounter.partition,
-      true, true, 0, 1.hour.toMillis)
-    val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
-      "_ns_".utf8 -> "my_ns".utf8)
-
-    // create 1000 time series with 10 metric names
-    for { i <- 0 until 1000} {
-      val counterNum = i % 10
-      val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, s"counter$counterNum",
-        seriesTags + ("instance".utf8 -> s"instance$i".utf8))
-      index3.addPartKey(partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), i, 5)()
-    }
-    index3.refreshReadersBlocking()
-    val filters1 = Seq(ColumnFilter("_ws_", Equals("my_ws")))
-
-    val partNums1 = index3.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1.length shouldEqual 1000
-
-    val labelValues1 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "_metric_")
-    labelValues1.toSet shouldEqual (0 until 10).map(c => s"counter$c").toSet
-
-    val filters2 = Seq(ColumnFilter("_ws_", Equals("NotExist")))
-    val labelValues2 = index3.labelValuesEfficient(filters2, 0, Long.MaxValue, "_metric_")
-    labelValues2.size shouldEqual 0
-
-    val filters3 = Seq(ColumnFilter("_metric_", Equals("counter1")))
-    val labelValues3 = index3.labelValuesEfficient(filters3, 0, Long.MaxValue, "_metric_")
-    labelValues3 shouldEqual Seq("counter1")
-
-    val labelValues4 = index3.labelValuesEfficient(filters1, 0, Long.MaxValue, "instance", 1000)
-    labelValues4.toSet shouldEqual (0 until 1000).map(c => s"instance$c").toSet
   }
 
   it("should be able to do regular operations when faceting is disabled") {
@@ -680,50 +188,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
 
   }
 
-  // Testcases to test additionalFacet config
-
-  it("should be able to fetch label values efficiently using additonal facets") {
-    val facetIndex = new PartKeyLuceneIndex(dataset7.ref, dataset7.schema.partition,
-      true, true, 0, 1.hour.toMillis)
-    val addedKeys = partKeyFromRecords(dataset7, records(dataset7, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val start = Math.abs(Random.nextLong())
-      facetIndex.addPartKey(partKeyOnHeap(dataset7.partKeySchema, ZeroPointer, addr), i, start)()
-    }
-    facetIndex.refreshReadersBlocking()
-    val filters1 = Seq.empty
-
-    val partNums1 = facetIndex.partIdsFromFilters(filters1, 0, Long.MaxValue)
-    partNums1.length shouldEqual 10
-
-    val labelValues1 = facetIndex.labelValuesEfficient(filters1, 0, Long.MaxValue, "Actor2Code")
-    labelValues1.length shouldEqual 7
-
-    val labelValues2 = facetIndex.labelValuesEfficient(filters1, 0, Long.MaxValue, "Actor2Code-Actor2Name")
-    labelValues2.length shouldEqual 8
-
-    val labelValues3 = facetIndex.labelValuesEfficient(filters1, 0, Long.MaxValue, "Actor2Name-Actor2Code")
-    labelValues3.length shouldEqual 8
-
-    labelValues1.sorted.toSet shouldEqual labelValues2.map(_.split("\u03C0")(0)).sorted.toSet
-    labelValues1.sorted.toSet shouldEqual labelValues3.map(_.split("\u03C0")(1)).sorted.toSet
-
-    val filters2 = Seq(ColumnFilter("Actor2Code", Equals("GOV")))
-
-    val labelValues12 = facetIndex.labelValuesEfficient(filters2, 0, Long.MaxValue, "Actor2Name")
-    labelValues12.length shouldEqual 2
-
-    val labelValues22 = facetIndex.labelValuesEfficient(filters2, 0, Long.MaxValue, "Actor2Code-Actor2Name")
-    labelValues22.length shouldEqual 2
-
-    val labelValues32 = facetIndex.labelValuesEfficient(filters2, 0, Long.MaxValue, "Actor2Name-Actor2Code")
-    labelValues32.length shouldEqual 2
-
-    labelValues12.sorted shouldEqual labelValues22.map(_.split("\u03C0")(1)).sorted
-    labelValues12.sorted shouldEqual labelValues32.map(_.split("\u03C0")(0)).sorted
-
-  }
-
   it("should be able to do regular operations when faceting is disabled and additional faceting in dataset") {
     val facetIndex = new PartKeyLuceneIndex(dataset7.ref, dataset7.schema.partition,
       false, true, 0, 1.hour.toMillis)
@@ -741,141 +205,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     the [IllegalArgumentException] thrownBy {
       facetIndex.labelValuesEfficient(filters1, 0, Long.MaxValue, "Actor2Code-Actor2Name")
     } should have message "requirement failed: Faceting not enabled for label Actor2Code-Actor2Name; labelValuesEfficient should not have been called"
-  }
-
-  it("must clean the input directory for Index state apart from Synced and Refreshing") {
-    val events = ArrayBuffer.empty[(IndexState.Value, Long)]
-    IndexState.values.foreach {
-      indexState =>
-        val indexDirectory = new File(
-          System.getProperty("java.io.tmpdir"), "part-key-lucene-index-event")
-        val shardDirectory = new File(indexDirectory, dataset6.ref + File.separator + "0")
-        shardDirectory.mkdirs()
-        new File(shardDirectory, "empty").createNewFile()
-        // Validate the file named empty exists
-        assert(shardDirectory.list().exists(_.equals("empty")))
-        val index = new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
-          Some(indexDirectory),
-          Some(new IndexMetadataStore {
-            def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
-              (indexState, None)
-
-            def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {
-              events.append((state, time))
-            }
-
-            override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
-              currentState(datasetRef: DatasetRef, shard: Int)
-
-            override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit
-            = {
-
-            }
-          }))
-        index.closeIndex()
-        events.toList match {
-          case (IndexState.Empty, _) :: Nil if indexState != IndexState.Synced && indexState != IndexState.Refreshing =>
-            // The file originally present must not be available
-            assert(!shardDirectory.list().exists(_.equals("empty")))
-            events.clear()
-          case Nil  if indexState == IndexState.Synced
-                    || indexState == IndexState.Refreshing
-                    || indexState == IndexState.Empty     =>
-            // Empty state denotes the FS is empty, it is not cleaned up again to ensure its empty
-            // The file originally present "must" be available, which means no cleanup was done
-            assert(shardDirectory.list().exists(_.equals("empty")))
-          case _                                                                                                      =>
-            fail("Expected an index state Empty after directory cleanup")
-        }
-    }
-  }
-
-
-  it("Should update the state as empty after the cleanup is from a corrupt index") {
-    val events = ArrayBuffer.empty[(IndexState.Value, Long)]
-    IndexState.values.foreach {
-      indexState =>
-        val indexDirectory = new File(
-          System.getProperty("java.io.tmpdir"), "part-key-lucene-index-event")
-        val shardDirectory = new File(indexDirectory, dataset6.ref + File.separator + "0")
-        // Delete directory to create an index from scratch
-        scala.reflect.io.Directory(shardDirectory).deleteRecursively()
-        shardDirectory.mkdirs()
-        // Validate the file named empty exists
-        val index = new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
-          Some(indexDirectory),None)
-        // Add some index entries
-        val seriesTags = Map("_ws_".utf8 -> "my_ws".utf8,
-          "_ns_".utf8 -> "my_ns".utf8)
-        for { i <- 0 until 1000} {
-          val counterNum = i % 10
-          val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, s"counter$counterNum",
-            seriesTags + ("instance".utf8 -> s"instance$i".utf8))
-          index.addPartKey(partKeyOnHeap(Schemas.promCounter.partition.binSchema, ZeroPointer, partKey), i, 5)()
-        }
-
-        index.closeIndex()
-        // Garble some index files to force a index corruption
-        // Just add some junk to the end of the segment files
-
-        shardDirectory.listFiles(new FileFilter {
-          override def accept(pathname: File): Boolean = pathname.toString.contains("segment")
-        }).foreach( file => {
-          Files.writeString(file.toPath, "Hello", StandardOpenOption.APPEND)
-        })
-
-        new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
-          Some(indexDirectory),
-          Some( new IndexMetadataStore {
-            def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
-              (indexState, None)
-
-            def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {
-              assert(shardDirectory.list().length == 0)
-              events.append((state, time))
-            }
-
-            override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
-              currentState(datasetRef: DatasetRef, shard: Int)
-
-            override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit
-            = {
-
-            }
-
-          })).closeIndex()
-        // For all states, including states where Index is Synced because the index is corrupt,
-        // the shard directory should be cleared and the new state should be Empty
-        events.toList match {
-          case (IndexState.Empty, _) :: Nil =>
-            // The file originally present must not be available
-            assert(!shardDirectory.list().exists(_.equals("empty")))
-            events.clear()
-          case _                                                               =>
-            fail("Expected an index state Empty after directory cleanup")
-        }
-    }
-  }
-
-  it("should get a single match for part keys by a filter") {
-
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, -1, i, i + 10)(
-        pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filter1 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1), 4, 10)
-
-    partKeyOpt.isDefined shouldBe true
-    partKeyOpt.get shouldEqual pkrs(7).partKey
-
-    val filter2 = ColumnFilter("Actor2Code", Equals("NonExist".utf8))
-    keyIndex.singlePartKeyFromFilters(Seq(filter2), 4, 10) shouldBe None
   }
 
   it("toStringPairsMap should return a map of label key value pairs") {
@@ -908,132 +237,6 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
       for(tag <- extraTags){
         labelKV(tag._1.toString) shouldEqual tag._2.toString
       }
-    }
-  }
-
-  it("should get a single match for part keys through a field with empty value") {
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.slice(95, 96)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, -1, i, i + 10)(
-        pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filter1_found = ColumnFilter("Actor2Code", Equals(""))
-    val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
-    partKeyOpt.isDefined shouldBe true
-    partKeyOpt.get shouldEqual pkrs.head.partKey
-
-    val filter2_found = ColumnFilter("Actor2Code", EqualsRegex(""))
-    val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
-    partKeyOpt2.isDefined shouldBe true
-    partKeyOpt2.get shouldEqual pkrs.head.partKey
-
-    val filter3_found = ColumnFilter("Actor2Code", EqualsRegex("^$"))
-    val partKeyOpt3 = keyIndex.singlePartKeyFromFilters(Seq(filter3_found), 4, 10)
-    partKeyOpt3.isDefined shouldBe true
-    partKeyOpt3.get shouldEqual pkrs.head.partKey
-  }
-
-  it("should get a single match for part keys through a non-existing field") {
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, -1, i, i + 10)(
-        pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filter1_found = ColumnFilter("NonExistingField", Equals(""))
-    val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
-    partKeyOpt.isDefined shouldBe true
-    partKeyOpt.get shouldEqual pkrs.head.partKey
-
-    val filter2_found = ColumnFilter("NonExistingField", EqualsRegex(""))
-    val partKeyOpt2 = keyIndex.singlePartKeyFromFilters(Seq(filter2_found), 4, 10)
-    partKeyOpt2.isDefined shouldBe true
-    partKeyOpt2.get shouldEqual pkrs.head.partKey
-
-    val filter3_found = ColumnFilter("NonExistingField", EqualsRegex("^$"))
-    val partKeyOpt3 = keyIndex.singlePartKeyFromFilters(Seq(filter3_found), 4, 10)
-    partKeyOpt3.isDefined shouldBe true
-    partKeyOpt3.get shouldEqual pkrs.head.partKey
-  }
-
-  it("should get a single match for part keys by a regex filter") {
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, -1, i, i + 10)(
-        pk.length, PartKeyLuceneIndex.partKeyByteRefToSHA256Digest(pk, 0, pk.length))
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-    val filter1_found = ColumnFilter("Actor2Code", EqualsRegex("""^GO.*$"""))
-    val partKeyOpt = keyIndex.singlePartKeyFromFilters(Seq(filter1_found), 4, 10)
-    partKeyOpt.isDefined shouldBe true
-    partKeyOpt.get shouldEqual pkrs(7).partKey
-
-    val filter1_not_found = ColumnFilter("Actor2Code", EqualsRegex("""^GO.*$\$"""))
-    keyIndex.singlePartKeyFromFilters(Seq(filter1_not_found), 4, 10) shouldBe None
-
-    val filter2 = ColumnFilter("Actor2Code", NotEqualsRegex("^.*".utf8))
-    keyIndex.singlePartKeyFromFilters(Seq(filter2), 4, 10) shouldBe None
-  }
-
-  it("Should update the state as TriggerRebuild and throw an exception for any error other than CorruptIndexException")
-  {
-    val events = ArrayBuffer.empty[(IndexState.Value, Long)]
-    IndexState.values.foreach {
-      indexState =>
-        val indexDirectory = new File(
-          System.getProperty("java.io.tmpdir"), "part-key-lucene-index-event")
-        val shardDirectory = new File(indexDirectory, dataset6.ref + File.separator + "0")
-        shardDirectory.mkdirs()
-        new File(shardDirectory, "empty").createNewFile()
-        // Make directory readonly to for an IOException when attempting to write
-        shardDirectory.setWritable(false)
-        // Validate the file named empty exists
-        assert(shardDirectory.list().exists(_.equals("empty")))
-        try {
-          val index = new PartKeyLuceneIndex(dataset6.ref, dataset6.schema.partition, true, true,0, 1.hour.toMillis,
-            Some(indexDirectory),
-            Some( new IndexMetadataStore {
-              def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
-                (indexState, None)
-
-              def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {
-                events.append((state, time))
-              }
-
-              override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) =
-                currentState(datasetRef: DatasetRef, shard: Int)
-
-              override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long)
-              :Unit = {
-
-              }
-            }))
-          index.closeIndex()
-        } catch {
-          case is: IllegalStateException =>
-            assert(is.getMessage.equals("Unable to clean up index directory"))
-            events.toList match {
-              case (IndexState.TriggerRebuild, _) :: Nil =>
-                // The file originally present would still be there as the directory
-                // is made readonly
-                assert(shardDirectory.list().exists(_.equals("empty")))
-                events.clear()
-              case _                                                               =>
-                fail("Expected an index state Empty after directory cleanup")
-            }
-        } finally {
-          shardDirectory.setWritable(true)
-        }
     }
   }
 
@@ -1078,60 +281,4 @@ class PartKeyLuceneIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     cardTracker.close()
   }
 
-  it("should match records without label when .* is provided on a non existent label") {
-
-    val pkrs = partKeyFromRecords(dataset6, records(dataset6, readers.take(10)), Some(partBuilder))
-      .zipWithIndex.map { case (addr, i) =>
-      val pk = partKeyOnHeap(dataset6.schema.partKeySchema, ZeroPointer, addr)
-      keyIndex.addPartKey(pk, i, i, i + 10)()
-      PartKeyLuceneIndexRecord(pk, i, i + 10)
-    }
-    keyIndex.refreshReadersBlocking()
-
-
-   // Query with just the existing Label name
-    val filter1 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result1 = keyIndex.partKeyRecordsFromFilters(Seq(filter1), 0, Long.MaxValue)
-    val expected1 = Seq(pkrs(7), pkrs(8), pkrs(9))
-
-    result1.map(_.partKey.toSeq) shouldEqual expected1.map(_.partKey.toSeq)
-    result1.map(p => (p.startTime, p.endTime)) shouldEqual expected1.map(p => (p.startTime, p.endTime))
-
-    // Query with non existent label name with an empty regex
-    val filter2 = ColumnFilter("dummy", EqualsRegex(".*".utf8))
-    val filter3 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result2 = keyIndex.partKeyRecordsFromFilters(Seq(filter2, filter3), 0, Long.MaxValue)
-    val expected2 = Seq(pkrs(7), pkrs(8), pkrs(9))
-
-    result2.map(_.partKey.toSeq) shouldEqual expected2.map(_.partKey.toSeq)
-    result2.map(p => (p.startTime, p.endTime)) shouldEqual expected2.map(p => (p.startTime, p.endTime))
-
-    // Query with non existent label name with an regex matching at least 1 character
-    val filter4 = ColumnFilter("dummy", EqualsRegex(".+".utf8))
-    val filter5 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result3 = keyIndex.partKeyRecordsFromFilters(Seq(filter4, filter5), 0, Long.MaxValue)
-    result3 shouldEqual Seq()
-
-    // Query with non existent label name with an empty regex
-    val filter6 = ColumnFilter("dummy", EqualsRegex("".utf8))
-    val filter7 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result4 = keyIndex.partKeyRecordsFromFilters(Seq(filter6, filter7), 0, Long.MaxValue)
-    val expected4 = Seq(pkrs(7), pkrs(8), pkrs(9))
-    result4.map(_.partKey.toSeq) shouldEqual expected4.map(_.partKey.toSeq)
-    result4.map(p => (p.startTime, p.endTime)) shouldEqual expected4.map(p => (p.startTime, p.endTime))
-
-    // Query with non existent label name with an empty equals
-    val filter8 = ColumnFilter("dummy", Equals("".utf8))
-    val filter9 = ColumnFilter("Actor2Code", Equals("GOV".utf8))
-    val result5 = keyIndex.partKeyRecordsFromFilters(Seq(filter8, filter9), 0, Long.MaxValue)
-    val expected5 = Seq(pkrs(7), pkrs(8), pkrs(9))
-    result5.map(_.partKey.toSeq) shouldEqual expected5.map(_.partKey.toSeq)
-    result5.map(p => (p.startTime, p.endTime)) shouldEqual expected5.map(p => (p.startTime, p.endTime))
-
-
-    val filter10 = ColumnFilter("Actor2Code", EqualsRegex(".*".utf8))
-    val result10= keyIndex.partKeyRecordsFromFilters(Seq(filter10), 0, Long.MaxValue)
-    result10.map(_.partKey.toSeq) shouldEqual pkrs.map(_.partKey.toSeq)
-    result10.map(p => (p.startTime, p.endTime)) shouldEqual pkrs.map(p => (p.startTime, p.endTime))
-  }
 }

--- a/core/src/test/scala/filodb.core/memstore/PartKeyTantivyIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyTantivyIndexSpec.scala
@@ -1,0 +1,127 @@
+package filodb.core.memstore
+
+import filodb.core.GdeltTestData.dataset6
+import filodb.core.{DatasetRef, TestData}
+import filodb.core.binaryrecord2.RecordBuilder
+import filodb.core.metadata.PartitionSchema
+import filodb.core.query.ColumnFilter
+import filodb.core.query.Filter.{Equals, EqualsRegex, In}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import java.io.File
+
+class PartKeyTantivyIndexSpec extends AnyFunSpec with Matchers with BeforeAndAfter with PartKeyIndexRawSpec {
+  val keyIndex = new PartKeyTantivyIndex(dataset6.ref, dataset6.schema.partition, 0, 1.hour.toMillis,
+    Some(new File(System.getProperty("java.io.tmpdir"), "part-key-lucene-index")))
+
+  val partBuilder = new RecordBuilder(TestData.nativeMem)
+
+  before {
+    keyIndex.reset()
+    keyIndex.refreshReadersBlocking()
+  }
+
+  after {
+    partBuilder.removeAndFreeContainers(partBuilder.allContainers.length)
+  }
+
+  protected def createNewIndex(ref: DatasetRef,
+                               schema: PartitionSchema,
+                               facetEnabledAllLabels: Boolean,
+                               facetEnabledShardKeyLabels: Boolean,
+                               shardNum: Int,
+                               retentionMillis: Long,
+                               diskLocation: Option[File],
+                               lifecycleManager: Option[IndexMetadataStore]): PartKeyIndexRaw = {
+    new PartKeyTantivyIndex(ref, schema, shardNum, retentionMillis, diskLocation, lifecycleManager)
+  }
+
+  it should behave like commonPartKeyTests(keyIndex, partBuilder)
+
+  it("should encode equals queries correctly") {
+    val builder = new TantivyQueryBuilder()
+
+    // Simple equals filter
+    val filters = List(ColumnFilter("col1", Equals("abcd")))
+    val query = builder.buildQuery(filters)
+
+    query should contain theSameElementsInOrderAs List(1,// Boolean
+      1, // Must
+      2, // Equals
+      4, 0, // Length 4
+      99, 111, 108, 49, // col1
+      4, 0, // Length 4
+      97, 98, 99, 100, // abcd
+      0) // End boolean
+  }
+
+  it("should encode equals regex correctly") {
+    val builder = new TantivyQueryBuilder()
+
+    // Simple equals filter
+    val filters = List(ColumnFilter("col1", EqualsRegex("a.*b")))
+    val query = builder.buildQuery(filters)
+
+    query should contain theSameElementsInOrderAs List(1,// Boolean
+      1, // Must
+      3, // Regex
+      4, 0, // Length 4
+      99, 111, 108, 49, // col1
+      4, 0, // Length 4
+      97, 46, 42, 98, // a.*b
+      0) // End boolean
+  }
+
+  it("should encode term in correctly") {
+    val builder = new TantivyQueryBuilder()
+
+    // Simple equals filter
+    val filters = List(ColumnFilter("col1", In(Set("a","b"))))
+    val query = builder.buildQuery(filters)
+
+    query should contain theSameElementsInOrderAs List(1,// Boolean
+      1, // Must
+      4, // Term In
+      4, 0, // Length 4
+      99, 111, 108, 49, // col1
+      2, 0, // Term count 2
+      1, 0, // Length 1
+      97, // a
+      1, 0, // Length 1
+      98, // b
+      0) // End boolean
+  }
+
+  it("should encode prefix correctly") {
+    val builder = new TantivyQueryBuilder()
+
+    // Simple equals filter
+    val filters = List(ColumnFilter("col1", EqualsRegex("a.*")))
+    val query = builder.buildQuery(filters)
+
+    query should contain theSameElementsInOrderAs List(1,// Boolean
+      1, // Must
+      5, // Prefix
+      4, 0, // Length 4
+      99, 111, 108, 49, // col1
+      1, 0, // Length 1
+      97, // a
+      0) // End boolean
+  }
+
+  it("should encode match all correctly") {
+    val builder = new TantivyQueryBuilder()
+
+    // Simple equals filter
+    val filters = List(ColumnFilter("col1", EqualsRegex(".*")))
+    val query = builder.buildQuery(filters)
+
+    query should contain theSameElementsInOrderAs List(1,// Boolean
+      1, // Must
+      6, // Match All
+      0) // End boolean
+  }
+}

--- a/core/src/test/scala/filodb.core/memstore/PartKeyTantivyIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyTantivyIndexSpec.scala
@@ -124,4 +124,22 @@ class PartKeyTantivyIndexSpec extends AnyFunSpec with Matchers with BeforeAndAft
       6, // Match All
       0) // End boolean
   }
+
+  it("should encode start and end time properly") {
+    val builder = new TantivyQueryBuilder()
+
+    // Simple equals filter
+    val filters = List(ColumnFilter("col1", EqualsRegex(".*")))
+    val query = builder.buildQueryWithStartAndEnd(filters, 1, Long.MaxValue)
+
+    query should contain theSameElementsInOrderAs List(1,// Boolean
+      1, // Must
+      6, // Match All
+      1, // Must
+      7, // Long Range
+      11, 0, 95, 95, 101, 110, 100, 84, 105, 109, 101, 95, 95, // __endTime__
+      1, 0, 0, 0, 0, 0, 0, 0, // 0x1
+      -1, -1, -1, -1, -1, -1, -1, 127, // Long.MAX_VALUE
+      0) // End boolean
+  }
 }

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexExternalBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexExternalBenchmark.scala
@@ -1,0 +1,215 @@
+package filodb.jmh
+
+import java.io.File
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+import scala.io.Source
+
+import ch.qos.logback.classic.{Level, Logger}
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, State, TearDown}
+import org.openjdk.jmh.annotations
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import filodb.core.DatasetRef
+import filodb.core.memstore.{IndexMetadataStore, IndexState, PartKeyIndexRaw, PartKeyLuceneIndex, PartKeyTantivyIndex}
+import filodb.core.metadata.Schemas.untyped
+import filodb.core.query.{ColumnFilter, Filter}
+
+/*
+  A benchmark that loads data from an external file full of part keys.
+  This is meant to be used with real world exported data to simulate / evaluate changes.
+
+  The input file is specified as a file path and should be a csv with the following columns:
+
+  * partKey (base64 encoded)
+  * startTime (long)
+  * endTime (long)
+
+  A header row can be optionally included.
+
+  To use this with a data set change the file path below and benchmark queries as needed.
+ */
+// scalastyle:off
+@State(Scope.Benchmark)
+abstract class PartKeyIndexExternalBenchmark {
+  // File path to load from
+  final private val inputPath = "partKeys.csv"
+  // File path to use for index storage
+  final protected val indexPath = "index/path"
+
+  // Filters to create queries below
+  private def wsFilter = ColumnFilter("_ws_", Filter.Equals("myws"))
+  private def nsFilter = ColumnFilter("_ns_", Filter.Equals("myns"))
+  private def narrowFilter = ColumnFilter("hostname", Filter.Equals("example"))
+
+  org.slf4j.LoggerFactory.getLogger("filodb").asInstanceOf[Logger].setLevel(Level.ERROR)
+
+  protected def computeIndexPath(): Option[File] = {
+    val file = new File(s"${indexPath}${this.getClass.getSimpleName}")
+
+    if (!file.exists()) {
+      new File(s"${file.toPath}/${ref.dataset}/0").mkdirs()
+    }
+
+    Some(file)
+  }
+
+  protected def createPartKeyIndex(): PartKeyIndexRaw
+
+  println(s"Building Part Keys")
+  val ref = DatasetRef("prometheus")
+  val partKeyIndex = createPartKeyIndex()
+
+  var partId = 1
+
+  private def load_data(): Unit = {
+    val source = Source.fromFile(inputPath)
+    for (line <- source.getLines()) {
+      if (!line.startsWith("partkey")) {
+        val parts = line.split(',')
+
+        val partKey = Base64.getDecoder.decode(parts(0))
+        val startTime = parts(1).toLong
+        val endTime = parts(2).toLong
+
+        partKeyIndex.addPartKey(partKey, partId, startTime, endTime)()
+        partId += 1
+      }
+    }
+    source.close()
+  }
+
+  if (partKeyIndex.indexNumEntries == 0) {
+    val start = System.nanoTime()
+    println(s"Indexing started at path ${partKeyIndex.indexDiskLocation}")
+    load_data()
+    partKeyIndex.refreshReadersBlocking()
+    val end = System.nanoTime()
+
+    println(s"Indexing finished. Added $partId part keys Took ${(end - start) / 1000000000L}s")
+  } else {
+    partKeyIndex.refreshReadersBlocking()
+    println(s"Loaded existing index with ${partKeyIndex.indexNumEntries} part keys")
+  }
+
+  @TearDown(annotations.Level.Trial)
+  def teardown2(): Unit = {
+    println(s"Ram usage after testing ${partKeyIndex.indexRamBytes}")
+    println(s"Mmap usage after testing ${partKeyIndex.indexMmapBytes}")
+  }
+
+  private var lookupTime = 1
+
+  @inline
+  private def currentLookupTime(): Long = {
+    lookupTime += 1
+
+    lookupTime
+  }
+
+  // Wide query - matches most documents
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def labelValuesWide(): Unit = {
+    partKeyIndex.labelValuesEfficient(Seq(wsFilter),
+      currentLookupTime(), Long.MaxValue, "_ns_")
+  }
+
+  // Wide query - matches most documents
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def partIdsFromFiltersWide(): Unit = {
+    partKeyIndex.partIdsFromFilters(Seq(wsFilter,
+      nsFilter),
+      currentLookupTime(), Long.MaxValue, 10000)
+  }
+
+  // Wide query - matches most documents
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def partKeysFromFiltersWide(): Unit = {
+    partKeyIndex.partKeyRecordsFromFilters(Seq(wsFilter,
+      nsFilter),
+      currentLookupTime(), Long.MaxValue, 100)
+  }
+
+  // Narrow query - matches few (< 10) documents
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def labelValuesNarrow(): Unit = {
+    partKeyIndex.labelValuesEfficient(Seq(wsFilter,
+      nsFilter,
+      narrowFilter),
+      currentLookupTime(), Long.MaxValue, "pod")
+  }
+
+  // Narrow query - matches few (< 10) documents
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def partIdsFromFiltersNarrow(): Unit = {
+    partKeyIndex.partIdsFromFilters(Seq(wsFilter,
+      nsFilter,
+      narrowFilter),
+      currentLookupTime(), Long.MaxValue, 10000)
+  }
+
+  // Narrow query - matches few (< 10) documents
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def partKeysFromFiltersNarrow(): Unit = {
+    partKeyIndex.partKeyRecordsFromFilters(Seq(wsFilter,
+      nsFilter,
+      narrowFilter),
+      currentLookupTime(), Long.MaxValue, 100)
+  }
+}
+
+@State(Scope.Benchmark)
+class PartKeyLuceneIndexExternalBenchmark extends PartKeyIndexExternalBenchmark {
+  override protected def createPartKeyIndex(): PartKeyIndexRaw = {
+    new PartKeyLuceneIndex(ref, untyped.partition, true, true, 0, 1.hour.toMillis, diskLocation = computeIndexPath(),
+      lifecycleManager = Some(new MockLifecycleManager()))
+  }
+
+  @TearDown(annotations.Level.Trial)
+  def teardown(): Unit = {
+    // This is needed to keep data consistent between runs with Lucene
+    partKeyIndex.closeIndex()
+  }
+}
+
+@State(Scope.Benchmark)
+class PartKeyTantivyIndexExternalBenchmark extends PartKeyIndexExternalBenchmark {
+  override protected def createPartKeyIndex(): PartKeyIndexRaw = {
+    PartKeyTantivyIndex.startMemoryProfiling()
+
+    new PartKeyTantivyIndex(ref, untyped.partition, 0, 1.hour.toMillis, diskLocation = computeIndexPath(),
+      lifecycleManager = Some(new MockLifecycleManager()))
+  }
+
+  @TearDown(annotations.Level.Trial)
+  def teardown(): Unit = {
+    PartKeyTantivyIndex.stopMemoryProfiling()
+    val index = partKeyIndex.asInstanceOf[PartKeyTantivyIndex]
+
+    println(s"\nCache stats:\n${index.dumpCacheStats()}\n")
+  }
+}
+
+class MockLifecycleManager extends IndexMetadataStore {
+
+  override def initState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) = (IndexState.Synced, None)
+
+  override def currentState(datasetRef: DatasetRef, shard: Int): (IndexState.Value, Option[Long]) = (IndexState.Synced, None)
+
+  override def updateState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {}
+
+  override def updateInitState(datasetRef: DatasetRef, shard: Int, state: IndexState.Value, time: Long): Unit = {}
+}

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexIngestionBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexIngestionBenchmark.scala
@@ -1,0 +1,87 @@
+package filodb.jmh
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.openjdk.jmh.annotations.{Level, Param, Scope, Setup, State, TearDown}
+import org.openjdk.jmh.annotations
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import spire.syntax.cfor.cforRange
+
+import filodb.core.memstore.{PartKeyIndexRaw, PartKeyLuceneIndex, PartKeyTantivyIndex}
+import filodb.core.metadata.Schemas.untyped
+import filodb.memory.BinaryRegionConsumer
+
+// scalastyle:off
+@State(Scope.Benchmark)
+abstract class PartKeyIndexIngestionBenchmark extends PartKeyIndexBenchmark {
+  // How many part keys are added / removed per second
+  final val itemsPerSecond = 10
+  // How often do we commit to disk / refresh readers
+  final val commitWindowInSeconds = 30
+
+  // 0 days, 1 day, 5 days, 30 days
+  @Param(Array("0", "1", "5", "30"))
+  var durationInDays: Long = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    println(s"Simulating $durationInDays days of churn")
+    val start = System.nanoTime()
+    val churnSteps = ((durationInDays * 24 * 60 * 60) / commitWindowInSeconds).toInt
+    var partId = 0
+    val itemsPerStep = commitWindowInSeconds * itemsPerSecond
+
+    val partKeys = new ArrayBuffer[Array[Byte]]()
+    val consumer = new BinaryRegionConsumer {
+      def onNext(base: Any, offset: Long): Unit = {
+        val partKey = untyped.partition.binSchema.asByteArray(base, offset)
+        partKeys += partKey
+      }
+    }
+    partKeyBuilder.allContainers.foreach(_.consumeRecords(consumer))
+
+    cforRange ( 0 until churnSteps ) { _ =>
+      cforRange ( 0 until itemsPerStep ) { _ =>
+        val partKey = partKeys(partId)
+        // When we ingested we used 1 based part IDs, not 0 based
+        partKeyIndex.upsertPartKey(partKey, partId+1, now)()
+
+        partId += 1
+        partId = partId % numSeries
+      }
+    }
+
+    val end = System.nanoTime()
+    println(s"Finished ingesting new changes. Took ${(end-start)/1000000000L}s")
+
+    partKeyIndex.refreshReadersBlocking()
+    val end2 = System.nanoTime()
+    println(s"Churning finished. Took ${(end2-start)/1000000000L}s")
+    println(s"New Index Memory Map Size: ${partKeyIndex.indexMmapBytes}")
+    println(s"Doc count: ${partKeyIndex.indexNumEntries}")
+  }
+}
+
+@State(Scope.Benchmark)
+class PartKeyLuceneIndexIngestionBenchmark extends PartKeyIndexIngestionBenchmark {
+  override protected def createPartKeyIndex(): PartKeyIndexRaw = {
+    new PartKeyLuceneIndex(ref, untyped.partition, true, true, 0, 1.hour.toMillis)
+  }
+}
+
+@State(Scope.Benchmark)
+class PartKeyTantivyIndexIngestionBenchmark extends PartKeyIndexIngestionBenchmark {
+  override protected def createPartKeyIndex(): PartKeyIndexRaw = {
+    PartKeyTantivyIndex.startMemoryProfiling()
+
+    new PartKeyTantivyIndex(ref, untyped.partition, 0, 1.hour.toMillis)
+  }
+
+  @TearDown(annotations.Level.Trial)
+  def teardown(): Unit = {
+    PartKeyTantivyIndex.stopMemoryProfiling()
+    val index = partKeyIndex.asInstanceOf[PartKeyTantivyIndex]
+
+    println(s"\nCache stats:\n${index.dumpCacheStats()}\n")
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sbt "jmh/jmh:run -rf json -i 5 -wi 3 -f 1 -jvmArgsAppend -XX:MaxInlineLevel=20 \
+sbt -Drust.optimize=true "jmh/jmh:run -rf json -i 5 -wi 3 -f 1 -jvmArgsAppend -XX:MaxInlineLevel=20 \
  -jvmArgsAppend -Xmx4g -jvmArgsAppend -XX:MaxInlineSize=99 \
  filodb.jmh.QueryHiCardInMemoryBenchmark \
  filodb.jmh.QueryInMemoryBenchmark \
@@ -7,4 +7,5 @@ sbt "jmh/jmh:run -rf json -i 5 -wi 3 -f 1 -jvmArgsAppend -XX:MaxInlineLevel=20 \
  filodb.jmh.IngestionBenchmark \
  filodb.jmh.QueryOnDemandBenchmark \
  filodb.jmh.GatewayBenchmark \
- filodb.jmh.PartKeyIndexBenchmark"
+ filodb.jmh.PartKeyLuceneIndexBenchmark \
+ filodb.jmh.PartKeyTantivyIndexBenchmark"


### PR DESCRIPTION
This contains the Scala side of query support.  This completes the basic end to end flow, so it also includes regression and performance tests.

There will be some small cleanup PRs after this for things like additional metrics, but with this PR the Tantivy index can be successfully activated via config.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

Adds query logic to call into Rust code and tests