### PR TITLE
fix(memstore): fix flaky rate-limiter test

### DIFF
--- a/core/src/main/scala/filodb.core/RateLimiter.scala
+++ b/core/src/main/scala/filodb.core/RateLimiter.scala
@@ -20,7 +20,7 @@ class RateLimiter(period: Duration) {
    *   may be acceptable in some use-cases).
    */
   def attempt(): Boolean = {
-    val nowMillis = System.currentTimeMillis()
+    val nowMillis = Math.max(System.currentTimeMillis(), lastSuccessMillis)
     if (nowMillis - lastSuccessMillis > period.toMillis) {
       lastSuccessMillis = nowMillis
       return true

--- a/core/src/main/scala/filodb.core/RateLimiter.scala
+++ b/core/src/main/scala/filodb.core/RateLimiter.scala
@@ -20,6 +20,7 @@ class RateLimiter(period: Duration) {
    *   may be acceptable in some use-cases).
    */
   def attempt(): Boolean = {
+    // Wrapping in a max() because System.currentTimeMillis() is not monotonic.
     val nowMillis = Math.max(System.currentTimeMillis(), lastSuccessMillis)
     if (nowMillis - lastSuccessMillis > period.toMillis) {
       lastSuccessMillis = nowMillis

--- a/core/src/main/scala/filodb.core/RateLimiter.scala
+++ b/core/src/main/scala/filodb.core/RateLimiter.scala
@@ -20,6 +20,7 @@ class RateLimiter(period: Duration) {
    *   may be acceptable in some use-cases).
    */
   def attempt(): Boolean = {
+    // Using nanoTime() because it is monotonic.
     val nowNanos = System.nanoTime()
     if (nowNanos - lastSuccessNanos > period.toNanos) {
       lastSuccessNanos = nowNanos

--- a/core/src/main/scala/filodb.core/RateLimiter.scala
+++ b/core/src/main/scala/filodb.core/RateLimiter.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
  *               period has elapsed since the previous success.
  */
 class RateLimiter(period: Duration) {
-  private var lastSuccessMillis = 0L;
+  private var lastSuccessNanos = 0L;
 
   /**
    * Returns true to indicate an attempt was "successful", else it was "failed".
@@ -20,10 +20,9 @@ class RateLimiter(period: Duration) {
    *   may be acceptable in some use-cases).
    */
   def attempt(): Boolean = {
-    // Wrapping in a max() because System.currentTimeMillis() is not monotonic.
-    val nowMillis = Math.max(System.currentTimeMillis(), lastSuccessMillis)
-    if (nowMillis - lastSuccessMillis > period.toMillis) {
-      lastSuccessMillis = nowMillis
+    val nowNanos = System.nanoTime()
+    if (nowNanos - lastSuccessNanos > period.toNanos) {
+      lastSuccessNanos = nowNanos
       return true
     }
     false

--- a/core/src/test/scala/filodb.core/RateLimiterSpec.scala
+++ b/core/src/test/scala/filodb.core/RateLimiterSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.Duration
 
 class RateLimiterSpec extends AnyFunSpec with Matchers {
   it("should apply rate-limits accordingly") {
-    val rateLimiter = new RateLimiter(Duration(2, TimeUnit.SECONDS))
+    val rateLimiter = new RateLimiter(Duration(1, TimeUnit.SECONDS))
 
     // First attempt should succeed.
     rateLimiter.attempt() shouldEqual true


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

New `RateLimiter` tests are flaky. Two possible resons:
- `System.currentTimeMillis()` is [random enough](https://stackoverflow.com/a/2979239) that the tests fail.
- One of the test’s `Thread.sleep()`s was too short prior to a validation.

This PR addresses both possible problems (and will be merged only after 5 consecutive PRB successes).