### PR TITLE
feat(core): Optimize Rust code by default

### DIFF
--- a/project/RustPlugin.scala
+++ b/project/RustPlugin.scala
@@ -43,12 +43,7 @@ object RustPlugin extends AutoPlugin {
       features
     },
     rustOptimize := {
-      val optimize = Option(System.getProperty("rust.optimize")).getOrElse(
-        if (rustArchitectures.value.length > 1) {
-          "true"
-        } else {
-          "false"
-        })
+      val optimize = Option(System.getProperty("rust.optimize")).getOrElse("true")
 
       optimize.toBoolean
     },


### PR DESCRIPTION
Previously the code only optimized if a flag was passed during sbt invocation or if we're building multi-arch.  This has created confusing results where perf drifts because debug mode was used.

After doing testing and development it was found that release is a suitable default - it does incremental build, includes symbols for debugging, and while not as fast as debug builds is still fast enough for an inner loop.

You can still build with debug by setting rust.optimize=false for any cases where it is needed during local development.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Defaults to building debug rust code

**New behavior :**

Defaults to building release rust code
