### PR TITLE
fix(core): Improve performance for Tantivy indexValues call

### DIFF
--- a/core/src/rust/tantivy_utils/src/collectors.rs
+++ b/core/src/rust/tantivy_utils/src/collectors.rs
@@ -1,6 +1,7 @@
 //! Common collectors
 
 pub mod column_cache;
+pub mod index_collector;
 pub mod limited_collector;
 pub mod part_id_collector;
 pub mod part_key_collector;

--- a/core/src/rust/tantivy_utils/src/collectors/index_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/index_collector.rs
@@ -1,0 +1,43 @@
+//! Collector that can run over an entire index without a query
+//!
+
+use tantivy::{collector::SegmentCollector, Searcher, SegmentReader, TantivyError};
+
+use super::limited_collector::{LimitCounter, LimitedCollector, LimitedSegmentCollector};
+
+/// Index Segment collector
+pub trait IndexCollector: LimitedCollector
+where
+    Self::Child: LimitedSegmentCollector,
+{
+    /// Colllect data across an entire index segment
+    fn collect_over_index(
+        &self,
+        reader: &SegmentReader,
+        limiter: &mut LimitCounter,
+    ) -> Result<<Self::Child as SegmentCollector>::Fruit, TantivyError>;
+}
+
+pub fn collect_from_index<C>(searcher: &Searcher, collector: C) -> Result<C::Fruit, TantivyError>
+where
+    C: IndexCollector,
+    C::Child: LimitedSegmentCollector,
+{
+    let segment_readers = searcher.segment_readers();
+    let mut fruits: Vec<<C::Child as SegmentCollector>::Fruit> =
+        Vec::with_capacity(segment_readers.len());
+
+    let mut limiter = LimitCounter::new(collector.limit());
+
+    for segment_reader in segment_readers.iter() {
+        let results = collector.collect_over_index(segment_reader, &mut limiter)?;
+
+        fruits.push(results);
+
+        if limiter.at_limit() {
+            break;
+        }
+    }
+
+    collector.merge_fruits(fruits)
+}

--- a/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
@@ -71,7 +71,11 @@ impl<'a> Collector for StringFieldCollector<'a> {
         &self,
         segment_fruits: Vec<HashMap<String, u64>>,
     ) -> tantivy::Result<Vec<(String, u64)>> {
-        let mut results = HashMap::with_capacity(self.limit);
+        let mut results = if self.limit < usize::MAX {
+            HashMap::with_capacity(self.limit)
+        } else {
+            HashMap::new()
+        };
 
         for mut map in segment_fruits.into_iter() {
             for (value, count) in map.drain() {
@@ -159,7 +163,11 @@ impl<'a> IndexCollector for StringFieldCollector<'a> {
             return Err(TantivyError::FieldNotFound(self.field.to_string()));
         };
 
-        let mut ret = HashMap::with_capacity(self.limit);
+        let mut ret = if self.limit < usize::MAX {
+            HashMap::with_capacity(self.limit)
+        } else {
+            HashMap::new()
+        };
 
         if limiter.at_limit() {
             return Ok(ret);

--- a/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
@@ -1,5 +1,6 @@
 //! Collector to string values from a document
 
+use core::str;
 use std::collections::hash_map::Entry;
 
 use hashbrown::HashMap;
@@ -7,12 +8,16 @@ use nohash_hasher::IntMap;
 use tantivy::{
     collector::{Collector, SegmentCollector},
     columnar::StrColumn,
+    TantivyError,
 };
 
 use crate::collectors::column_cache::ColumnCache;
 
-use super::limited_collector::{
-    LimitCounterOptionExt, LimitResult, LimitedCollector, LimitedSegmentCollector,
+use super::{
+    index_collector::IndexCollector,
+    limited_collector::{
+        LimitCounter, LimitCounterOptionExt, LimitResult, LimitedCollector, LimitedSegmentCollector,
+    },
 };
 
 pub struct StringFieldCollector<'a> {
@@ -66,7 +71,7 @@ impl<'a> Collector for StringFieldCollector<'a> {
         &self,
         segment_fruits: Vec<HashMap<String, u64>>,
     ) -> tantivy::Result<Vec<(String, u64)>> {
-        let mut results = HashMap::new();
+        let mut results = HashMap::with_capacity(self.limit);
 
         for mut map in segment_fruits.into_iter() {
             for (value, count) in map.drain() {
@@ -144,15 +149,80 @@ impl SegmentCollector for StringFieldSegmentCollector {
     }
 }
 
+impl<'a> IndexCollector for StringFieldCollector<'a> {
+    fn collect_over_index(
+        &self,
+        reader: &tantivy::SegmentReader,
+        limiter: &mut LimitCounter,
+    ) -> Result<<Self::Child as SegmentCollector>::Fruit, tantivy::TantivyError> {
+        let Some((field, prefix)) = reader.schema().find_field(self.field) else {
+            return Err(TantivyError::FieldNotFound(self.field.to_string()));
+        };
+
+        let mut ret = HashMap::with_capacity(self.limit);
+
+        if limiter.at_limit() {
+            return Ok(ret);
+        }
+
+        let index_reader = reader.inverted_index(field)?;
+        let mut index_reader = index_reader.terms().range();
+        if !prefix.is_empty() {
+            // Only look at prefix range
+            index_reader = index_reader.ge(format!("{}\0", prefix));
+            index_reader = index_reader.lt(format!("{}\u{001}", prefix));
+        }
+        let mut index_reader = index_reader.into_stream()?;
+        while !limiter.at_limit() && index_reader.advance() {
+            let mut key_bytes = index_reader.key();
+            if !prefix.is_empty() {
+                // Skip prefix
+                key_bytes = &key_bytes[prefix.len() + 2..];
+            }
+            let key = str::from_utf8(key_bytes)
+                .map_err(|e| TantivyError::InternalError(e.to_string()))?;
+
+            // capture it
+            ret.insert(key.to_string(), index_reader.value().doc_freq as u64);
+
+            // No need to check error, the check at the top of the while will handle it
+            let _ = limiter.increment();
+        }
+
+        Ok(ret)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
 
     use tantivy::query::AllQuery;
 
-    use crate::test_utils::{build_test_schema, COL1_NAME, JSON_COL_NAME};
+    use crate::{
+        collectors::index_collector::collect_from_index,
+        test_utils::{build_test_schema, COL1_NAME, JSON_COL_NAME},
+    };
 
     use super::*;
+
+    #[test]
+    fn test_string_field_index_collector() {
+        let index = build_test_schema();
+        let column_cache = ColumnCache::default();
+
+        let collector = StringFieldCollector::new(COL1_NAME, usize::MAX, usize::MAX, column_cache);
+
+        let results = collect_from_index(&index.searcher, collector).expect("Should succeed");
+
+        // Two docs
+        assert_eq!(
+            results.into_iter().collect::<HashSet<_>>(),
+            [("ABC".to_string(), 1), ("DEF".to_string(), 1)]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+    }
 
     #[test]
     fn test_string_field_collector() {
@@ -200,6 +270,25 @@ mod tests {
     }
 
     #[test]
+    fn test_string_field_index_collector_json() {
+        let index = build_test_schema();
+        let column_cache = ColumnCache::default();
+
+        let col_name = format!("{}.{}", JSON_COL_NAME, "f1");
+        let collector = StringFieldCollector::new(&col_name, usize::MAX, usize::MAX, column_cache);
+
+        let results = collect_from_index(&index.searcher, collector).expect("Should succeed");
+
+        // Two docs
+        assert_eq!(
+            results.into_iter().collect::<HashSet<_>>(),
+            [("value".to_string(), 1), ("othervalue".to_string(), 1)]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
     fn test_string_field_collector_json_invalid_field() {
         let index = build_test_schema();
         let column_cache = ColumnCache::default();
@@ -221,6 +310,23 @@ mod tests {
     }
 
     #[test]
+    fn test_string_field_collector_index_json_invalid_field() {
+        let index = build_test_schema();
+        let column_cache = ColumnCache::default();
+
+        let col_name = format!("{}.{}", JSON_COL_NAME, "invalid");
+        let collector = StringFieldCollector::new(&col_name, usize::MAX, usize::MAX, column_cache);
+
+        let results = collect_from_index(&index.searcher, collector).expect("Should succeed");
+
+        // No results, no failure
+        assert_eq!(
+            results.into_iter().collect::<HashSet<_>>(),
+            [].into_iter().collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
     fn test_string_field_collector_with_limit() {
         let index = build_test_schema();
         let column_cache = ColumnCache::default();
@@ -232,6 +338,19 @@ mod tests {
             .searcher
             .search(&query, &collector)
             .expect("Should succeed");
+
+        // Which doc matches first is non deterministic, just check length
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_string_field_index_collector_with_limit() {
+        let index = build_test_schema();
+        let column_cache = ColumnCache::default();
+
+        let collector = StringFieldCollector::new(COL1_NAME, 1, usize::MAX, column_cache);
+
+        let results = collect_from_index(&index.searcher, collector).expect("Should succeed");
 
         // Which doc matches first is non deterministic, just check length
         assert_eq!(results.len(), 1);

--- a/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
@@ -187,6 +187,10 @@ impl<'a> IndexCollector for StringFieldCollector<'a> {
                 // Skip prefix
                 key_bytes = &key_bytes[prefix.len() + 2..];
             }
+            if key_bytes.is_empty() {
+                continue;
+            }
+
             let key = str::from_utf8(key_bytes)
                 .map_err(|e| TantivyError::InternalError(e.to_string()))?;
 

--- a/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PartKeyIndexBenchmark.scala
@@ -178,6 +178,38 @@ abstract class PartKeyIndexBenchmark {
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   @OperationsPerInvocation(8)
+  def indexNames(): Unit = {
+    cforRange ( 0 until 8 ) { i =>
+      partKeyIndex.indexNames(10000)
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
+  def indexValues(): Unit = {
+    cforRange ( 0 until 8 ) { i =>
+      partKeyIndex.indexValues("instance", 10000)
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
+  def getLabelNames(): Unit = {
+    cforRange ( 0 until 8 ) { i =>
+      val filter = Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),
+        ColumnFilter("_ws_", Filter.Equals("demo")))
+      partKeyIndex.labelNamesEfficient(filter, now, currentLookupTime())
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(8)
   def getMetricNames(): Unit = {
     cforRange ( 0 until 8 ) { i =>
       val filter = Seq(ColumnFilter("_ns_", Filter.Equals(s"App-$i")),


### PR DESCRIPTION
indexValues was falling way behind Lucene due to a few reasons:

1. We were copying results directly into Java objects, which was incurring a lot of JNI back and forth overhead
2. When querying the entire index we were looking at docs instead of the reverse index, which increased the count of items to process

This PR does a few things:

1. Add perf benchmarks for the missing functions
2. Add a new IndexCollector trait that can be used to walk the index vs docs
3. Remove the JNI object usage in indexValues vs byte serialized data
4. Return encoded string arrays instead of creating JVM strings in native code
5. Glue all these optimizations togther.

With this Tantivy is still a bit behind Lucene for this path, but it's almost 100x faster than before.

**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
