### PR TITLE
query(fix) planning for local and remote clusters only if absolutely needed

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -175,8 +175,6 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
     if (execPlans.size == 1) execPlans.head
     else stitchPlans(rootLogicalPlan, execPlans, qContext)
   }
-  //scalastyle:on method.length
-
 
   override def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
     val origQueryParams = qContext.origQueryParams
@@ -216,7 +214,8 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
       // we need to populate planner params with the shard maps
       val localActiveShardMapper = getLocalActiveShardMapper(qContext.plannerParams)
       val remoteActiveShardMapper = getRemoteActiveShardMapper(qContext.plannerParams)
-      val shardLevelFailoverIsNeeded = (!localActiveShardMapper.allShardsActive) && (!remoteActiveShardMapper.allShardsActive)
+      val shardLevelFailoverIsNeeded =
+        (!localActiveShardMapper.allShardsActive) && (!remoteActiveShardMapper.allShardsActive)
       if (shardLevelFailoverIsNeeded) {
         val plannerParams = qContext.plannerParams.copy(
           localShardMapper = Some(localActiveShardMapper),
@@ -231,6 +230,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
       materializeLegacy(logicalPlan, qContext)
     }
   }
+  //scalastyle:on method.length
 
   def materializeLegacy(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
     // lazy because we want to fetch failures only if needed


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
If shard level failover (SLFO) is enabled even if a full failover happens (ie the entire query is forwarded to the buddy cluster), planning of the entire query happens on a remote cluster. In that case the plan might be fairly big because proto execution plans do not have references. This might cause issues as the plan size can go above 30MB. 


**New behavior :**
When FULL failover happens (ie we do not just pull data from a few shards from the buddy cluster), we will continue to forward promql as we used to do previously (legacy full failover). Shard level failover would be planned entirely on the cluster that received the request. This should not cause issues as the proto plans that would be sent to the buddy clusters will be very small (not entire query plan but just the plans corresponding to the raw data of the shards).


**BREAKING CHANGES**

n/a

**Other information**: