### PR TITLE
fix(core): Error downsampled query if lookback is short when querying rate/increase

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -74,9 +74,7 @@ extends ChunkMap(initMapSize) with ReadablePartition {
   def partKeyBase: Array[Byte] = UnsafeUtils.ZeroPointer.asInstanceOf[Array[Byte]]
   def partKeyOffset: Long = partitionKey
 
-  def publishInterval: Option[Long] = {
-    publishIntervalFinder.findPublishIntervalMs(schema.partition.hash, UnsafeUtils.ZeroArray, partitionKey)
-  }
+  def publishInterval: Option[Long] = None
   /**
     * Incoming, unencoded data gets appended to these BinaryAppendableVectors.
     * There is one element for each column of the schema. All of them have the same chunkId.

--- a/core/src/main/scala/filodb.core/metadata/Column.scala
+++ b/core/src/main/scala/filodb.core/metadata/Column.scala
@@ -43,6 +43,8 @@ case class DataColumn(id: Int,
                       columnType: Column.ColumnType,
                       params: Config = ConfigFactory.empty) extends Column {
 
+  def isCumulativeTemporality: Boolean = params.hasPath("detectDrops") && params.getBoolean("detectDrops")
+
   // Use this for efficient serialization over the wire.
   // We leave out the dataset because that is almost always inferred from context.
   // NOTE: this is one reason why column names cannot have commas

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -187,6 +187,11 @@ final case class Schema(partition: PartitionSchema, data: DataSchema, var downsa
 
   def name: String = data.name
 
+  def hasCumulativeTemporalityColumn: Boolean = data.columns.exists {
+    case d: DataColumn => d.isCumulativeTemporality
+    case _ => false
+  }
+
   /**
     * Fetches reader for a binary vector
     */

--- a/core/src/test/scala/filodb.core/metadata/ColumnSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/ColumnSpec.scala
@@ -10,6 +10,8 @@ class ColumnSpec extends AnyFunSpec with Matchers {
   import Dataset._
 
   val firstColumn = DataColumn(0, "first", ColumnType.StringColumn)
+  val cumulHistColumn = DataColumn(3, "hist", ColumnType.HistogramColumn,
+                              ConfigFactory.parseString("detectDrops = true"))
   val ageColumn = DataColumn(2, "age", ColumnType.IntColumn)
   val histColumnOpts = DataColumn(3, "hist", ColumnType.HistogramColumn,
                                   ConfigFactory.parseString("counter = true"))
@@ -23,6 +25,12 @@ class ColumnSpec extends AnyFunSpec with Matchers {
       val res1 = Column.validateColumnName(":illegal")
       res1.isBad shouldEqual true
       res1.swap.get.head shouldBe a[BadColumnName]
+    }
+
+    it("should return correct value for hasCumulativeIncrement") {
+      cumulHistColumn.isCumulativeTemporality shouldEqual true
+      deltaCountColumn.isCumulativeTemporality shouldEqual false
+      firstColumn.isCumulativeTemporality shouldEqual false
     }
 
     it("should check that column names cannot contain illegal chars") {

--- a/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/SchemasSpec.scala
@@ -153,6 +153,15 @@ class SchemasSpec extends AnyFunSpec with Matchers {
       resp3.swap.get shouldBe an[IllegalMapColumn]
     }
 
+    it ("should return correct value for hasCumulativeTemporalityColumn") {
+      Schemas.promHistogram.hasCumulativeTemporalityColumn shouldEqual true
+      Schemas.promCounter.hasCumulativeTemporalityColumn shouldEqual true
+      Schemas.otelCumulativeHistogram.hasCumulativeTemporalityColumn shouldEqual true
+      Schemas.deltaCounter.hasCumulativeTemporalityColumn shouldEqual false
+      Schemas.deltaHistogram.hasCumulativeTemporalityColumn shouldEqual false
+      Schemas.otelDeltaHistogram.hasCumulativeTemporalityColumn shouldEqual false
+    }
+
     it("should return BadColumnType if unsupported type specified in column spec") {
       val resp1 = PartitionSchema.make(Seq("first:strolo"), DatasetOptions.DefaultOptions)
       resp1.isBad shouldEqual true

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -87,11 +87,11 @@ final case class PeriodicSamplesMapper(startMs: Long,
           val rdrv = rv.asInstanceOf[RawDataRangeVector]
           val chunkedHRangeFunc = rangeFuncGen().asChunkedH
           val minResolutionMs = rdrv.minResolutionMs
-          if (chunkedHRangeFunc.isInstanceOf[CounterChunkedRangeFunction[_]] && windowLength < minResolutionMs)
+          if (chunkedHRangeFunc.isInstanceOf[CounterChunkedRangeFunction[_]] && windowLength < minResolutionMs * 2)
             throw new IllegalArgumentException(s"Minimum resolution of data for this time range is " +
               s"${minResolutionMs}ms. However, a lookback of ${windowLength}ms was chosen. This will not " +
-              s"yield intended results for rate/increase functions since each lookback window contains " +
-              s"lesser than 2 samples. Increase lookback to more than ${minResolutionMs}ms")
+              s"yield intended results for rate/increase functions since each lookback window can contain " +
+              s"lesser than 2 samples. Increase lookback to more than ${minResolutionMs * 2}ms")
           val windowPlusPubInt = extendLookback(rv, windowLength)
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorH(rdrv, startWithOffset, adjustedStep, endWithOffset,
@@ -102,13 +102,13 @@ final case class PeriodicSamplesMapper(startMs: Long,
           qLogger.trace(s"Creating ChunkedWindowIterator for rv=${rv.key}, adjustedStep=$adjustedStep " +
             s"windowLength=$windowLength")
           val rdrv = rv.asInstanceOf[RawDataRangeVector]
-          val minResolutionMs = rdrv.minResolutionMs
+          val minResolutionMs = rdrv.minResolutionMs * 2
           val chunkedDRangeFunc = rangeFuncGen().asChunkedD
-          if (chunkedDRangeFunc.isInstanceOf[CounterChunkedRangeFunction[_]] && windowLength < rdrv.minResolutionMs)
+          if (chunkedDRangeFunc.isInstanceOf[CounterChunkedRangeFunction[_]] && windowLength < rdrv.minResolutionMs * 2)
             throw new IllegalArgumentException(s"Minimum resolution of data for this time range is " +
               s"${minResolutionMs}ms. However, a lookback of ${windowLength}ms was chosen. This will not " +
-              s"yield intended results for rate/increase functions since each lookback window contains " +
-              s"lesser than 2 samples. Increase lookback to more than ${minResolutionMs}ms")
+              s"yield intended results for rate/increase functions since each lookback window can contain " +
+              s"lesser than 2 samples. Increase lookback to more than ${minResolutionMs * 2}ms")
           val windowPlusPubInt = extendLookback(rv, windowLength)
           IteratorBackedRangeVector(rv.key,
             new ChunkedWindowIteratorD(rdrv, startWithOffset, adjustedStep, endWithOffset,

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -174,21 +174,22 @@ final case class PeriodicSamplesMapper(startMs: Long,
    * will lead to incorrect results.
    */
   private[exec] def extendLookback(rv: RangeVector, window: Long): Long = {
-    if (functionId.contains(InternalRangeFunction.Rate)) { // only extend for rate function
-      val pubInt = rv match {
-        case rvrd: RawDataRangeVector =>
-          if (rvrd.partition.schema.hasCumulativeTemporalityColumn) // only extend for cumulative schemas
-            rvrd.partition.publishInterval.getOrElse(0L)
-          else 0L
-        case _ => 0L
-      }
-      if (window < 2 * pubInt) 2 * pubInt // 2 * publish interval since we want 2 samples for rate
-      else window
-    } else {
-      window
-    }
-    // TODO consider returning an error when known publish interval is less than 2*windowLength for increase function
-    // instead of silently returning empty rate (and implicitly zero for sum functions) for the window
+    window
+// following code is commented, but uncomment when we want to extend window for rate function
+
+//    if (functionId.contains(InternalRangeFunction.Rate)) { // only extend for rate function
+//      val pubInt = rv match {
+//        case rvrd: RawDataRangeVector =>
+//          if (rvrd.partition.schema.hasCumulativeTemporalityColumn) // only extend for cumulative schemas
+//            rvrd.partition.publishInterval.getOrElse(0L)
+//          else 0L
+//        case _ => 0L
+//      }
+//      if (window < 2 * pubInt) 2 * pubInt // 2 * publish interval since we want 2 samples for rate
+//      else window
+//    } else {
+//      window
+//    }
   }
 
   // Transform source double or long to double schema

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -102,7 +102,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
           qLogger.trace(s"Creating ChunkedWindowIterator for rv=${rv.key}, adjustedStep=$adjustedStep " +
             s"windowLength=$windowLength")
           val rdrv = rv.asInstanceOf[RawDataRangeVector]
-          val minResolutionMs = rdrv.minResolutionMs * 2
+          val minResolutionMs = rdrv.minResolutionMs
           val chunkedDRangeFunc = rangeFuncGen().asChunkedD
           val extendedWindow = extendLookback(rdrv, windowLength)
           if (chunkedDRangeFunc.isInstanceOf[CounterChunkedRangeFunction[_]] &&

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -6,7 +6,6 @@ import org.jctools.queues.SpscUnboundedArrayQueue
 
 import filodb.core.GlobalConfig.systemConfig
 import filodb.core.metadata.Column.ColumnType
-import filodb.core.metadata.Schemas
 import filodb.core.query._
 import filodb.core.store.WindowedChunkIterator
 import filodb.memory.format._
@@ -177,10 +176,7 @@ final case class PeriodicSamplesMapper(startMs: Long,
     if (functionId.contains(InternalRangeFunction.Rate)) { // only extend for rate function
       val pubInt = rv match {
         case rvrd: RawDataRangeVector =>
-          if (rvrd.partition.schema == Schemas.promCounter ||
-              rvrd.partition.schema == Schemas.promHistogram ||
-              rvrd.partition.schema == Schemas.otelCumulativeHistogram ||
-              rvrd.partition.schema == Schemas.otelCumulativeHistogram) // only extend for cumulative schemas
+          if (rvrd.partition.schema.hasCumulativeTemporalityColumn) // only extend for cumulative schemas
             rvrd.partition.publishInterval.getOrElse(0L)
           else 0L
         case _ => 0L

--- a/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/PeriodicRateFunctionsSpec.scala
@@ -190,35 +190,36 @@ class PeriodicRateFunctionsSpec extends RawDataWindowingSpec with ScalaFutures {
     it.next.getDouble(1) shouldEqual expectedDelta
   }
 
-  it("should extend lookback window for rate function when lookback < 2 * publishInterval if it exists") {
-    val publishInterval = 1.minute.toMillis.toInt
-    val rawData = RawPartData(Array.empty, Seq.empty)
-    // simulate downsampled partition with resolution set as publishInterval
-    val p1 = new PagedReadablePartition(Schemas.promCounter, 0, -1, rawData, publishInterval)
-    val rv = RawDataRangeVector(CustomRangeVectorKey(Map.empty), p1, InMemoryChunkScan, Array(), new AtomicLong(0), 0, "")
+  ignore (" disabled since the lookback extension is disabled for now. See PeriodicSamplesMapper::extendLookback") {
+    it("should extend lookback window for rate function when lookback < 2 * publishInterval if it exists") {
+      val publishInterval = 1.minute.toMillis.toInt
+      val rawData = RawPartData(Array.empty, Seq.empty)
+      // simulate downsampled partition with resolution set as publishInterval
+      val p1 = new PagedReadablePartition(Schemas.promCounter, 0, -1, rawData, publishInterval)
+      val rv = RawDataRangeVector(CustomRangeVectorKey(Map.empty), p1, InMemoryChunkScan, Array(), new AtomicLong(0), 0, "")
 
-    // looback is extended to 2 * publishInterval when less than 2 * publishInterval
-    val periodicSamplesVectorFnMapper = exec.PeriodicSamplesMapper(500000L, 400000L, 1300000L,
-      Some(publishInterval), Some(Rate), QueryContext(), stepMultipleNotationUsed = false, Nil, None)
-    periodicSamplesVectorFnMapper.extendLookback(rv, 3) shouldEqual 2 * publishInterval
+      // looback is extended to 2 * publishInterval when less than 2 * publishInterval
+      val periodicSamplesVectorFnMapper = exec.PeriodicSamplesMapper(500000L, 400000L, 1300000L,
+        Some(publishInterval), Some(Rate), QueryContext(), stepMultipleNotationUsed = false, Nil, None)
+      periodicSamplesVectorFnMapper.extendLookback(rv, 3) shouldEqual 2 * publishInterval
 
-    // lookback is not extended when lookback >= 2 * publishInterval
-    val periodicSamplesVectorFnMapper2 = exec.PeriodicSamplesMapper(500000L, 400000L, 1300000L,
-      Some(publishInterval), Some(Rate), QueryContext(), stepMultipleNotationUsed = false, Nil, None)
-    periodicSamplesVectorFnMapper2.extendLookback(rv, publishInterval * 2 + 1) shouldEqual (2 * publishInterval + 1)
+      // lookback is not extended when lookback >= 2 * publishInterval
+      val periodicSamplesVectorFnMapper2 = exec.PeriodicSamplesMapper(500000L, 400000L, 1300000L,
+        Some(publishInterval), Some(Rate), QueryContext(), stepMultipleNotationUsed = false, Nil, None)
+      periodicSamplesVectorFnMapper2.extendLookback(rv, publishInterval * 2 + 1) shouldEqual (2 * publishInterval + 1)
 
-    // lookback is not extended for increase function
-    val periodicSamplesVectorFnMapper3 = exec.PeriodicSamplesMapper(500000L, 400000L, 1300000L,
-      Some(publishInterval), Some(Increase), QueryContext(), stepMultipleNotationUsed = false, Nil, None)
-    periodicSamplesVectorFnMapper3.extendLookback(rv, 3) shouldEqual 3
+      // lookback is not extended for increase function
+      val periodicSamplesVectorFnMapper3 = exec.PeriodicSamplesMapper(500000L, 400000L, 1300000L,
+        Some(publishInterval), Some(Increase), QueryContext(), stepMultipleNotationUsed = false, Nil, None)
+      periodicSamplesVectorFnMapper3.extendLookback(rv, 3) shouldEqual 3
 
-    // lookback is not extended for delta schemas
-    val p2 = new PagedReadablePartition(Schemas.otelDeltaHistogram, 0, -1, rawData, publishInterval)
-    val rv2 = RawDataRangeVector(CustomRangeVectorKey(Map.empty), p2, InMemoryChunkScan, Array(), new AtomicLong(0), 0, "")
-    periodicSamplesVectorFnMapper3.extendLookback(rv, 3) shouldEqual 3
+      // lookback is not extended for delta schemas
+      val p2 = new PagedReadablePartition(Schemas.otelDeltaHistogram, 0, -1, rawData, publishInterval)
+      val rv2 = RawDataRangeVector(CustomRangeVectorKey(Map.empty), p2, InMemoryChunkScan, Array(), new AtomicLong(0), 0, "")
+      periodicSamplesVectorFnMapper3.extendLookback(rv, 3) shouldEqual 3
 
+    }
   }
-
   it("appropriate increase function is used for prom-counter type") {
     val samples = Seq(
       100000L -> 100d,

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1921,6 +1921,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val exec = MultiSchemaPartitionsExec(qc,
       InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
       AllChunkScan, "_metric_")
+    // window should be auto-extended to 10m
     exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(310000),
       Some(InternalRangeFunction.Rate), qc))
 
@@ -1935,7 +1936,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     downsampleTSStore.shutdown()
   }
 
-  it("should encounter error when doing rate on DownsampledTimeSeriesShard when lookback < 5m resolution ") {
+  it("should encounter error when doing increase on DownsampledTimeSeriesShard when lookback < 10m resolution ") {
 
     val downsampleTSStore = new DownsampledTimeSeriesStore(downsampleColStore, rawColStore,
       settings.filodbConfig)
@@ -1953,7 +1954,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
       AllChunkScan, "_metric_")
     exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(290000),
-      Some(InternalRangeFunction.Rate), qc))
+      Some(InternalRangeFunction.Increase), qc))
 
     val querySession = QuerySession(QueryContext(), queryConfig)
     val queryScheduler = Scheduler.fixedPool(s"$QuerySchedName", 3)

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1922,7 +1922,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), batchDownsampler.rawDatasetRef, 0, queryFilters,
       AllChunkScan, "_metric_")
     // window should be auto-extended to 10m
-    exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(310000),
+    exec.addRangeVectorTransformer(PeriodicSamplesMapper(74373042000L, 10, 74373042000L,Some(610000),
       Some(InternalRangeFunction.Rate), qc))
 
     val querySession = QuerySession(QueryContext(), queryConfig)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Rate requires 2 samples in lookback window. Instead of returning empty result for rate in downsampled dataset (such queries with small window and smaller publish interval are encountered frequently in downsampled dataset), ~~we extend the lookback to two downsampled resolutions~~  we error the query out when lookback is insufficient. This fix is imperfect, but serves as a workaround until a better solution is delivered. Status quo affects customers by producing wrong query results and leads to thinking that there is data loss, or even worse, implicit trust that the query results are right.
