### PR TITLE
perf(memstore) TimeRangeChunkScan optimization when querying data in current ingesting chunk

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -336,9 +336,19 @@ extends ChunkMap(initMapSize) with ReadablePartition {
   def infos(method: ChunkScanMethod): ChunkInfoIterator = method match {
     case AllChunkScan        => allInfos
     case InMemoryChunkScan   => allInfos
-    case r: TimeRangeChunkScan => allInfos.filter { ic =>
-                                    ic.intersection(r.startTime, r.endTime).isDefined
-                                  }
+    case r: TimeRangeChunkScan => if (currentInfo != nullInfo
+                                      && r.startTime <= r.endTime
+                                      && currentInfo.startTime <= r.startTime) {
+                                     try {
+                                        new OneChunkInfo(currentInfo)
+                                     } catch {
+                                        case e: Throwable => chunkmapReleaseShared(); throw e;
+                                     }
+                                 } else {
+                                    allInfos.filter { ic =>
+                                      ic.intersection(r.startTime, r.endTime).isDefined
+                                    }
+                                }
     case WriteBufferChunkScan => if (currentInfo == nullInfo) ChunkInfoIterator.empty
                                 else {
                                   // Return a single element iterator which holds a shared lock.

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -336,10 +336,12 @@ extends ChunkMap(initMapSize) with ReadablePartition {
   def infos(method: ChunkScanMethod): ChunkInfoIterator = method match {
     case AllChunkScan        => allInfos
     case InMemoryChunkScan   => allInfos
-    case r: TimeRangeChunkScan => if (currentInfo != nullInfo
+    case r: TimeRangeChunkScan =>
+                                     if (currentInfo != nullInfo
                                       && r.startTime <= r.endTime
                                       && currentInfo.startTime <= r.startTime) {
                                      try {
+                                        chunkmapAcquireShared()
                                         new OneChunkInfo(currentInfo)
                                      } catch {
                                         case e: Throwable => chunkmapReleaseShared(); throw e;

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -2,12 +2,14 @@ package filodb.core.memstore
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
+
 import filodb.core._
 import filodb.core.metadata.Dataset
 import filodb.core.store._


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

When ``TimeRangeChunkScan`` is provided, all chunkInfos are iterated and the relevant ``ChunkSetInfos`` are filtered that contains the data for the given range. The change will avoid this scan and first check if the requested data is available in the currentInfo and return that one chunk of interest. 


**New behavior :**

Just return the ``currentInfo`` if thats where all the requested data range lies.
