### PR TITLE
cherry-pick fix(query): fixing shard level failover by allowing bigger GRPC requests

### DIFF
--- a/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
+++ b/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
@@ -46,8 +46,10 @@ class PromQLGrpcServer(queryPlannerSelector: String => QueryPlanner,
   extends StrictLogging {
 
   private val port  = filoSettings.allConfig.getInt("filodb.grpc.bind-grpc-port")
+  private val maxInboundMessageSizeBytes = filoSettings.allConfig.getInt("filodb.grpc.max-inbound-message-size")
   private val server = ServerBuilder.forPort(this.port)
     .intercept(TracingInterceptor).asInstanceOf[ServerBuilder[NettyServerBuilder]]
+    .maxInboundMessageSize(maxInboundMessageSizeBytes)
     //.executor(scheduler).asInstanceOf[ServerBuilder[NettyServerBuilder]]
     .addService(new PromQLGrpcService()).asInstanceOf[ServerBuilder[NettyServerBuilder]].build()
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.28.0"
+version in ThisBuild := "0.9.28.1"


### PR DESCRIPTION
**Pull Request checklist**

- [ X ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
PromQLGrpcServer does not process requests bigger than 4MB.

**New behavior :**
PromQLGrpcServer would process requests up to the limit given in the configuraiton.

