### PR TITLE
misc(sparkjobs): force push metrics publish from index job

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -1,6 +1,7 @@
 package filodb.downsampler.index
 
 import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
 
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
@@ -88,8 +89,11 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
       sparkTasksFailed.increment
       throw e
     }
+
+    // quick & dirty hack to ensure that the completed metric gets published
     if (dsSettings.shouldSleepForMetricsFlush)
-      Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
+      Await.result(Kamon.stopModules(), 62.seconds)
+
   }
 
   def migrateWithDownsamplePartKeys(partKeys: Observable[PartKeyRecord], shard: Int): Int = {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

- sometimes spark executor exits before Kamon flushes the metrics. This change is to wait for upto 62seconds for Kamon to flush and close the modules.