### PR TITLE
fix(downsample): Back compatibility of legacy and otel histograms in downsample cluster

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -117,6 +117,6 @@
         # Retention of downsampled data for the corresponding resolution
         ttls = [ 30 days, 183 days ]
         # Raw schemas from which to downsample
-        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram", "delta-counter", "delta-histogram", "otel-delta-histogram"]
+        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram", "delta-counter", "delta-histogram", "otel-delta-histogram", "otel-cumulative-histogram"]
       }
     }

--- a/core/src/main/scala/filodb.core/Utils.scala
+++ b/core/src/main/scala/filodb.core/Utils.scala
@@ -69,4 +69,23 @@ object Utils extends StrictLogging {
     }
 
   }
+
+  /**
+   * @param schemaName Source schema name.
+   * @param schemaHash Source schema hash.
+   * @param schemaNameToCheck the schema name to check against.
+   * @param schemaHashToCheck the schema hash to check against.
+   * @return true if the schema name and hash match or if the schemas are back compatible histograms
+   */
+  def doesSchemaMatchOrBackCompatibleHistograms(schemaName : String, schemaHash : Int,
+                                                      schemaNameToCheck : String, schemaHashToCheck : Int) : Boolean = {
+    if (schemaHash == schemaHashToCheck) { true }
+    else {
+      val sortedSchemas = Seq(schemaName, schemaNameToCheck).sortBy(_.length)
+      val ret = if ((sortedSchemas(0) == "prom-histogram") && (sortedSchemas(1) == "otel-cumulative-histogram")) true
+      else if ((sortedSchemas(0) == "delta-histogram") && (sortedSchemas(1) == "otel-delta-histogram")) true
+      else false
+      ret
+    }
+  }
 }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -523,7 +523,11 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                                  minResolutionMs: Int,
                                  colIds: Seq[Types.ColumnId]): ReadablePartition = {
     val schemaId = RecordSchema.schemaID(part.partitionKey, UnsafeUtils.arayOffset)
-    if (schemaId != firstSchemaId) {
+    val isCompatibleSchemas = Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      schemas.schemaName(schemaId), schemaId, schemas.schemaName(firstSchemaId), firstSchemaId)
+    if (!isCompatibleSchemas) {
+      logger.debug(
+        s"Schema mismatch! Expected schema ${schemas.schemaName(firstSchemaId)}, got ${schemas.schemaName(schemaId)}")
       throw SchemaMismatch(schemas.schemaName(firstSchemaId), schemas.schemaName(schemaId), getClass.getSimpleName)
     }
     // FIXME It'd be nice to pass in the correct partId here instead of -1

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -526,8 +526,6 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     val isCompatibleSchemas = Utils.doesSchemaMatchOrBackCompatibleHistograms(
       schemas.schemaName(schemaId), schemaId, schemas.schemaName(firstSchemaId), firstSchemaId)
     if (!isCompatibleSchemas) {
-      logger.debug(
-        s"Schema mismatch! Expected schema ${schemas.schemaName(firstSchemaId)}, got ${schemas.schemaName(schemaId)}")
       throw SchemaMismatch(schemas.schemaName(firstSchemaId), schemas.schemaName(schemaId), getClass.getSimpleName)
     }
     // FIXME It'd be nice to pass in the correct partId here instead of -1

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -175,8 +175,12 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       lookupRes.firstSchemaId match {
         case Some(reqSchemaId) =>
           scanPartitions(ref, lookupRes, columnIDs, querySession).filter { p =>
-            if (!p.doesSchemaMatchOrBackCompatibleHistograms(Schemas.global.schemaName(reqSchemaId), reqSchemaId))
+            if (!Utils.doesSchemaMatchOrBackCompatibleHistograms(
+                  p.schema.name, p.schema.schemaHash, // current partition
+                  Schemas.global.schemaName(reqSchemaId), reqSchemaId) // requested schema
+            ) {
               throw SchemaMismatch(Schemas.global.schemaName(reqSchemaId), p.schema.name, getClass.getSimpleName)
+            }
             p.hasChunks(lookupRes.chunkMethod)
           }
         case None =>

--- a/core/src/main/scala/filodb.core/store/ReadablePartition.scala
+++ b/core/src/main/scala/filodb.core/store/ReadablePartition.scala
@@ -129,21 +129,5 @@ trait ReadablePartition extends FiloPartition {
                           countInfoIterator: CountingChunkInfoIterator): RangeVectorCursor =
     new PartitionTimeRangeReader(this, method.startTime, method.endTime, countInfoIterator, columnIDs)
 
-  /**
-   * @param schemaNameToCheck the schema name to check against
-   * @param schemaHashToCheck the schema hash to check against
-   * @return true if the schema name and hash match or if the schemas are back compatible histograms
-   */
-  final def doesSchemaMatchOrBackCompatibleHistograms(schemaNameToCheck : String, schemaHashToCheck : Int) : Boolean = {
-    if (schema.schemaHash == schemaHashToCheck) { true }
-    else {
-      val sortedSchemas = Seq(schema.name, schemaNameToCheck).sortBy(_.length)
-      val ret = if ((sortedSchemas(0) == "prom-histogram") && (sortedSchemas(1) == "otel-cumulative-histogram")) true
-      else if ((sortedSchemas(0) == "delta-histogram") && (sortedSchemas(1) == "otel-delta-histogram")) true
-      else false
-      ret
-    }
-  }
-
   def publishInterval: Option[Long]
 }

--- a/core/src/test/scala/filodb.core/store/ReadablePartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ReadablePartitionSpec.scala
@@ -1,6 +1,6 @@
 package filodb.core.store
 
-import filodb.core.GlobalConfig
+import filodb.core.{GlobalConfig, Utils}
 import filodb.core.NamesTestData.dataset
 import filodb.core.downsample.OffHeapMemory
 import filodb.core.memstore.{PagedReadablePartition, TimeSeriesPartition, TimeSeriesShardInfo, TimeSeriesShardStats}
@@ -14,33 +14,55 @@ class ReadablePartitionSpec extends AnyFunSpec with Matchers with BeforeAndAfter
     val rawData = RawPartData(Array.empty, Seq.empty)
     val p1 = new PagedReadablePartition(Schemas.deltaHistogram, 0, -1, rawData, 10)
     val p2 = new PagedReadablePartition(Schemas.otelDeltaHistogram, 0, -1, rawData, 10)
-    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p1.schema.name, p1.schema.schemaHash, p2.schema.name, p2.schema.schemaHash) shouldEqual true
+  }
+
+  it("doesSchemaMatchOrBackCompatibleHistograms should return true for otel-delta and delta") {
+    val rawData = RawPartData(Array.empty, Seq.empty)
+    val p1 = new PagedReadablePartition(Schemas.otelDeltaHistogram, 0, -1, rawData, 10)
+    val p2 = new PagedReadablePartition(Schemas.deltaHistogram, 0, -1, rawData, 10)
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p1.schema.name, p1.schema.schemaHash, p2.schema.name, p2.schema.schemaHash) shouldEqual true
   }
 
   it("doesSchemaMatchOrBackCompatibleHistograms should return true for cumulative and otel-cumulative") {
     val rawData = RawPartData(Array.empty, Seq.empty)
     val p1 = new PagedReadablePartition(Schemas.promHistogram, 0, -1, rawData, 10)
     val p2 = new PagedReadablePartition(Schemas.otelCumulativeHistogram, 0, -1, rawData, 10)
-    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p1.schema.name, p1.schema.schemaHash, p2.schema.name, p2.schema.schemaHash) shouldEqual true
+  }
+
+  it("doesSchemaMatchOrBackCompatibleHistograms should return true for otel-cumulative and prom histogram") {
+    val rawData = RawPartData(Array.empty, Seq.empty)
+    val p1 = new PagedReadablePartition(Schemas.otelCumulativeHistogram, 0, -1, rawData, 10)
+    val p2 = new PagedReadablePartition(Schemas.promHistogram, 0, -1, rawData, 10)
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p1.schema.name, p1.schema.schemaHash, p2.schema.name, p2.schema.schemaHash) shouldEqual true
   }
 
   it("doesSchemaMatchOrBackCompatibleHistograms should return true if schema matches paged readble partition") {
     val rawData = RawPartData(Array.empty, Seq.empty)
     val p1 = new PagedReadablePartition(Schemas.deltaCounter, 0, -1, rawData, 10)
     val p2 = new PagedReadablePartition(Schemas.deltaCounter, 0, -1, rawData, 10)
-    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p1.schema.name, p1.schema.schemaHash, p2.schema.name, p2.schema.schemaHash) shouldEqual true
 
     val p3 = new PagedReadablePartition(Schemas.gauge, 0, -1, rawData, 10)
     val p4 = new PagedReadablePartition(Schemas.gauge, 0, -1, rawData, 10)
-    p3.doesSchemaMatchOrBackCompatibleHistograms(p4.schema.name, p4.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p3.schema.name, p3.schema.schemaHash, p4.schema.name, p4.schema.schemaHash) shouldEqual true
 
     val p5 = new PagedReadablePartition(Schemas.promHistogram, 0, -1, rawData, 10)
     val p6 = new PagedReadablePartition(Schemas.promHistogram, 0, -1, rawData, 10)
-    p5.doesSchemaMatchOrBackCompatibleHistograms(p6.schema.name, p6.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p5.schema.name, p5.schema.schemaHash, p6.schema.name, p6.schema.schemaHash) shouldEqual true
 
     val p7 = new PagedReadablePartition(Schemas.promCounter, 0, -1, rawData, 10)
     val p8 = new PagedReadablePartition(Schemas.promCounter, 0, -1, rawData, 10)
-    p7.doesSchemaMatchOrBackCompatibleHistograms(p8.schema.name, p8.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p7.schema.name, p7.schema.schemaHash, p8.schema.name, p8.schema.schemaHash) shouldEqual true
   }
 
   it("doesSchemaMatchOrBackCompatibleHistograms should return true if schema matches timeseries partition") {
@@ -52,11 +74,13 @@ class ReadablePartitionSpec extends AnyFunSpec with Matchers with BeforeAndAfter
 
     val p1 = new TimeSeriesPartition(0, Schemas.deltaHistogram, 0, shardInfo, 1)
     val p2 = new TimeSeriesPartition(0, Schemas.otelDeltaHistogram, 0, shardInfo, 1)
-    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p1.schema.name, p1.schema.schemaHash, p2.schema.name, p2.schema.schemaHash) shouldEqual true
 
     val p3 = new TimeSeriesPartition(0, Schemas.gauge, 0, shardInfo, 1)
     val p4 = new TimeSeriesPartition(0, Schemas.gauge, 0, shardInfo, 1)
-    p3.doesSchemaMatchOrBackCompatibleHistograms(p4.schema.name, p4.schema.schemaHash) shouldEqual true
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p3.schema.name, p3.schema.schemaHash, p4.schema.name, p4.schema.schemaHash) shouldEqual true
   }
 
   it("doesSchemaMatchOrBackCompatibleHistograms should return false if schema does not matches timeseries partition") {
@@ -68,10 +92,22 @@ class ReadablePartitionSpec extends AnyFunSpec with Matchers with BeforeAndAfter
 
     val p1 = new TimeSeriesPartition(0, Schemas.deltaHistogram, 0, shardInfo, 1)
     val p2 = new TimeSeriesPartition(0, Schemas.promHistogram, 0, shardInfo, 1)
-    p1.doesSchemaMatchOrBackCompatibleHistograms(p2.schema.name, p2.schema.schemaHash) shouldEqual false
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p1.schema.name, p1.schema.schemaHash, p2.schema.name, p2.schema.schemaHash) shouldEqual false
 
     val p3 = new TimeSeriesPartition(0, Schemas.promCounter, 0, shardInfo, 1)
     val p4 = new TimeSeriesPartition(0, Schemas.deltaCounter, 0, shardInfo, 1)
-    p3.doesSchemaMatchOrBackCompatibleHistograms(p4.schema.name, p4.schema.schemaHash) shouldEqual false
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p3.schema.name, p3.schema.schemaHash, p4.schema.name, p4.schema.schemaHash) shouldEqual false
+
+    val p5 = new TimeSeriesPartition(0, Schemas.gauge, 0, shardInfo, 1)
+    val p6 = new TimeSeriesPartition(0, Schemas.dsGauge, 0, shardInfo, 1)
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p5.schema.name, p5.schema.schemaHash, p6.schema.name, p6.schema.schemaHash) shouldEqual false
+
+    val p7 = new TimeSeriesPartition(0, Schemas.otelCumulativeHistogram, 0, shardInfo, 1)
+    val p8 = new TimeSeriesPartition(0, Schemas.otelDeltaHistogram, 0, shardInfo, 1)
+    Utils.doesSchemaMatchOrBackCompatibleHistograms(
+      p7.schema.name, p7.schema.schemaHash, p8.schema.name, p8.schema.schemaHash) shouldEqual false
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

1. Queries are throwing SchemaMismatch errors when the metrics are transitioning from legacy histogram types ( prom, delta ) to ( otel-cummulative, otel-delta).

2. Code is not seamlessly handling the above scenario as it is for raw chunk source. The issue stems when the data is being paged from cassandra.

3. Unit test gaps in downsampling of otel-histograms ( both ingestion and queries).


**New behavior :**

1. Handling the SchemaMismatch errors while paging data from cassandra in downsample cluster.

2. Improving the unit test coverage by adding tests for `otel-cummulative`, `otel-delta` and mixed histogram schemas ( `prom + otel-cummulative` and `delta + otel-delta` )