### PR TITLE
fix Unexpected Range Vector Transformer.

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
@@ -1923,6 +1923,25 @@ object ProtoConverters {
     }
   }
 
+  // RepeatTransformer
+  implicit class RepeatTransformerToProtoConverter(rpt: RepeatTransformer) {
+    def toProto: GrpcMultiPartitionQueryService.RepeatTransformer = {
+      val builder = GrpcMultiPartitionQueryService.RepeatTransformer.newBuilder()
+      builder.setStartMs(rpt.startMs)
+      builder.setStepMs(rpt.stepMs)
+      builder.setEndMs(rpt.endMs)
+      builder.setExecPlan(rpt.execPlan)
+      builder.build()
+    }
+  }
+
+  implicit class RepeatTransformerFromProtoConverter(rpt: GrpcMultiPartitionQueryService.RepeatTransformer) {
+    def fromProto(): RepeatTransformer = {
+      //      RepeatTransformer(0, 0, 0, "")
+      RepeatTransformer(rpt.getStartMs, rpt.getStepMs, rpt.getEndMs, rpt.getExecPlan)
+    }
+  }
+
 
   implicit class RangeVectorTransformerToProtoConverter(rangeVectorTransformer: RangeVectorTransformer) {
     def toProto(): GrpcMultiPartitionQueryService.RangeVectorTransformerContainer = {
@@ -1943,6 +1962,7 @@ object ProtoConverters {
         case vfm: VectorFunctionMapper => b.setVectorFunctionMapper(vfm.toProto).build()
         case ap: AggregatePresenter => b.setAggregatePresenter(ap.toProto).build()
         case afm: AbsentFunctionMapper => b.setAbsentFunctionMapper(afm.toProto).build()
+        case rpt: RepeatTransformer => b.setRepeatTransformer(rpt.toProto).build()
         case _ => throw new IllegalArgumentException("Unexpected Range Vector Transformer")
       }
     }
@@ -1967,6 +1987,7 @@ object ProtoConverters {
         case RangeVectorTransfomerCase.VECTORFUNCTIONMAPPER => rvtc.getVectorFunctionMapper().fromProto
         case RangeVectorTransfomerCase.AGGREGATEPRESENTER => rvtc.getAggregatePresenter().fromProto(queryContext)
         case RangeVectorTransfomerCase.ABSENTFUNCTIONMAPPER => rvtc.getAbsentFunctionMapper().fromProto
+        case RangeVectorTransfomerCase.REPEATTRANSFORMER => rvtc.getRepeatTransformer().fromProto
         case RangeVectorTransfomerCase.RANGEVECTORTRANSFOMER_NOT_SET =>
           throw new IllegalArgumentException("Unexpected Range Vector Transformer")
       }

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -777,6 +777,13 @@ message AbsentFunctionMapper {
   string metricColumn                = 3;
 }
 
+message RepeatTransformer {
+    int64 startMs     = 1;
+    int64 stepMs      = 2;
+    int64 endMs       = 3;
+    string execPlan   = 4;
+}
+
 message RangeVectorTransformerContainer {
   oneof rangeVectorTransfomer {
     StitchRvsMapper stitchRvsMapper                         =  1;
@@ -794,6 +801,7 @@ message RangeVectorTransformerContainer {
     VectorFunctionMapper vectorFunctionMapper               = 13;
     AggregatePresenter aggregatePresenter                   = 14;
     AbsentFunctionMapper AbsentFunctionMapper               = 15;
+    RepeatTransformer  repeatTransformer                    = 16;
   }
 }
 


### PR DESCRIPTION
RepeatTransformer should be added as a case.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: