### PR TITLE
misc(sparkjobs): add sleep to make sure metrics are flushed

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -91,8 +91,10 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
     }
 
     // quick & dirty hack to ensure that the completed metric gets published
-    if (dsSettings.shouldSleepForMetricsFlush)
+    if (dsSettings.shouldSleepForMetricsFlush) {
+      Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
       Await.result(Kamon.stopModules(), 62.seconds)
+    }
 
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?

add additional sleep/wait to make sure metrics are flushed before job exits