### PR TITLE
feat(coord): Raw data export route to downsample cluster when needed

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -244,7 +244,7 @@ import filodb.query.exec._
   /**
    * Materializes a raw series plan and routes the query to either the Raw or DownSample cluster based on lookback time.
    * - If the target time range falls within the raw data retention period, the query is routed to the Raw cluster.
-   * - Otherwise, it is routed to the DownSample cluster, In this case, it will have no data after
+   * - Otherwise, it is routed to the DownSample cluster only, In this case, it will have no data after
    *   latestDownsampleTimestampFn because they are unavailable.
    *
    * Limitations:
@@ -259,7 +259,7 @@ import filodb.query.exec._
 
     // use rawClusterMaterialize to handle range Raw data queries with range expression []
     if(timeRange.startMs != timeRange.endMs){
-      logger.info("Materializing ranged raw series export against raw cluster:: {}", queryContext.origQueryParams)
+      logger.error("Materializing ranged raw series export against raw cluster:: {}", queryContext.origQueryParams)
       return rawClusterMaterialize(queryContext, logicalPlan)
     }
     val lookbackMs = logicalPlan.lookbackMs.getOrElse(0L)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -241,6 +241,39 @@ import filodb.query.exec._
     PlanResult(Seq(stitchedPlan))
   }
 
+  /**
+   * Materializes a raw series plan and routes the query to either the Raw or DownSample cluster based on lookback time.
+   * - If the target time range falls within the raw data retention period, the query is routed to the Raw cluster.
+   * - Otherwise, it is routed to the DownSample cluster, In this case, it will have no data after
+   *   latestDownsampleTimestampFn because they are unavailable.
+   *
+   * Limitations:
+   * - Stitching data from the Raw and DownSample clusters is not supported due to schema differences.
+   *
+   * @param logicalPlan  The raw series logical plan to materialize.
+   * @param queryContext The QueryContext object.
+   * @return
+   */
+  private def materializeRawSeries(queryContext: QueryContext, logicalPlan: RawSeries): PlanResult = {
+    val timeRange = getTimeFromLogicalPlan(logicalPlan)
+
+    // use rawClusterMaterialize to handle range Raw data queries with range expression []
+    if(timeRange.startMs != timeRange.endMs){
+      logger.info("Materializing ranged raw series export against raw cluster:: {}", queryContext.origQueryParams)
+      return rawClusterMaterialize(queryContext, logicalPlan)
+    }
+    val lookbackMs = logicalPlan.lookbackMs.getOrElse(0L)
+    val offsetMs = logicalPlan.offsetMs.getOrElse(0L)
+    val (startTime, endTime) = (timeRange.endMs - lookbackMs - offsetMs, timeRange.endMs - offsetMs)
+    val execPlan = if (startTime > earliestRawTimestampFn) {
+      // This is the case where no data will be retrieved from DownsampleStore, simply push down to raw planner.
+      rawClusterPlanner.materialize(logicalPlan, queryContext)
+    } else {
+      // This is the case where data in RawStore isn't enough, simply push down to DS planner.
+      downsampleClusterPlanner.materialize(logicalPlan, queryContext)
+    }
+    PlanResult(Seq(execPlan))
+  }
 
   // scalastyle:off cyclomatic.complexity
   override def walkLogicalPlanTree(logicalPlan: LogicalPlan,
@@ -252,11 +285,11 @@ import filodb.query.exec._
         case p: PeriodicSeriesPlan         => materializePeriodicSeriesPlan(qContext, p)
         case lc: LabelCardinality          => materializeLabelCardinalityPlan(lc, qContext)
         case ts: TsCardinalities           => materializeTSCardinalityPlan(qContext, ts)
+        case rs: RawSeries                 => materializeRawSeries(qContext, rs)
         case _: LabelValues |
              _: ApplyLimitFunction |
              _: SeriesKeysByFilters |
              _: ApplyInstantFunctionRaw |
-             _: RawSeries |
              _: LabelNames                 => rawClusterMaterialize(qContext, logicalPlan)
       }
     }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -293,6 +293,11 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
     val ep2 = longTermPlanner.materialize(logicalPlan2, QueryContext()).asInstanceOf[MockExecPlan]
     ep2.name shouldEqual "downsample"
     ep2.lp shouldEqual logicalPlan2
+
+    val logicalPlan3 = Parser.queryToLogicalPlan("foo[10m] offset 20m", start, step)
+    val ep3= longTermPlanner.materialize(logicalPlan3, QueryContext()).asInstanceOf[MockExecPlan]
+    ep3.name shouldEqual "downsample"
+    ep3.lp shouldEqual logicalPlan3
   }
 
   it("should direct raw-cluster-only queries to raw planner for scalar vector queries") {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -263,14 +263,36 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
 
   }
 
-  it("should direct raw-data queries to both raw planner only irrespective of time length") {
+  it("should direct instant raw-data queries with lookback to raw cluster when only need raw data"){
+    val start = now/1000
+    val step = 1.second.toSeconds
 
-    Seq(5, 10, 20).foreach { t =>
-      val logicalPlan = Parser.queryToLogicalPlan(s"foo[${t}m]", now, 1000)
-      val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
-      ep.name shouldEqual "raw"
-      ep.lp shouldEqual logicalPlan
-    }
+    // raw retention is 10m
+    val logicalPlan = Parser.queryToLogicalPlan("foo[9m]", start, step)
+    val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
+    ep.name shouldEqual "raw"
+    ep.lp shouldEqual logicalPlan
+
+    val logicalPlan2 = Parser.queryToLogicalPlan("foo[4m] offset 5m", start, step)
+    val ep2 = longTermPlanner.materialize(logicalPlan2, QueryContext()).asInstanceOf[MockExecPlan]
+    ep2.name shouldEqual "raw"
+    ep2.lp shouldEqual logicalPlan2
+  }
+
+  it("should direct instant raw-data queries with lookback to downSample cluster when range is over raw retention"){
+    val start = now/1000
+    val step = 1.second.toSeconds
+
+    // raw retention is 10m
+    val logicalPlan = Parser.queryToLogicalPlan("foo[10m]", start, step)
+    val ep = longTermPlanner.materialize(logicalPlan, QueryContext()).asInstanceOf[MockExecPlan]
+    ep.name shouldEqual "downsample"
+    ep.lp shouldEqual logicalPlan
+
+    val logicalPlan2 = Parser.queryToLogicalPlan("foo[10m] offset 5m", start, step)
+    val ep2 = longTermPlanner.materialize(logicalPlan2, QueryContext()).asInstanceOf[MockExecPlan]
+    ep2.name shouldEqual "downsample"
+    ep2.lp shouldEqual logicalPlan2
   }
 
   it("should direct raw-cluster-only queries to raw planner for scalar vector queries") {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
@@ -188,6 +188,28 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
 
   private val queryParams = PromQlQueryParams("notUsedQuery", 100, 1, 1000)
 
+  it("should route raw data export to raw cluster"){
+    val lp = Parser.queryToLogicalPlan(
+      """foo{_ws_ = "demo", _ns_ = "localNs"}[3d]""",
+      endSeconds, step, Antlr)
+    val execPlan = rootPlanner.materialize(lp, QueryContext(origQueryParams = queryParams))
+    val expected = """E~LocalPartitionDistConcatExec() on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1304969071],raw)
+                     |-E~MultiSchemaPartitionsExec(dataset=timeseries, shard=0, chunkMethod=TimeRangeChunkScan(1634518130000,1634777330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1304969071],raw)
+                     |-E~MultiSchemaPartitionsExec(dataset=timeseries, shard=1, chunkMethod=TimeRangeChunkScan(1634518130000,1634777330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#1304969071],raw)""".stripMargin
+    validatePlan(execPlan, expected)
+  }
+
+  it("should route raw data export to downSample cluster"){
+    val lp = Parser.queryToLogicalPlan(
+      """foo{_ws_ = "demo", _ns_ = "localNs"}[3d]""",
+      startSeconds, step, Antlr)
+    val execPlan = rootPlanner.materialize(lp, QueryContext(origQueryParams = queryParams))
+    val expected = """E~LocalPartitionDistConcatExec() on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-1525018619],downsample)
+                     |-E~MultiSchemaPartitionsExec(dataset=timeseries, shard=0, chunkMethod=TimeRangeChunkScan(1633654130000,1633913330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-1525018619],downsample)
+                     |-E~MultiSchemaPartitionsExec(dataset=timeseries, shard=1, chunkMethod=TimeRangeChunkScan(1633654130000,1633913330000), filters=List(ColumnFilter(_ws_,Equals(demo)), ColumnFilter(_ns_,Equals(localNs)), ColumnFilter(_metric_,Equals(foo))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#-1525018619],downsample)""".stripMargin
+    validatePlan(execPlan, expected)
+  }
+
   it("Plan with unary expression should be equals to its binary counterpart.") {
     val lp = Parser.queryRangeToLogicalPlan(
       """-foo{_ws_ = "demo", _ns_ = "localNs"} > -1""",


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

- Instant queries with a range expression (raw data export) are routed only to raw clusters.
- These queries do not retrieve data beyond the raw retention period (7 days).


**New behavior :**

- Queries are routed only to downsampled clusters when the time range exceeds the raw retention period.
- No stitching occurs between raw data and downsampled data.
- Queries within the raw retention period retrieve all data from raw clusters.
- Queries beyond the raw retention period retrieve all data from downsampled clusters (data loss may occur after latestDownsampleTime: now - 6h).


