### PR TITLE
fix(cluster): Fixing minimal events for state `ShardStatusError`

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardHealthStats.scala
@@ -35,7 +35,7 @@ class ShardHealthStats(ref: DatasetRef,
     numRecovering.update(mapper.statuses.count(_.isInstanceOf[ShardStatusRecovery]))
     numAssigned.update(mapper.statuses.count(_ == ShardStatusAssigned))
     if (!skipUnassigned) numUnassigned.update(mapper.statuses.count(_ == ShardStatusUnassigned))
-    numError.update(mapper.statuses.count(_ == ShardStatusError))
+    numError.update(mapper.statuses.count(_.isInstanceOf[ShardStatusError]))
     numStopped.update(mapper.statuses.count(_ == ShardStatusStopped))
     numDown.update(mapper.statuses.count(_ == ShardStatusDown))
   }

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -217,7 +217,7 @@ class ShardMapper(val numShards: Int) extends Serializable {
       statusMap(shard) = ShardStatusRecovery(progress)
       registerNode(Seq(shard), node)
     case IngestionError(_, shard, error) =>
-      statusMap(shard) = ShardStatusError(error)
+      statusMap(shard) = ShardStatusError(error.getMessage)
       unassignShard(shard)
     case IngestionStopped(_, shard) =>
       statusMap(shard) = ShardStatusStopped

--- a/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardMapper.scala
@@ -216,8 +216,8 @@ class ShardMapper(val numShards: Int) extends Serializable {
     case RecoveryInProgress(_, shard, node, progress) =>
       statusMap(shard) = ShardStatusRecovery(progress)
       registerNode(Seq(shard), node)
-    case IngestionError(_, shard, _) =>
-      statusMap(shard) = ShardStatusError
+    case IngestionError(_, shard, error) =>
+      statusMap(shard) = ShardStatusError(error)
       unassignShard(shard)
     case IngestionStopped(_, shard) =>
       statusMap(shard) = ShardStatusStopped
@@ -316,7 +316,7 @@ private[filodb] object ShardMapper extends StrictLogging {
     case ShardStatusUnassigned  => "."
     case ShardStatusAssigned    => "N"
     case ShardStatusActive      => "A"
-    case ShardStatusError       => "E"
+    case e: ShardStatusError    => "E"
     case s: ShardStatusRecovery => "R"
     case ShardStatusStopped     => "S"
     case ShardStatusDown        => "D"

--- a/coordinator/src/main/scala/filodb.coordinator/ShardStatus.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardStatus.scala
@@ -180,9 +180,12 @@ case object ShardStatusActive extends ShardStatus {
     Seq(IngestionStarted(ref, shard, node))
 }
 
-final case class ShardStatusError(error: Throwable) extends ShardStatus {
+// NOTE: why are we not using the full throwable instead of String? This is because
+// ShardStatus is used in many API responses in ClusterRoute and HealthRoute. Having a `Throwable` type member
+// variable will lead to Marshalling errors. Hence, we are using a String here to store the exception message.
+case class ShardStatusError(error: String) extends ShardStatus {
   def minimalEvents(ref: DatasetRef, shard: Int, node: ActorRef): Seq[ShardEvent] =
-    Seq(IngestionError(ref, shard, error))
+    Seq(IngestionError(ref, shard, new Exception(error)))
 }
 
 final case class ShardStatusRecovery(progressPct: Int) extends ShardStatus {

--- a/coordinator/src/main/scala/filodb.coordinator/ShardStatus.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ShardStatus.scala
@@ -180,9 +180,9 @@ case object ShardStatusActive extends ShardStatus {
     Seq(IngestionStarted(ref, shard, node))
 }
 
-case object ShardStatusError extends ShardStatus {
+final case class ShardStatusError(error: Throwable) extends ShardStatus {
   def minimalEvents(ref: DatasetRef, shard: Int, node: ActorRef): Seq[ShardEvent] =
-    Seq(IngestionStarted(ref, shard, node))
+    Seq(IngestionError(ref, shard, error))
 }
 
 final case class ShardStatusRecovery(progressPct: Int) extends ShardStatus {

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -89,6 +89,11 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
           if (!latestStatus.isInstanceOf[ShardStatusError]) {
             mapper.shardsForCoord(coordinatorActor) shouldEqual Seq(0)
           }
+          else {
+            // check if it is the same error
+            latestStatus.asInstanceOf[ShardStatusError].error.getMessage shouldEqual
+              waitFor.asInstanceOf[ShardStatusError].error.getMessage
+          }
       }
       info(s"Latest status = $latestStatus")
     }
@@ -127,7 +132,8 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
   // but then we need to query for it.
   it("should fail if cannot parse input record during coordinator ingestion") {
     setup(dataset33, "/GDELT-sample-test-errors.csv", rowsToRead = 5, None)
-    waitForShardStatusError(dataset33.ref, ShardStatusError.apply(new IllegalArgumentException("bad data")))
+    waitForShardStatusError(dataset33.ref, ShardStatusError.apply(
+      new IllegalArgumentException("Invalid format: \"NananananaXX\"")))
   }
 
   // TODO: Simulate more failures.  Maybe simulate I/O failure or use a custom source

--- a/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/IngestionStreamSpec.scala
@@ -91,8 +91,8 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
           }
           else {
             // check if it is the same error
-            latestStatus.asInstanceOf[ShardStatusError].error.getMessage shouldEqual
-              waitFor.asInstanceOf[ShardStatusError].error.getMessage
+            latestStatus.asInstanceOf[ShardStatusError].error shouldEqual
+              waitFor.asInstanceOf[ShardStatusError].error
           }
       }
       info(s"Latest status = $latestStatus")
@@ -132,8 +132,7 @@ class IngestionStreamSpec extends ActorTest(IngestionStreamSpec.getNewSystem) wi
   // but then we need to query for it.
   it("should fail if cannot parse input record during coordinator ingestion") {
     setup(dataset33, "/GDELT-sample-test-errors.csv", rowsToRead = 5, None)
-    waitForShardStatusError(dataset33.ref, ShardStatusError.apply(
-      new IllegalArgumentException("Invalid format: \"NananananaXX\"")))
+    waitForShardStatusError(dataset33.ref, ShardStatusError.apply("Invalid format: \"NananananaXX\""))
   }
 
   // TODO: Simulate more failures.  Maybe simulate I/O failure or use a custom source

--- a/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
@@ -236,7 +236,8 @@ class ShardMapperSpec extends ActorTest(ShardMapperSpec.getNewSystem) {
     map.updateFromEvent(ShardAssignmentStarted(dataset, 1, ref1))
     map.updateFromEvent(IngestionStarted(dataset, 1, ref1))
     map.updateFromEvent(IngestionError(dataset, 1, new java.io.IOException("e")))
-    map.statusForShard(1) shouldEqual ShardStatusError
+    map.statusForShard(1).isInstanceOf[ShardStatusError] shouldEqual true
+    map.statusForShard(1).asInstanceOf[ShardStatusError].error.isInstanceOf[java.io.IOException] shouldEqual true
   }
 
   it("should be idempotent for registerNode and assign/unassign/register/unregister as expected") {

--- a/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ShardMapperSpec.scala
@@ -235,9 +235,9 @@ class ShardMapperSpec extends ActorTest(ShardMapperSpec.getNewSystem) {
     val map = new ShardMapper(numShards)
     map.updateFromEvent(ShardAssignmentStarted(dataset, 1, ref1))
     map.updateFromEvent(IngestionStarted(dataset, 1, ref1))
-    map.updateFromEvent(IngestionError(dataset, 1, new java.io.IOException("e")))
+    map.updateFromEvent(IngestionError(dataset, 1, new java.io.IOException("bad data")))
     map.statusForShard(1).isInstanceOf[ShardStatusError] shouldEqual true
-    map.statusForShard(1).asInstanceOf[ShardStatusError].error.isInstanceOf[java.io.IOException] shouldEqual true
+    map.statusForShard(1).asInstanceOf[ShardStatusError].error shouldEqual "bad data"
   }
 
   it("should be idempotent for registerNode and assign/unassign/register/unregister as expected") {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** minimalEvents for state `ShardStatusError` incorrectly marks shards as `ShardStatusActive`. 

**New behavior :** minimalEvents is marking the shards correctly as `ShardStatusActive` using `IngestionError` shardEvent.

Shard Status Response will look as following:

```
{
  "status": "success",
  "data": [
    {
      "shard": 0,
      "status": "ShardStatusActive",
      "address": "akka://filo-standalone"
    },
    {
      "shard": 1,
      "status": "ShardStatusActive",
      "address": "akka://filo-standalone"
    },
    {
      "shard": 2,
      "status": "ShardStatusError(test exception)",
      "address": ""
    },
    {
      "shard": 3,
      "status": "ShardStatusRecovery(0)",
      "address": "akka.tcp://filo-standalone@127.0.0.1:3552"
    }
  ]
}
```