### PR TITLE
query(fix): enforce legacy failover when needed

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -232,7 +232,12 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
   }
   //scalastyle:on method.length
 
-  def materializeLegacy(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
+  def materializeLegacy(logicalPlan: LogicalPlan, oqContext: QueryContext): ExecPlan = {
+    // ensure that we do not use any features of shard level failover
+    val plannerParams = oqContext.plannerParams.copy(
+      failoverMode = LegacyFailoverMode
+    )
+    val qContext = oqContext.copy(plannerParams = plannerParams)
     // lazy because we want to fetch failures only if needed
     lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan)
     lazy val periodicSeriesTime = getTimeFromLogicalPlan(logicalPlan)


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
If shard level failover is enabled but is not required, ie the local cluster is not healthy but the remote cluster is healthy we switch to legacy failover when promql is issued to the buddy cluster. However, the query context parameters still have shard level failover flag enabled that does not allow to properly resolve shards.

**New behavior :**
When legacy failover is enabled the query context parameter is set to "legacy".


**BREAKING CHANGES**

n/a