### PR TITLE
fix (core): removing logger from an execution plan

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/GrpcPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/GrpcPlanDispatcher.scala
@@ -1,6 +1,5 @@
 package filodb.coordinator
 
-import com.typesafe.scalalogging.StrictLogging
 import io.grpc.Metadata
 import io.grpc.stub.{MetadataUtils, StreamObserver}
 import java.net.InetAddress
@@ -29,7 +28,7 @@ object GrpcPlanDispatcher {
   Runtime.getRuntime.addShutdownHook(new Thread(() => channelMap.values.foreach(_.shutdown())))
 }
 
-case class GrpcPlanDispatcher(endpoint: String, requestTimeoutMs: Long) extends PlanDispatcher with StrictLogging {
+case class GrpcPlanDispatcher(endpoint: String, requestTimeoutMs: Long) extends PlanDispatcher {
 
   val clusterName = InetAddress.getLocalHost().getHostName()
 
@@ -67,8 +66,6 @@ case class GrpcPlanDispatcher(endpoint: String, requestTimeoutMs: Long) extends 
     val genericRemoteExec = plan.execPlan.asInstanceOf[GenericRemoteExec]
     import filodb.coordinator.ProtoConverters._
     val protoPlan = genericRemoteExec.execPlan.toExecPlanContainerProto
-    logger.debug(s"Query ${plan.execPlan.queryContext.queryId} proto plan size is  ${protoPlan.toByteArray.length}B")
-    logger.debug(s"Query ${plan.execPlan.queryContext.queryId} exec plan ${genericRemoteExec.execPlan.printTree()}")
     val queryContextProto = genericRemoteExec.execPlan.queryContext.toProto
     val remoteExecPlan : RemoteExecPlan = RemoteExecPlan.newBuilder()
       .setExecPlan(protoPlan)


### PR DESCRIPTION
**Pull Request checklist**

- [ X ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
When a GRPCPlanDispatcher needs to be serialized using Kryo (as opposed to ProtoBuf) it fails because the class has a member that does not have a default constructor (logger). Serialization fails and shard level failover fails.


**New behavior :**
Removed the logger from the execution class, serialization does not fail.


**BREAKING CHANGES**
n/a

**Other information**: