### PR TITLE
fix potential resource leak.

### DIFF
--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -296,11 +296,11 @@ object RepeatValueVector extends StrictLogging {
     val startNs = Utils.currentThreadCpuTimeNanos
     try {
       ChunkMap.validateNoSharedLocks(execPlan)
-      Using(rv.rows()){
+      Using.resource(rv.rows()){
         rows =>
           val nextRow = if (rows.hasNext) Some(rows.next()) else None
           new RepeatValueVector(rv.key, startMs, stepMs, endMs, nextRow, schema)
-      }.get
+      }
     } finally {
       ChunkMap.releaseAllSharedLocks()
       queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentThreadCpuTimeNanos - startNs)
@@ -573,20 +573,19 @@ object SerializedRangeVector extends StrictLogging {
       val startRecordNo = oldContainerOpt.map(_.numRecords).getOrElse(0)
       try {
         ChunkMap.validateNoSharedLocks(execPlan)
-        val rows = rv.rows
-        while (rows.hasNext) {
-          val nextRow = rows.next()
-          // Don't encode empty / NaN data over the wire
-          if (!canRemoveEmptyRows(rv.outputRange, schema) ||
-            schema.columns(1).colType == DoubleColumn && !java.lang.Double.isNaN(nextRow.getDouble(1)) ||
-            schema.columns(1).colType == HistogramColumn && !nextRow.getHistogram(1).isEmpty) {
-            numRows += 1
-            builder.addFromReader(nextRow, schema, 0)
-          }
+        Using.resource(rv.rows()) {
+          rows => while (rows.hasNext) {
+              val nextRow = rows.next()
+              // Don't encode empty / NaN data over the wire
+              if (!canRemoveEmptyRows(rv.outputRange, schema) ||
+                schema.columns(1).colType == DoubleColumn && !java.lang.Double.isNaN(nextRow.getDouble(1)) ||
+                schema.columns(1).colType == HistogramColumn && !nextRow.getHistogram(1).isEmpty) {
+                numRows += 1
+                builder.addFromReader(nextRow, schema, 0)
+              }
+            }
         }
       } finally {
-        rv.rows().close()
-        // clear exec plan
         // When the query is done, clean up lingering shared locks caused by iterator limit.
         ChunkMap.releaseAllSharedLocks()
       }


### PR DESCRIPTION
The rows() is a closable resources. We can use Using to protect it. However, the current logic calls rows() twice and only close it once. This commit would fix this issue.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Potential resource leak due to unclosed resources.

**New behavior :**
Resource leak fixed.

**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: