### PR TITLE
fix(index) Clean directory before rebuild

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -215,6 +215,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                                 // do not notify listener as the map operation will be updating the state
                                 indexRefresh(endHour, startHour, periodicRefresh = false)
       case None             => // No checkpoint time found, start refresh from scratch
+                                // Clean the index directory  first to ensure we are starting from scratch
+                                partKeyIndex.cleanIndexDirectory()
                                 val parallelism = Math.round(downsampleConfig.indexRebuildParallelismMultiplier *
                                                     Runtime.getRuntime.availableProcessors()).toInt.max(1)
                                 logger.info("Rebuilding index with parallelism {}", parallelism)

--- a/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
@@ -99,9 +99,6 @@ abstract class PartKeyIndexRaw(ref: DatasetRef,
     logger.info(s"Cleaning up indexDirectory=$indexDiskLocation for  dataset=$ref, shard=$shardNum")
     cleanIndexDirectory()
   }
-  //else {
-  // TODO here we assume there is non-empty index which we need to validate
-  //}
 
   def cleanIndexDirectory(): Unit = {
     Utils.deleteRecursively(indexDiskLocation.toFile) match {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
If an index rebuild is interrupted mid way, the snap and generation file is not present, this will cause the index to be rebuilt from scratch building upon the existing half built index which will elevate the disk usage

**New behavior :**
Since the index is rebuilt from scratch, delete what's all already in place. 


