### PR TITLE
bug(core): Type field not returned in mult-label-value query + unit test fix

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -117,6 +117,6 @@
         # Retention of downsampled data for the corresponding resolution
         ttls = [ 30 days, 183 days ]
         # Raw schemas from which to downsample
-        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram", "delta-counter", "delta-histogram"]
+        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram", "delta-counter", "delta-histogram", "otel-delta-histogram"]
       }
     }

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -333,7 +333,7 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
       case (DoubleColumn, i) if cols.contains(colNames(i)) =>
                               res(cols.indexOf(colNames(i))) = getDouble(base, offset, i).toString
       case (StringColumn, i) if cols.contains(colNames(i)) =>
-                              res(cols.indexOf(colNames(i))) = asJavaString(base, offset, i).toString
+                              res(cols.indexOf(colNames(i))) = asJavaString(base, offset, i)
       case (TimestampColumn, i) if cols.contains(colNames(i)) =>
                               res(cols.indexOf(colNames(i))) = getLong(base, offset, i).toString
       case (MapColumn, i)    => val consumer = new SelectColsMapItemConsumer(cols, res)
@@ -342,6 +342,8 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
       case (HistogramColumn, i) => ???
       case _ => // column not selected
     }
+    if (cols.contains(Schemas.TypeLabel)) res(cols.indexOf(Schemas.TypeLabel)) =
+      Schemas.global.schemaName(RecordSchema.schemaID(base, offset))
     res
   }
 

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -103,6 +103,19 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
     metadata.next shouldEqual Map("instance".utf8 -> "someHost:8787".utf8)
   }
 
+  it ("should read the metadata label values for multiple labels: instance, _type_") {
+    import ZeroCopyUTF8String._
+    val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
+      ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+
+    val metadata = memStore.labelValuesWithFilters(timeseriesDataset.ref, 0,
+      filters, labelNames = Seq("instance", "_type_"), now, now - 5000, QuerySession.makeForTestingOnly, 10)
+
+    metadata.hasNext shouldEqual true
+    metadata.next shouldEqual Map("instance".utf8 -> "someHost:8787".utf8, "_type_".utf8 -> "schemaID:35859".utf8)
+  }
+
+
   it ("should return expected values for isCorrectPartitionForCardinalityQuery") {
     memStore.isCorrectPartitionForCardinalityQuery(QueryContext(),"") shouldEqual true
     memStore.isCorrectPartitionForCardinalityQuery(QueryContext(),"partition1") shouldEqual true


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Two fixes:
1. When multiple labels are queried in label-value query, and `_type_` is included, it would not work
2. Downsample Main Spec's exponential histogram unit test was using wrong schema and didnt test min/max
