### PR TITLE
increase the sleep time for ds jobs metrics publish.

### DIFF
--- a/conf/timeseries-filodb-durable-downsample-index-server.conf
+++ b/conf/timeseries-filodb-durable-downsample-index-server.conf
@@ -57,7 +57,7 @@ filodb {
   downsampler {
     raw-dataset-name = "prometheus"
     should-sleep-for-metrics-flush = false
-
+    sleep-time-for-metrics-flush = 120 seconds
   }
   ds-index-job {
     raw-dataset-name = "prometheus"

--- a/conf/timeseries-filodb-server.conf
+++ b/conf/timeseries-filodb-server.conf
@@ -67,6 +67,7 @@ filodb {
   downsampler {
     raw-dataset-name = "prometheus"
     should-sleep-for-metrics-flush = false
+    sleep-time-for-metrics-flush = 120 seconds
   }
   ds-index-job {
     raw-dataset-name = "prometheus"

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -581,6 +581,7 @@ filodb {
 
     # whether to sleep at end for metrics flush
     should-sleep-for-metrics-flush = true
+    sleep-time-for-metrics-flush = 120 seconds
 
     # configure only these three items.
     downsample-store-config {

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -69,6 +69,9 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
   @transient lazy val downsampleChunkDuration = downsampleStoreConfig.flushInterval.toMillis
 
   @transient lazy val shouldSleepForMetricsFlush = downsamplerConfig.as[Boolean]("should-sleep-for-metrics-flush")
+  @transient lazy val sleepTimeForMetricsFlush = if (downsamplerConfig.hasPath ("sleep-time-for-metrics-flush"))
+    downsamplerConfig.as[FiniteDuration]("sleep-time-for-metrics-flush") else 120 seconds
+
 
   @transient lazy val allow = downsamplerConfig.as[Seq[Map[String, String]]]("allow-filters").map(_.toSeq)
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -2,14 +2,13 @@ package filodb.downsampler.index
 
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-
 import kamon.Kamon
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-
 import filodb.coordinator.KamonShutdownHook
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.DownsamplerSettings
+import filodb.query.Query.qLogger
 
 /**
   *
@@ -122,8 +121,13 @@ class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSInde
         .withTag("downsamplePeriod", downsamplePeriodStr)
       downsampleHourStartGauge.update(userTimeStart / 1000 / 60 / 60)
     }
-    if (dsSettings.shouldSleepForMetricsFlush)
-      Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
+    if (dsSettings.shouldSleepForMetricsFlush) {
+      val sleepTime = dsSettings.sleepTimeForMetricsFlush
+      qLogger.info(s"The job is about to finish. Will sleep extra time=${sleepTime}" +
+        s" to make sure the metrics publish finishes")
+      Thread.sleep(sleepTime.toMillis) // quick & dirty hack to ensure that the completed metric gets published
+      qLogger.info(s"The job finished. You may increase sleepTime=${sleepTime} if you see metrics publish failure.")
+    }
     spark
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**Will wait 120s (also configurable) to make sure the metrics are published**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: