### PR TITLE
fix(query): Ignoring query-filter labels with .* regex in the HQE higher level checks

### DIFF
--- a/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
+++ b/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
@@ -5,7 +5,7 @@ import kamon.Kamon
 import scala.jdk.CollectionConverters.asScalaBufferConverter
 
 import filodb.core.GlobalConfig
-import filodb.core.query.ColumnFilter
+import filodb.core.query.{ColumnFilter, Filter}
 import filodb.core.query.Filter.Equals
 import filodb.query.{AggregateClause, AggregationOperator, LogicalPlan, TsCardinalities}
 
@@ -237,6 +237,19 @@ object HierarchicalQueryExperience extends StrictLogging {
     }
 
   /**
+   * @param filters - Seq[ColumnFilter] - label filters of the query/lp
+   * @return - Seq[String] - List of filter tags/labels after filtering out the .* regex. We want to optimize the
+   *         aggregation queries which have .* regex in the filters as they are selecting all the relevant time-series
+   *         and hence not applicable for filter check in the aggregation rules.
+   */
+  def getColumnsAfterFilteringOutDotStarRegexFilters(filters: Seq[ColumnFilter]): Seq[String] = {
+    filters.filter {
+      case ColumnFilter(_, Filter.EqualsRegex(value)) if value.toString == ".*" => false
+      case _ => true
+    }.map(x => x.column)
+  }
+
+  /**
    * Updates the metric column filter if higher level aggregation is applicable
    * @param params - HierarchicalQueryExperienceParams - Contains metricDelimiter and aggRules
    * @param filters - Seq[ColumnFilter] - label filters of the query/lp
@@ -244,7 +257,7 @@ object HierarchicalQueryExperience extends StrictLogging {
    */
   def upsertMetricColumnFilterIfHigherLevelAggregationApplicable(params: HierarchicalQueryExperienceParams,
                                                                  filters: Seq[ColumnFilter]): Seq[ColumnFilter] = {
-    val filterTags = filters.map(x => x.column)
+    val filterTags = getColumnsAfterFilteringOutDotStarRegexFilters(filters)
     val metricColumnFilter = getMetricColumnFilterTag(filterTags, GlobalConfig.datasetOptions.get.metricColumn)
     val currentMetricName = getMetricName(metricColumnFilter, filters)
     if (currentMetricName.isDefined) {

--- a/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
+++ b/query/src/main/scala/filodb/query/util/HierarchicalQueryExperience.scala
@@ -5,8 +5,8 @@ import kamon.Kamon
 import scala.jdk.CollectionConverters.asScalaBufferConverter
 
 import filodb.core.GlobalConfig
-import filodb.core.query.{ColumnFilter, Filter}
-import filodb.core.query.Filter.Equals
+import filodb.core.query.ColumnFilter
+import filodb.core.query.Filter.{Equals, EqualsRegex}
 import filodb.query.{AggregateClause, AggregationOperator, LogicalPlan, TsCardinalities}
 
 /**
@@ -244,7 +244,7 @@ object HierarchicalQueryExperience extends StrictLogging {
    */
   def getColumnsAfterFilteringOutDotStarRegexFilters(filters: Seq[ColumnFilter]): Seq[String] = {
     filters.filter {
-      case ColumnFilter(_, Filter.EqualsRegex(value)) if value.toString == ".*" => false
+      case ColumnFilter(_, EqualsRegex(value)) if value.toString == ".*" => false
       case _ => true
     }.map(x => x.column)
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Aggregation queries with labels/tags with `.*` regex is included in the HQE check against the higher level aggregation rule. So queries like following won't be optimized - 

```
aggregation rule - includeTags - {
     
     level1:[ "device", "host"],
     level2:["host"] 
     
 }
 
 query - sum(rate(my_metric{host="abc", "device"=~".*"}[5m]))
```

**New behavior :** We are ignoring the labels / tags with `.*` regex for the HQE check. So the above query will be optimized.
