### PR TITLE
feat(histogram): add meaningful exception when histograms add buckets with different sizes

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -154,7 +154,11 @@ final case class LongHistogram(buckets: HistogramBuckets, values: Array[Long]) e
    * Adds the buckets from other into this LongHistogram
    */
   final def add(other: LongHistogram): Unit = {
-    assert(other.buckets == buckets)
+    if (other.buckets != buckets) {
+      throw new IllegalArgumentException(
+        "Mismatch in bucket sizes. Cannot add histograms with different bucket configurations."
+      )
+    }
     cforRange { 0 until numBuckets } { b =>
       values(b) += other.values(b)
     }

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -156,7 +156,8 @@ final case class LongHistogram(buckets: HistogramBuckets, values: Array[Long]) e
   final def add(other: LongHistogram): Unit = {
     if (other.buckets != buckets) {
       throw new IllegalArgumentException(
-           s"Mismatch in bucket sizes. Cannot add histograms with different bucket configurations. Expected: ${buckets}, Found: ${other.buckets}"
+           s"Mismatch in bucket sizes. Cannot add histograms with different bucket configurations. " +
+             s"Expected: ${buckets}, Found: ${other.buckets}"
       )
     }
     cforRange { 0 until numBuckets } { b =>

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -156,7 +156,7 @@ final case class LongHistogram(buckets: HistogramBuckets, values: Array[Long]) e
   final def add(other: LongHistogram): Unit = {
     if (other.buckets != buckets) {
       throw new IllegalArgumentException(
-        "Mismatch in bucket sizes. Cannot add histograms with different bucket configurations."
+           s"Mismatch in bucket sizes. Cannot add histograms with different bucket configurations. Expected: ${buckets}, Found: ${other.buckets}"
       )
     }
     cforRange { 0 until numBuckets } { b =>

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -78,7 +78,8 @@ class HistogramTest extends NativeVectorTest {
           hist1.add(histWithDifferentBuckets)
         }
 
-        thrown.getMessage shouldEqual "Mismatch in bucket sizes. Cannot add histograms with different bucket configurations."
+        thrown.getMessage shouldEqual s"Mismatch in bucket sizes. Cannot add histograms with different bucket configurations. " +
+          s"Expected: ${hist1.buckets}, Found: ${histWithDifferentBuckets.buckets}"
       }
     it("should calculate quantile correctly") {
       mutableHistograms.zip(quantile50Result).foreach { case (h, res) =>

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -62,6 +62,24 @@ class HistogramTest extends NativeVectorTest {
   }
 
   describe("Histogram") {
+      it("should add two histograms with the same bucket scheme correctly") {
+        val hist1 = LongHistogram(bucketScheme, Array(1, 2, 3, 4, 5, 6, 7, 8))
+        val hist2 = LongHistogram(bucketScheme, Array(2, 4, 6, 8, 10, 12, 14, 18))
+        hist1.add(hist2)
+
+        hist1.values shouldEqual Array(3, 6, 9, 12, 15, 18, 21, 26)
+      }
+
+      it("should not add histograms with different bucket schemes") {
+        val hist1 = LongHistogram(bucketScheme, Array(1, 2, 3, 4, 5, 6, 7, 8))
+        val histWithDifferentBuckets = LongHistogram(customScheme, Array(1, 2, 3, 4, 5, 6, 7))
+
+        val thrown = intercept[IllegalArgumentException] {
+          hist1.add(histWithDifferentBuckets)
+        }
+
+        thrown.getMessage shouldEqual "Mismatch in bucket sizes. Cannot add histograms with different bucket configurations."
+      }
     it("should calculate quantile correctly") {
       mutableHistograms.zip(quantile50Result).foreach { case (h, res) =>
         val quantile = h.quantile(0.50)


### PR DESCRIPTION
Pull Request checklist

- [x]  The commit(s) message(s) follows the contribution [guidelines](https://github.com/filodb/FiloDB/pull/CONTRIBUTING.md) ?
- [x]  Tests for the changes have been added (for bug fixes / features) ?
- [x]  Docs have been added / updated (for bug fixes / features) ?

Current behavior : when histograms add buckets with different sizes, it returns a 5xx error

New behavior : it returns an IllegalArgumentException with a meaningful message