### PR TITLE
fix(query): Fix metrics name for failovers

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -19,7 +19,7 @@ import filodb.query.{LabelNames, LabelValues, LogicalPlan, SeriesKeysByFilters}
 import filodb.query.exec._
 
 object HighAvailabilityPlanner {
-  final val FailoverCounterName = "single-cluster-plans-materialized"
+  final val FailoverCounterName = "single-cluster-failovers-materialized"
 }
 /**
   * HighAvailabilityPlanner responsible for using underlying local planner and FailureProvider


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
name is "plans" materialized


**New behavior :**
changed it to "failovers" materialized

