### PR TITLE
feat(query) Range function to identify outliers using MAD

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
@@ -996,6 +996,7 @@ object ProtoConverters {
         case InternalRangeFunction.AbsentOverTime => GrpcMultiPartitionQueryService.InternalRangeFunction.ABSENT_OVER_TIME
         case InternalRangeFunction.PresentOverTime => GrpcMultiPartitionQueryService.InternalRangeFunction.PRESENT_OVER_TIME
         case InternalRangeFunction.MedianAbsoluteDeviationOverTime => GrpcMultiPartitionQueryService.InternalRangeFunction.MEDIAN_ABSOLUTE_DEVIATION_OVER_TIME
+        case InternalRangeFunction.LastOverTimeIsMadOutlier => GrpcMultiPartitionQueryService.InternalRangeFunction.LAST_OVER_TIME_IS_MAD_OUTLIER
       }
       function
     }
@@ -1034,6 +1035,7 @@ object ProtoConverters {
         case GrpcMultiPartitionQueryService.InternalRangeFunction.ABSENT_OVER_TIME => InternalRangeFunction.AbsentOverTime
         case GrpcMultiPartitionQueryService.InternalRangeFunction.PRESENT_OVER_TIME => InternalRangeFunction.PresentOverTime
         case GrpcMultiPartitionQueryService.InternalRangeFunction.MEDIAN_ABSOLUTE_DEVIATION_OVER_TIME => InternalRangeFunction.MedianAbsoluteDeviationOverTime
+        case GrpcMultiPartitionQueryService.InternalRangeFunction.LAST_OVER_TIME_IS_MAD_OUTLIER => InternalRangeFunction.LastOverTimeIsMadOutlier
         case GrpcMultiPartitionQueryService.InternalRangeFunction.UNRECOGNIZED =>
           throw new IllegalArgumentException(s"Unrecognized InternalRangeFunction ${f}")
       }

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -642,6 +642,7 @@ enum InternalRangeFunction {
   PRESENT_OVER_TIME     = 27;
   MEDIAN_ABSOLUTE_DEVIATION_OVER_TIME = 28;
   RATE_AND_MIN_MAX_OVER_TIME = 29;
+  LAST_OVER_TIME_IS_MAD_OUTLIER = 30;
 }
 
 enum SortFunctionId {

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -77,6 +77,7 @@ object RangeFunctionId extends Enum[RangeFunctionId] {
   case object AbsentOverTime extends RangeFunctionId("absent_over_time", Seq(RangeVectorParam()))
   case object PresentOverTime extends RangeFunctionId("present_over_time", Seq(RangeVectorParam()))
   case object MedianAbsoluteDeviationOverTime extends RangeFunctionId("mad_over_time", Seq(RangeVectorParam()))
+  case object LastOverTimeIsMadOutlier extends RangeFunctionId("last_over_time_is_mad_outlier", Seq(RangeVectorParam()))
 }
 
 sealed abstract class FiloFunctionId(override val entryName: String) extends EnumEntry

--- a/query/src/main/scala/filodb/query/exec/InternalRangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/InternalRangeFunction.scala
@@ -67,6 +67,8 @@ object InternalRangeFunction {
 
   case object MedianAbsoluteDeviationOverTime extends InternalRangeFunction
 
+  case object LastOverTimeIsMadOutlier extends InternalRangeFunction
+
   //scalastyle:off cyclomatic.complexity
   def lpToInternalFunc(extFuncId: RangeFunctionId): InternalRangeFunction = extFuncId match {
     case RangeFunctionId.AvgOverTime      => AvgOverTime
@@ -94,6 +96,7 @@ object InternalRangeFunction {
     case RangeFunctionId.AbsentOverTime   => AbsentOverTime
     case RangeFunctionId.PresentOverTime  => PresentOverTime
     case RangeFunctionId.MedianAbsoluteDeviationOverTime => MedianAbsoluteDeviationOverTime
+    case RangeFunctionId.LastOverTimeIsMadOutlier => LastOverTimeIsMadOutlier
   }
   //scalastyle:on cyclomatic.complexity
 }

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -961,7 +961,6 @@ class MedianAbsoluteDeviationOverTimeChunkedFunctionD
                                 doubleReader: bv.DoubleVectorDataReader,
                                 startRowNum: Int,
                                 endRowNum: Int): Unit = {
-    var rowNum = startRowNum
     val it = doubleReader.iterate(doubleVectAcc, doubleVect, startRowNum)
 
     for (_ <- startRowNum to endRowNum) {

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -1,9 +1,9 @@
 package filodb.query.exec.rangefn
 
 import java.lang.{Double => JLDouble}
+import java.util
 
 import debox.Buffer
-import java.util
 
 import filodb.core.query.{QueryConfig, TransientHistMaxMinRow, TransientHistRow, TransientRow}
 import filodb.core.store.ChunkSetInfoReader
@@ -268,7 +268,62 @@ class MedianAbsoluteDeviationOverTimeFunction(funcParams: Seq[Any]) extends Rang
       medianAbsoluteDeviationResult = diffFromMedians(lowerIndex)*(1-weight) + diffFromMedians(upperIndex)*weight
     }
     sampleToEmit.setValues(endTimestamp, medianAbsoluteDeviationResult)
+  }
+}
 
+class LastOverTimeIsMadOutlierFunction(funcParams: Seq[Any]) extends RangeFunction {
+  require(funcParams.size == 1, "last_over_time_is_mad_outlier function needs a single tolerance argument")
+  require(funcParams.head.isInstanceOf[StaticFuncArgs], "tolerance parameter must be a number")
+
+  override def addedToWindow(row: TransientRow, window: Window): Unit = {
+  }
+
+  override def removedFromWindow(row: TransientRow, window: Window): Unit = {
+  }
+
+  override def apply(startTimestamp: Long, endTimestamp: Long, window: Window,
+                      sampleToEmit: TransientRow,
+                      queryConfig: QueryConfig
+                    ): Unit = {
+    val size = window.size
+    if (size > 0) {
+      // find median
+      val q = 0.5
+      val values: Buffer[Double] = Buffer.ofSize(size)
+      for (i <- 0 until size) {
+        val curValue = window.apply(i).getDouble(1)
+        if (!curValue.isNaN) {
+          values.append(curValue)
+        }
+      }
+      values.sort(spire.algebra.Order.fromOrdering[Double])
+      val (weight, upperIndex, lowerIndex) = QuantileOverTimeFunction.calculateRank(q, size)
+      val median = values(lowerIndex)*(1-weight) + values(upperIndex)*weight
+
+      // distance from median
+      val distFromMedian: Buffer[Double] = Buffer.ofSize(size)
+      for (i <- 0 until size) {
+        val curValue = window.apply(i).getDouble(1)
+        distFromMedian.append(Math.abs(median - curValue))
+      }
+
+      // mad = median of absolute distances from median
+      distFromMedian.sort(spire.algebra.Order.fromOrdering[Double])
+      val mad = distFromMedian(lowerIndex)*(1-weight) + distFromMedian(upperIndex)*weight
+
+      // classify last point as anomaly if it's more than `tolerance * mad` away from median
+      val tolerance = funcParams.head.asInstanceOf[StaticFuncArgs].scalar
+      val lowerBound = median - tolerance * mad
+      val upperBound = median + tolerance * mad
+      val lastValue = window.last.getDouble(1)
+      if (lastValue < lowerBound || lastValue > upperBound) {
+        sampleToEmit.setValues(endTimestamp, lastValue)
+      } else {
+        sampleToEmit.setValues(endTimestamp, Double.NaN)
+      }
+    } else {
+      sampleToEmit.setValues(endTimestamp, Double.NaN)
+    }
   }
 }
 

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -310,7 +310,7 @@ object RangeFunction {
       case Some(CountOverTime)                    => () => new CountOverTimeChunkedFunction()
       case Some(SumOverTime)                      => () => new SumOverTimeChunkedFunctionL
       case Some(AvgWithSumAndCountOverTime)       => require(schema.columns(2).name == "count")
-                                   () => new AvgWithSumAndCountOverTimeFuncL(schema.colIDs(2))
+                                                     () => new AvgWithSumAndCountOverTimeFuncL(schema.colIDs(2))
       case Some(AvgOverTime)                      => () => new AvgOverTimeChunkedFunctionL
       case Some(MinOverTime)                      => () => new MinOverTimeChunkedFunctionL
       case Some(MaxOverTime)                      => () => new MaxOverTimeChunkedFunctionL

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -431,7 +431,8 @@ object RangeFunction {
     case Some(Changes)                          => () => ChangesOverTimeFunction
     case Some(QuantileOverTime)                 => () => new QuantileOverTimeFunction(funcParams)
     case Some(MedianAbsoluteDeviationOverTime)  => () => new MedianAbsoluteDeviationOverTimeFunction(funcParams)
-    case _                            => ??? //TODO enumerate all possible cases
+    case Some(LastOverTimeIsMadOutlier)         => () => new LastOverTimeIsMadOutlierFunction(funcParams)
+    case _                                      => ??? //TODO enumerate all possible cases
   }
 }
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -364,6 +364,8 @@ class AggrOverTimeFunctionsSpec extends RawDataWindowingSpec {
     val minSlidingIt = slidingWindowIt(data, rv, new LastOverTimeIsMadOutlierFunction(Seq(StaticFuncArgs(4, rangeParams))), windowSize, step)
     val result = minSlidingIt.map(_.getDouble(1)).toBuffer
     minSlidingIt.close()
+    info("Anomalies: " + anomalies)
+    info("Result: " + result)
     result.zip(anomalies).foreach { case (r, a) =>
       if (a.isNaN) r.isNaN shouldEqual true
       else r shouldEqual a

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -347,6 +347,29 @@ class AggrOverTimeFunctionsSpec extends RawDataWindowingSpec {
     }
   }
 
+  it("should correctly identify outliers with mad using sliding iterators") {
+    val data = (0 until 200).map { i =>
+      if ((i+1) % 20 == 0) 2.3d
+      else rand.nextDouble()
+    }
+    val rv = timeValueRV(data)
+    val rangeParams = RangeParams(100, 20, 500)
+    val windowSize = 20
+    val step = 5
+
+    val anomalies = data.sliding(windowSize, step).map { k =>
+      if (k.last > 1.0) k.last else Double.NaN
+    }.toBuffer
+
+    val minSlidingIt = slidingWindowIt(data, rv, new LastOverTimeIsMadOutlierFunction(Seq(StaticFuncArgs(4, rangeParams))), windowSize, step)
+    val result = minSlidingIt.map(_.getDouble(1)).toBuffer
+    minSlidingIt.close()
+    result.zip(anomalies).foreach { case (r, a) =>
+      if (a.isNaN) r.isNaN shouldEqual true
+      else r shouldEqual a
+    }
+  }
+
   it("should correctly aggregate min_over_time / max_over_time using both chunked and sliding iterators") {
     val data = (1 to 240).map(_.toDouble)
     val chunkSize = 40


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

New range function `last_over_time_is_mad_outlier()` which classifies the last data point in the range window as an anomaly  or not based on other points in the window.

This is especially useful in subqueries. This query executes a subquery and calculates outliers in request rate for a service. The outlier points are returned as part of the results.
```
last_over_time_is_mad_outlier(3, sum(rate(http_req_total{...}[5m]))[1d:5m])
```

