### PR TITLE
fix(core): Fix Rust publishing of x86_64 binaries

### DIFF
--- a/project/RustPlugin.scala
+++ b/project/RustPlugin.scala
@@ -200,6 +200,8 @@ object RustPlugin extends AutoPlugin {
     val RustPattern = "([^-]+)-([^-]+)-([^-]+).*".r
     arch match {
       case "host" => s"$getHostKernel/${SystemUtils.OS_ARCH}"
+      // Java uses amd64, Rust uses x86_64
+      case RustPattern("x86_64", _, kernel) => s"$kernel/amd64"
       case RustPattern(arch, _, kernel) => s"$kernel/$arch"
       case x => sys.error(s"Unsupported architecture $x")
     }


### PR DESCRIPTION
Rust names the x86-64 architecture as x86_64.  Java names it as amd64. This mismatch causes errors during library load as they can't agree on the file path.

The fix is to normalize the Rust name into the Java name, so it can locate the output binaries.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
