### PR TITLE
Cherry-pick bug(memory): MutableHistogram vectors when serialized with Exp histog…

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/NibblePack.scala
+++ b/memory/src/main/scala/filodb.memory/format/NibblePack.scala
@@ -65,6 +65,9 @@ object NibblePack {
   /**
    * Packs Double values using XOR encoding to find minimal # of bits difference between successive values.
    * Initial Double value is written first.
+   *
+   * Unpack bytes compressed with this method using unpackDoubleXOR.method.
+   *
    * @return the final position within the buffer after packing
    */
   final def packDoubles(inputs: Array[Double], buf: MutableDirectBuffer, bufindex: Int): Int = {
@@ -335,6 +338,8 @@ object NibblePack {
 
   /**
    * Generic unpack function which outputs values to a Sink which can process raw 64-bit values from unpack8.
+   * Use when you have compressed bytes using the `packDelta` method.
+   *
    * @param compressed a DirectBuffer wrapping the compressed bytes. Position 0 must be the beginning of the buffer
    *                   to unpack.  NOTE: the passed in DirectBuffer will be mutated to wrap the NEXT bytes that
    *                   can be unpacked.
@@ -349,6 +354,10 @@ object NibblePack {
     res
   }
 
+  /**
+   * Use to unpack bytes that were compressed using the `packDoubles` method.
+   * Do not use for `packDelta` or others.
+   */
   final def unpackDoubleXOR(compressed: DirectBuffer, outArray: Array[Double]): UnpackResult = {
     if (compressed.capacity < 8) {
       InputTooShort

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramVectorTest.scala
@@ -3,7 +3,7 @@ package filodb.memory.format.vectors
 import java.nio.ByteBuffer
 import org.agrona.concurrent.UnsafeBuffer
 import filodb.memory.format._
-import filodb.memory.format.vectors.BinaryHistogram.{BinHistogram, HistFormat_Geometric1_Delta, HistFormat_OtelExp_Delta}
+import filodb.memory.format.vectors.BinaryHistogram.{BinHistogram, HistFormat_Geometric1_Delta}
 
 class HistogramVectorTest extends NativeVectorTest {
   import HistogramTest._
@@ -144,35 +144,14 @@ class HistogramVectorTest extends NativeVectorTest {
 
   }
 
-  it("should accept MutableHistograms with otel exp scheme and query them back") {
-    val appender = HistogramVector.appending(memFactory, 1024)
-    val mutHistograms = otelExpHistograms.map(h => MutableHistogram(h.buckets, h.valueArray))
+  it("should accept MutableHistograms with rate doubles that have fractional value with" +
+    " otel exp scheme and query them back") {
+    val mutHistograms = otelExpHistograms.map(h => MutableHistogram(h.buckets, h.valueArray.map(_ + 4.6992d)))
     mutHistograms.foreach { custHist =>
       custHist.serialize(Some(buffer))
-      appender.addData(buffer) shouldEqual Ack
+      val hist2 = BinaryHistogram.BinHistogram(buffer).toHistogram
+      hist2 shouldEqual custHist
     }
-    appender.length shouldEqual mutHistograms.length
-    val reader = appender.reader.asInstanceOf[RowHistogramReader]
-    reader.length shouldEqual mutHistograms.length
-
-    (0 until otelExpHistograms.length).foreach { i =>
-      val h = reader(i)
-      h.buckets shouldEqual otelExpHistograms.head.buckets
-      h shouldEqual mutHistograms(i)
-    }
-  }
-
-  it("Bin Histogram from otel exponential histogram should go through serialize and query cycle correctly") {
-    val appender = HistogramVector.appending(memFactory, 1024)
-    val otelExpBuckets = Base2ExpHistogramBuckets(3, -20, 41)
-    val h = MutableHistogram(otelExpBuckets, Array.fill(42)(1L))
-    h.serialize(Some(buffer))
-    appender.addData(buffer) shouldEqual Ack
-    val mutableHisto = appender.reader.asHistReader.sum(0,0)
-    val binHist = BinHistogram(mutableHisto.serialize())
-    binHist.formatCode shouldEqual HistFormat_OtelExp_Delta
-    val deserHist = binHist.toHistogram
-    deserHist shouldEqual h
   }
 
   it("should optimize histograms and be able to query optimized vectors") {


### PR DESCRIPTION
…rams were truncating decimals (#1965)

Mutable histograms, when used for exponential histograms rate calculations were truncating decimals since they were being converted to Long during serialization at query time. This fixes the conversion to use writeDoubles instead of writeDeltas. The latter should be used for LongHistogram only during ingestion.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: