### PR TITLE
misc(query): Adding supporting function to get the logical plan tree in string form

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -641,4 +641,17 @@ object LogicalPlanUtils extends StrictLogging {
       .distinct
       .map(_.toSeq)
   }
+
+  def getLogicalPlanTreeStringRepresentation(logicalPlan: LogicalPlan) : String = {
+    // iterate over all the children of the logical plan and get the string representation
+    val children = logicalPlan match {
+      case nl: NonLeafLogicalPlan => nl.children.map(getLogicalPlanTreeStringRepresentation)
+      case _ => Seq()
+    }
+    if (children.isEmpty) {
+      logicalPlan.getClass.getSimpleName
+    } else {
+      s"${logicalPlan.getClass.getSimpleName}(${children.mkString(",")})"
+    }
+  }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanUtilsSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanUtilsSpec.scala
@@ -181,4 +181,14 @@ class LogicalPlanUtilsSpec   extends AnyFunSpec with Matchers {
     getMaxLookbackInMillis(query1) shouldEqual 900000 // max of 15 and 10m
     getMaxLookbackInMillis(query2) shouldEqual 300000 // default lookback is 5m
   }
+
+  it ("getLogicalPlanTreeStringRepresentation should return result as expected") {
+    val timeParamsSec = TimeStepParams(1000, 10, 10000)
+    val query1 = """rate(test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"}[15m]) + rate(test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"}[10m])"""
+    val query2 = """test_metric{_ns_="test-ns", _ws_="test-ns", cluster="test1"} offset 1d * 1000"""
+    val lp = Parser.queryRangeToLogicalPlan(query1, timeParamsSec)
+    LogicalPlanUtils.getLogicalPlanTreeStringRepresentation(lp) shouldEqual "BinaryJoin(PeriodicSeriesWithWindowing(RawSeries),PeriodicSeriesWithWindowing(RawSeries))"
+    val lp2 = Parser.queryToLogicalPlan(query2, 100, 10)
+    LogicalPlanUtils.getLogicalPlanTreeStringRepresentation(lp2) shouldEqual "ScalarVectorBinaryOperation(PeriodicSeries(RawSeries),ScalarFixedDoublePlan)"
+  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :** Adding new helper function to get the logical plan tree in string format. This can be used for logging and debugging purposes.