### PR TITLE
bug(memory): MutableHistogram vectors when serialized with Exp histograms were truncating decimals

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/NibblePack.scala
+++ b/memory/src/main/scala/filodb.memory/format/NibblePack.scala
@@ -65,6 +65,9 @@ object NibblePack {
   /**
    * Packs Double values using XOR encoding to find minimal # of bits difference between successive values.
    * Initial Double value is written first.
+   *
+   * Unpack bytes compressed with this method using unpackDoubleXOR.method.
+   *
    * @return the final position within the buffer after packing
    */
   final def packDoubles(inputs: Array[Double], buf: MutableDirectBuffer, bufindex: Int): Int = {
@@ -335,6 +338,8 @@ object NibblePack {
 
   /**
    * Generic unpack function which outputs values to a Sink which can process raw 64-bit values from unpack8.
+   * Use when you have compressed bytes using the `packDelta` method.
+   *
    * @param compressed a DirectBuffer wrapping the compressed bytes. Position 0 must be the beginning of the buffer
    *                   to unpack.  NOTE: the passed in DirectBuffer will be mutated to wrap the NEXT bytes that
    *                   can be unpacked.
@@ -349,6 +354,10 @@ object NibblePack {
     res
   }
 
+  /**
+   * Use to unpack bytes that were compressed using the `packDoubles` method.
+   * Do not use for `packDelta` or others.
+   */
   final def unpackDoubleXOR(compressed: DirectBuffer, outArray: Array[Double]): UnpackResult = {
     if (compressed.capacity < 8) {
       InputTooShort

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -312,7 +312,6 @@ final case class MutableHistogram(var buckets: HistogramBuckets,
     val buf = intoBuf.getOrElse(BinaryHistogram.histBuf)
     buckets match {
       case g: GeometricBuckets if g.minusOne => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
-      case g: Base2ExpHistogramBuckets => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
       case _ => BinaryHistogram.writeDoubles(buckets, values, buf)
     }
     buf

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -301,7 +301,8 @@ object LongHistogram {
 }
 
 /**
- * A histogram class that can be used for aggregation and to represent intermediate values
+ * A histogram class that can be used for aggregation and to represent intermediate values.
+ * MutableHistogram is primarily used in histogram queries, where query results like rate can be double values.
  */
 final case class MutableHistogram(var buckets: HistogramBuckets,
                                   var values: Array[Double]) extends HistogramWithBuckets {
@@ -310,6 +311,9 @@ final case class MutableHistogram(var buckets: HistogramBuckets,
   final def bucketValue(no: Int): Double = values(no)
   final def serialize(intoBuf: Option[MutableDirectBuffer] = None): MutableDirectBuffer = {
     val buf = intoBuf.getOrElse(BinaryHistogram.histBuf)
+    // Since MutableHistograms can have rate values, we should use writeDoubles method to serialize and encode data.
+    // FIXME why is Geo minus one using delta encoding ? Possible bug since unpack assumes double encoding.
+    // Not changing right now since outside scope of current PR
     buckets match {
       case g: GeometricBuckets if g.minusOne => BinaryHistogram.writeDelta(g, values.map(_.toLong), buf)
       case _ => BinaryHistogram.writeDoubles(buckets, values, buf)

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -76,6 +76,9 @@ object BinaryHistogram extends StrictLogging {
       case HistFormat_Custom_XOR =>
         val bucketDef = HistogramBuckets.custom(buf.byteArray, bucketDefOffset - 2)
         MutableHistogram.fromPacked(bucketDef, valuesByteSlice).getOrElse(Histogram.empty)
+      case HistFormat_OtelExp_XOR =>
+        val bucketDef = HistogramBuckets.otelExp(buf.byteArray, bucketDefOffset)
+        MutableHistogram.fromPacked(bucketDef, valuesByteSlice).getOrElse(Histogram.empty)
       case x =>
         logger.debug(s"Unrecognizable histogram format code $x, returning empty histogram")
         Histogram.empty
@@ -110,10 +113,11 @@ object BinaryHistogram extends StrictLogging {
   val HistFormat_Custom_Delta = 0x05.toByte
   val HistFormat_Geometric_XOR = 0x08.toByte    // Double values XOR compressed
   val HistFormat_Custom_XOR = 0x0a.toByte
+  val HistFormat_OtelExp_XOR = 0x10.toByte
 
   def isValidFormatCode(code: Byte): Boolean = {
     (code == HistFormat_Null) || (code == HistFormat_Geometric1_Delta) || (code == HistFormat_Geometric_Delta) ||
-    (code == HistFormat_Custom_Delta) || (code == HistFormat_OtelExp_Delta)
+    (code == HistFormat_Custom_Delta) || (code == HistFormat_OtelExp_Delta || (code == HistFormat_OtelExp_XOR))
     // Question: why are other formats like HistFormat_Geometric_XOR not here as valid ?
   }
 
@@ -180,7 +184,7 @@ object BinaryHistogram extends StrictLogging {
     val formatCode = if (buckets.numBuckets == 0) HistFormat_Null else buckets match {
       case g: GeometricBuckets               => HistFormat_Geometric_XOR
       case c: CustomBuckets                  => HistFormat_Custom_XOR
-      case o: Base2ExpHistogramBuckets        => HistFormat_OtelExp_Delta
+      case o: Base2ExpHistogramBuckets        => HistFormat_OtelExp_XOR
     }
 
     buf.putByte(2, formatCode)

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -58,6 +58,8 @@ object BinaryHistogram extends StrictLogging {
      * Ingestion ingests BinHistograms directly without conversion to Histogram first.
      */
     def toHistogram: Histogram = formatCode match {
+
+      // All the delta encoding formats decode into LongHistograms and are generally used during ingestion
       case HistFormat_Geometric_Delta =>
         val bucketDef = HistogramBuckets.geometric(buf.byteArray, bucketDefOffset, false)
         LongHistogram.fromPacked(bucketDef, valuesByteSlice).getOrElse(Histogram.empty)
@@ -70,6 +72,8 @@ object BinaryHistogram extends StrictLogging {
       case HistFormat_Custom_Delta =>
         val bucketDef = HistogramBuckets.custom(buf.byteArray, bucketDefOffset - 2)
         LongHistogram.fromPacked(bucketDef, valuesByteSlice).getOrElse(Histogram.empty)
+
+      // All the XOR encoding formats decode into MutableHistograms and are generally used during querying
       case HistFormat_Geometric_XOR =>
         val bucketDef = HistogramBuckets.geometric(buf.byteArray, bucketDefOffset, false)
         MutableHistogram.fromPacked(bucketDef, valuesByteSlice).getOrElse(Histogram.empty)
@@ -117,7 +121,7 @@ object BinaryHistogram extends StrictLogging {
 
   def isValidFormatCode(code: Byte): Boolean = {
     (code == HistFormat_Null) || (code == HistFormat_Geometric1_Delta) || (code == HistFormat_Geometric_Delta) ||
-    (code == HistFormat_Custom_Delta) || (code == HistFormat_OtelExp_Delta || (code == HistFormat_OtelExp_XOR))
+    (code == HistFormat_Custom_Delta) || (code == HistFormat_OtelExp_Delta) || (code == HistFormat_OtelExp_XOR)
     // Question: why are other formats like HistFormat_Geometric_XOR not here as valid ?
   }
 

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -3,7 +3,7 @@ package filodb.memory.format.vectors
 import java.nio.ByteBuffer
 import org.agrona.concurrent.UnsafeBuffer
 import filodb.memory.format._
-import filodb.memory.format.vectors.BinaryHistogram.{BinHistogram, HistFormat_Geometric1_Delta, HistFormat_OtelExp_Delta}
+import filodb.memory.format.vectors.BinaryHistogram.{BinHistogram, HistFormat_Geometric1_Delta}
 
 class HistogramVectorTest extends NativeVectorTest {
   import HistogramTest._

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -144,35 +144,14 @@ class HistogramVectorTest extends NativeVectorTest {
 
   }
 
-  it("should accept MutableHistograms with otel exp scheme and query them back") {
-    val appender = HistogramVector.appending(memFactory, 1024)
-    val mutHistograms = otelExpHistograms.map(h => MutableHistogram(h.buckets, h.valueArray))
+  it("should accept MutableHistograms with rate doubles that have fractional value with" +
+    " otel exp scheme and query them back") {
+    val mutHistograms = otelExpHistograms.map(h => MutableHistogram(h.buckets, h.valueArray.map(_ + 4.6992d)))
     mutHistograms.foreach { custHist =>
       custHist.serialize(Some(buffer))
-      appender.addData(buffer) shouldEqual Ack
+      val hist2 = BinaryHistogram.BinHistogram(buffer).toHistogram
+      hist2 shouldEqual custHist
     }
-    appender.length shouldEqual mutHistograms.length
-    val reader = appender.reader.asInstanceOf[RowHistogramReader]
-    reader.length shouldEqual mutHistograms.length
-
-    (0 until otelExpHistograms.length).foreach { i =>
-      val h = reader(i)
-      h.buckets shouldEqual otelExpHistograms.head.buckets
-      h shouldEqual mutHistograms(i)
-    }
-  }
-
-  it("Bin Histogram from otel exponential histogram should go through serialize and query cycle correctly") {
-    val appender = HistogramVector.appending(memFactory, 1024)
-    val otelExpBuckets = Base2ExpHistogramBuckets(3, -20, 41)
-    val h = MutableHistogram(otelExpBuckets, Array.fill(42)(1L))
-    h.serialize(Some(buffer))
-    appender.addData(buffer) shouldEqual Ack
-    val mutableHisto = appender.reader.asHistReader.sum(0,0)
-    val binHist = BinHistogram(mutableHisto.serialize())
-    binHist.formatCode shouldEqual HistFormat_OtelExp_Delta
-    val deserHist = binHist.toHistogram
-    deserHist shouldEqual h
   }
 
   it("should optimize histograms and be able to query optimized vectors") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Mutable histograms, when used for exponential histograms rate calculations were truncating decimals since they were being converted to Long during serialization. This fixes the conversion to use `writeDoubles` instead of `writeDeltas`. The latter should be used for LongHistogram only during ingestion. 