### PR TITLE
perf(query) Eliminate the allocation of memory for RepeatValueVector

### DIFF
--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -2,11 +2,14 @@ package filodb.core.query
 
 import java.time.{LocalDateTime, YearMonth, ZoneOffset}
 import java.util.concurrent.atomic.AtomicLong
+
 import com.typesafe.scalalogging.StrictLogging
 import debox.Buffer
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import org.joda.time.DateTime
+import scala.util.Using
+
 import filodb.core.binaryrecord2.{MapItemConsumer, RecordBuilder, RecordContainer, RecordSchema}
 import filodb.core.metadata.Column
 import filodb.core.metadata.Column.ColumnType._
@@ -16,7 +19,7 @@ import filodb.memory.data.ChunkMap
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String => UTF8Str}
 import filodb.memory.format.vectors.Histogram
 
-import scala.util.Using
+
 
 /**
   * Identifier for a single RangeVector.

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -218,7 +218,7 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
 
   // This will now be used only during serialization of this vector in protos
   // This is room for optimization here as we cant instantiate anything under 2048 bytes which is the MinContainerSize
-  lazy val containers: Seq[RecordContainer] = {
+  def containers: Seq[RecordContainer] = {
     val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
     rowReader.map(builder.addFromReader(_, schema, 0))
     builder.allContainers.toList

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -2,13 +2,11 @@ package filodb.core.query
 
 import java.time.{LocalDateTime, YearMonth, ZoneOffset}
 import java.util.concurrent.atomic.AtomicLong
-
 import com.typesafe.scalalogging.StrictLogging
 import debox.Buffer
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 import org.joda.time.DateTime
-
 import filodb.core.binaryrecord2.{MapItemConsumer, RecordBuilder, RecordContainer, RecordSchema}
 import filodb.core.metadata.Column
 import filodb.core.metadata.Column.ColumnType._
@@ -17,6 +15,8 @@ import filodb.memory.{BinaryRegionLarge, MemFactory, UTF8StringMedium, UTF8Strin
 import filodb.memory.data.ChunkMap
 import filodb.memory.format.{RowReader, ZeroCopyUTF8String => UTF8Str}
 import filodb.memory.format.vectors.Histogram
+
+import scala.util.Using
 
 /**
   * Identifier for a single RangeVector.
@@ -213,12 +213,6 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
   override def outputRange: Option[RvRange] = Some(RvRange(startMs, stepMs, endMs))
   override val numRows: Option[Int] = Some((endMs - startMs) / math.max(1, stepMs) + 1).map(_.toInt)
 
-  lazy val containers: Seq[RecordContainer] = {
-    val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
-    rowReader.map(builder.addFromReader(_, schema, 0))
-    builder.allContainers.toList
-  }
-
   val recordSchema: RecordSchema = schema
 
   // There is potential for optimization.
@@ -260,7 +254,23 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
   /**
    * Estimates the total size (in bytes) of all rows after serialization.
    */
-  override def estimateSerializedRowBytes: Long = containers.size
+  override def estimateSerializedRowBytes: Long =
+    this.schema.columns.zipWithIndex.map { case (col, idx) =>
+      col.colType match {
+        case DoubleColumn       => SerializableRangeVector.SizeOfDouble
+        case LongColumn         => SerializableRangeVector.SizeOfLong
+        case IntColumn          => SerializableRangeVector.SizeOfInt
+        case StringColumn       => this.rowReader.map(rr => rr.getString(idx).length).getOrElse(0)
+        case TimestampColumn    => SerializableRangeVector.SizeOfLong
+        case BinaryRecordColumn => this.rowReader.map(rr => rr.getBlobNumBytes(idx)).getOrElse(0)
+        // We will take the worst case where histogram has buckets, each bucket has 2 doubles, one for the bucket
+        //  itself and one for the bin count. We will have 4 more columns for sum, total, min and max,
+        case HistogramColumn    => this.rowReader.map(
+                                      rr => rr.getHistogram(idx).numBuckets * SerializableRangeVector.SizeOfDouble * 2
+                                            + SerializableRangeVector.SizeOfDouble * 4).getOrElse(0)
+        case MapColumn          => 0 // Not supported yet
+      }
+    }.sum
 }
 
 object RepeatValueVector extends StrictLogging {
@@ -272,21 +282,14 @@ object RepeatValueVector extends StrictLogging {
             queryStats: QueryStats): RepeatValueVector = {
     val startNs = Utils.currentThreadCpuTimeNanos
     try {
-      var nextRow: Option[RowReader] = None
-      try {
-        ChunkMap.validateNoSharedLocks(execPlan)
-        val rows = rv.rows()
-        if (rows.hasNext) {
-           nextRow = Some(rows.next())
-        }
-      } finally {
-        rv.rows().close()
-        // clear exec plan
-        // When the query is done, clean up lingering shared locks caused by iterator limit.
-        ChunkMap.releaseAllSharedLocks()
-      }
-      new RepeatValueVector(rv.key, startMs, stepMs, endMs, nextRow, schema)
+      ChunkMap.validateNoSharedLocks(execPlan)
+      Using(rv.rows()){
+        rows =>
+          val nextRow = if (rows.hasNext) Some(rows.next()) else None
+          new RepeatValueVector(rv.key, startMs, stepMs, endMs, nextRow, schema)
+      }.get
     } finally {
+      ChunkMap.releaseAllSharedLocks()
       queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentThreadCpuTimeNanos - startNs)
     }
   }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -212,7 +212,7 @@ final case class RangeParams(startSecs: Long, stepSecs: Long, endSecs: Long)
 final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
                               startMs: Long, stepMs: Long, endMs: Long,
                               rowReader: Option[RowReader],
-                              schema: RecordSchema) extends SerializableRangeVector {
+                              schema: RecordSchema) extends SerializableRangeVector with StrictLogging {
   override def outputRange: Option[RvRange] = Some(RvRange(startMs, stepMs, endMs))
   override val numRows: Option[Int] = Some((endMs - startMs) / math.max(1, stepMs) + 1).map(_.toInt)
 
@@ -279,7 +279,9 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
         case HistogramColumn    => this.rowReader.map(
                                       rr => rr.getHistogram(idx).numBuckets * SerializableRangeVector.SizeOfDouble * 2
                                             + SerializableRangeVector.SizeOfDouble * 4).getOrElse(0)
-        case MapColumn          => 0 // Not supported yet
+        case MapColumn          =>
+                                    logger.warn("MapColumn estimate RepeatValueVector not yet supported")
+                                    0 // Not supported yet
       }
     }.sum
 }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -216,6 +216,14 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
   override def outputRange: Option[RvRange] = Some(RvRange(startMs, stepMs, endMs))
   override val numRows: Option[Int] = Some((endMs - startMs) / math.max(1, stepMs) + 1).map(_.toInt)
 
+  // This will now be used only during serialization of this vector in protos
+  // This is room for optimization here as we cant instantiate anything under 2048 bytes which is the MinContainerSize
+  lazy val containers: Seq[RecordContainer] = {
+    val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+    rowReader.map(builder.addFromReader(_, schema, 0))
+    builder.allContainers.toList
+  }
+
   val recordSchema: RecordSchema = schema
 
   // There is potential for optimization.

--- a/grpc/src/main/protobuf/range_vector.proto
+++ b/grpc/src/main/protobuf/range_vector.proto
@@ -17,6 +17,7 @@ message SerializedRangeVector {
 
 message RepeatValueVector {
   RangeVectorKey key                = 1;
+  // Record containers are kept for backward compatibility and wont be supported in subsequent versions
   repeated bytes recordContainers   = 2;
   RecordSchema recordSchema         = 3;
   optional RvRange rvRange          = 4;

--- a/grpc/src/main/protobuf/range_vector.proto
+++ b/grpc/src/main/protobuf/range_vector.proto
@@ -17,7 +17,6 @@ message SerializedRangeVector {
 
 message RepeatValueVector {
   RangeVectorKey key                = 1;
-  // Record containers are kept for backward compatibility and wont be supported in subsequent versions
   repeated bytes recordContainers   = 2;
   RecordSchema recordSchema         = 3;
   optional RvRange rvRange          = 4;

--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -927,6 +927,10 @@ object ProtoConverters {
       rv.outputRange.map(_.toProto).map(builder.setRvRange)
       builder.setRecordSchema(rv.recordSchema.toProto)
       builder.setKey(rv.key.toProto)
+      builder.addAllRecordContainers(rv.containers.map(
+        container => ByteString.copyFrom(
+          if (container.hasArray) container.array else container.trimmedArray)
+      ).asJava)
       builder.build()
     }
   }

--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -927,10 +927,6 @@ object ProtoConverters {
       rv.outputRange.map(_.toProto).map(builder.setRvRange)
       builder.setRecordSchema(rv.recordSchema.toProto)
       builder.setKey(rv.key.toProto)
-      builder.addAllRecordContainers(rv.containers.map(
-        container => ByteString.copyFrom(
-        if (container.hasArray) container.array else container.trimmedArray)
-      ).asJava)
       builder.build()
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

RepeatValueVector creates containers and incorrectly estimates the size of the row. This record creation creation shows up in the  Memory allocation profile and is unnecessary. 

![image](https://github.com/user-attachments/assets/4aee1e85-4ed5-4fc6-b0f9-17ff9a2fcc4e)


**New behavior :**

Unnecessary allocations are avoided 


