### PR TITLE
fix(query) Make _type_ field a fast text field in tantivy

### DIFF
--- a/core/src/rust/filodb_core/src/index.rs
+++ b/core/src/rust/filodb_core/src/index.rs
@@ -133,7 +133,7 @@ fn build_schema(
     builder.add_bytes_field(field_constants::PART_KEY, byte_options);
     builder.add_i64_field(field_constants::START_TIME, numeric_options.clone());
     builder.add_i64_field(field_constants::END_TIME, numeric_options.clone());
-    builder.add_text_field(field_constants::TYPE, text_options.clone());
+    builder.add_text_field(field_constants::TYPE, random_access_text_options.clone());
 
     // Fields from input schema
     env.foreach_string_in_array(schema_fields, |name| {


### PR DESCRIPTION
When pulling the label cardinality we get the following error,  similar to other labels this change makes the type field a `random_access_text_options` which is a text_field with fast access. 

```
java.lang.RuntimeException: An invalid argument was passed: 'Field "_type_" is not configured as fast field'
	at filodb.core.memstore.TantivyNativeMethods$.labelValues(Native Method)
	at filodb.core.memstore.PartKeyTantivyIndex.labelValuesEfficient(PartKeyTantivyIndex.scala:220)
	at filodb.core.memstore.TimeSeriesShard.singleLabelValuesWithFilters(TimeSeriesShard.scala:1805)
	at filodb.core.memstore.TimeSeriesMemStore.$anonfun$singleLabelValueWithFilters$1(TimeSeriesMemStore.scala:195)
	at scala.Option.map(Option.scala:230)
	at filodb.core.memstore.TimeSeriesMemStore.singleLabelValueWithFilters(TimeSeriesMemStore.scala:195)
	at filodb.query.exec.LabelCardinalityExec.$anonfun$doExecute$7(MetadataExecPlan.scala:436)
	at filodb.query.exec.LabelCardinalityExec.$anonfun$doExecute$7$adapted(MetadataExecPlan.scala:432)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at filodb.query.exec.LabelCardinalityExec.doExecute(MetadataExecPlan.scala:432)
	at filodb.query.exec.ExecPlan.$anonfun$execute$2(ExecPlan.scala:375)
	at kamon.ContextStorage.runWithContext(ContextStorage.scala:67)
	at kamon.ContextStorage.runWithContext$(ContextStorage.scala:64)
	at kamon.Kamon$.runWithContext(Kamon.scala:19)
	at kamon.ContextStorage.runWithContextEntry(ContextStorage.scala:79)
	at kamon.ContextStorage.runWithContextEntry$(ContextStorage.scala:78)
	at kamon.Kamon$.runWithContextEntry(Kamon.scala:19)
	at kamon.ContextStorage.runWithSpan(ContextStorage.scala:119)
	at kamon.ContextStorage.runWithSpan$(ContextStorage.scala:117)
	at kamon.Kamon$.runWithSpan(Kamon.scala:19)
	at filodb.query.exec.ExecPlan.$anonfun$execute$1(ExecPlan.scala:372)
	at flatMap @ filodb.query.exec.ExecPlan.execute(ExecPlan.scala:493)
	at map @ filodb.coordinator.QueryActor.$anonfun$execPhysicalPlan2$1(QueryActor.scala:154)
	at runToFuture @ filodb.coordinator.IngestionActor.$anonfun$doRecovery$1(IngestionActor.scala:320)
	at guarantee @ filodb.coordinator.QueryActor.$anonfun$execPhysicalPlan2$1(QueryActor.scala:170)
```

The change will enable us to query the values of the _type_field just like any other label