### PR TITLE
fix(ingestion): shard recovery should fetch the end of IngestionStream to recover the index

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionActor.scala
@@ -228,9 +228,9 @@ private[filodb] final class IngestionActor(ref: DatasetRef,
           val endRecoveryWatermark = checkpoints.values.max
           val lastFlushedGroup = checkpoints.find(_._2 == endRecoveryWatermark).get._1
           logger.info(s"Checkpoints=$checkpoints for dataset=$ref shard=$shard! lastFlushedGroup=$lastFlushedGroup")
-          GlobalConfig.indexRecoveryRecursiveOffsetMaxDepth.isDefined match {
+          GlobalConfig.indexRecoveryMaxDepth.isDefined match {
             case true => {
-              val maxRecursionDepth = GlobalConfig.indexRecoveryRecursiveOffsetMaxDepth.get
+              val maxRecursionDepth = GlobalConfig.indexRecoveryMaxDepth.get
               logger.info(s"[RecoverIndex] Using recursive strategy to fetch endOffset from IngestionStream!" +
                 s" dataset=$ref shard=$shard startOffset=$startRecoveryWatermark maxRecursionDepth=$maxRecursionDepth")
 

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionStream.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionStream.scala
@@ -19,6 +19,12 @@ trait IngestionStream {
   def get: Observable[SomeData]
 
   /**
+   * @return returns the offset of the last record in the stream, if applicable. This is used in
+   *         "IngestionActor.doRecovery" method to retrieve the ending watermark for shard recovery.
+   */
+  def endOffset: Option[Long]
+
+  /**
    * NOTE: this does not cancel any subscriptions to the Observable.  That should be done prior to
    * calling this, which is more for release of resources.
    */
@@ -32,6 +38,7 @@ object IngestionStream {
   def apply(stream: Observable[SomeData]): IngestionStream = new IngestionStream {
     val get = stream
     def teardown(): Unit = {}
+    def endOffset: Option[Long] = None
   }
 
   val empty = apply(Observable.empty[SomeData])

--- a/coordinator/src/main/scala/filodb.coordinator/IngestionStream.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/IngestionStream.scala
@@ -27,8 +27,12 @@ trait IngestionStream {
   /**
    * NOTE: this does not cancel any subscriptions to the Observable.  That should be done prior to
    * calling this, which is more for release of resources.
+   * @param isForced if true, then the teardown should clean up all the resources without waiting for the scheduler
+   *                 to invoke the cancel-task, which cleans up the state. For example, in the case of Kafka, this
+   *                 would mean closing the Kafka consumer and releasing the resources, without waiting for the
+   *                 KafkaConsumerObservable task to cancel.
    */
-  def teardown(): Unit
+  def teardown(isForced: Boolean = false): Unit
 }
 
 object IngestionStream {
@@ -37,7 +41,7 @@ object IngestionStream {
    */
   def apply(stream: Observable[SomeData]): IngestionStream = new IngestionStream {
     val get = stream
-    def teardown(): Unit = {}
+    def teardown(isForced: Boolean): Unit = {}
     def endOffset: Option[Long] = None
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/sources/CsvStream.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/sources/CsvStream.scala
@@ -119,7 +119,7 @@ private[filodb] class CsvStream(csvReader: CSVReader,
                         }
   val get = Observable.fromIteratorUnsafe(batchIterator)
 
-  def teardown(): Unit = {
+  def teardown(isForced: Boolean = false): Unit = {
     csvReader.close()
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/sources/CsvStream.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/sources/CsvStream.scala
@@ -122,4 +122,6 @@ private[filodb] class CsvStream(csvReader: CSVReader,
   def teardown(): Unit = {
     csvReader.close()
   }
+
+  override def endOffset: Option[Long] = None
 }

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -203,8 +203,10 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
     IngestionActor.getRecoveryProgressPercentage(1, 3, 200, 100, 500) shouldEqual 8
     IngestionActor.getRecoveryProgressPercentage(1, 3, 400, 100, 500) shouldEqual 24
     IngestionActor.getRecoveryProgressPercentage(1, 3, 500, 100, 500) shouldEqual 33
+    IngestionActor.getRecoveryProgressPercentage(1, 3, 500, 500, 500) shouldEqual 33
     IngestionActor.getRecoveryProgressPercentage(2, 3, 600, 500, 700) shouldEqual 49
     IngestionActor.getRecoveryProgressPercentage(2, 3, 700, 500, 700) shouldEqual 66
+    IngestionActor.getRecoveryProgressPercentage(2, 3, 700, 700, 700) shouldEqual 66
     IngestionActor.getRecoveryProgressPercentage(3, 3, 800, 700, 1000) shouldEqual 77
     IngestionActor.getRecoveryProgressPercentage(3, 3, 900, 700, 1000) shouldEqual 88
     IngestionActor.getRecoveryProgressPercentage(3, 3, 1000, 700, 1000) shouldEqual 100

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -198,4 +198,15 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
     coordinatorActor ! GetIngestionStats(dataset33.ref)
     expectMsg(IngestionActor.IngestionStatus(85))    // <-- must be rounded to 5, we ingest entire batches
   }
+
+  it ("should calculate recoveryPct correctly") {
+    IngestionActor.getRecoveryProgressPercentage(1, 3, 200, 100, 500) shouldEqual 8
+    IngestionActor.getRecoveryProgressPercentage(1, 3, 400, 100, 500) shouldEqual 24
+    IngestionActor.getRecoveryProgressPercentage(1, 3, 500, 100, 500) shouldEqual 33
+    IngestionActor.getRecoveryProgressPercentage(2, 3, 600, 500, 700) shouldEqual 49
+    IngestionActor.getRecoveryProgressPercentage(2, 3, 700, 500, 700) shouldEqual 66
+    IngestionActor.getRecoveryProgressPercentage(3, 3, 800, 700, 1000) shouldEqual 77
+    IngestionActor.getRecoveryProgressPercentage(3, 3, 900, 700, 1000) shouldEqual 88
+    IngestionActor.getRecoveryProgressPercentage(3, 3, 1000, 700, 1000) shouldEqual 100
+  }
 }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -4,7 +4,7 @@ filodb {
   partition = ""
 
   index-recovery {
-    recursive-offset-max-depth = 3
+    recursive-offset-max-depth = -1
   }
 
   # Number of nodes in cluster; used to calculate per-shard resources based

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -3,6 +3,10 @@ filodb {
 
   partition = ""
 
+  index-recovery {
+    recursive-offset-max-depth = 3
+  }
+
   # Number of nodes in cluster; used to calculate per-shard resources based
   # on how many shards assigned to node.
   # Required config if v2-clustering or automatic memory-alloc is enabled

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -4,7 +4,7 @@ filodb {
   partition = ""
 
   index-recovery {
-    recursive-offset-max-depth = -1
+    max-depth = -1
   }
 
   # Number of nodes in cluster; used to calculate per-shard resources based

--- a/core/src/main/scala/filodb.core/GlobalConfig.scala
+++ b/core/src/main/scala/filodb.core/GlobalConfig.scala
@@ -73,11 +73,11 @@ object GlobalConfig extends StrictLogging {
     }
   }
 
-  val indexRecoveryRecursiveOffsetMaxDepth: Option[Int] = {
-    systemConfig.hasPath("filodb.index-recovery.recursive-offset-max-depth") match {
+  val indexRecoveryMaxDepth: Option[Int] = {
+    systemConfig.hasPath("filodb.index-recovery.max-depth") match {
       case false => None
-      case true => if (systemConfig.getInt("filodb.index-recovery.recursive-offset-max-depth") > 0) {
-        Some(systemConfig.getInt("filodb.index-recovery.recursive-offset-max-depth"))
+      case true => if (systemConfig.getInt("filodb.index-recovery.max-depth") > 0) {
+        Some(systemConfig.getInt("filodb.index-recovery.max-depth"))
       } else {
         None
       }

--- a/core/src/main/scala/filodb.core/GlobalConfig.scala
+++ b/core/src/main/scala/filodb.core/GlobalConfig.scala
@@ -72,4 +72,11 @@ object GlobalConfig extends StrictLogging {
       case true => Some(systemConfig.getConfig("filodb.query.hierarchical"))
     }
   }
+
+  val indexRecoveryRecursiveOffsetMaxDepth: Option[Int] = {
+    systemConfig.hasPath("filodb.index-recovery.recursive-offset-max-depth") match {
+      case false => None
+      case true => Some(systemConfig.getInt("filodb.index-recovery.recursive-offset-max-depth"))
+    }
+  }
 }

--- a/core/src/main/scala/filodb.core/GlobalConfig.scala
+++ b/core/src/main/scala/filodb.core/GlobalConfig.scala
@@ -76,7 +76,11 @@ object GlobalConfig extends StrictLogging {
   val indexRecoveryRecursiveOffsetMaxDepth: Option[Int] = {
     systemConfig.hasPath("filodb.index-recovery.recursive-offset-max-depth") match {
       case false => None
-      case true => Some(systemConfig.getInt("filodb.index-recovery.recursive-offset-max-depth"))
+      case true => if (systemConfig.getInt("filodb.index-recovery.recursive-offset-max-depth") > 0) {
+        Some(systemConfig.getInt("filodb.index-recovery.recursive-offset-max-depth"))
+      } else {
+        None
+      }
     }
   }
 }

--- a/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
+++ b/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
@@ -86,6 +86,7 @@ class KafkaIngestionStream(config: Config,
 
   override def teardown(): Unit = {
     logger.info(s"Shutting down stream $tp")
+    kafkaConsumer.close()
     // consumer does callback to close but confirm
    }
 

--- a/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
+++ b/kafka/src/main/scala/filodb/kafka/KafkaIngestionStream.scala
@@ -86,6 +86,9 @@ class KafkaIngestionStream(config: Config,
 
   override def teardown(): Unit = {
     logger.info(s"Shutting down stream $tp")
+    // Manually closing the kafka consumer on teardown. KCO on cancelTask calls close on the kafka consumer,
+    // but there is a delay in the callback to close the consumer at times. Hence, closing the consumer here. Multiple
+    // invocations of close is safe. This will avoid the `InstanceAlreadyExistsException` we see.
     kafkaConsumer.close()
     // consumer does callback to close but confirm
    }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

1. `doRecovery` during shard startup only recovers to the max of "previously flushed group checkpoints for the shard". 

2. In case the shard is down for multiple minutes or hours and ingestion is actively happening, the shard doesn't recovers to latest ingestion stream offset and becomes active for query much sooner.  This will result in incorrect queries.

**New behavior :** 

1.  Adding a new config driven functionality, where the shard recovery process can fetch the end offset of the ingestion stream and recover to that offset. 

2. This can be done multiple times in recursive fashion to reach to the latest ingested offset before marking shard as ready for query.