### PR TITLE
fix(query): Fix histogram query rewrite to exclude summaries

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -4,6 +4,7 @@ import kamon.Kamon
 import monix.execution.Scheduler
 
 import filodb.core.{DatasetRef, GlobalConfig}
+import filodb.core.memstore.PartLookupResult
 import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, QueryConfig, QueryContext, QuerySession, QueryWarnings}
 import filodb.core.query.Filter.Equals
@@ -44,6 +45,8 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
   // Remove _columnName suffix from metricName and generate PartLookupResult
   private def removeSuffixAndGenerateLookupResult(filters: Seq[ColumnFilter], metricName: String, columnName: String,
                                                   source: ChunkSource,
+                                                  datasetRef: DatasetRef,
+                                                  originalLookupResult: PartLookupResult,
                                                   querySession: QuerySession) = {
     // Assume metric name has only equal filter
     val filterWithoutColumn = filters.filterNot(_.column == metricColumn) :+
@@ -53,7 +56,15 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
     // clear stats since previous call to lookupPartitions set the stat with metric name that has suffix
     querySession.queryStats.clear()
     val lookupRes = source.lookupPartitions(dataset, partMethod, chunkMethod, querySession)
-    (lookupRes, Some(columnName))
+    // Accept only if lookupResult schema has a data column with name as the requested columnName.
+    // This is true generally for histogram queries where we rewrite the query to remove _sum, _count suffix.
+    // Check is needed since summaries are not columnized, and we don't want the rewrite to happen for summaries.
+    // If column does not exist, return original lookup result and don't change the query
+    val schemas = source.schemas(datasetRef).get
+    if (lookupRes.firstSchemaId.exists(s => schemas.apply(s).data.columns.exists(_.name == columnName)))
+      (lookupRes, Some(columnName))
+    else
+      (originalLookupResult, None)
   }
 
   /**
@@ -90,9 +101,9 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
     if (lookupRes.firstSchemaId.isEmpty && querySession.queryConfig.translatePromToFilodbHistogram &&
         colName.isEmpty && metricName.isDefined) {
       val res = if (metricName.get.endsWith("_sum"))
-        removeSuffixAndGenerateLookupResult(filters, metricName.get, "sum", source, querySession)
+        removeSuffixAndGenerateLookupResult(filters, metricName.get, "sum", source, dataset, lookupRes, querySession)
       else if (metricName.get.endsWith("_count"))
-        removeSuffixAndGenerateLookupResult(filters, metricName.get, "count", source, querySession)
+        removeSuffixAndGenerateLookupResult(filters, metricName.get, "count", source, dataset, lookupRes, querySession)
       else (lookupRes, newColName)
 
       lookupRes = res._1


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Today we ingest summaries are three or more time series. For example, for a summary named `foo`: 
* One or more quantiles can be reported as time series with metric name `foo`. Today, this is ingested as a gauge in FiloDB.
* We have a sum reported at `foo_sum`. This is a counter.
* We have a `foo_count`. This is also a counter.
Details [in the original prom doc](https://prometheus.io/docs/concepts/metric_types/#summary)

Problem:
When `foo_count` is queried, we lookup to see if metric name `foo` exists. If it exists, we simply rewrite the query to `foo::count` which ends up querying the `count` column on `foo`. This is for backward compatibility on prometheus histograms.

In the case of summaries, the `count` column does not exist on `foo` and it leads to query failure.

Fix:
Rewrite the query only if the second lookup exists, and *additionally has a column called `count`*. This additional check will be true for histograms only.

Testing:
Existing unit tests in `MultiSchemaPartitionsExecSpec` cover this case.