### PR TITLE
fix(build): pinning the ubuntu base version of github action workflow to unblock test suites

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** FiloDB's test suite is not compatible with the ubuntu-latest image of GitHub actions - [ubuntu-24 image rollout announcement](https://github.com/actions/runner-images/issues/10636)


**New behavior :** Pinning the FiloDB github action's image to `ubuntu-22` image for now, to unblock the test runs.