### PR TITLE
fix(core): Lifting bucketOffset restriction for exp histograms

### DIFF
--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -159,6 +159,12 @@ extends ChunkMap(initMapSize) with ReadablePartition {
               return
             // Different histogram bucket schema: need a new vector here
             case BucketSchemaMismatch =>
+              // TODO For exponential histograms, there is a possibility to optimize if we end up with a bunch
+              // of one-observation histograms with frequently changing bucket schema. This can create lot of
+              // chunks. We can reduce chunk count by conditionally coalescing and adding this sample to the previous
+              // histogram. Work deferred to next iteration for now since it requires mutation of previous samples in
+              // write buffer, which is not something we have done before. It would also be contrary the principle of
+              // storing data in TSDB as it arrives without modification or taking loss in precision.
               switchBuffersAndIngest(ingestionTime, ts, row, overflowBlockHolder,
                 createChunkAtFlushBoundary, flushIntervalMillis, acceptDuplicateSamples, maxChunkTime)
               return

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -73,8 +73,14 @@ class HistogramTest extends NativeVectorTest {
       HistogramBuckets(writeBuf, HistFormat_Custom_Delta) shouldEqual customScheme
 
       val buckets3 = Base2ExpHistogramBuckets(3, -5, 16)
-      buckets3.serialize(writeBuf, 0) shouldEqual 14
+      buckets3.serialize(writeBuf, 0) shouldEqual 18
       HistogramBuckets(writeBuf, HistFormat_OtelExp_Delta) shouldEqual buckets3
+
+      // bugfix: accommodate large offsets that exceed short-int
+      val buckets4 = Base2ExpHistogramBuckets(3, -9037032, 150)
+      buckets4.serialize(writeBuf, 0) shouldEqual 18
+      HistogramBuckets(writeBuf, HistFormat_OtelExp_Delta) shouldEqual buckets4
+
     }
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Lifting constraints for bucket offset in exponential bucket schema. When scale is large (like 20), large offsets are possible in incoming data.

Breaking change: We change the format of histogram vector to store bucket offset as Int instead of Short.

