### PR TITLE
fix(core): Support Rust 1.78

### DIFF
--- a/core/src/rust/filodb_core/Cargo.toml
+++ b/core/src/rust/filodb_core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "filodb_core"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.78"
 
 [lib]
 crate-type = ["cdylib"]

--- a/core/src/rust/tantivy_utils/Cargo.toml
+++ b/core/src/rust/tantivy_utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tantivy_utils"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.78"
 
 [dependencies]
 hashbrown = "0.14.5"

--- a/core/src/rust/tantivy_utils/src/collectors/part_key_record_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/part_key_record_collector.rs
@@ -1,6 +1,7 @@
 //! Collector for part key binary data
 
 use std::cmp::min;
+use std::mem::size_of;
 
 use crate::collectors::column_cache::ColumnCache;
 use crate::field_constants::{END_TIME, PART_KEY, START_TIME};


### PR DESCRIPTION
Add a qualifier to imports to support slightly older Rust versions. 
Tag cargo metadata with min tested version to give a better error.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
