### PR TITLE
fix(query): histogram le filter should support +Inf gracefully

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -790,7 +790,13 @@ class SingleClusterPlanner(val dataset: Dataset,
     // Add the le filter transformer to select the required bucket
     (nameFilter, leFilter) match {
       case (Some(filter), Some (le)) if filter.endsWith("_bucket") => {
-        val paramsExec = StaticFuncArgs(le.toDouble, RangeParams(realScanStartMs / 1000,
+        // if le filter matches for Inf or +Inf, set the double value to PositiveInfinity
+        val doubleVal = le match {
+          case "+Inf" => Double.PositiveInfinity
+          case "Inf" => Double.PositiveInfinity
+          case _ => le.toDouble
+        }
+        val paramsExec = StaticFuncArgs(doubleVal, RangeParams(realScanStartMs / 1000,
           realScanStepMs / 1000, realScanEndMs / 1000))
         series.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
           Seq(paramsExec))))


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** Queries are failing when le=+Inf bucket is being selected for functions like rate, increase

**New behavior :** Supporting le=+Inf, le=Inf bucket values