### PR TITLE
Revert "feat(coord): raw-data query with range expression also route to downSample cluster (#1947)"

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -241,6 +241,7 @@ import filodb.query.exec._
     PlanResult(Seq(stitchedPlan))
   }
 
+
   // scalastyle:off cyclomatic.complexity
   override def walkLogicalPlanTree(logicalPlan: LogicalPlan,
                                    qContext: QueryContext,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.StrictLogging
 
 import filodb.coordinator.queryplanner.LogicalPlanUtils._
 import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
-import filodb.core.query.{QueryConfig, QueryContext, RvRange}
+import filodb.core.query.{QueryConfig, QueryContext}
 import filodb.query._
 import filodb.query.exec._
 
@@ -241,73 +241,6 @@ import filodb.query.exec._
     PlanResult(Seq(stitchedPlan))
   }
 
-  /**
-   * Materialize raw series plan. Route to raw cluster or downSample cluster based on the lookback time
-   * and stitch them if needed.
-   *
-   * For stitching case:
-   * time ----->   |---| < offset
-   * |-------|-----|     < range with offset
-   *     |---|---------| < range no offset
-   *     s   R         e
-   *
-   * If we were building a plan without offsets to query the physical data we want, we'd use the ranges:
-   * Raw: [R, e - o]
-   * DS:  [s - o, R)
-   *
-   * Which means the plans would be built as:
-   *
-   * Raw:
-   * Lookback:  (e - o) - R
-   * Timestamp: e - o
-   * DS:
-   * Lookback:  R - (s - o)
-   * Timestamp: R
-   *
-   * But since we'll preserve the offset in the plan, we'll shift the above timestamps to the right:
-   *
-   * Raw:
-   * Lookback:  (e - o) - R
-   * Timestamp: e
-   * DS:
-   * Lookback:  R - (s - o)
-   * Timestamp: R + o
-   *
-   * @param logicalPlan  The raw series logical plan to materialize
-   * @param queryContext The QueryContext object
-   * @return
-   */
-  private def materializeRawSeries(queryContext: QueryContext, logicalPlan: RawSeries): PlanResult = {
-    val timeRange = getTimeFromLogicalPlan(logicalPlan)
-
-    // use rawClusterMaterialize to handle range Raw data queries with range expression []
-    if(timeRange.startMs != timeRange.endMs){
-      logger.info("Materializing ranged raw series export against raw cluster:: {}", queryContext.origQueryParams)
-      return rawClusterMaterialize(queryContext, logicalPlan)
-    }
-    val lookbackMs = logicalPlan.lookbackMs.getOrElse(0L)
-    val offsetMs = logicalPlan.offsetMs.getOrElse(0L)
-    val (startTime, endTime) = (timeRange.endMs - lookbackMs - offsetMs, timeRange.endMs - offsetMs)
-    val execPlan = if (startTime > earliestRawTimestampFn) {
-      // This is the case where no data will be retrieved from DownsampleStore, simply push down to raw planner
-      rawClusterPlanner.materialize(logicalPlan, queryContext)
-    } else if (endTime < earliestRawTimestampFn) {
-      // This is the case where no data will be retrieved from RawStore, simply push down to DS planner
-      downsampleClusterPlanner.materialize(logicalPlan, queryContext)
-    } else {
-      val rawLookbackMs = timeRange.endMs - earliestRawTimestampFn - offsetMs
-      val rawLp = logicalPlan.copy(lookbackMs = Some(rawLookbackMs))
-      val rawEp = rawClusterPlanner.materialize(rawLp, queryContext)
-      val downSampleLp = logicalPlan.copy(lookbackMs = Some(lookbackMs - rawLookbackMs),
-        rangeSelector = IntervalSelector(earliestRawTimestampFn + offsetMs, earliestRawTimestampFn + offsetMs))
-      val downSampleEp = downsampleClusterPlanner.materialize(downSampleLp, queryContext)
-
-      val rvRange = RvRange(timeRange.endMs, 1000, timeRange.endMs)
-      StitchRvsExec(queryContext, stitchDispatcher, Some(rvRange), Seq(rawEp, downSampleEp))
-    }
-    PlanResult(Seq(execPlan))
-  }
-
   // scalastyle:off cyclomatic.complexity
   override def walkLogicalPlanTree(logicalPlan: LogicalPlan,
                                    qContext: QueryContext,
@@ -318,11 +251,11 @@ import filodb.query.exec._
         case p: PeriodicSeriesPlan         => materializePeriodicSeriesPlan(qContext, p)
         case lc: LabelCardinality          => materializeLabelCardinalityPlan(lc, qContext)
         case ts: TsCardinalities           => materializeTSCardinalityPlan(qContext, ts)
-        case rs: RawSeries                 => materializeRawSeries(qContext, rs)
         case _: LabelValues |
              _: ApplyLimitFunction |
              _: SeriesKeysByFilters |
              _: ApplyInstantFunctionRaw |
+             _: RawSeries |
              _: LabelNames                 => rawClusterMaterialize(qContext, logicalPlan)
       }
     }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -263,66 +263,14 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
 
   }
 
-  it("should not direct range raw-data queries with lookback"){
-    val start = now/1000 - 30.minutes.toSeconds
-    val step = 1.minute.toSeconds
-    val end = now/1000
-    val thrown = the[UnsupportedOperationException] thrownBy
-      Parser.queryRangeToLogicalPlan("foo[20m]", TimeStepParams(start, step, end))
-    thrown.toString.contains("Range expression is not allowed in query_range")
-  }
+  it("should direct raw-data queries to both raw planner only irrespective of time length") {
 
-  it("should direct instant raw-data queries with lookback to raw cluster when only need raw data"){
-    val start = now/1000
-    val step = 1.second.toSeconds
-    val end = start
-
-    // raw retention is 10m
-    val logicalPlan = Parser.queryToLogicalPlan("foo[9m]", start, step)
-    val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
-    ep.name shouldEqual "raw"
-    ep.lp shouldEqual logicalPlan
-  }
-
-  it("should direct instant raw-data queries with lookback to downSample cluster when only need downSample data"){
-    val start = now/1000 - 11.minutes.toSeconds
-    val step = 1.second.toSeconds
-    val end = start
-
-    // raw retention is 10m
-    val logicalPlan = Parser.queryToLogicalPlan("foo[10m]", start, step)
-    val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
-    ep.name shouldEqual "downsample"
-    ep.lp shouldEqual logicalPlan
-
-    val logicalPlan2 = Parser.queryToLogicalPlan("foo[10m] offset 5m", start+5.minutes.toSeconds, step)
-    val ep2 = longTermPlanner.materialize(logicalPlan2, QueryContext()).asInstanceOf[MockExecPlan]
-    ep2.name shouldEqual "downsample"
-    ep2.lp shouldEqual logicalPlan2
-  }
-
-  it("should direct raw-data instant queries with lookback to both raw and downSample cluster when needed"){
-    val start = now/1000
-    val step = 1.second.toSeconds
-    val end = start
-
-    val logicalPlan = Parser.queryRangeToLogicalPlan("foo[20m]", TimeStepParams(start, step, end))
-    val ep = longTermPlanner.materialize(logicalPlan, QueryContext())
-    val stitchExec = ep.asInstanceOf[StitchRvsExec]
-    stitchExec.children.size shouldEqual 2
-
-    val rawEp = stitchExec.children.head.asInstanceOf[MockExecPlan]
-    val downSampleEp = stitchExec.children.last.asInstanceOf[MockExecPlan]
-
-    rawEp.name shouldEqual "raw"
-    downSampleEp.name shouldEqual "downsample"
-
-    val rawLp = rawEp.lp.asInstanceOf[RawSeries]
-    val downSampleLp = downSampleEp.lp.asInstanceOf[RawSeries]
-
-    downSampleLp.rangeSelector.asInstanceOf[IntervalSelector].to shouldEqual earliestRawTime
-    rawLp.rangeSelector.asInstanceOf[IntervalSelector].to shouldEqual start*1000
-    downSampleLp.lookbackMs.get + rawLp.lookbackMs.get shouldEqual 20.minutes.toMillis
+    Seq(5, 10, 20).foreach { t =>
+      val logicalPlan = Parser.queryToLogicalPlan(s"foo[${t}m]", now, 1000)
+      val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
+      ep.name shouldEqual "raw"
+      ep.lp shouldEqual logicalPlan
+    }
   }
 
   it("should direct raw-cluster-only queries to raw planner for scalar vector queries") {


### PR DESCRIPTION
This reverts commit 4e62a494733feefe13fa081a630332203a431677.

Stitching data from the Raw and DownSample clusters is not supported due to schema differences:
Raw cluster data schema has a column of (value),
DownSample cluster data schema has a column of (avg).
When stitching these two plan, it tries to reduce schema and throws SchemaMismatch Error. 
Reverting this commit to remove the stitch logic.