### PR TITLE
misc(query): Adding helper functions for hqe

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -247,6 +247,14 @@ object LogicalPlanUtils extends StrictLogging {
     }
   }
 
+  /**
+   * @param logicalPlan LogicalPlan
+   * @return maximum offset in milliseconds
+   */
+  def getMaxOffetInMillis(logicalPlan: LogicalPlan): Long = {
+    getOffsetMillis(logicalPlan).max
+  }
+
   def getLookBackMillis(logicalPlan: LogicalPlan): Seq[Long] = {
     // getLookBackMillis is used primarily for LongTimeRangePlanner,
     // SubqueryWtihWindowing returns lookback but TopLevelSubquery does not. The conceptual meaning of the lookback
@@ -258,6 +266,14 @@ object LogicalPlanUtils extends StrictLogging {
       case rs: RawSeries => Seq(rs.lookbackMs.getOrElse(WindowConstants.staleDataLookbackMillis))
       case _             => Seq(0)
     }
+  }
+
+  /**
+   * @param logicalPlan LogicalPlan
+   * @return maximum lookback in milliseconds
+   */
+  def getMaxLookBackInMillis(logicalPlan: LogicalPlan): Long = {
+    getLookBackMillis(logicalPlan).max
   }
 
   def getMetricName(logicalPlan: LogicalPlan, datasetMetricColumn: String): Set[String] = {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanUtilsSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanUtilsSpec.scala
@@ -155,4 +155,30 @@ class LogicalPlanUtilsSpec   extends AnyFunSpec with Matchers {
     counts._1 shouldEqual 1
     counts._2 shouldEqual 0
   }
+
+  it ("getMaxOffetInMillis should return result as expected") {
+    val timeParamsSec = TimeStepParams(1000, 10, 10000)
+    val query1 = """rate(test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"}[5m]) * 1000"""
+    val query2 = """rate(test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"}[5m] offset 1h) + rate(test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"}[5m] offset 2h)"""
+
+    def getMaxOffsetInMillis(query: String) : Long = {
+      val lp = Parser.queryRangeToLogicalPlan(query, timeParamsSec)
+      LogicalPlanUtils.getMaxOffetInMillis(lp)
+    }
+    getMaxOffsetInMillis(query1) shouldEqual 0
+    getMaxOffsetInMillis(query2) shouldEqual 7200000
+  }
+
+  it ("getMaxLookbackInMillis should return result as expected") {
+    val timeParamsSec = TimeStepParams(1000, 10, 10000)
+    val query1 = """rate(test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"}[15m]) + rate(test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"}[10m])"""
+    val query2 = """test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"} offset 1d * 1000"""
+
+    def getMaxLookbackInMillis(query: String) : Long = {
+      val lp = Parser.queryRangeToLogicalPlan(query, timeParamsSec)
+      LogicalPlanUtils.getMaxLookBackInMillis(lp)
+    }
+    getMaxLookbackInMillis(query1) shouldEqual 900000 // max of 15 and 10m
+    getMaxLookbackInMillis(query2) shouldEqual 300000 // default lookback is 5m
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :** Adding helper functions to get the max offset and lookback in milliseconds. 