### PR TITLE
perf(query) Optimize RepeatValueVector to not store the key and the first item in the data eagerly

### DIFF
--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -209,18 +209,22 @@ final case class RangeParams(startSecs: Long, stepSecs: Long, endSecs: Long)
  * @param rowReader the row read that provide the value.
  * @param schema the schema.
  */
-final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
+final case class RepeatValueVector(rv: RangeVector,
                               startMs: Long, stepMs: Long, endMs: Long,
-                              rowReader: Option[RowReader],
                               schema: RecordSchema) extends SerializableRangeVector with StrictLogging {
   override def outputRange: Option[RvRange] = Some(RvRange(startMs, stepMs, endMs))
   override val numRows: Option[Int] = Some((endMs - startMs) / math.max(1, stepMs) + 1).map(_.toInt)
+
+  lazy val key: RangeVectorKey = rv.key
 
   // This will now be used only during serialization of this vector in protos
   // This is room for optimization here as we cant instantiate anything under 2048 bytes which is the MinContainerSize
   def containers: Seq[RecordContainer] = {
     val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
-    rowReader.map(builder.addFromReader(_, schema, 0))
+    val rvCursor = rows()
+    if (rvCursor.hasNext) {
+      builder.addFromReader(rvCursor.next(), schema, 0)
+    }
     builder.allContainers.toList
   }
 
@@ -231,31 +235,36 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
   // It can transform one data because data at all steps are identical. It just need to return a RepeatValueVector.
   override def rows(): RangeVectorCursor = {
     import NoCloseCursor._
-    // If rowReader is empty, iterate nothing.
-    val it = Iterator.from(0, rowReader.map(_ => stepMs.toInt).getOrElse(1))
-      .takeWhile(_ <= endMs - startMs).map { i =>
-      val rr = rowReader.get
-      val t = i + startMs
-      new RowReader {
-        override def notNull(columnNo: Int): Boolean = rr.notNull(columnNo)
-        override def getBoolean(columnNo: Int): Boolean = rr.getBoolean(columnNo)
-        override def getInt(columnNo: Int): Int = rr.getInt(columnNo)
-        override def getLong(columnNo: Int): Long = if (columnNo == 0) t else rr.getLong(columnNo)
-        override def getDouble(columnNo: Int): Double = rr.getDouble(columnNo)
-        override def getFloat(columnNo: Int): Float = rr.getFloat(columnNo)
-        override def getString(columnNo: Int): String = rr.getString(columnNo)
-        override def getAny(columnNo: Int): Any = rr.getAny(columnNo)
-        override def getBlobBase(columnNo: Int): Any = rr.getBlobBase(columnNo)
-        override def getBlobOffset(columnNo: Int): Long = rr.getBlobOffset(columnNo)
-        override def getBlobNumBytes(columnNo: Int): Int = rr.getBlobNumBytes(columnNo)
-        override def getHistogram(columnNo: Int): Histogram = rr.getHistogram(columnNo)
-      }
+    val it = Using.resource(rv.rows()) {
+      rows =>
+        if (rows.hasNext) {
+          val rr = rows.next()
+          Iterator.from(0, stepMs.toInt)
+            .takeWhile(_ <= endMs - startMs).map {
+              i => {
+                val t = i + startMs
+                new RowReader {
+                  override def notNull(columnNo: Int): Boolean = rr.notNull(columnNo)
+                  override def getBoolean(columnNo: Int): Boolean = rr.getBoolean(columnNo)
+                  override def getInt(columnNo: Int): Int = rr.getInt(columnNo)
+                  override def getLong(columnNo: Int): Long = if (columnNo == 0) t else rr.getLong(columnNo)
+                  override def getDouble(columnNo: Int): Double = rr.getDouble(columnNo)
+                  override def getFloat(columnNo: Int): Float = rr.getFloat(columnNo)
+                  override def getString(columnNo: Int): String = rr.getString(columnNo)
+                  override def getAny(columnNo: Int): Any = rr.getAny(columnNo)
+                  override def getBlobBase(columnNo: Int): Any = rr.getBlobBase(columnNo)
+                  override def getBlobOffset(columnNo: Int): Long = rr.getBlobOffset(columnNo)
+                  override def getBlobNumBytes(columnNo: Int): Int = rr.getBlobNumBytes(columnNo)
+                  override def getHistogram(columnNo: Int): Histogram = rr.getHistogram(columnNo)
+                }
+              }
+            }
+      } else
+        Iterator.empty
     }
-    // address step == 0 case
     if (startMs == endMs) it.take(1)
     else it
   }
-  override def key: RangeVectorKey = rangeVectorKey
 
   /**
    * Used to calculate number of samples sent over the wire for limiting resources used by query
@@ -271,14 +280,14 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
         case DoubleColumn       => SerializableRangeVector.SizeOfDouble
         case LongColumn         => SerializableRangeVector.SizeOfLong
         case IntColumn          => SerializableRangeVector.SizeOfInt
-        case StringColumn       => this.rowReader.map(rr => rr.getString(idx).length).getOrElse(0)
+        case StringColumn       => 0 // TODO: This will give incorrect estimates
         case TimestampColumn    => SerializableRangeVector.SizeOfLong
-        case BinaryRecordColumn => this.rowReader.map(rr => rr.getBlobNumBytes(idx)).getOrElse(0)
+        case BinaryRecordColumn => 0
         // We will take the worst case where histogram has buckets, each bucket has 2 doubles, one for the bucket
         //  itself and one for the bin count. We will have 4 more columns for sum, total, min and max,
-        case HistogramColumn    => this.rowReader.map(
-                                      rr => rr.getHistogram(idx).numBuckets * SerializableRangeVector.SizeOfDouble * 2
-                                            + SerializableRangeVector.SizeOfDouble * 4).getOrElse(0)
+        case HistogramColumn    =>   val numBuckets = 20 // Hardcoding the approximate number of buckets
+                                     numBuckets * SerializableRangeVector.SizeOfDouble * 2
+                                            + SerializableRangeVector.SizeOfDouble * 4
         case MapColumn          =>
                                     logger.warn("MapColumn estimate RepeatValueVector not yet supported")
                                     0 // Not supported yet
@@ -286,27 +295,6 @@ final class RepeatValueVector(rangeVectorKey: RangeVectorKey,
     }.sum
 }
 
-object RepeatValueVector extends StrictLogging {
-  import filodb.core._
-  def apply(rv: RangeVector,
-            startMs: Long, stepMs: Long, endMs: Long,
-            schema: RecordSchema,
-            execPlan: String,
-            queryStats: QueryStats): RepeatValueVector = {
-    val startNs = Utils.currentThreadCpuTimeNanos
-    try {
-      ChunkMap.validateNoSharedLocks(execPlan)
-      Using.resource(rv.rows()){
-        rows =>
-          val nextRow = if (rows.hasNext) Some(rows.next()) else None
-          new RepeatValueVector(rv.key, startMs, stepMs, endMs, nextRow, schema)
-      }
-    } finally {
-      ChunkMap.releaseAllSharedLocks()
-      queryStats.getCpuNanosCounter(Nil).addAndGet(Utils.currentThreadCpuTimeNanos - startNs)
-    }
-  }
-}
 
 sealed trait ScalarSingleValue extends ScalarRangeVector {
   def rangeParams: RangeParams

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -342,9 +342,7 @@ final case class RepeatTransformer(startMs: Long, stepMs: Long, endMs: Long, exe
             paramResponse: Seq[Observable[ScalarRangeVector]]): Observable[RepeatValueVector] = {
     source.map { rv =>
         RepeatValueVector(rv, startMs, stepMs, endMs,
-          new RecordSchema(sourceSchema.columns, brSchema = sourceSchema.brSchemas),
-          execPlan,
-          querySession.queryStats)
+          new RecordSchema(sourceSchema.columns, brSchema = sourceSchema.brSchemas))
     }
   }
   override def schema(source: ResultSchema): ResultSchema = {

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -5,7 +5,6 @@ import scala.collection.mutable.ListBuffer
 import monix.reactive.Observable
 import spire.syntax.cfor._
 
-import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.metadata.PartitionSchema
 import filodb.core.query._
@@ -340,9 +339,8 @@ final case class RepeatTransformer(startMs: Long, stepMs: Long, endMs: Long, exe
             limit: Int,
             sourceSchema: ResultSchema,
             paramResponse: Seq[Observable[ScalarRangeVector]]): Observable[RepeatValueVector] = {
-    val rs = new RecordSchema(sourceSchema.columns, brSchema = sourceSchema.brSchemas)
     source.map { rv =>
-        RepeatValueVector(rv, startMs, stepMs, endMs, rs)
+        RepeatValueVector(rv, startMs, stepMs, endMs)
     }
   }
   override def schema(source: ResultSchema): ResultSchema = {

--- a/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
+++ b/query/src/main/scala/filodb/query/exec/RangeVectorTransformer.scala
@@ -340,9 +340,9 @@ final case class RepeatTransformer(startMs: Long, stepMs: Long, endMs: Long, exe
             limit: Int,
             sourceSchema: ResultSchema,
             paramResponse: Seq[Observable[ScalarRangeVector]]): Observable[RepeatValueVector] = {
+    val rs = new RecordSchema(sourceSchema.columns, brSchema = sourceSchema.brSchemas)
     source.map { rv =>
-        RepeatValueVector(rv, startMs, stepMs, endMs,
-          new RecordSchema(sourceSchema.columns, brSchema = sourceSchema.brSchemas))
+        RepeatValueVector(rv, startMs, stepMs, endMs, rs)
     }
   }
   override def schema(source: ResultSchema): ResultSchema = {

--- a/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
+++ b/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
@@ -774,46 +774,4 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     deserializedise.getMessage shouldBe ise.getMessage
     deserializedise.getCause shouldEqual isecause
   }
-
-
-  it("should convert RepeatValueVector double to proto and back") {
-    val recSchema = new RecordSchema(Seq(ColumnInfo("time", ColumnType.TimestampColumn),
-      ColumnInfo("value", ColumnType.DoubleColumn)))
-    val keysMap = Map("key1".utf8 -> "val1".utf8,
-      "key2".utf8 -> "val2".utf8)
-    val key = CustomRangeVectorKey(keysMap)
-
-    val rv = toRv(Seq((100, 599)), key, RvRange(100, 10, 600))
-    val repeatValueVector = new RepeatValueVector(rv, 100, 10, 600, recSchema)
-
-    val proto = repeatValueVector.toProto.fromProto
-    proto.key shouldEqual repeatValueVector.key
-    proto.numRows shouldEqual repeatValueVector.numRows
-    proto.outputRange shouldEqual repeatValueVector.outputRange
-    proto.rows().map(r => (r.getLong(0), r.getDouble(1))).toList shouldEqual
-      repeatValueVector.rows().map(r => (r.getLong(0), r.getDouble(1))).toList
-    proto.recordSchema shouldEqual repeatValueVector.recordSchema
-  }
-
-  it("should convert RepeatValueVector histogram to proto and back") {
-    val recSchema = new RecordSchema(Seq(ColumnInfo("time", ColumnType.TimestampColumn),
-      ColumnInfo("value", ColumnType.HistogramColumn)))
-
-    val customScheme = CustomBuckets(Array(0.25, 0.5, 1.0, 2.5, 5.0, 10, Double.PositiveInfinity))
-    val longHist = LongHistogram(customScheme, Array[Long](10, 15, 17, 20, 25, 34, 76))
-
-    val keysMap = Map("key1".utf8 -> "val1".utf8,
-      "key2".utf8 -> "val2".utf8)
-    val key = CustomRangeVectorKey(keysMap)
-
-    val rv = toHistRv(Seq((40, longHist)), key, RvRange(100, 10, 600))
-    val repeatValueVector = new RepeatValueVector(rv, 100, 10, 600, recSchema)
-    val proto = repeatValueVector.toProto.fromProto
-    proto.key shouldEqual repeatValueVector.key
-    proto.numRows shouldEqual repeatValueVector.numRows
-    proto.outputRange shouldEqual repeatValueVector.outputRange
-    proto.rows().map(r => (r.getLong(0), r.getHistogram(1))).toList shouldEqual
-      repeatValueVector.rows().map(r => (r.getLong(0), r.getHistogram(1))).toList
-    proto.recordSchema shouldEqual repeatValueVector.recordSchema
-  }
 }

--- a/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
+++ b/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
@@ -13,7 +13,7 @@ import filodb.core.metadata.Column
 import filodb.core.metadata.Column.ColumnType
 import filodb.grpc.{GrpcMultiPartitionQueryService, ProtoRangeVector}
 import filodb.memory.format.ZeroCopyUTF8String._
-import filodb.memory.format.vectors.{CustomBuckets, HistogramWithBuckets, LongHistogram}
+import filodb.memory.format.vectors.HistogramWithBuckets
 
 
 class ProtoConvertersSpec extends AnyFunSpec with Matchers {

--- a/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
+++ b/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
@@ -5,7 +5,6 @@ import org.scalatest.matchers.should.Matchers
 import filodb.core.query._
 import ProtoConverters._
 import QueryResponseConverter._
-
 import akka.pattern.AskTimeoutException
 import filodb.core.QueryTimeoutException
 import filodb.core.binaryrecord2.RecordSchema
@@ -14,7 +13,7 @@ import filodb.core.metadata.Column
 import filodb.core.metadata.Column.ColumnType
 import filodb.grpc.{GrpcMultiPartitionQueryService, ProtoRangeVector}
 import filodb.memory.format.ZeroCopyUTF8String._
-import filodb.memory.format.vectors.{CustomBuckets, LongHistogram}
+import filodb.memory.format.vectors.{CustomBuckets, HistogramWithBuckets, LongHistogram}
 
 
 class ProtoConvertersSpec extends AnyFunSpec with Matchers {
@@ -26,6 +25,19 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
       import NoCloseCursor._
       override def key: RangeVectorKey = rangeVectorKey
       override def rows(): RangeVectorCursor = samples.map(r => new TransientRow(r._1, r._2)).iterator
+
+      override def outputRange: Option[RvRange] = Some(rvPeriod)
+    }
+  }
+
+
+  private def toHistRv(samples: Seq[(Long, HistogramWithBuckets)],
+                       rangeVectorKey: RangeVectorKey,
+                       rvPeriod: RvRange): RangeVector = {
+    new RangeVector {
+      import NoCloseCursor._
+      override def key: RangeVectorKey = rangeVectorKey
+      override def rows(): RangeVectorCursor = samples.map(r => new TransientHistRow(r._1, r._2)).iterator
 
       override def outputRange: Option[RvRange] = Some(rvPeriod)
     }
@@ -771,8 +783,8 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
       "key2".utf8 -> "val2".utf8)
     val key = CustomRangeVectorKey(keysMap)
 
-    val repeatValueVector = new RepeatValueVector(key, 100, 10, 600,
-      Some(new TransientRow(100, 599)), recSchema)
+    val rv = toRv(Seq((100, 599)), key, RvRange(100, 10, 600))
+    val repeatValueVector = new RepeatValueVector(rv, 100, 10, 600, recSchema)
 
     val proto = repeatValueVector.toProto.fromProto
     proto.key shouldEqual repeatValueVector.key
@@ -794,8 +806,8 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
       "key2".utf8 -> "val2".utf8)
     val key = CustomRangeVectorKey(keysMap)
 
-    val repeatValueVector = new RepeatValueVector(key, 100, 10, 600,
-      Some(new TransientHistRow(40, longHist)), recSchema)
+    val rv = toHistRv(Seq((40, longHist)), key, RvRange(100, 10, 600))
+    val repeatValueVector = new RepeatValueVector(rv, 100, 10, 600, recSchema)
     val proto = repeatValueVector.toProto.fromProto
     proto.key shouldEqual repeatValueVector.key
     proto.numRows shouldEqual repeatValueVector.numRows


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

``RepeatValueVector``  calls ``next`` on the underlying transformer and stores the value of the first item as part of it. This might be unnecessary and the call is deferred to the point when ``rows`` is invoked. Currently both the key and the first item of the underlying  RV (as ``TransientRow``) is stored in the instance of RepeatValueVector.

**New behavior :**

We do not invoke next or keys on the wrapped RangeVector until the rows are requested.

**BREAKING CHANGES :**

`RepeatValueVector` no longer implements `SerializableRangeVector` This means , any deserialization of this vector will arrive over the wire as a SerializableRangeVector (which would have consumed ``RepeatValueVector`` on the producer side ) and the not as ``RepeatValueVector`` itself.  The change in signature of ``RepeatValueVector`` which now accepts a ``RangeVector`` which may or mayn't be serializable, requires us to consume this range vector on the producer side and send as a ``SerializedRangeVector``.