### PR TITLE
perf(query) Use the last chunk and avoid scan if the data is availlable in the latest ingesting chunk

### DIFF
--- a/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
@@ -220,6 +220,19 @@ abstract class ChunkMap(var capacity: Int) {
     arrayGet(realIndex(first + size - 1))
   }
 
+
+  final def chunkmapDoGetLastIterator(): ElementIterator = {
+    new LazyElementIterator(() => {
+      chunkmapAcquireShared()
+      try {
+        val lastIdx = realIndex(first + size - 1)
+        new MapIterator(lastIdx, lastIdx + 1)
+      } catch {
+        case e: Throwable => chunkmapReleaseShared(); throw e;
+      }
+    })
+  }
+
   /**
    * Produces an ElementIterator for going through every element of the map in increasing key order.
    */
@@ -708,7 +721,7 @@ abstract class ChunkMap(var capacity: Int) {
    * @param index initialized to first index to read from
    * @param lastIndex last index to read from (exclusive)
    */
-  private class MapIterator(var index: Int, val lastIndex: Int) extends ElementIterator {
+  protected class MapIterator(var index: Int, val lastIndex: Int) extends ElementIterator {
     private var closed: Boolean = false
     private var nextElem: NativePointer = 0
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

When TimeRangeChunkScan is provided, all chunkInfos are iterated and the relevant ChunkSetInfos are filtered that contains the data for the given range. The change will avoid this scan and first check if the requested data is available in the currentInfo and return that one chunk of interest.

New behavior :

Just return the currentInfo if thats where all the requested data range lies.