### PR TITLE
fix(core): Fix tantivy column cache not releasing memory from deleted segments

### DIFF
--- a/core/src/rust/filodb_core/src/index.rs
+++ b/core/src/rust/filodb_core/src/index.rs
@@ -87,7 +87,7 @@ pub extern "system" fn Java_filodb_core_memstore_TantivyNativeMethods_00024_newI
             column_cache_size as u64,
             query_cache_max_size as u64,
             query_cache_estimated_item_size as u64,
-        ))
+        )?)
     })
 }
 

--- a/core/src/rust/tantivy_utils/src/collectors/column_cache.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/column_cache.rs
@@ -52,6 +52,10 @@ impl ColumnCache {
         }
     }
 
+    pub fn clear(&self) {
+        self.cache.clear();
+    }
+
     pub fn stats(&self) -> (u64, u64) {
         (self.cache.hits(), self.cache.misses())
     }


### PR DESCRIPTION
Columns in the column cache hold a reference to the mmaped file data that backs the segment.  These segments can be deleted during segment merging, but if a column for that segment is in the cache it prevents the mmap from closing and releasing RAM.

To fix this we subscribe for notifications on segment list changes and clear the column cache when these occur so stale segments can be reclaimed.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

**Current behavior :** 

Old segments can remain in memory via column cache

**New behavior :**

Column cache is reset on segment list changes
