### PR TITLE
fix(query): negative rate/increase due to NaN chunk

### DIFF
--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -522,11 +522,14 @@ class DropOutOfOrderSamplesIterator(iter: Iterator[RowReader]) extends Iterator[
       val nxt = iter.next()
       val t = nxt.getLong(0)
       val v = nxt.getDouble(1)
-      if (t > cur.timestamp) { // if next sample is later than current sample
-        nextVal.setValues(t, v)
-        hasNextVal = true
-      } else {
-        Query.droppedSamples.increment()
+      // skip if value is NaN, to handle end of time-series markers
+      if (!v.isNaN) {
+        if (t > cur.timestamp) { // if next sample is later than current sample
+          nextVal.setValues(t, v)
+          hasNextVal = true
+        } else {
+          Query.droppedSamples.increment()
+        }
       }
     }
   }

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -522,14 +522,11 @@ class DropOutOfOrderSamplesIterator(iter: Iterator[RowReader]) extends Iterator[
       val nxt = iter.next()
       val t = nxt.getLong(0)
       val v = nxt.getDouble(1)
-      // skip if value is NaN, to handle end of time-series markers
-      if (!v.isNaN) {
-        if (t > cur.timestamp) { // if next sample is later than current sample
-          nextVal.setValues(t, v)
-          hasNextVal = true
-        } else {
-          Query.droppedSamples.increment()
-        }
+      if (t > cur.timestamp) { // if next sample is later than current sample
+        nextVal.setValues(t, v)
+        hasNextVal = true
+      } else {
+        Query.droppedSamples.increment()
       }
     }
   }

--- a/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RateFunctions.scala
@@ -173,6 +173,10 @@ abstract class ChunkedRateFunctionBase extends CounterChunkedRangeFunction[Trans
                     startRowNum: Int, endRowNum: Int,
                     startTime: Long, endTime: Long): Unit = {
     val dblReader = reader.asDoubleReader
+    // if the chunk is a single row NaN value, then return. Prometheus end of time series marker.
+    // This is to make sure we don't set highestValue to zero. avoids negative rate/increase values.
+    if (startRowNum == 0 && endRowNum == 0 && dblReader.apply(acc, vector, startRowNum).isNaN)
+      return
     if (startTime < lowestTime || endTime > highestTime) {
       numSamples += endRowNum - startRowNum + 1
       if (startTime < lowestTime) {

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -223,7 +223,12 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
       //   (w.last._2 - w.head._2) / (windowTime) * 1000
       //   // (w.last._2 - w.head._2) / (w.last._1 - w.head._1) * 1000
       // }
-      rates shouldEqual slidingResults
+      rates.dropRight(1) shouldEqual slidingResults.dropRight(1)
+
+      // sliding window is not used for rate/increase. We use ChunkedRateFunction. There may be slight difference
+      // in the way NaN is handled, which is okay.
+      val percentError: Double = math.abs(rates.takeRight(1)(0) - slidingResults.takeRight(1)(0))/rates.takeRight(1)(0)
+      percentError shouldBe < (0.1d)
     }
   }
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -225,9 +225,13 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
       // }
       rates.dropRight(1) shouldEqual slidingResults.dropRight(1)
 
+      // rate should be positive
+      val resultLen = rates.length
+      rates(resultLen - 1) shouldBe > (0d) // positive
+
       // sliding window is not used for rate/increase. We use ChunkedRateFunction. There may be slight difference
       // in the way NaN is handled, which is okay.
-      val percentError: Double = math.abs(rates.takeRight(1)(0) - slidingResults.takeRight(1)(0))/rates.takeRight(1)(0)
+      val percentError: Double = math.abs(rates(resultLen - 1) - slidingResults(resultLen - 1))/rates(resultLen - 1)
       percentError shouldBe < (0.1d)
     }
   }

--- a/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/RateFunctionsSpec.scala
@@ -231,7 +231,7 @@ class RateFunctionsSpec extends RawDataWindowingSpec {
 
       // sliding window is not used for rate/increase. We use ChunkedRateFunction. There may be slight difference
       // in the way NaN is handled, which is okay.
-      val percentError: Double = math.abs(rates(resultLen - 1) - slidingResults(resultLen - 1))/rates(resultLen - 1)
+      val percentError: Double = math.abs(rates(resultLen - 1) - slidingResults(resultLen - 1))/slidingResults(resultLen - 1)
       percentError shouldBe < (0.1d)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?

This change is to handle a case where a time series ends with a NaN value. Currently this results into a new chunk/row with a single NaN value. 
As we default NaN to zero value during rate/increase window calculation, this sets highestValue to be zero. This is resulting into negative rate/increase values, since rate = highestValue-lowestValue.
This fix is to short `addTimeChunks` operation and return without any effect on highestValue calculation.