### PR TITLE
feat(query): Adding support of optimize_with_agg logical plan to make use of aggregated metrics in HQE

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -18,7 +18,7 @@ import filodb.query.LogicalPlan._
 import filodb.query.exec._
 import filodb.query.exec.InternalRangeFunction.Last
 
-
+//scalastyle:off file.size.limit
 /**
   * Intermediate Plan Result includes the exec plan(s) along with any state to be passed up the
   * plan building call tree during query planning.

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -239,7 +239,7 @@ trait  DefaultPlanner {
         // and applied correctly during the aggregation phase, without interfering with the underlying data
         // or query execution flow.
         vectors
-      }else{
+      } else {
         if (lp.function == MiscellaneousFunctionId.HistToPromVectors)
           vectors.plans.foreach(_.addRangeVectorTransformer(HistToPromSeriesMapper(schemas.part)))
         else

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -2,8 +2,10 @@ package filodb.coordinator.queryplanner
 
 
 import java.util.concurrent.ThreadLocalRandom
+
 import akka.serialization.SerializationExtension
 import com.typesafe.scalalogging.StrictLogging
+
 import filodb.coordinator.{ActorPlanDispatcher, ActorSystemHolder, GrpcPlanDispatcher, RemoteActorPlanDispatcher}
 import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
 import filodb.core.query._
@@ -231,13 +233,9 @@ trait  DefaultPlanner {
                                               lp: ApplyMiscellaneousFunction,
                                               forceInProcess: Boolean = false): PlanResult = {
       val vectors = walkLogicalPlanTree(lp.vectors, qContext, forceInProcess)
-      if (lp.function == MiscellaneousFunctionId.OptimizeWithAgg)
-      {
-        // The `Optimize` function is a no-operation (no-op), meaning it does not perform any transformation or
-        // computation. However, it is necessary to pass it through to the execution plan without any modifications when
-        // dealing with an "Optimize with Aggregation" query. This ensures that the optimization logic is preserved
-        // and applied correctly during the aggregation phase, without interfering with the underlying data
-        // or query execution flow.
+      if (lp.function == MiscellaneousFunctionId.OptimizeWithAgg) {
+        // Optimize` is a no-op that preserves optimization logic in
+        // aggregation queries, ensuring correct execution without modifying underlying data.
         vectors
       } else {
         if (lp.function == MiscellaneousFunctionId.HistToPromVectors)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -234,8 +234,8 @@ trait  DefaultPlanner {
                                               forceInProcess: Boolean = false): PlanResult = {
       val vectors = walkLogicalPlanTree(lp.vectors, qContext, forceInProcess)
       if (lp.function == MiscellaneousFunctionId.OptimizeWithAgg) {
-        // Optimize` is a no-op that preserves optimization logic in
-        // aggregation queries, ensuring correct execution without modifying underlying data.
+        // Optimize with aggregation is a no-op, doing no transformation. It must pass through
+        // the execution plan to apply optimization logic correctly during aggregation.
         vectors
       } else {
         if (lp.function == MiscellaneousFunctionId.HistToPromVectors)

--- a/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
@@ -1065,6 +1065,8 @@ object ProtoConverters {
         case filodb.query.MiscellaneousFunctionId.LabelJoin => GrpcMultiPartitionQueryService.MiscellaneousFunctionId.LABEL_JOIN
         case filodb.query.MiscellaneousFunctionId.HistToPromVectors =>
           GrpcMultiPartitionQueryService.MiscellaneousFunctionId.HIST_TO_PROM_VECTORS
+        case filodb.query.MiscellaneousFunctionId.OptimizeWithAgg =>
+          GrpcMultiPartitionQueryService.MiscellaneousFunctionId.OPTIMIZE_WITH_AGG
       }
       function
     }
@@ -1077,6 +1079,8 @@ object ProtoConverters {
         case GrpcMultiPartitionQueryService.MiscellaneousFunctionId.LABEL_JOIN => filodb.query.MiscellaneousFunctionId.LabelJoin
         case GrpcMultiPartitionQueryService.MiscellaneousFunctionId.HIST_TO_PROM_VECTORS =>
           filodb.query.MiscellaneousFunctionId.HistToPromVectors
+        case GrpcMultiPartitionQueryService.MiscellaneousFunctionId.OPTIMIZE_WITH_AGG =>
+          filodb.query.MiscellaneousFunctionId.OptimizeWithAgg
         case GrpcMultiPartitionQueryService.MiscellaneousFunctionId.UNRECOGNIZED =>
           throw new IllegalArgumentException(s"Unrecognized MiscellaneousFunctionId ${f}")
       }

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -653,6 +653,7 @@ enum MiscellaneousFunctionId {
   LABEL_REPLACE        = 0;
   LABEL_JOIN           = 1;
   HIST_TO_PROM_VECTORS = 2;
+  OPTIMIZE_WITH_AGG    = 3;
 }
 
 enum BinaryOperator {

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -96,7 +96,6 @@ case class Function(name: String, allParams: Seq[Expression]) extends Expression
     val instantFunctionIdOpt = InstantFunctionId.withNameInsensitiveOption(name)
     val filoFunctionIdOpt = FiloFunctionId.withNameInsensitiveOption(name)
     val scalarFunctionIdOpt = ScalarFunctionId.withNameInsensitiveOption(name)
-    val miscellaneousFunctionId = MiscellaneousFunctionId.withNameInsensitiveOption(name);
     if (vectorFn.isDefined) {
       allParams.head match {
         case num: ScalarExpression => val params = RangeParams(timeParams.start, timeParams.step, timeParams.end)
@@ -139,11 +138,7 @@ case class Function(name: String, allParams: Seq[Expression]) extends Expression
           case FiloFunctionId.ChunkMetaAll =>   // Just get the raw chunk metadata
             RawChunkMeta(rangeSelector, filters, column.getOrElse(""))
         }
-      } else if(miscellaneousFunctionId.isDefined) { //
-        toSeriesPlanMisc(seriesParam, otherParams, timeParams) // need to update this logic
-      }
-      else toSeriesPlanMisc(seriesParam, otherParams, timeParams)
-      }
+      } else toSeriesPlanMisc(seriesParam, otherParams, timeParams)
     }
   }
 

--- a/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/ast/Functions.scala
@@ -96,6 +96,7 @@ case class Function(name: String, allParams: Seq[Expression]) extends Expression
     val instantFunctionIdOpt = InstantFunctionId.withNameInsensitiveOption(name)
     val filoFunctionIdOpt = FiloFunctionId.withNameInsensitiveOption(name)
     val scalarFunctionIdOpt = ScalarFunctionId.withNameInsensitiveOption(name)
+    val miscellaneousFunctionId = MiscellaneousFunctionId.withNameInsensitiveOption(name);
     if (vectorFn.isDefined) {
       allParams.head match {
         case num: ScalarExpression => val params = RangeParams(timeParams.start, timeParams.step, timeParams.end)
@@ -138,7 +139,11 @@ case class Function(name: String, allParams: Seq[Expression]) extends Expression
           case FiloFunctionId.ChunkMetaAll =>   // Just get the raw chunk metadata
             RawChunkMeta(rangeSelector, filters, column.getOrElse(""))
         }
-      } else toSeriesPlanMisc(seriesParam, otherParams, timeParams)
+      } else if(miscellaneousFunctionId.isDefined) { //
+        toSeriesPlanMisc(seriesParam, otherParams, timeParams) // need to update this logic
+      }
+      else toSeriesPlanMisc(seriesParam, otherParams, timeParams)
+      }
     }
   }
 

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -177,6 +177,7 @@ object MiscellaneousFunctionId extends Enum[MiscellaneousFunctionId] {
   case object LabelReplace extends MiscellaneousFunctionId("label_replace")
   case object LabelJoin extends MiscellaneousFunctionId("label_join")
   case object HistToPromVectors extends MiscellaneousFunctionId("hist_to_prom_vectors")
+  case object OptimizeWithAgg extends MiscellaneousFunctionId("optimize_with_agg")
 }
 
 sealed abstract class SortFunctionId(override val entryName: String) extends EnumEntry


### PR DESCRIPTION
### Context
This PR introduces support for the optimize_with_agg function in the Logical Plan. The optimize_with_agg function is a no-operation (no-op) that is used in conjunction with aggregation queries. It ensures that the optimization logic is preserved and applied correctly during the aggregation phase without interfering with the underlying data or query execution flow. This enhancement allows users to pass queries with optimize_with_agg and see a proper Logical Plan with the correct tree structure.

### What Does This PR Do?
1. Adds `optimize_with_agg` to MiscellaneousFunctionId.
2. Updates ProtoConverters to support `optimize_with_agg`.
3. Updates Query Service Proto to include `OPTIMIZE_WITH_AGG`.
4. Modifies DefaultPlanner to handle `optimize_with_agg` as a no-op.
5. Ensures proper Logical Plan tree structure for queries with `optimize_with_agg`.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
Unsupported optimize_with_agg Function


**New behavior :**
Supported optimize_with_agg Function
