### PR TITLE
fix(histogram): delete misleading words in exception message

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -156,7 +156,7 @@ final case class LongHistogram(buckets: HistogramBuckets, values: Array[Long]) e
   final def add(other: LongHistogram): Unit = {
     if (other.buckets != buckets) {
       throw new IllegalArgumentException(
-           s"Mismatch in bucket sizes. Cannot add histograms with different bucket configurations. " +
+           s"Cannot add histograms with different bucket configurations. " +
              s"Expected: ${buckets}, Found: ${other.buckets}"
       )
     }

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -78,7 +78,7 @@ class HistogramTest extends NativeVectorTest {
           hist1.add(histWithDifferentBuckets)
         }
 
-        thrown.getMessage shouldEqual s"Mismatch in bucket sizes. Cannot add histograms with different bucket configurations. " +
+        thrown.getMessage shouldEqual s"Cannot add histograms with different bucket configurations. " +
           s"Expected: ${hist1.buckets}, Found: ${histWithDifferentBuckets.buckets}"
       }
     it("should calculate quantile correctly") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Removed 'size' from error message to clarify bucket configuration differences and avoid misleading users about bucket sizes.