### PR TITLE
fix (query): cherry picking ensure that legacy failover stays legacy failover 

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -232,7 +232,12 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
   }
   //scalastyle:on method.length
 
-  def materializeLegacy(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
+  def materializeLegacy(logicalPlan: LogicalPlan, oqContext: QueryContext): ExecPlan = {
+    // ensure that we do not use any features of shard level failover
+    val plannerParams = oqContext.plannerParams.copy(
+      failoverMode = LegacyFailoverMode
+    )
+    val qContext = oqContext.copy(plannerParams = plannerParams)
     // lazy because we want to fetch failures only if needed
     lazy val offsetMillis = LogicalPlanUtils.getOffsetMillis(logicalPlan)
     lazy val periodicSeriesTime = getTimeFromLogicalPlan(logicalPlan)


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: