### PR TITLE
fix(core): Fix latest clippy errors in Rust code (#1895)

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -25,6 +25,7 @@ jobs:
         components: rustfmt, clippy
         target: x86_64-apple-darwin, aarch64-apple-darwin, aarch64-unknown-linux-gnu
         cache-workspaces: "core/src/rust -> target"
+        toolchain: 1.83.0
     - name: Install cargo-zigbuild
       run: pip install cargo-zigbuild
     - name: Run tests

--- a/core/src/rust/filodb_core/src/ingestion/fields.rs
+++ b/core/src/rust/filodb_core/src/ingestion/fields.rs
@@ -80,7 +80,7 @@ fn parse_map_field<'a>(
     // Capture value
     doc.map_values
         .get_mut(map_name.as_ref())
-        .ok_or_else(|| Err::Failure(ParserError::InternalMapError))?
+        .ok_or(Err::Failure(ParserError::InternalMapError))?
         .insert(field_name.to_string(), value.to_string().into());
     doc.field_names.push(field_name.to_string());
 

--- a/core/src/rust/filodb_core/src/query_parser.rs
+++ b/core/src/rust/filodb_core/src/query_parser.rs
@@ -51,7 +51,7 @@ pub mod filodb_query;
 ///         03 00 - string of length 3
 ///         44 45 46 - UTF8 encoding of 'DEF'
 ///     00 - end of boolean query
-
+///
 /// Query type encoding
 #[derive(FromPrimitive)]
 #[repr(u8)]

--- a/core/src/rust/tantivy_utils/src/collectors/column_cache.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/column_cache.rs
@@ -22,7 +22,7 @@ impl<'a> From<CacheKey<'a>> for (SegmentId, String) {
     }
 }
 
-impl<'a> Equivalent<(SegmentId, String)> for CacheKey<'a> {
+impl Equivalent<(SegmentId, String)> for CacheKey<'_> {
     fn equivalent(&self, key: &(SegmentId, String)) -> bool {
         self.0 == key.0 && self.1 == key.1
     }

--- a/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/string_field_collector.rs
@@ -38,13 +38,13 @@ impl<'a> StringFieldCollector<'a> {
     }
 }
 
-impl<'a> LimitedCollector for StringFieldCollector<'a> {
+impl LimitedCollector for StringFieldCollector<'_> {
     fn limit(&self) -> usize {
         self.limit
     }
 }
 
-impl<'a> Collector for StringFieldCollector<'a> {
+impl Collector for StringFieldCollector<'_> {
     type Fruit = Vec<(String, u64)>;
 
     type Child = StringFieldSegmentCollector;
@@ -153,7 +153,7 @@ impl SegmentCollector for StringFieldSegmentCollector {
     }
 }
 
-impl<'a> IndexCollector for StringFieldCollector<'a> {
+impl IndexCollector for StringFieldCollector<'_> {
     fn collect_over_index(
         &self,
         reader: &tantivy::SegmentReader,

--- a/core/src/rust/tantivy_utils/src/collectors/time_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/time_collector.rs
@@ -31,13 +31,13 @@ impl<'a> TimeCollector<'a> {
     }
 }
 
-impl<'a> LimitedCollector for TimeCollector<'a> {
+impl LimitedCollector for TimeCollector<'_> {
     fn limit(&self) -> usize {
         self.limit
     }
 }
 
-impl<'a> Collector for TimeCollector<'a> {
+impl Collector for TimeCollector<'_> {
     // Tuple of part_id, time
     type Fruit = Vec<(i32, i64)>;
 

--- a/core/src/rust/tantivy_utils/src/collectors/time_range_filter.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/time_range_filter.rs
@@ -42,7 +42,7 @@ where
     }
 }
 
-impl<'a, T> LimitedCollector for TimeRangeFilter<'a, T>
+impl<T> LimitedCollector for TimeRangeFilter<'_, T>
 where
     T: LimitedCollector,
     T::Child: LimitedSegmentCollector,
@@ -52,7 +52,7 @@ where
     }
 }
 
-impl<'a, T> Collector for TimeRangeFilter<'a, T>
+impl<T> Collector for TimeRangeFilter<'_, T>
 where
     T: LimitedCollector,
     T::Child: LimitedSegmentCollector,

--- a/core/src/rust/tantivy_utils/src/query/cache.rs
+++ b/core/src/rust/tantivy_utils/src/query/cache.rs
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<'a, QueryType> Equivalent<(SegmentId, QueryType)> for CachableQueryKey<'a, QueryType>
+impl<QueryType> Equivalent<(SegmentId, QueryType)> for CachableQueryKey<'_, QueryType>
 where
     QueryType: Clone + PartialEq + Eq,
 {


### PR DESCRIPTION
* Fix doc comments that had a incorrect line break
* Remove unneeded explicit lifetimes from many impls that can elide them
* Pin Rust toolchain version in workflow to avoid unexpected breaks like this going forward

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: