### PR TITLE
fix(memstore): account for clock drift during latency measurement

### DIFF
--- a/core/src/main/scala/filodb.core/RateLimiter.scala
+++ b/core/src/main/scala/filodb.core/RateLimiter.scala
@@ -21,7 +21,7 @@ class RateLimiter(period: Duration) {
    */
   def attempt(): Boolean = {
     val nowMillis = System.currentTimeMillis()
-    if (System.currentTimeMillis() - lastSuccessMillis > period.toMillis) {
+    if (nowMillis - lastSuccessMillis > period.toMillis) {
       lastSuccessMillis = nowMillis
       return true
     }

--- a/core/src/main/scala/filodb.core/RateLimiter.scala
+++ b/core/src/main/scala/filodb.core/RateLimiter.scala
@@ -1,0 +1,30 @@
+package filodb.core
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Rate-limiter utility.
+ * @param period a "successful" attempt will be indicated only after a full
+ *               period has elapsed since the previous success.
+ */
+class RateLimiter(period: Duration) {
+  var lastSuccessMillis = 0L;
+
+  /**
+   * Returns true to indicate an attempt was "successful", else it was "failed".
+   * Successes are returned only after a full period has elapsed since the previous success.
+   *
+   * NOTE: this operation is not thread-safe, but if at least one concurrent invocation is
+   *   successful, then one of the successful timestamps will be recorded internally as the
+   *   most-recent success. In practice, this means async calls may succeed in bursts (which
+   *   may be acceptable in some use-cases).
+   */
+  def attempt(): Boolean = {
+    val nowMillis = System.currentTimeMillis()
+    if (System.currentTimeMillis() - lastSuccessMillis > period.toMillis) {
+      lastSuccessMillis = nowMillis
+      return true
+    }
+    false
+  }
+}

--- a/core/src/main/scala/filodb.core/RateLimiter.scala
+++ b/core/src/main/scala/filodb.core/RateLimiter.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
  *               period has elapsed since the previous success.
  */
 class RateLimiter(period: Duration) {
-  var lastSuccessMillis = 0L;
+  private var lastSuccessMillis = 0L;
 
   /**
    * Returns true to indicate an attempt was "successful", else it was "failed".

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -321,7 +321,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   // This should be handled by a logging-specific class if rate-limited logs become a common use-case.
   // NOTE: This is not thread-safe, but it's good enough for this application--
   //   see RateLimiter's javadoc for details.
-  private val negativeIngestionTimeLogRateLimiter = new RateLimiter(Duration(10, TimeUnit.SECONDS))
+  private val negativeIngestionTimeLogRateLimiter = new RateLimiter(Duration(30, TimeUnit.SECONDS))
 
   /**
     * This index helps identify which partitions have any given column-value.

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -126,8 +126,6 @@ class TimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
 
   /**
    * Records the absolute value of otherwise-negative ingestion pipeline latencies.
-   * Negative latencies are exclusively recorded here; they are not recorded
-   *   by the above ingestionPipelineLatency metric.
    */
   val negativeIngestionPipelineLatency = Kamon.histogram("negative-ingestion-pipeline-latency",
     MeasurementUnit.time.milliseconds).withTags(TagSet.from(tags))

--- a/core/src/test/scala/filodb.core/RateLimiterSpec.scala
+++ b/core/src/test/scala/filodb.core/RateLimiterSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration.Duration
 
 class RateLimiterSpec extends AnyFunSpec with Matchers {
   it("should apply rate-limits accordingly") {
-    val rateLimiter = new RateLimiter(Duration(1, TimeUnit.SECONDS))
+    val rateLimiter = new RateLimiter(Duration(2, TimeUnit.SECONDS))
 
     // First attempt should succeed.
     rateLimiter.attempt() shouldEqual true
@@ -20,7 +20,7 @@ class RateLimiterSpec extends AnyFunSpec with Matchers {
     rateLimiter.attempt() shouldEqual false
 
     // Wait the period...
-    Thread.sleep(1000)
+    Thread.sleep(2000)
 
     // Next attempt should succeed.
     rateLimiter.attempt() shouldEqual true

--- a/core/src/test/scala/filodb.core/RateLimiterSpec.scala
+++ b/core/src/test/scala/filodb.core/RateLimiterSpec.scala
@@ -4,7 +4,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Executors, TimeUnit}
 import scala.concurrent.duration.Duration
 
 class RateLimiterSpec extends AnyFunSpec with Matchers {
@@ -29,5 +30,62 @@ class RateLimiterSpec extends AnyFunSpec with Matchers {
     rateLimiter.attempt() shouldEqual false
     rateLimiter.attempt() shouldEqual false
     rateLimiter.attempt() shouldEqual false
+  }
+
+  it("should reasonably rate-limit concurrent threads") {
+    val nThreads = 100
+    val period = Duration(1, TimeUnit.SECONDS)
+    val nPeriods = 5
+
+    val rateLimiter = new RateLimiter(period)
+    val pool = Executors.newFixedThreadPool(nThreads)
+
+    // All threads will try to increment the time-appropriate counter.
+    // At the end of the test, there should be at least one counted per period,
+    //   and no single counter should exceed the count of threads (i.e. at least one thread
+    //   was paused long enough that it updated the RateLimiter's internal timestamp
+    //   to something in the previous period.
+    val periodCounters = (0 until nPeriods).map(_ => new AtomicInteger(0))
+
+    // Prep the runnable (some of these variables are updated later).
+    var startMillis = -1L
+    var isStarted = false
+    var isShutdown = false
+    val runnable: Runnable = () => {
+      while (!isStarted) {
+        Thread.sleep(500)
+      }
+      while (!isShutdown) {
+        if (rateLimiter.attempt()) {
+          val iPeriod = (System.currentTimeMillis() - startMillis) / period.toMillis
+          periodCounters(iPeriod.toInt).incrementAndGet()
+        }
+      }
+    }
+
+    // Kick off the threads and start the test.
+    for (i <- 0 until nThreads) {
+      pool.submit(runnable)
+    }
+    startMillis = System.currentTimeMillis()
+    isStarted = true
+
+    // Wait for all periods to elapse.
+    Thread.sleep(nPeriods * period.toMillis)
+
+    // Shutdown and wait for everything to finish.
+    isShutdown = true
+    pool.shutdown()
+    while (!pool.isTerminated) {
+      Thread.sleep(1000)
+    }
+
+    periodCounters.forall(_.get() > 0) shouldEqual true
+    periodCounters.map(_.get()).max <= nThreads
+
+    // Typical local "println(periodCounters)" output:
+    //   Vector(1, 34, 1, 1, 1)
+    //   Vector(1, 20, 1, 1, 1)
+    //   Vector(1, 13, 1, 2, 1)
   }
 }

--- a/core/src/test/scala/filodb.core/RateLimiterSpec.scala
+++ b/core/src/test/scala/filodb.core/RateLimiterSpec.scala
@@ -1,0 +1,33 @@
+package filodb.core
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+
+class RateLimiterSpec extends AnyFunSpec with Matchers {
+  it("should apply rate-limits accordingly") {
+    val rateLimiter = new RateLimiter(Duration(1, TimeUnit.SECONDS))
+
+    // First attempt should succeed.
+    rateLimiter.attempt() shouldEqual true
+
+    // Others before a full period has elapsed should fail.
+    rateLimiter.attempt() shouldEqual false
+    rateLimiter.attempt() shouldEqual false
+    rateLimiter.attempt() shouldEqual false
+
+    // Wait the period...
+    Thread.sleep(1000)
+
+    // Next attempt should succeed.
+    rateLimiter.attempt() shouldEqual true
+
+    // Again, attempts should fail until a period has elapsed.
+    rateLimiter.attempt() shouldEqual false
+    rateLimiter.attempt() shouldEqual false
+    rateLimiter.attempt() shouldEqual false
+  }
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

"Negative" ingestion latencies i.e. where a `RecordContainer`'s timestamp occurs after the current time) might occur as a result of clock skew.

Currently, negative ingestion latencies will cause Kamon histograms to throw exceptions.

This PR adds one additional metric `negativeIngestionPipelineLatency` to record negative pipeline latencies (as their absolute values). Additionally, values recorded into the two usual ingestion latency metrics are now wrapped inside `Math.max(0, value)` calls.