### PR TITLE
perf(query) Memoize the part of the logical plan tree traversal for reduced memory allocation and faster planning

### DIFF
--- a/conf/logback-dev.xml
+++ b/conf/logback-dev.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <logger name="filodb.coordinator" level="DEBUG" />
+    <logger name="filodb.coordinator" level="INFO" />
     <logger name="filodb.core" level="DEBUG" />
     <logger name="filodb.memory" level="DEBUG" />
     <logger name="filodb.query" level="DEBUG" />

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -246,7 +246,7 @@ class ShardMapper(val numShards: Int) extends Serializable {
    * Registers a new node to the given shards.  Modifies state in place.
    * Idempotent.
    */
-  private[coordinator] def registerNode(shards: Seq[Int], coordinator: ActorRef): Try[Unit] = {
+  def registerNode(shards: Seq[Int], coordinator: ActorRef): Try[Unit] = {
     shards foreach {
       case shard =>
         //we always override the mapping. There was code earlier which prevent from

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -1,5 +1,6 @@
 package filodb.coordinator.queryplanner
 
+//scalastyle:off
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
@@ -386,6 +387,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   // Target-Schema start
 
   it("should stitch results when target-schema changes during query range") {
+    engine.invalidateCaches()
     val lp = Parser.queryRangeToLogicalPlan("""foo{job="bar"}""", TimeStepParams(20000, 100, 30000))
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
       Seq(SpreadChange(0, 2))
@@ -444,6 +446,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   it("should create a single plan and not stitch results when target-schema has not changed in query range") {
+    engine.invalidateCaches()
     val lp = Parser.queryRangeToLogicalPlan("""foo{job="bar"}""", TimeStepParams(20000, 100, 30000))
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
       Seq(SpreadChange(0, 2))
@@ -459,6 +462,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   it("should stitch results when target-schema has not changed but spread changed in query range") {
+    engine.invalidateCaches()
     val lp = Parser.queryRangeToLogicalPlan("""foo{job="bar"}""", TimeStepParams(20000, 100, 30000))
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
       Seq(SpreadChange(0, 1), SpreadChange(25000000, 2)) // spread change time is in ms
@@ -474,6 +478,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   it("should stitch results when target-schema has changed but spread did not change in query range") {
+    engine.invalidateCaches()
     val lp = Parser.queryRangeToLogicalPlan("""foo{job="bar", instance="inst1"}""", TimeStepParams(20000, 100, 30000))
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
       Seq(SpreadChange(0, 2)) // Spread 4
@@ -489,6 +494,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
 
   it("should not stitch when all the target-schema labels are present in column filters in a binary join") {
+    engine.invalidateCaches()
     val lp = Parser.queryRangeToLogicalPlan("""count(foo{job="bar"} + baz{job="bar"})""",
       TimeStepParams(20000, 100, 30000))
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
@@ -508,6 +514,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it("should create single child plan for LHS where target-schema filters provided" +
     " and 4 (spread 2) children for RHS (no target-schema filters) of the binary join") {
+    engine.invalidateCaches()
     val lp = Parser.queryRangeToLogicalPlan("""count(foo{job="bar", instance="inst1"} + baz{job="bar"})""",
       TimeStepParams(20000, 100, 30000))
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
@@ -605,6 +612,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it ("should pushdown BinaryJoins/Aggregates when valid") {
 
+    engine.invalidateCaches()
     def spread(filter: Seq[ColumnFilter]): Seq[SpreadChange] = {
       Seq(SpreadChange(0, 1))
     }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -427,6 +427,11 @@ filodb {
     # config to figure out the tenant column filter to enable max min column selection
     max-min-tenant-column-filter = "_ws_"
 
+    single.cluster.cache {
+        enabled = true
+        # The maximum number of entries in the cache
+        cache-size = 2048
+    }
     routing {
       enable-remote-raw-exports = false
       max-time-range-remote-raw-export = 180 minutes

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -43,6 +43,10 @@ object QueryConfig {
       periodOfUncertaintyMs
       )
 
+    val scCachingEnabled = queryConfig.as[Boolean]("single.cluster.cache.enabled")
+    val scCacheSize = queryConfig.as[Int]("single.cluster.cache.cache-size")
+    val cachingConfig = CachingConfig(scCachingEnabled, scCacheSize)
+
     QueryConfig(askTimeout, staleSampleAfterMs, minStepMs, fastReduceMaxWindows, parser, translatePromToFilodbHistogram,
       fasterRateEnabled, routingConfig.as[Option[String]]("partition_name"),
       routingConfig.as[Option[Long]]("remote.http.timeout"),
@@ -52,7 +56,7 @@ object QueryConfig {
       allowPartialResultsRangeQuery, allowPartialResultsMetadataQuery,
       grpcDenyList.split(",").map(_.trim.toLowerCase).toSet,
       None,
-      containerOverrides, rc)
+      containerOverrides, rc, cachingConfig)
   }
 
   import scala.concurrent.duration._
@@ -84,6 +88,11 @@ case class RoutingConfig(
                           periodOfUncertaintyMs: Long                    = (5 minutes).toMillis
                         )
 
+case class CachingConfig(
+                        singleClusterPlannerCachingEnabled: Boolean = true,
+                        singleClusterPlannerCachingSize: Int = 2048
+                        )
+
 case class QueryConfig(askTimeout: FiniteDuration,
                        staleSampleAfterMs: Long,
                        minStepMs: Long,
@@ -102,4 +111,5 @@ case class QueryConfig(askTimeout: FiniteDuration,
                        grpcPartitionsDenyList: Set[String] = Set.empty,
                        plannerSelector: Option[String] = None,
                        recordContainerOverrides: Map[String, Int] = Map.empty,
-                       routingConfig: RoutingConfig               = RoutingConfig())
+                       routingConfig: RoutingConfig               = RoutingConfig(),
+                       cachingConfig: CachingConfig               = CachingConfig())

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -148,7 +148,14 @@ filodb {
     }
     grpc {
           partitions-deny-list = ""
-       }
+    }
+
+    single.cluster.cache {
+       enabled = true
+       # The maximum number of entries in the cache
+       cache-size = 2048
+    }
+
     routing {
       enable-remote-raw-exports = false
       max-time-range-remote-raw-export = 30 minutes

--- a/jmh/src/main/scala/filodb.jmh/PlannerBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PlannerBenchmark.scala
@@ -1,0 +1,118 @@
+// scalastyle:off
+package filodb.jmh
+
+import java.util.concurrent.TimeUnit
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.Logger
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.duration._
+import filodb.coordinator.ShardMapper
+import filodb.coordinator.client.QueryCommands.{FunctionalSpreadProvider, FunctionalTargetSchemaProvider}
+import filodb.coordinator.queryplanner.SingleClusterPlanner
+import filodb.core.{MetricsTestData, SpreadChange, SpreadProvider, TargetSchemaChange}
+import filodb.core.metadata.Schemas
+import filodb.core.query.{PlannerParams, PromQlQueryParams, QueryConfig, QueryContext}
+import filodb.prometheus.ast.TimeStepParams
+import filodb.prometheus.parse.Parser
+import filodb.query.exec.ExecPlan
+
+@State(Scope.Thread)
+class PlannerBenchmark {
+
+  // Run using the following in sbt
+  // jmh/jmh:run  -rf json -i 5 -wi 3 -f 1 -jvmArgsAppend -XX:MaxInlineLevel=20 -jvmArgsAppend -Xmx4g -jvmArgsAppend -XX:MaxInlineSize=99  -jvmArgsAppend -Dlogback.configurationFile=<filodb local path>/conf/logback-dev.xml  filodb.jmh.PlannerBenchmark -prof "async:libPath=<async profiler path>/lib/libasyncProfiler.dylib;output=jfr;alloc=0"
+
+
+  var system: Option[ActorSystem] = None
+  var planner: Option[SingleClusterPlanner] = None
+  var now = 0L;
+  val logger: Logger = Logger("PlannerBenchmark")
+  private val spreadProvider: Option[SpreadProvider] = Some(
+                    FunctionalSpreadProvider(
+                      _ => Seq(SpreadChange(0, 8)))
+                    )
+  private val tSchemaProvider: Option[FunctionalTargetSchemaProvider] = Some(
+                    FunctionalTargetSchemaProvider(
+                      _ => Seq(TargetSchemaChange(0, Seq("job", "app")))
+                    )
+                  )
+
+
+  var execPlan: Option[ExecPlan] = None
+
+
+  val query = """    foo { job="baz" , node!="", ns="ns"}
+                |      OR on (app)
+                |    bar { job="baz", node!="", ns="ns" }
+                |      * on (app) group_right()
+                |    baz{ job="baz", node!="", ns="ns" } == 1""".stripMargin
+
+
+  private def buildPlanners(): Unit = {
+    implicit val system: ActorSystem = ActorSystem()
+    this.system = Some(system)
+    val node = TestProbe().ref
+    val mapper = new ShardMapper(256)
+    for (i <- 0 until 256) {
+      mapper.registerNode(Seq(i), node)
+    }
+    this.now = System.currentTimeMillis()
+
+    val rawRetention = 7.days.toMillis
+
+    val routingConfigString = "routing {\n  remote {\n    http {\n      timeout = 10000\n    }\n  }\n}"
+    val routingConfig = ConfigFactory.parseString(routingConfigString)
+    val config = ConfigFactory.load("application_test.conf").getConfig("filodb.query").withFallback(routingConfig)
+    val queryConfig = QueryConfig(config).copy(plannerSelector = Some("plannerSelector"))
+
+    val dataset = MetricsTestData.timeseriesDataset
+    val schemas = Schemas(dataset.schema)
+
+    planner = Some(new SingleClusterPlanner(dataset, schemas, mapper,
+        earliestRetainedTimestampFn = now - rawRetention, queryConfig, "raw"))
+  }
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    buildPlanners()
+  }
+
+  @TearDown(Level.Trial)
+  def teardown(): Unit = {
+    this.system.foreach(_.terminate())
+//    println("\n\n===================================\n\n")
+//    print(s"${execPlan.get.printTree()}")
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @Warmup(iterations = 1, time = 1)
+  @Measurement(iterations = 5, time = 1)
+  @throws[Exception]
+  def benchmarkMaterializePlan(): Unit = {
+
+    var i = 0;
+    // Materialize the query every hour for past 5 days
+    for (endTime <- (now - 3.hour.toMillis) to  now by 1.hour.toMillis) {
+        val endSecs = endTime / 1000;
+        val timeParams = TimeStepParams(endSecs - 1.day.toSeconds, 60, endSecs)
+        val lp = Parser.queryRangeToLogicalPlan(query, timeParams)
+        execPlan = Some(planner.get.materialize(lp,
+            QueryContext(PromQlQueryParams("dummy", timeParams.start, timeParams.step, timeParams.end),
+                         plannerParams = PlannerParams(
+                                            spreadOverride = spreadProvider,
+                                            targetSchemaProviderOverride = tSchemaProvider,
+                                             queryTimeoutMillis = 1000000))))
+    }
+  }
+
+}
+
+
+
+
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -197,7 +197,8 @@ object Dependencies {
   //  )
 
   lazy val jmhDeps = Seq(
-    "org.apache.spark" %% "spark-sql" % sparkVersion excludeAll(excludeSlf4jLog4j, excludeZK, excludeJersey)
+    "org.apache.spark" %% "spark-sql" % sparkVersion excludeAll(excludeSlf4jLog4j, excludeZK, excludeJersey),
+    "com.typesafe.akka"      %% "akka-testkit"                % akkaVersion
   )
 
   lazy val gatlingDeps = Seq(


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Though there is no expected change in the behavior for the end users,  the memory allocation for  methods ``getPushdownShards``, ``isTargetSchemaChanging`` and  ``QueryUtils.makeAllKeyValueCombos`` is high. This high memory allocation can be reduced by memoizing the responses which are repeatedly called by recursing the logical plan tree

With no caching enabled the JMH tests for materialize give following results

```
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                        Mode  Cnt   Score    Error  Units
[info] PlannerBenchmark.benchmarkMaterializePlan        avgt    5  20.819 ± 13.145  ms/op
```

<img width="1373" alt="Screenshot 2024-10-29 at 3 03 08 PM" src="https://github.com/user-attachments/assets/b6606178-3718-46d9-a885-d45171906f5e">

<img width="1387" alt="Screenshot 2024-10-29 at 3 02 34 PM" src="https://github.com/user-attachments/assets/255e3ba3-0e51-40ae-a601-e3c2debdacdd">


As seen above, ``getPushdownShards``, ``isTargetSchemaChanging``  show up as two hotspots for memory allocation profiling. 


**New behavior :**

After memoizing the responses, the hotspots are no longer visible. The planner's materialize is 2-3X improvement in materialize times and then two calls don't show up in allocation hotspots anymore. 

```
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                        Mode  Cnt  Score   Error  Units
[info] PlannerBenchmark.benchmarkMaterializePlan        avgt    5  7.642 ± 3.868  ms/op
```

<img width="2077" alt="Screenshot 2024-10-29 at 3 18 34 PM" src="https://github.com/user-attachments/assets/11549838-edde-49bd-8055-718e6dcd33f2">

