### PR TITLE
fix(query): removing max/min aggregations from hierarchical query experience

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -716,26 +716,6 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
       filterSet => filterSet.filter(x => x.column == "__name__").head.filter.valuesStrings.head.asInstanceOf[String]
         .shouldEqual("my_counter:::agg")
     )
-    // CASE 4: min aggregate should be allowed
-    query = "min(my_gauge:::agg{job=\"spark\", application=\"app\"})"
-    lp = Parser.queryRangeToLogicalPlan(query, t)
-    lp.isInstanceOf[Aggregate] shouldEqual true
-    lpUpdated = lp.useHigherLevelAggregatedMetric(includeParams)
-    filterGroups = getColumnFilterGroup(lpUpdated)
-    filterGroups.foreach(
-      filterSet => filterSet.filter(x => x.column == "__name__").head.filter.valuesStrings.head.asInstanceOf[String]
-        .shouldEqual("my_gauge:::agg_2")
-    )
-    // CASE 5: max aggregate should be allowed
-    query = "max(my_gauge:::agg{job=\"spark\", application=\"app\"})"
-    lp = Parser.queryRangeToLogicalPlan(query, t)
-    lp.isInstanceOf[Aggregate] shouldEqual true
-    lpUpdated = lp.useHigherLevelAggregatedMetric(includeParams)
-    filterGroups = getColumnFilterGroup(lpUpdated)
-    filterGroups.foreach(
-      filterSet => filterSet.filter(x => x.column == "__name__").head.filter.valuesStrings.head.asInstanceOf[String]
-        .shouldEqual("my_gauge:::agg_2")
-    )
   }
 
   it("LogicalPlan update for hierarchical nested aggregation queries") {
@@ -764,7 +744,7 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
         .shouldEqual("my_gauge:::agg")
     )
     // CASE 3: should update since min aggregate operator is allowed
-    query = "sum by (aggTag1, aggTag2) (min by (aggTag1, aggTag2) (my_gauge:::agg{aggTag1=\"a\",aggTag2=\"b\"}))"
+    query = "sum by (aggTag1, aggTag2) (sum by (aggTag1, aggTag2) (my_gauge:::agg{aggTag1=\"a\",aggTag2=\"b\"}))"
     lp = Parser.queryRangeToLogicalPlan(query, t)
     lpUpdated = lp.useHigherLevelAggregatedMetric(includeParams)
     filterGroups = getColumnFilterGroup(lpUpdated)

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -353,7 +353,7 @@ filodb {
       ]
 
       # Aggregations allowed for hierarchical query experience
-      allowed-aggregation-operators = ["sum", "min", "max"]
+      allowed-aggregation-operators = ["sum"]
     }
 
     # feature flag to enable start time inclusive in window lookback

--- a/query/src/test/scala/filodb/query/util/HierarchicalQueryExperienceSpec.scala
+++ b/query/src/test/scala/filodb/query/util/HierarchicalQueryExperienceSpec.scala
@@ -47,8 +47,8 @@ class HierarchicalQueryExperienceSpec extends AnyFunSpec with Matchers {
 
   it("isAggregationOperatorAllowed should return expected values") {
     HierarchicalQueryExperience.isAggregationOperatorAllowed("sum") shouldEqual true
-    HierarchicalQueryExperience.isAggregationOperatorAllowed("min") shouldEqual true
-    HierarchicalQueryExperience.isAggregationOperatorAllowed("max") shouldEqual true
+    HierarchicalQueryExperience.isAggregationOperatorAllowed("min") shouldEqual false
+    HierarchicalQueryExperience.isAggregationOperatorAllowed("max") shouldEqual false
     HierarchicalQueryExperience.isAggregationOperatorAllowed("avg") shouldEqual false
     HierarchicalQueryExperience.isAggregationOperatorAllowed("count") shouldEqual false
     HierarchicalQueryExperience.isAggregationOperatorAllowed("topk") shouldEqual false


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**  aggregation operator like max and min will not work with rate and increase 

**New behavior :** removing these aggregation operators