### PR TITLE
feat(query): Mad outlier function can be customized for lower/upper bounds checks

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -192,8 +192,13 @@ object LogicalPlanParser {
     val at = sqww.atMs.fold("")(atMs => s" $At${atMs / 1000}")
     val suffix = s"$sqClause$offset$at$ClosingRoundBracket"
     if (sqww.functionArgs.isEmpty) s"$prefix$periodicSeriesQuery$suffix"
-    else {
+    else if (sqww.functionArgs.size <= 1) {
       s"$prefix${functionArgsToQuery(sqww.functionArgs.head)}$Comma$periodicSeriesQuery$suffix"
+    } else if (sqww.functionArgs.size == 2) {
+      s"$prefix${functionArgsToQuery(sqww.functionArgs.head)}$Comma" +
+        s"${functionArgsToQuery(sqww.functionArgs(1))}$Comma$periodicSeriesQuery$suffix"
+    } else {
+      throw new UnsupportedOperationException(s"Unable to write query for $sqww")
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -192,7 +192,7 @@ object LogicalPlanParser {
     val at = sqww.atMs.fold("")(atMs => s" $At${atMs / 1000}")
     val suffix = s"$sqClause$offset$at$ClosingRoundBracket"
     if (sqww.functionArgs.isEmpty) s"$prefix$periodicSeriesQuery$suffix"
-    else if (sqww.functionArgs.size <= 1) {
+    else if (sqww.functionArgs.size == 1) {
       s"$prefix${functionArgsToQuery(sqww.functionArgs.head)}$Comma$periodicSeriesQuery$suffix"
     } else if (sqww.functionArgs.size == 2) {
       s"$prefix${functionArgsToQuery(sqww.functionArgs.head)}$Comma" +

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -72,7 +72,7 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     parseAndAssertResult("""test{_ws_="demo",_ns_="App1",instance="Inst-1"}[600s]""")("""test{_ws_="demo",_ns_="App1",instance="Inst-1"}[600s]""")
     parseAndAssertResult("""test{_ws_="demo",_ns_="App1",instance="Inst-1"}[600s] offset 1000s""")("""test{_ws_="demo",_ns_="App1",instance="Inst-1"}[600s] offset 1000s""")
     parseAndAssertResult("""foo[5m:1m]""")("""foo[300s:60s]""")
-    parseAndAssertResult("""last_over_time_is_mad_outlier(3.0,sum(rate(http_requests_total{job="app"}[300s]))[432000s:300s])""")()
+    parseAndAssertResult("""last_over_time_is_mad_outlier(3.0,1.0,sum(rate(http_requests_total{job="app"}[300s]))[432000s:300s])""")()
   }
 
   it("should generate query from LogicalPlan having offset") {

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -78,7 +78,7 @@ object RangeFunctionId extends Enum[RangeFunctionId] {
   case object PresentOverTime extends RangeFunctionId("present_over_time", Seq(RangeVectorParam()))
   case object MedianAbsoluteDeviationOverTime extends RangeFunctionId("mad_over_time", Seq(RangeVectorParam()))
   case object LastOverTimeIsMadOutlier extends RangeFunctionId("last_over_time_is_mad_outlier",
-      Seq(ScalarParam(), RangeVectorParam()))
+      Seq(ScalarParam(), ScalarParam(), RangeVectorParam()))
 }
 
 sealed abstract class FiloFunctionId(override val entryName: String) extends EnumEntry

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -272,8 +272,13 @@ class MedianAbsoluteDeviationOverTimeFunction(funcParams: Seq[Any]) extends Rang
 }
 
 class LastOverTimeIsMadOutlierFunction(funcParams: Seq[Any]) extends RangeFunction {
-  require(funcParams.size == 1, "last_over_time_is_mad_outlier function needs a single tolerance argument")
-  require(funcParams.head.isInstanceOf[StaticFuncArgs], "tolerance parameter must be a number")
+  require(funcParams.size == 2, "last_over_time_is_mad_outlier function needs a two scalar arguments" +
+                  " (tolerance, bounds)")
+  require(funcParams(0).isInstanceOf[StaticFuncArgs], "first tolerance parameter must be a number")
+  require(funcParams(1).isInstanceOf[StaticFuncArgs], "second bounds parameter must be a number(0, 1, 2)")
+
+  private val boundsCheck = funcParams(1).asInstanceOf[StaticFuncArgs].scalar.toInt
+  require(boundsCheck == 0 || boundsCheck == 1 || boundsCheck == 2, "boundsCheck parameter should be 0, 1 or 2")
 
   override def addedToWindow(row: TransientRow, window: Window): Unit = {
   }
@@ -316,7 +321,7 @@ class LastOverTimeIsMadOutlierFunction(funcParams: Seq[Any]) extends RangeFuncti
       val lowerBound = median - tolerance * mad
       val upperBound = median + tolerance * mad
       val lastValue = window.last.getDouble(1)
-      if (lastValue < lowerBound || lastValue > upperBound) {
+      if (lastValue < lowerBound && boundsCheck <= 1 || lastValue > upperBound && boundsCheck >= 1) {
         sampleToEmit.setValues(endTimestamp, lastValue)
       } else {
         sampleToEmit.setValues(endTimestamp, Double.NaN)

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -282,6 +282,9 @@ class LastOverTimeIsMadOutlierFunction(funcParams: Seq[Any]) extends RangeFuncti
   require(boundsCheck == 0 || boundsCheck == 1 || boundsCheck == 2,
     "boundsCheck parameter should be 0 (lower only), 1 (both lower and upper) or 2 (upper only)")
 
+  private val tolerance = funcParams.head.asInstanceOf[StaticFuncArgs].scalar
+  require(tolerance > 0, "tolerance must be a positive number")
+
   override def addedToWindow(row: TransientRow, window: Window): Unit = {
   }
 
@@ -319,7 +322,6 @@ class LastOverTimeIsMadOutlierFunction(funcParams: Seq[Any]) extends RangeFuncti
       val mad = distFromMedian(lowerIndex)*(1-weight) + distFromMedian(upperIndex)*weight
 
       // classify last point as anomaly if it's more than `tolerance * mad` away from median
-      val tolerance = funcParams.head.asInstanceOf[StaticFuncArgs].scalar
       val lowerBound = median - tolerance * mad
       val upperBound = median + tolerance * mad
       val lastValue = window.last.getDouble(1)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Users of the `last_over_time_is_mad_outlier` function can now customize to do upper, or lower or both bounds check