### PR TITLE
fix(query): Generalizing the column filter check to span multiple tenants instead of just `_ws_`.

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -400,6 +400,9 @@ filodb {
     # If unspecified, all workspaces are disabled by default.
     workspaces-disabled-max-min = ["disabled_ws"]
 
+    # config to figure out the tenant column filter to enable max min column selection
+    max-min-tenant-column-filter = "_ws_"
+
     routing {
       enable-remote-raw-exports = false
       max-time-range-remote-raw-export = 180 minutes

--- a/core/src/main/scala/filodb.core/GlobalConfig.scala
+++ b/core/src/main/scala/filodb.core/GlobalConfig.scala
@@ -49,4 +49,7 @@ object GlobalConfig extends StrictLogging {
       case true => Some(systemConfig.getStringList("filodb.query.workspaces-disabled-max-min").asScala.toSet)
   }
 
+  // Column filter used to check the enabling/disabling the use of max-min columns
+  val maxMinTenantColumnFilter = systemConfig.getString("filodb.query.max-min-tenant-column-filter")
+
 }

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -458,9 +458,9 @@ class MultiSchemaPartitionsExecSpec extends AnyFunSpec with Matchers with ScalaF
   it("test isMaxMinEnabledForWorkspace correctly returns expected values") {
     val execPlan = MultiSchemaPartitionsExec(QueryContext(), dummyDispatcher, MMD.histMaxMinDS.ref, 0,
       Seq(), AllChunkScan, "_metric_", colName = Some("h"))
-    execPlan.isMaxMinEnabledForWorkspace(Some("demo")) shouldEqual true
-    execPlan.isMaxMinEnabledForWorkspace(Some(GlobalConfig.workspacesDisabledForMaxMin.get.head)) shouldEqual false
-    execPlan.isMaxMinEnabledForWorkspace(None) shouldEqual false
+    execPlan.isMaxMinColumnsEnabled(Some("demo")) shouldEqual true
+    execPlan.isMaxMinColumnsEnabled(Some(GlobalConfig.workspacesDisabledForMaxMin.get.head)) shouldEqual false
+    execPlan.isMaxMinColumnsEnabled(None) shouldEqual false
   }
 
   it("should return chunk metadata from MemStore") {


### PR DESCRIPTION
Generalizing the column filter check to span multiple tenants instead of just `_ws_`.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Currently enabling of max-min columns is  dependent on having the `_ws_` label.  This will cause issues if a timeseries doesn't have this required label.

**New behavior :** Allowing for users to configure to use any desired label for this feature flag. 