### PR TITLE
misc(query): increment counter when query plan updated with next level aggregated metric

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,8 @@ object Dependencies {
   val circeParser       = "io.circe"                   %% "circe-parser"         % "0.9.3"
 
   lazy val commonDeps = Seq(
-    "io.kamon" %% "kamon-bundle" % kamonBundleVersion,
+    "io.kamon" %% "kamon-bundle"  % kamonBundleVersion,
+    "io.kamon" %% "kamon-testkit" % kamonBundleVersion % Test,
     logbackDep % Test,
     scalaTest  % Test,
     "com.softwaremill.quicklens" %% "quicklens" % "1.4.12" % Test,

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -1,5 +1,6 @@
 package filodb.query
 
+import filodb.core.GlobalConfig
 import filodb.core.query.{ColumnFilter, RangeParams, RvRange}
 import filodb.core.query.Filter.Equals
 import filodb.query.util.{AggRule, HierarchicalQueryExperience}
@@ -225,7 +226,8 @@ case class SeriesKeysByFilters(filters: Seq[ColumnFilter],
 
 object TsCardinalities {
   val LABEL_WORKSPACE = "_ws_"
-  val SHARD_KEY_LABELS = Seq(LABEL_WORKSPACE, "_ns_", "__name__")
+  val LABEL_NAMESPACE = "_ns_"
+  val SHARD_KEY_LABELS = Seq(LABEL_WORKSPACE, LABEL_NAMESPACE, GlobalConfig.PromMetricLabel)
 }
 
 /**

--- a/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
+++ b/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
@@ -1,12 +1,14 @@
 package filodb.query.util
 
 import com.typesafe.scalalogging.StrictLogging
-import scala.jdk.CollectionConverters.asScalaBufferConverter
+import kamon.Kamon
 
+import scala.jdk.CollectionConverters.asScalaBufferConverter
 import filodb.core.GlobalConfig
 import filodb.core.query.ColumnFilter
 import filodb.core.query.Filter.Equals
-import filodb.query.{AggregateClause, AggregationOperator, LogicalPlan}
+import filodb.query.{AggregateClause, AggregationOperator, LogicalPlan, TsCardinalities}
+
 
 /**
  * Aggregation rule definition. Contains the following information:
@@ -58,6 +60,8 @@ case class ExcludeAggRule(metricRegex: String, metricSuffix: String, tags: Set[S
 }
 
 object HierarchicalQueryExperience extends StrictLogging {
+
+  val hierarchicalQueryOptimizedCounter = Kamon.counter("hierarchical-query-plans-optimized")
 
   // Get the shard key columns from the dataset options along with all the metric labels used
   lazy val shardKeyColumnsOption: Option[Set[String]] = GlobalConfig.datasetOptions match {
@@ -152,7 +156,7 @@ object HierarchicalQueryExperience extends StrictLogging {
   /** Returns the next level aggregated metric name. Example
    *  metricRegex = :::
    *  metricSuffix = agg_2
-   *  Exiting metric name - metric1:::agg
+   *  Existing metric name - metric1:::agg
    *  After update - metric1:::agg -> metric1:::agg_2
    * @param metricColumnFilter - String - Metric ColumnFilter tag/label
    * @param params - HierarchicalQueryExperience - Contains
@@ -231,14 +235,42 @@ object HierarchicalQueryExperience extends StrictLogging {
       val updatedMetricName = getNextLevelAggregatedMetricName(metricColumnFilter, params, filters)
       updatedMetricName match {
         case Some(metricName) =>
-          val updatedFilters = upsertFilters(filters, Seq(ColumnFilter(metricColumnFilter, Equals(metricName))))
-          logger.info(s"[HierarchicalQueryExperience] Query optimized with filters: ${updatedFilters.toString()}")
-          updatedFilters
+          // Checking if the metric actually ends with the next level aggregation metricSuffix.
+          // If so, update the filters and emit metric
+          // else, return the filters as is
+          metricName.endsWith(params.metricSuffix) match {
+            case true =>
+              val updatedFilters = upsertFilters(filters, Seq(ColumnFilter(metricColumnFilter, Equals(metricName))))
+              logger.info(s"[HierarchicalQueryExperience] Query optimized with filters: ${updatedFilters.toString()}")
+              incrementHierarcicalQueryOptimizedCounter(updatedFilters)
+              updatedFilters
+            case false => filters
+          }
         case None => filters
       }
     } else {
       filters
     }
+  }
+
+  /**
+   * Track the queries optimized by workspace and namespace
+   * @param filters
+   */
+  private def incrementHierarcicalQueryOptimizedCounter(filters: Seq[ColumnFilter]): Unit = {
+    // track query optimized per workspace and namespace in the counter
+    val metric_ws = LogicalPlan.getColumnValues(filters, TsCardinalities.LABEL_WORKSPACE) match {
+      case Seq() => ""
+      case ws => ws.head
+    }
+    val metric_ns = LogicalPlan.getColumnValues(filters, TsCardinalities.LABEL_NAMESPACE) match {
+      case Seq() => ""
+      case ns => ns.head
+    }
+    hierarchicalQueryOptimizedCounter
+      .withTag("metric_ws", metric_ws)
+      .withTag("metric_ns", metric_ns)
+      .increment()
   }
 
   /**

--- a/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
+++ b/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
@@ -2,13 +2,12 @@ package filodb.query.util
 
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
-
 import scala.jdk.CollectionConverters.asScalaBufferConverter
+
 import filodb.core.GlobalConfig
 import filodb.core.query.ColumnFilter
 import filodb.core.query.Filter.Equals
 import filodb.query.{AggregateClause, AggregationOperator, LogicalPlan, TsCardinalities}
-
 
 /**
  * Aggregation rule definition. Contains the following information:


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** No metric to track the updated hierarchical query plans. 

**New behavior :** 

1. Added a counter to track the updated hierarchical query plans
2. Added capability to test kamon metric updates in our unit tests