### PR TITLE
feat(core): Exponential histogram vector to address volatility in exp bucketing scheme

### DIFF
--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -117,6 +117,6 @@
         # Retention of downsampled data for the corresponding resolution
         ttls = [ 30 days, 183 days ]
         # Raw schemas from which to downsample
-        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram", "delta-counter", "delta-histogram", "otel-delta-histogram", "otel-cumulative-histogram"]
+        raw-schema-names = [ "gauge", "untyped", "prom-counter", "prom-histogram", "delta-counter", "delta-histogram", "otel-delta-histogram", "otel-exp-delta-histogram", "otel-cumulative-histogram"]
       }
     }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -212,6 +212,19 @@ filodb {
       downsample-schema = "otel-delta-histogram"
     }
 
+    otel-exp-delta-histogram {
+      columns = ["timestamp:ts",
+        "sum:double:{detectDrops=false,delta=true}",
+        "count:double:{detectDrops=false,delta=true}",
+        "h:hist:{counter=false,delta=true,exp=true}",
+        "min:double:{detectDrops=false,delta=true}",
+        "max:double:{detectDrops=false,delta=true}"]
+      value-column = "h"
+      downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "hSum(3)", "dMin(4)", "dMax(5)"]
+      downsample-period-marker = "time(0)"
+      downsample-schema = "otel-exp-delta-histogram"
+    }
+
     # PreAgg Schema defintions.
     # preagg-gauge and preagg-delta-counter have same schemas. Defining two different data-schemas to enable
     # additional features/functionalities at query-time.
@@ -264,6 +277,20 @@ filodb {
       downsample-period-marker = "time(0)"
       downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "dSum(3)", "hSum(4)", "dMin(5)", "dMax(6)"]
       downsample-schema = "preagg-otel-delta-histogram"
+    }
+
+    preagg-otel-exp-delta-histogram {
+      columns = ["timestamp:ts",
+        "sum:double:{detectDrops=false,delta=true}",
+        "count:double:{detectDrops=false,delta=true}",
+        "tscount:double:{detectDrops=false,delta=true}",
+        "h:hist:{counter=false,delta=true,exp=true}",
+        "min:double:{detectDrops=false,delta=true}",
+        "max:double:{detectDrops=false,delta=true}"]
+      value-column = "h"
+      downsample-period-marker = "time(0)"
+      downsamplers = ["tTime(0)", "dSum(1)", "dSum(2)", "dSum(3)", "hSum(4)", "dMin(5)", "dMax(6)"]
+      downsample-schema = "preagg-otel-exp-delta-histogram"
     }
 
     # Used for downsampled gauge data

--- a/core/src/main/scala/filodb.core/downsample/ChunkDownsampler.scala
+++ b/core/src/main/scala/filodb.core/downsample/ChunkDownsampler.scala
@@ -147,7 +147,9 @@ case class HistSumDownsampler(val inputColIds: Seq[Int]) extends HistChunkDownsa
     val vecPtr = chunkset.vectorAddress(inputColIds(0))
     val histReader = part.chunkReader(inputColIds(0), vecAcc, vecPtr).asHistReader
     val summedHist = histReader.sum(startRow, endRow)
-    LongHistogram(summedHist.buckets, summedHist.values.map(_.toLong))
+    // taking first numBuckets values from the summed histogram since exp histograms can return more values
+    val values = summedHist.values.take(summedHist.buckets.numBuckets).map(_.toLong)
+    LongHistogram(summedHist.buckets, values)
   }
 }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
@@ -275,8 +275,10 @@ object TimeSeriesStore {
         case TimestampColumn => bv.LongBinaryVector.timestampVector(memFactory, maxElements)
         case StringColumn    => bv.UTF8Vector.appendingVector(memFactory, maxElements, config.maxBlobBufferSize)
         case HistogramColumn => val counter = col.params.as[Option[Boolean]]("counter").getOrElse(false)
-                                if (counter) bv.HistogramVector.appendingSect(memFactory, config.maxBlobBufferSize)
-                                else         bv.HistogramVector.appending(memFactory, config.maxBlobBufferSize)
+                                val exponential = col.params.as[Option[Boolean]]("exp").getOrElse(false)
+                            if (counter) bv.HistogramVector.appendingSect(memFactory, config.maxBlobBufferSize)
+                            else if (exponential) bv.HistogramVector.appendingExp(memFactory, config.maxBlobBufferSize)
+                            else                  bv.HistogramVector.appending(memFactory, config.maxBlobBufferSize)
         case other: Column.ColumnType => ???
       }
     }.toArray

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
@@ -276,9 +276,12 @@ object TimeSeriesStore {
         case StringColumn    => bv.UTF8Vector.appendingVector(memFactory, maxElements, config.maxBlobBufferSize)
         case HistogramColumn => val counter = col.params.as[Option[Boolean]]("counter").getOrElse(false)
                                 val exponential = col.params.as[Option[Boolean]]("exp").getOrElse(false)
-                            if (counter) bv.HistogramVector.appendingSect(memFactory, config.maxBlobBufferSize)
-                            else if (exponential) bv.HistogramVector.appendingExp(memFactory, config.maxBlobBufferSize)
-                            else                  bv.HistogramVector.appending(memFactory, config.maxBlobBufferSize)
+                                if (counter)
+                                  bv.HistogramVector.appendingSect(memFactory, config.maxBlobBufferSize)
+                                else if (exponential)
+                                  bv.HistogramVector.appendingExp(memFactory, config.maxBlobBufferSize)
+                                else
+                                  bv.HistogramVector.appending(memFactory, config.maxBlobBufferSize)
         case other: Column.ColumnType => ???
       }
     }.toArray

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -470,9 +470,11 @@ object Schemas extends StrictLogging {
   val deltaHistogram = global.schemas("delta-histogram")
   val otelCumulativeHistogram = global.schemas("otel-cumulative-histogram")
   val otelDeltaHistogram = global.schemas("otel-delta-histogram")
+  val otelExpDeltaHistogram = global.schemas("otel-exp-delta-histogram")
   val dsGauge = global.schemas("ds-gauge")
   val preaggGauge = global.schemas("preagg-gauge")
   val preaggDeltaCounter = global.schemas("preagg-delta-counter")
   val preaggDeltaHistogram = global.schemas("preagg-delta-histogram")
   val preaggOtelDeltaHistogram = global.schemas("preagg-otel-delta-histogram")
+  val preaggOtelExpDeltaHistogram = global.schemas("preagg-otel-exp-delta-histogram")
 }

--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -28,8 +28,8 @@ import org.rogach.scallop._
 import filodb.coordinator.{FilodbSettings, ShardMapper, StoreFactory}
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.metadata.Dataset
-import filodb.core.metadata.Schemas.{deltaCounter, deltaHistogram, gauge, otelCumulativeHistogram, otelDeltaHistogram,
-  promHistogram}
+import filodb.core.metadata.Schemas.{deltaCounter, deltaHistogram, gauge, otelCumulativeHistogram,
+           otelDeltaHistogram, otelExpDeltaHistogram, promHistogram}
 import filodb.gateway.conversion._
 import filodb.memory.MemFactory
 import filodb.timeseries.TestTimeseriesProducer
@@ -156,7 +156,7 @@ object GatewayServer extends StrictLogging {
                    else if (genOtelDeltaHistData) TestTimeseriesProducer.genHistogramData(startTime, numSeries,
                                                   otelDeltaHistogram)
                    else if (genOtelExpDeltaHistData) TestTimeseriesProducer.genHistogramData(startTime, numSeries,
-                     otelDeltaHistogram, otelExponential = true)
+                                                  otelExpDeltaHistogram)
                    else if (genDeltaHist)
                      TestTimeseriesProducer.genHistogramData(startTime, numSeries, deltaHistogram)
                    else if (genGaugeData) TestTimeseriesProducer.timeSeriesData(startTime, numSeries,

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -240,6 +240,8 @@ object InputRecord {
                                      timestamp: Long,
                                      kvs: Seq[(String, Double)],
                                      isDelta: Boolean): Unit = {
+    require(isDelta, "Cumulative exponential histograms not supported")
+
     var sum = Double.NaN
     var count = Double.NaN
     var min = Double.NaN
@@ -274,8 +276,7 @@ object InputRecord {
       val hist = LongHistogram(buckets, bucketValues)
 
       // Now, write out histogram
-      builder.startNewRecord(if (isDelta) otelExpDeltaHistogram
-                             else throw new IllegalArgumentException("cumulative exp histogram not supported"))
+      builder.startNewRecord(otelExpDeltaHistogram)
       builder.addLong(timestamp)
       builder.addDouble(sum)
       builder.addDouble(count)

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -274,7 +274,8 @@ object InputRecord {
       val hist = LongHistogram(buckets, bucketValues)
 
       // Now, write out histogram
-      builder.startNewRecord(if (isDelta) otelDeltaHistogram else otelCumulativeHistogram)
+      builder.startNewRecord(if (isDelta) otelExpDeltaHistogram
+                             else throw new IllegalArgumentException("cumulative exp histogram not supported"))
       builder.addLong(timestamp)
       builder.addDouble(sum)
       builder.addDouble(count)

--- a/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
@@ -113,7 +113,7 @@ class InputRecordBuilderSpec extends AnyFunSpec with Matchers {
 
     InputRecord.writeOtelExponentialHistRecord(builder3, metric, baseTags, 100000L,
                                                bucketKVs ++ sumCountMinMaxKVs ++ more, isDelta = true)
-    builder3.allContainers.head.iterate(Schemas.otelDeltaHistogram.ingestionSchema).foreach { row =>
+    builder3.allContainers.head.iterate(Schemas.otelExpDeltaHistogram.ingestionSchema).foreach { row =>
       row.getDouble(1) shouldEqual sum
       row.getDouble(2) shouldEqual count
       row.getDouble(4) shouldEqual min

--- a/jmh/src/main/scala/filodb.jmh/Base2ExponentialHistogramQueryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/Base2ExponentialHistogramQueryBenchmark.scala
@@ -80,7 +80,7 @@ class Base2ExponentialHistogramQueryBenchmark extends StrictLogging {
   final val numShards = 8
   final val numSamplesPerTs = 720   // 2 hours * 3600 / 10 sec interval
   final val numSeries = 100
-  final val numQueries = 100
+  final val numQueries = 50
   final val numBuckets = 160
   val spread = 3
 

--- a/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
@@ -1,0 +1,97 @@
+package filodb.jmh
+
+import java.util.concurrent.TimeUnit
+
+import org.agrona.concurrent.UnsafeBuffer
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import filodb.memory.NativeMemoryManager
+import filodb.memory.format._
+
+@State(Scope.Thread)
+class HistVectorBenchmark {
+  import vectors._
+
+  val memFactory = new NativeMemoryManager(100 * 1024 * 1024)
+  final val numDataPoints = 60
+  val bucketScheme = Base2ExpHistogramBuckets(3, -78, 126)
+  val counts = Array.fill(bucketScheme.numBuckets)(5L)
+  val buffer = new UnsafeBuffer(new Array[Byte](4096))
+
+  val appender = HistogramVector.appending(memFactory, 15000) // 15k bytes is default blob size
+  val appender2 = HistogramVector.appending(memFactory, 15000) // 15k bytes is default blob size
+  (0 until numDataPoints).foreach { i =>
+    val hist = LongHistogram(bucketScheme, counts)
+    hist.serialize(Some(buffer))
+    if (appender2.addData(buffer) != Ack) {
+      throw new RuntimeException(s"Failed to add histogram $i")
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(numDataPoints)
+  def ingestion(): Unit = {
+    (0 until numDataPoints).foreach { i =>
+      val hist = LongHistogram(bucketScheme, counts)
+      hist.serialize(Some(buffer))
+      if (appender.addData(buffer) != Ack) {
+        throw new RuntimeException(s"Failed to add histogram $i")
+      }
+    }
+    appender.reset()
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def queries(blackhole: Blackhole): Unit = {
+    val r2 = appender2.reader.asHistReader
+    val len = r2.length(MemoryAccessor.nativePtrAccessor, appender.addr)
+    (0 until len).foreach { i =>
+      val h = r2(i)
+      blackhole.consume(h)
+    }
+  }
+
+  val appenderExp = HistogramVector.appendingExp(memFactory, 15000) // 15k bytes is default blob size
+  val appenderExp2 = HistogramVector.appendingExp(memFactory, 15000) // 15k bytes is default blob size
+  (0 until numDataPoints).foreach { i =>
+    val hist = LongHistogram(bucketScheme, counts)
+    hist.serialize(Some(buffer))
+    if (appenderExp2.addData(buffer) != Ack) {
+      throw new RuntimeException(s"Failed to add histogram $i")
+    }
+  }
+
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @OperationsPerInvocation(numDataPoints)
+  def ingestionExpVector(): Unit = {
+    (0 until 60).foreach { i =>
+      val hist = LongHistogram(bucketScheme, counts)
+      hist.serialize(Some(buffer))
+      if (appenderExp.addData(buffer) != Ack) {
+        throw new RuntimeException(s"Failed to add histogram $i")
+      }
+    }
+    appenderExp.reset()
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def queriesExpVector(blackhole: Blackhole): Unit = {
+    val r2 = appenderExp2.reader.asHistReader
+    val len = r2.length(MemoryAccessor.nativePtrAccessor, appenderExp2.addr)
+    (0 until len).foreach { i =>
+      val h = r2(i)
+      blackhole.consume(h)
+    }
+  }
+
+}

--- a/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
@@ -121,7 +121,6 @@ object NativePointerAccessor extends MemoryAccessor {
   val baseOffset: Long = 0
 
   override def wrapInto(buf: DirectBuffer, addr: Long, length: Int): Unit = {
-    println(s"Wrapping native pointer into addr: $addr, length: $length")
     buf.wrap(addr, length)
   }
 }
@@ -135,7 +134,6 @@ class ByteArrayAccessor(val base: Array[Byte]) extends MemoryAccessor {
   val baseOffset: Long = UnsafeUtils.arayOffset
 
   override def wrapInto(buf: DirectBuffer, addr: Long, length: Int): Unit = {
-    println(s"Wrapping array buffer into addr: $addr, length: $length")
     buf.wrap(base, addr.toInt, length)
   }
 }
@@ -166,7 +164,6 @@ class OnHeapByteBufferAccessor(buf: ByteBuffer) extends MemoryAccessor {
   }
 
   override def wrapInto(dBuf: DirectBuffer, addr: Long, length: Int): Unit = {
-    println(s"Wrapping on heap buffer into addr: $addr, length: $length")
     dBuf.wrap(buf, origBufPos + addr.toInt, length)
   }
 
@@ -188,7 +185,6 @@ case class DirectBufferAccessor(buf: ByteBuffer) extends MemoryAccessor {
   val length: Int = buf.limit() - buf.position()
 
   override def wrapInto(dBuf: DirectBuffer, addr: Long, length: Int): Unit = {
-    println(s"Wrapping direct buffer into addr: $addr, length: $length")
     dBuf.wrap(buf, addr.toInt, length)
   }
 

--- a/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
+++ b/memory/src/main/scala/filodb.memory/format/MemoryReader.scala
@@ -121,6 +121,7 @@ object NativePointerAccessor extends MemoryAccessor {
   val baseOffset: Long = 0
 
   override def wrapInto(buf: DirectBuffer, addr: Long, length: Int): Unit = {
+    println(s"Wrapping native pointer into addr: $addr, length: $length")
     buf.wrap(addr, length)
   }
 }
@@ -134,6 +135,7 @@ class ByteArrayAccessor(val base: Array[Byte]) extends MemoryAccessor {
   val baseOffset: Long = UnsafeUtils.arayOffset
 
   override def wrapInto(buf: DirectBuffer, addr: Long, length: Int): Unit = {
+    println(s"Wrapping array buffer into addr: $addr, length: $length")
     buf.wrap(base, addr.toInt, length)
   }
 }
@@ -164,6 +166,7 @@ class OnHeapByteBufferAccessor(buf: ByteBuffer) extends MemoryAccessor {
   }
 
   override def wrapInto(dBuf: DirectBuffer, addr: Long, length: Int): Unit = {
+    println(s"Wrapping on heap buffer into addr: $addr, length: $length")
     dBuf.wrap(buf, origBufPos + addr.toInt, length)
   }
 
@@ -185,6 +188,7 @@ case class DirectBufferAccessor(buf: ByteBuffer) extends MemoryAccessor {
   val length: Int = buf.limit() - buf.position()
 
   override def wrapInto(dBuf: DirectBuffer, addr: Long, length: Int): Unit = {
+    println(s"Wrapping direct buffer into addr: $addr, length: $length")
     dBuf.wrap(buf, addr.toInt, length)
   }
 

--- a/memory/src/main/scala/filodb.memory/format/NibblePack.scala
+++ b/memory/src/main/scala/filodb.memory/format/NibblePack.scala
@@ -206,12 +206,13 @@ object NibblePack {
   }
 
   final case class DeltaSink(outArray: Array[Long]) extends Sink {
+    private var length = outArray.length
     private var current: Long = 0L
     private var i: Int = 0
     final def process(data: Array[Long]): Unit = {
       // It's necessary to ignore "extra" elements because NibblePack always unpacks in multiples of 8, but the
       // user might not intuitively allocate output arrays in elements of 8.
-      val numElems = Math.min(outArray.size - i, 8)
+      val numElems = Math.min(length - i, 8)
       require(numElems > 0)
       cforRange { 0 until numElems } { n =>
         current += data(n)
@@ -222,6 +223,9 @@ object NibblePack {
     def reset(): Unit = {
       i = 0
       current = 0L
+    }
+    def setLength(newLen: Int): Unit = {
+      length = newLen
     }
   }
 

--- a/memory/src/main/scala/filodb.memory/format/Section.scala
+++ b/memory/src/main/scala/filodb.memory/format/Section.scala
@@ -47,9 +47,7 @@ final case class Section private(addr: Long) extends AnyVal {
     val newNumElements = numElements(acc) + addedElements
     val newNumBytes = sectionNumBytes(acc) + addedBytes
     require(newNumElements <= 255 && newNumBytes <= 65535)
-    println(s"Updating section at $addr: numBytes=$newNumBytes, numElements=$newNumElements")
     Ptr.I32(addr).asMut.set(acc, newNumBytes | (newNumElements << 16) | (sectionType(acc).n << 24))
-    println(s"Now: ${debugString(acc)}")
   }
 
   final def setNumElements(acc: MemoryAccessor, num: Int): Unit = {
@@ -131,9 +129,7 @@ trait SectionWriter {
     if (bytesLeft >= (numBytes + 2)) {
       val writeAddr = curSection.endAddr(nativePtrReader)
       // write length prefix for the record
-      println(s"Writing length prefix of $numBytes bytes to section at $writeAddr")
       writeAddr.asU16.asMut.set(MemoryAccessor.nativePtrAccessor, numBytes)
-      println(s"Copying blob of $numBytes bytes to section at ${writeAddr + 2}")
       // copy record bytes
       UnsafeUtils.unsafe.copyMemory(base, offset, UnsafeUtils.ZeroPointer, (writeAddr + 2).addr, numBytes)
       bytesLeft -= (numBytes + 2)

--- a/memory/src/main/scala/filodb.memory/format/Section.scala
+++ b/memory/src/main/scala/filodb.memory/format/Section.scala
@@ -47,7 +47,9 @@ final case class Section private(addr: Long) extends AnyVal {
     val newNumElements = numElements(acc) + addedElements
     val newNumBytes = sectionNumBytes(acc) + addedBytes
     require(newNumElements <= 255 && newNumBytes <= 65535)
+    println(s"Updating section at $addr: numBytes=$newNumBytes, numElements=$newNumElements")
     Ptr.I32(addr).asMut.set(acc, newNumBytes | (newNumElements << 16) | (sectionType(acc).n << 24))
+    println(s"Now: ${debugString(acc)}")
   }
 
   final def setNumElements(acc: MemoryAccessor, num: Int): Unit = {
@@ -124,16 +126,22 @@ trait SectionWriter {
     addBlobInner(base, offset, numBytes)
   }
 
-  private def addBlobInner(base: Any, offset: Long, numBytes: Int): AddResponse =
+  private def addBlobInner(base: Any, offset: Long, numBytes: Int): AddResponse = {
     // Copy bytes to end address, update variables
     if (bytesLeft >= (numBytes + 2)) {
       val writeAddr = curSection.endAddr(nativePtrReader)
+      // write length prefix for the record
+      println(s"Writing length prefix of $numBytes bytes to section at $writeAddr")
       writeAddr.asU16.asMut.set(MemoryAccessor.nativePtrAccessor, numBytes)
+      println(s"Copying blob of $numBytes bytes to section at ${writeAddr + 2}")
+      // copy record bytes
       UnsafeUtils.unsafe.copyMemory(base, offset, UnsafeUtils.ZeroPointer, (writeAddr + 2).addr, numBytes)
       bytesLeft -= (numBytes + 2)
+      // update section length
       curSection.update(MemoryAccessor.nativePtrAccessor, numBytes + 2, 1)
       Ack
     } else VectorTooSmall(numBytes + 2, bytesLeft)
+  }
 }
 
 /**

--- a/memory/src/main/scala/filodb.memory/format/WireFormat.scala
+++ b/memory/src/main/scala/filodb.memory/format/WireFormat.scala
@@ -35,6 +35,7 @@ object WireFormat {
   val SUBTYPE_H_SIMPLE = 0x10         // Histograms, stored as is (Long/u64 values)
   val SUBTYPE_H_2DDELTA = 0x11        // Histograms, 2D-Delta encoded
   val SUBTYPE_H_SECTDELTA = 0x12      // Histograms, Section-Delta encoded
+  val SUBTYPE_H_EXP_SIMPLE = 0x13     // Histograms, exponential, stored as is (Long/u64 values)
 
   def vectorSubType(headerBytes: Int): Int = (headerBytes & 0x00ff00) >> 8
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
@@ -158,7 +158,14 @@ class RowExpHistogramReader(val acc: MemoryReader, val histVect: Ptr.U8) extends
   private val returnHist = LongHistogram(buckets, new Array[Long](Base2ExpHistogramBuckets.maxBuckets))
   protected val dSink = NibblePack.DeltaSink(returnHist.values)
 
-  // WARNING: histogram returned is shared between calls, do not reuse!
+  /**
+   * Returns a histogram for the given index.  The histogram is a shared instance and should not be modified.
+   * Warning1: Returned instance is reused across calls, should not be modified or referenced for longer.
+   * Warning2: The values array in the LongHistogram can be longer than the number of buckets. Take only the prefix
+   *           of the array that is needed.
+   * @param index the index of the histogram to return
+   * @return a histogram for the given index
+   */
   def apply(index: Int): HistogramWithBuckets = {
     require(length > 0)
     val histPtr = locate(index)

--- a/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
@@ -175,10 +175,10 @@ class RowExpHistogramReader(val acc: MemoryReader, val histVect: Ptr.U8) extends
 
     val binHist = BinaryHistogram.BinHistogram(buf)
     val bucketDef = returnHist.buckets.asInstanceOf[Base2ExpHistogramBuckets]
-    bucketDef.scale = HistogramBuckets.otelExpScale(buf.byteArray(), binHist.bucketDefOffset)
-    bucketDef.startIndexPositiveBuckets = HistogramBuckets.otelExpStartIndexPositiveBuckets(buf.byteArray(),
-                                                                                            binHist.bucketDefOffset)
-    bucketDef.numPositiveBuckets = HistogramBuckets.otelExpNumPositiveBuckets(buf.byteArray(), binHist.bucketDefOffset)
+    bucketDef.setScheme(HistogramBuckets.otelExpScale(buf.byteArray(), binHist.bucketDefOffset),
+                        HistogramBuckets.otelExpStartIndexPositiveBuckets(buf.byteArray(), binHist.bucketDefOffset),
+                        HistogramBuckets.otelExpNumPositiveBuckets(buf.byteArray(), binHist.bucketDefOffset))
+
     dSink.reset()
     dSink.setLength(bucketDef.numBuckets)
     val buf2 = binHist.valuesByteSlice // no object allocation here, valuesBuf is reused

--- a/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
@@ -1,0 +1,191 @@
+package filodb.memory.format.vectors
+
+import debox.Buffer
+import org.agrona.DirectBuffer
+import spire.syntax.cfor._
+
+import filodb.memory.{BinaryRegion, MemFactory}
+import filodb.memory.format._
+import filodb.memory.format.BinaryVector.BinaryVectorPtr
+import filodb.memory.format.MemoryReader._
+
+/**
+ * A HistogramVector appender storing compressed histogram values for less storage space.
+ * This is a Section-based vector - sections of up to 64 histograms are stored at a time.
+ * It stores histograms up to a maximum allowed size (since histograms are variable length)
+ * Note that the bucket schema is not set until getting the first item.
+ * This one stores the compressed histograms as-is, with no other transformation.
+ *
+ * Read/Write/Lock semantics: everything is gated by the number of elements.
+ * When it is 0, nothing is initialized so the reader guards against that.
+ * When it is > 0, then all structures are initialized.
+ */
+class AppendableExpHistogramVector(factory: MemFactory,
+                                vectPtr: Ptr.U8,
+                                val maxBytes: Int) extends BinaryAppendableVector[DirectBuffer] with SectionWriter {
+  import HistogramVector._
+  import BinaryHistogram._
+
+  protected def vectSubType: Int = WireFormat.SUBTYPE_H_EXP_SIMPLE
+
+  // Initialize header
+  BinaryVector.writeMajorAndSubType(MemoryAccessor.nativePtrAccessor,
+    addr, WireFormat.VECTORTYPE_HISTOGRAM, vectSubType)
+  reset()
+
+  final def addr: BinaryVectorPtr = vectPtr.addr
+  def maxElementsPerSection: IntU8 = IntU8(64)
+
+  val dispose = () => {
+    // free our own memory
+    factory.freeMemory(addr)
+  }
+
+  final def numBytes: Int = vectPtr.asI32.getI32(nativePtrReader) + 4
+  final def length: Int = getNumHistograms(nativePtrReader, vectPtr)
+  final def isAvailable(index: Int): Boolean = true
+  final def isAllNA: Boolean = (length == 0)
+  final def noNAs: Boolean = (length > 0)
+
+  private def setNumBytes(len: Int): Unit = {
+    require(len >= 0)
+    vectPtr.asI32.asMut.set(MemoryAccessor.nativePtrAccessor, len)
+  }
+
+  // NOTE: to eliminate allocations, re-use the DirectBuffer and keep passing the same instance to addData
+  final def addData(buf: DirectBuffer): AddResponse = {
+    val h = BinHistogram(buf)
+    // Validate it's a valid bin histogram
+    if (buf.capacity < 5 || !isValidFormatCode(h.formatCode) ||
+        h.formatCode == HistFormat_Null) {
+      return InvalidHistogram
+    }
+    if (h.bucketDefNumBytes > h.totalLength) return InvalidHistogram
+
+    val numItems = getNumHistograms(nativePtrReader, vectPtr)
+    if (numItems == 0) {
+      // Copy the bucket definition and set the bucket def size
+//      UnsafeUtils.unsafe.copyMemory(buf.byteArray, h.bucketDefOffset,
+//        UnsafeUtils.ZeroPointer, bucketDefAddr(vectPtr).addr,
+//        h.bucketDefNumBytes)
+//      UnsafeUtils.setShort(addr + OffsetBucketDefSize, h.bucketDefNumBytes.toShort)
+      UnsafeUtils.setByte(addr + OffsetFormatCode, h.formatCode)
+
+      // Initialize the first section
+      val firstSectPtr = afterFormatCode(nativePtrReader, vectPtr)
+      initSectionWriter(firstSectPtr, ((vectPtr + maxBytes).addr - firstSectPtr.addr).toInt)
+    }
+
+    val res = appendHist(buf, h, numItems)
+    if (res == Ack) {
+      // set new number of bytes first. Remember to exclude initial 4 byte length prefix
+      setNumBytes(maxBytes - bytesLeft - 4)
+      // Finally, increase # histograms which is the ultimate safe gate for access by readers
+      incrNumHistograms(MemoryAccessor.nativePtrAccessor, vectPtr)
+    }
+    res
+  }
+
+  def debugString: String = {
+    val hReader = reader.asInstanceOf[RowExpHistogramReader]
+    s"AppendableExpHistogramVector(vectPtr=$vectPtr maxBytes=$maxBytes) " +
+    s"numItems=${hReader.length} curSection=$curSection " +
+    { if (hReader.length > 0) s"bucketScheme: ${hReader.buckets} numBuckets=${hReader.numBuckets}" else "<noSchema>" }
+  }
+
+  // Inner method to add the histogram to this vector
+  protected def appendHist(buf: DirectBuffer, h: BinHistogram, numItems: Int): AddResponse = {
+    appendBlob(buf.byteArray, buf.addressOffset, h.totalLength)
+  }
+
+  final def addNA(): AddResponse = Ack  // TODO: Add a 0 to every appender
+
+  def addFromReaderNoNA(reader: RowReader, col: Int): AddResponse = addData(reader.blobAsBuffer(col))
+  def copyToBuffer: Buffer[DirectBuffer] = ???
+  def apply(index: Int): DirectBuffer = ???
+
+  def finishCompaction(newAddress: BinaryRegion.NativePointer): BinaryVectorPtr = newAddress
+
+  // NOTE: do not access reader below unless this vect is nonempty.  TODO: fix this, or don't if we don't use this class
+  lazy val reader: VectorDataReader = new RowExpHistogramReader(nativePtrReader, vectPtr)
+
+  def reset(): Unit = {
+    resetNumHistograms(MemoryAccessor.nativePtrAccessor, vectPtr)
+    setNumBytes(OffsetNumBuckets + 2)
+  }
+
+}
+
+/**
+ * A reader for row-based Exp Histogram vectors.  Mostly contains logic to skip around the vector to find the right
+ * record pointer.
+ */
+class RowExpHistogramReader(val acc: MemoryReader, histVect: Ptr.U8) extends HistogramReader with SectionReader {
+  import HistogramVector._
+
+  println(s"RowExpHistogramReader: $histVect")
+  final def length: Int = getNumHistograms(acc, histVect)
+  val numBuckets = if (length > 0) getNumBuckets(acc, histVect) else 0
+
+  val buckets = HistogramBuckets.emptyExpBuckets
+  private val returnHist = new LongHistogram(buckets, new Array[Long](0))
+  val endAddr = histVect + histVect.asI32.getI32(acc) + 4
+
+  def firstSectionAddr: Ptr.U8 = afterBucketDefAddr(acc, histVect)
+
+  /**
+   * Iterates through each histogram. Note this is expensive due to materializing the Histogram object
+   * every time.  Using higher level functions such as sum is going to be a much better bet usually.
+   */
+  def iterate(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr, startElement: Int): TypedIterator =
+  new Iterator[Histogram] with TypedIterator {
+    var elem = startElement
+    def hasNext: Boolean = elem < getNumHistograms(acc, histVect)
+    def next: Histogram = {
+      val h = apply(elem)
+      elem += 1
+      h
+    }
+  }
+
+  def debugString(acc: MemoryReader, vector: BinaryVectorPtr, sep: String = System.lineSeparator): String = {
+    val it = iterate(acc, vector)
+    val size = length(acc, vector)
+    (0 until size).map(_ => it.asHistIt.mkString(sep)).mkString(sep)
+  }
+
+  def length(accNotUsed: MemoryReader, vectorNotUsed: BinaryVectorPtr): Int = length
+
+  protected val dSink = NibblePack.DeltaSink(returnHist.values)
+
+  // WARNING: histogram returned is shared between calls, do not reuse!
+  def apply(index: Int): HistogramWithBuckets = {
+    require(length > 0)
+    val histPtr = locate(index)
+    val histLen = histPtr.asU16.getU16(acc)
+    val buf = BinaryHistogram.valuesBuf
+
+    acc.wrapInto(buf, histPtr.add(2).addr, histLen)
+    BinaryHistogram.BinHistogram(buf).toHistogram
+    // TODO optimize to use less memory
+    // buf now has the histogram
+    // bucketdef = extract bucketdef
+    // ensure returnHist.values has same length as bucketdef
+    // values =  NibblePack.unpackToSink(buf, dSink, numBuckets)
+    // returnHist.values = values
+    // returnHist.bucketdef = bucketdef
+//    returnHist
+  }
+
+  // sum_over_time returning a Histogram with sums for each bucket.  Start and end are inclusive row numbers
+  // NOTE: for now this is just a dumb implementation that decompresses each histogram fully
+  final def sum(start: Int, end: Int): MutableHistogram = {
+    require(length > 0 && start >= 0 && end < length)
+    val summedHist = MutableHistogram.empty(buckets)
+    cforRange { start to end } { i =>
+      summedHist.addNoCorrection(apply(i))
+    }
+    summedHist
+  }
+}
+

--- a/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/ExpHistogramVector.scala
@@ -73,16 +73,8 @@ class AppendableExpHistogramVector(factory: MemFactory,
 
     val numItems = getNumHistograms(nativePtrReader, vectPtr)
     if (numItems == 0) {
-      // Copy the bucket definition and set the bucket def size
-//      UnsafeUtils.unsafe.copyMemory(buf.byteArray, h.bucketDefOffset,
-//        UnsafeUtils.ZeroPointer, bucketDefAddr(vectPtr).addr,
-//        h.bucketDefNumBytes)
-//      UnsafeUtils.setShort(addr + OffsetBucketDefSize, h.bucketDefNumBytes.toShort)
-//      UnsafeUtils.setByte(addr + OffsetFormatCode, h.formatCode)
-
       // Initialize the first section
       val firstSectPtr = afterNumHistograms(nativePtrReader, vectPtr)
-      println(s"Initializing first section at $firstSectPtr")
       initSectionWriter(firstSectPtr, ((vectPtr + maxBytes).addr - firstSectPtr.addr).toInt)
     }
 
@@ -133,7 +125,6 @@ class AppendableExpHistogramVector(factory: MemFactory,
 class RowExpHistogramReader(val acc: MemoryReader, val histVect: Ptr.U8) extends HistogramReader with SectionReader {
   import HistogramVector._
 
-  println(s"RowExpHistogramReader: $histVect")
   final def length: Int = getNumHistograms(acc, histVect)
   val numBuckets = if (length > 0) getNumBuckets(acc, histVect) else 0
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -560,6 +560,7 @@ object HistogramBuckets {
   val binaryBuckets64 = GeometricBuckets(2.0d, 2.0d, 64, minusOne = true)
 
   val emptyBuckets = GeometricBuckets(2.0d, 2.0d, 0)
+  val emptyExpBuckets = Base2ExpHistogramBuckets(20, 0, 0)
 }
 
 /**

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -621,7 +621,7 @@ object Base2ExpHistogramBuckets {
   val maxBuckets = 180
   val maxAbsScale = 25
 
-  val precomputedBase = (-maxAbsScale to maxAbsScale).map(b => Math.pow(2, Math.pow(2, -b))).toArray
+  private val precomputedBase = (-maxAbsScale to maxAbsScale).map(b => pow(2, pow(2, -b))).toArray
   def base(scale: Int): Double = {
     if (scale < -maxAbsScale || scale > maxAbsScale) {
       throw new IllegalArgumentException(s"Invalid scale $scale should be between ${-maxAbsScale} and ${maxAbsScale}")
@@ -629,12 +629,32 @@ object Base2ExpHistogramBuckets {
     precomputedBase(scale + maxAbsScale)
   }
 
-  val precomputedLogBase = (-maxAbsScale to maxAbsScale).map(b => Math.log(base(b))).toArray
+  private val precomputedLogBase = (-maxAbsScale to maxAbsScale).map(b => Math.log(base(b))).toArray
   def logBase(scale: Int): Double = {
     if (scale < -maxAbsScale || scale > maxAbsScale) {
       throw new IllegalArgumentException(s"Invalid scale $scale should be between ${-maxAbsScale} and ${maxAbsScale}")
     }
     precomputedLogBase(scale + maxAbsScale)
+  }
+
+  /**
+   * Faster calculation of `a^b` using exp and log, rather than using Math.pow which is really slow.
+   */
+  def pow(a: Double, b: Double): Double = {
+    if (a == 0) 0.0
+    else if (a == 1) 1.0
+    else Math.exp(b * Math.log(a))
+  }
+
+  /**
+   * Calculates pow(base, i) where base = `2 ^ 2 ^ -scale`.
+   * Essentially `(2 ^ 2 ^ -scale) ^ i`
+   */
+  def basePow(scale: Int, i: Double): Double = {
+    if (scale < -maxAbsScale || scale > maxAbsScale) {
+      throw new IllegalArgumentException(s"Invalid scale $scale should be between ${-maxAbsScale} and ${maxAbsScale}")
+    }
+    Math.exp(i * precomputedLogBase(scale + maxAbsScale))
   }
 }
 
@@ -693,9 +713,7 @@ final case class Base2ExpHistogramBuckets(var scale: Int,
       // contains values that are greater than (base^index) and
       // less than or equal to (base^(index+1)).
       val index = startIndexPositiveBuckets + no - 1
-      // exp(b * log(a)) is faster than pow(a, b)
-      // Instead of Math.pow(base, index + 1) , use:
-      Math.exp((index + 1) * Base2ExpHistogramBuckets.logBase(scale))
+      basePow(scale, index + 1)
     }
   }
 

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -753,13 +753,6 @@ final case class Base2ExpHistogramBuckets(var scale: Int,
       // minus one below since there is  "+1" in `bucket(index) = base ^ (index + 1)`
       var newBucketIndexEnd = Math.ceil(Math.log(maxBucketTopNeeded) / Math.log(newBase)).toInt - 1 // exclusive
       var newBucketIndexStart = Math.floor(Math.log(minBucketTopNeeded) / Math.log(newBase)).toInt - 1 // inclusive
-      // scalastyle:off
-      // temporary line to debug unit test flakyness. Will remove in next commit
-      println(s"Starting with newScale=$newScale, newBase=$newBase " +
-        s"minBucketTopNeeded=$minBucketTopNeeded " +
-        s"maxBucketTopNeeded=$maxBucketTopNeeded " +
-        s"newBucketIndexStart=$newBucketIndexStart " +
-        s"newBucketIndexEnd=$newBucketIndexEnd")
       // Even if the two schemes are of same scale, they can have non-overlapping bucket ranges.
       // The new bucket scheme should have at most maxBuckets, so keep reducing scale until within limits.
       while (newBucketIndexEnd - newBucketIndexStart + 1 > maxBuckets) {
@@ -767,12 +760,6 @@ final case class Base2ExpHistogramBuckets(var scale: Int,
         newBase = Base2ExpHistogramBuckets.base(newScale)
         newBucketIndexEnd = Math.ceil(Math.log(maxBucketTopNeeded) / Math.log(newBase)).toInt - 1
         newBucketIndexStart = Math.floor(Math.log(minBucketTopNeeded) / Math.log(newBase)).toInt - 1
-        println(s"Reduced newScale=$newScale, newBase=$newBase " +
-          s"minBucketTopNeeded=$minBucketTopNeeded " +
-          s"maxBucketTopNeeded=$maxBucketTopNeeded " +
-          s"newBucketIndexStart=$newBucketIndexStart " +
-          s"newBucketIndexEnd=$newBucketIndexEnd")
-        // scalastyle:on
       }
       Base2ExpHistogramBuckets(newScale, newBucketIndexStart, newBucketIndexEnd - newBucketIndexStart + 1)
     }

--- a/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -723,8 +723,8 @@ final case class Base2ExpHistogramBuckets(var scale: Int,
   }
 
   override def toString: String = {
-    s"OTelExpHistogramBuckets(scale=$scale, startIndexPositiveBuckets=$startIndexPositiveBuckets, " +
-      s"numPositiveBuckets=$numPositiveBuckets) ${super.toString}"
+    s"Base2ExpHistogramBuckets(scale=$scale, startIndexPositiveBuckets=$startIndexPositiveBuckets, " +
+      s"numPositiveBuckets=$numPositiveBuckets)"
   }
   override def similarForMath(other: HistogramBuckets): Boolean = {
     other match {
@@ -753,13 +753,26 @@ final case class Base2ExpHistogramBuckets(var scale: Int,
       // minus one below since there is  "+1" in `bucket(index) = base ^ (index + 1)`
       var newBucketIndexEnd = Math.ceil(Math.log(maxBucketTopNeeded) / Math.log(newBase)).toInt - 1 // exclusive
       var newBucketIndexStart = Math.floor(Math.log(minBucketTopNeeded) / Math.log(newBase)).toInt - 1 // inclusive
+      // scalastyle:off
+      // temporary line to debug unit test flakyness. Will remove in next commit
+      println(s"Starting with newScale=$newScale, newBase=$newBase " +
+        s"minBucketTopNeeded=$minBucketTopNeeded " +
+        s"maxBucketTopNeeded=$maxBucketTopNeeded " +
+        s"newBucketIndexStart=$newBucketIndexStart " +
+        s"newBucketIndexEnd=$newBucketIndexEnd")
       // Even if the two schemes are of same scale, they can have non-overlapping bucket ranges.
       // The new bucket scheme should have at most maxBuckets, so keep reducing scale until within limits.
       while (newBucketIndexEnd - newBucketIndexStart + 1 > maxBuckets) {
         newScale -= 1
-        newBase = Math.pow(2, Math.pow(2, -newScale))
+        newBase = Base2ExpHistogramBuckets.base(newScale)
         newBucketIndexEnd = Math.ceil(Math.log(maxBucketTopNeeded) / Math.log(newBase)).toInt - 1
         newBucketIndexStart = Math.floor(Math.log(minBucketTopNeeded) / Math.log(newBase)).toInt - 1
+        println(s"Reduced newScale=$newScale, newBase=$newBase " +
+          s"minBucketTopNeeded=$minBucketTopNeeded " +
+          s"maxBucketTopNeeded=$maxBucketTopNeeded " +
+          s"newBucketIndexStart=$newBucketIndexStart " +
+          s"newBucketIndexEnd=$newBucketIndexEnd")
+        // scalastyle:on
       }
       Base2ExpHistogramBuckets(newScale, newBucketIndexStart, newBucketIndexEnd - newBucketIndexStart + 1)
     }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -84,7 +84,7 @@ object BinaryHistogram extends StrictLogging {
         val bucketDef = HistogramBuckets.otelExp(buf.byteArray, bucketDefOffset)
         MutableHistogram.fromPacked(bucketDef, valuesByteSlice).getOrElse(Histogram.empty)
       case x =>
-        logger.debug(s"Unrecognizable histogram format code $x, returning empty histogram")
+        logger.warn(s"Unrecognizable histogram format code $x, returning empty histogram")
         Histogram.empty
     }
   }

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -24,6 +24,7 @@ import filodb.memory.format.MemoryReader._
  *                  0x04   geometric_1 + NibblePacked delta Long values  (see [[HistogramBuckets]])
  *                  0x05   custom LE/bucket values + NibblePacked delta Long values
  *                  0x09   otelExp_Delta + NibblePacked delta Long values  (see [[Base2ExpHistogramBuckets]])
+ *                  0x10   otelExp_XOR   + NibblePacked delta Double values
  *
  *   +0003  u16  2-byte length of Histogram bucket definition
  *   +0005  [u8] Histogram bucket definition, see [[HistogramBuckets]]

--- a/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/HistogramVector.scala
@@ -230,8 +230,8 @@ object HistogramVector extends StrictLogging {
   final def bucketDefNumBytes(acc: MemoryReader, addr: Ptr.U8): Int =
     addr.add(OffsetBucketDefSize).asU16.getU16(acc)
   final def bucketDefAddr(addr: Ptr.U8): Ptr.U8 = addr + OffsetBucketDef
-  final def afterFormatCode(acc: MemoryReader, addr: Ptr.U8): Ptr.U8 =
-    addr.add(OffsetFormatCode).add(1)
+  final def afterNumHistograms(acc: MemoryReader, addr: Ptr.U8): Ptr.U8 =
+    addr.add(OffsetNumHistograms).add(2)
 
   // Matches the bucket definition whose # bytes is at (base, offset)
   final def matchBucketDef(hist: BinaryHistogram.BinHistogram, acc: MemoryReader, addr: Ptr.U8): Boolean =

--- a/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/NibblePackTest.scala
@@ -1,6 +1,5 @@
 package filodb.memory.format
 
-//import filodb.memory.format.vectors.Base2ExpHistogramBuckets
 import filodb.memory.format.vectors.Base2ExpHistogramBuckets
 import org.agrona.{DirectBuffer, ExpandableArrayBuffer}
 import org.agrona.concurrent.UnsafeBuffer

--- a/memory/src/test/scala/filodb.memory/format/vectors/ExpHistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/ExpHistogramVectorTest.scala
@@ -186,7 +186,7 @@ class ExpHistogramVectorTest extends NativeVectorTest {
     }
   }
 
-   it("histogram should have right formatCode after sum operation is applied") {
+   it("histogram should support sum and sum result should have right formatCode") {
      val appender = HistogramVector.appendingExp(memFactory, 1024)
      otelExpHistograms.foreach { h =>
        BinaryHistogram.writeDelta(h.buckets, h.values, buffer)
@@ -194,8 +194,10 @@ class ExpHistogramVectorTest extends NativeVectorTest {
      }
      appender.length shouldEqual otelExpHistograms.length
 
-    val mutableHisto = appender.reader.asHistReader.sum(0, 2)
-    BinHistogram(mutableHisto.serialize()).formatCode shouldEqual HistFormat_OtelExp_XOR
+    val sumHist = appender.reader.asHistReader.sum(0, 2)
+    sumHist.buckets shouldEqual Base2ExpHistogramBuckets(3, -8, 9)
+    sumHist.values shouldEqual Array(0.0, 0.0, 5.0, 5.0, 5.0, 5.0, 8.0, 8.0, 14.0, 20.0)
+    BinHistogram(sumHist.serialize()).formatCode shouldEqual HistFormat_OtelExp_XOR
   }
 
   it("should reject initially invalid BinaryHistogram") {

--- a/memory/src/test/scala/filodb.memory/format/vectors/ExpHistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/ExpHistogramVectorTest.scala
@@ -17,7 +17,6 @@ class ExpHistogramVectorTest extends NativeVectorTest {
     val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
 
     reader.length(acc, appender.addr) shouldEqual 0
-    reader.numBuckets shouldEqual 0
     intercept[IllegalArgumentException] { reader(0) }
   }
 
@@ -41,22 +40,15 @@ class ExpHistogramVectorTest extends NativeVectorTest {
 
   it("should accept BinaryHistograms of the different exp schema and be able to query them") {
     val appender = HistogramVector.appendingExp(memFactory, 1024)
-    val reader1 = appender.reader.asInstanceOf[RowExpHistogramReader]
-    println(s"Before add: " + reader1.toHexString(reader1.acc, reader1.histVect.addr))
 
     otelExpHistograms.foreach { h =>
       BinaryHistogram.writeDelta(h.buckets, h.values, buffer)
-      println(s"Adding histogram: " + buffer.byteArray().map("%02X" format _).mkString)
       appender.addData(buffer) shouldEqual Ack
-      val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
-      println(s"After add: " + reader.toHexString(reader.acc, reader.histVect.addr))
     }
-
     appender.length shouldEqual otelExpHistograms.length
 
     val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
     reader.length shouldEqual otelExpHistograms.length
-
 
     (0 until otelExpHistograms.length).foreach { i =>
       val h = reader(i)

--- a/memory/src/test/scala/filodb.memory/format/vectors/ExpHistogramVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/ExpHistogramVectorTest.scala
@@ -1,0 +1,304 @@
+package filodb.memory.format.vectors
+
+import filodb.memory.format._
+import filodb.memory.format.vectors.BinaryHistogram.{BinHistogram, HistFormat_OtelExp_XOR}
+import org.agrona.concurrent.UnsafeBuffer
+
+import java.nio.ByteBuffer
+
+class ExpHistogramVectorTest extends NativeVectorTest {
+  import HistogramTest._
+
+  it("should throw exceptions trying to query empty HistogramVector") {
+    val appender = HistogramVector.appendingExp(memFactory, 1024)
+
+    appender.length shouldEqual 0
+    appender.isAllNA shouldEqual true
+    val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
+
+    reader.length(acc, appender.addr) shouldEqual 0
+    reader.numBuckets shouldEqual 0
+    intercept[IllegalArgumentException] { reader(0) }
+  }
+
+  val buffer = new UnsafeBuffer(new Array[Byte](4096))
+
+  def verifyHistogram(h: Histogram, itemNo: Int,
+                      rawBuckets: Seq[Array[Double]] = rawHistBuckets,
+                      bucketScheme: HistogramBuckets = bucketScheme ): Unit = {
+    h.numBuckets shouldEqual bucketScheme.numBuckets
+    for { i <- 0 until bucketScheme.numBuckets } {
+      h.bucketTop(i) shouldEqual bucketScheme.bucketTop(i)
+      h.bucketValue(i) shouldEqual rawBuckets(itemNo)(i)
+    }
+  }
+
+  val otelExpHistograms = Seq(
+    LongHistogram(Base2ExpHistogramBuckets(3, -3, 1), Array(0L, 3L)),
+    LongHistogram(Base2ExpHistogramBuckets(20, -3, 9), Array(0L, 4, 5, 6, 7, 8, 9, 10, 11, 12)),
+    LongHistogram(Base2ExpHistogramBuckets(20, -888388, 1), Array(0L, 5L)),
+  )
+
+  it("should accept BinaryHistograms of the same schema and be able to query them") {
+    val appender = HistogramVector.appendingExp(memFactory, 1024)
+
+    otelExpHistograms.foreach { h =>
+      BinaryHistogram.writeDelta(h.buckets, h.values, buffer)
+      appender.addData(buffer) shouldEqual Ack
+    }
+
+    appender.length shouldEqual otelExpHistograms.length
+
+    val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
+    reader.length shouldEqual otelExpHistograms.length
+
+    (0 until otelExpHistograms.length).foreach { i =>
+      val h = reader(i)
+      h.compare(otelExpHistograms(i)) shouldEqual 0
+    }
+
+    reader.iterate(acc, 0, 0).asInstanceOf[Iterator[Histogram]]
+          .zipWithIndex.foreach { case (h, i) => h.compare(otelExpHistograms(i)) shouldEqual 0 }
+  }
+
+  // This test confirms that we can store 1-minutely exponential histogram samples of 160 buckets
+  // easily in a histogram appender / write buffer, and we can still hold samples for 1-hr flush interval
+  it("should be able to store sufficient hist samples in one 15k byte vector, the histogram appender default size") {
+    val str = "0.0=0.0, 0.0012664448775888738=0.0, 0.0013810679320049727=0.0, 0.001506065259187439=0.0, " +
+      "0.0016423758110424079=0.0, 0.0017910235218841198=0.0, 0.001953124999999996=0.0, 0.002129897915361827=0.0, " +
+      "0.002322670146489685=0.0, 0.0025328897551777484=0.0, 0.002762135864009946=0.0, 0.0030121305183748786=0.0, " +
+      "0.0032847516220848166=0.0, 0.0035820470437682404=0.0, 0.003906249999999993=0.0, 0.004259795830723655=0.0, " +
+      "0.004645340292979371=0.0, 0.005065779510355498=0.0, 0.005524271728019893=0.0, 0.006024261036749759=0.0, " +
+      "0.006569503244169634=0.0, 0.007164094087536483=0.0, 0.007812499999999988=0.0, 0.008519591661447312=0.0, " +
+      "0.009290680585958744=0.0, 0.010131559020710997=0.0, 0.011048543456039788=0.0, 0.012048522073499521=0.0, " +
+      "0.013139006488339272=0.0, 0.014328188175072969=0.0, 0.01562499999999998=0.0, 0.017039183322894627=0.0, " +
+      "0.018581361171917492=0.0, 0.020263118041422=0.0, 0.022097086912079584=0.0, 0.024097044146999046=0.0, " +
+      "0.026278012976678547=0.0, 0.028656376350145944=0.0, 0.031249999999999965=0.0, 0.03407836664578927=0.0, " +
+      "0.037162722343835=0.0, 0.04052623608284401=0.0, 0.044194173824159175=0.0, 0.0481940882939981=0.0, " +
+      "0.05255602595335711=0.0, 0.0573127527002919=0.0, 0.062499999999999944=0.0, 0.06815673329157855=0.0, " +
+      "0.07432544468767001=0.0, 0.08105247216568803=0.0, 0.08838834764831838=0.0, 0.09638817658799623=0.0, " +
+      "0.10511205190671424=0.0, 0.11462550540058382=0.0, 0.12499999999999992=0.0, 0.13631346658315713=1.0, " +
+      "0.14865088937534005=1.0, 0.16210494433137612=1.0, 0.17677669529663678=1.0, 0.1927763531759925=1.0, " +
+      "0.21022410381342854=1.0, 0.2292510108011677=1.0, 0.2499999999999999=2.0, 0.2726269331663143=2.0, " +
+      "0.29730177875068015=3.0, 0.3242098886627523=3.0, 0.3535533905932736=3.0, 0.3855527063519851=3.0, " +
+      "0.42044820762685714=4.0, 0.4585020216023355=5.0, 0.4999999999999999=5.0, 0.5452538663326287=5.0, " +
+      "0.5946035575013604=6.0, 0.6484197773255047=6.0, 0.7071067811865475=8.0, 0.7711054127039704=8.0, " +
+      "0.8408964152537145=9.0, 0.9170040432046712=9.0, 1.0=11.0, 1.0905077326652577=12.0, 1.189207115002721=14.0, " +
+      "1.2968395546510099=15.0, 1.4142135623730951=17.0, 1.542210825407941=19.0, 1.6817928305074294=20.0, " +
+      "1.8340080864093429=22.0, 2.0000000000000004=23.0, 2.181015465330516=26.0, 2.378414230005443=28.0, " +
+      "2.59367910930202=31.0, 2.8284271247461907=34.0, 3.084421650815883=37.0, 3.3635856610148593=41.0, " +
+      "3.6680161728186866=45.0, 4.000000000000002=48.0, 4.3620309306610325=53.0, 4.756828460010887=58.0, " +
+      "5.187358218604041=64.0, 5.656854249492383=70.0, 6.168843301631767=76.0, 6.7271713220297205=84.0, " +
+      "7.336032345637374=90.0, 8.000000000000005=99.0, 8.724061861322067=108.0, 9.513656920021775=118.0, " +
+      "10.374716437208086=129.0, 11.31370849898477=140.0, 12.337686603263537=152.0, 13.454342644059444=167.0, " +
+      "14.672064691274752=182.0, 16.000000000000014=199.0, 17.448123722644137=217.0, 19.027313840043554=237.0, " +
+      "20.749432874416176=258.0, 22.627416997969544=282.0, 24.675373206527077=308.0, 26.908685288118896=336.0, " +
+      "29.34412938254951=367.0, 32.000000000000036=400.0, 34.89624744528828=435.0, 38.05462768008712=474.0, " +
+      "41.49886574883236=517.0, 45.254833995939094=565.0, 49.35074641305417=617.0, 53.8173705762378=672.0, " +
+      "58.688258765099036=732.0, 64.00000000000009=749.0"
+
+    val appender = HistogramVector.appendingExp(memFactory, 15000) // 15k bytes is default blob size
+    val bucketScheme = Base2ExpHistogramBuckets(3, -78, 126)
+    var counts = str.split(", ").map { s =>
+      val kv = s.split("=")
+      kv(1).toDouble.toLong
+    }
+
+    (0 until 159).foreach { buckets =>
+      val hist = LongHistogram(bucketScheme, counts)
+      hist.serialize(Some(buffer))
+      if (buckets < 159) appender.addData(buffer) shouldEqual Ack
+      // should fail for 159th histogram because it crosses the size of write buffer
+      if (buckets >= 159) appender.addData(buffer) shouldEqual VectorTooSmall(73,42)
+      counts = counts.map(_ + 10)
+    }
+
+    val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
+    reader.length shouldEqual 159
+  }
+
+  it ("should be able to create a vector of one observation histograms of large bucket offset") {
+    val appender = HistogramVector.appendingExp(memFactory, 15000) // 15k bytes is default blob size
+    val bucketScheme = Base2ExpHistogramBuckets(20, 9037032, 1)
+    val counts = Array(0L, 1L)
+
+    (0 until 576).foreach { i =>
+      val hist = LongHistogram(bucketScheme, counts)
+      hist.serialize(Some(buffer))
+      println(i)
+      if (i < 575) appender.addData(buffer) shouldEqual Ack
+      // should fail for 206th histogram because it crosses the size of write buffer
+      if (i >= 575) appender.addData(buffer) shouldEqual VectorTooSmall(26,14)
+    }
+    val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
+    reader.length shouldEqual 575
+  }
+
+  it("should optimize histograms and be able to query optimized vectors") {
+    val appender = HistogramVector.appendingExp(memFactory, 1024)
+    otelExpHistograms.foreach { h =>
+      BinaryHistogram.writeDelta(h.buckets, h.values, buffer)
+      appender.addData(buffer) shouldEqual Ack
+    }
+
+    appender.length shouldEqual otelExpHistograms.length
+
+    val reader = appender.reader.asInstanceOf[RowExpHistogramReader]
+    reader.length shouldEqual otelExpHistograms.length
+    (0 until otelExpHistograms.length).foreach { i =>
+      val h = reader(i)
+      h.compare(otelExpHistograms(i)) shouldEqual 0
+    }
+
+    val optimized = appender.optimize(memFactory)
+    val optReader = HistogramVector(BinaryVector.asBuffer(optimized))
+    println(optReader.debugString(acc, optimized))
+
+    optReader.length(acc, optimized) shouldEqual otelExpHistograms.length
+    (0 until otelExpHistograms.length).foreach { i =>
+      val h = optReader(i)
+      println(h)
+      //h.compare(otelExpHistograms(i)) shouldEqual 0
+    }
+
+    appender.reset()
+    appender.length shouldEqual 0
+  }
+
+  it("should be able to read from on-heap Histogram Vector") {
+    val appender = HistogramVector.appendingExp(memFactory, 1024)
+    otelExpHistograms.foreach { h =>
+      BinaryHistogram.writeDelta(h.buckets, h.values, buffer)
+      appender.addData(buffer) shouldEqual Ack
+    }
+
+    val optimized = appender.optimize(memFactory)
+    val optReader = HistogramVector(BinaryVector.asBuffer(optimized))
+
+    val bytes = optReader.toBytes(acc, optimized)
+
+    val onHeapAcc = Seq(MemoryReader.fromArray(bytes),
+      MemoryReader.fromByteBuffer(BinaryVector.asBuffer(optimized)),
+      MemoryReader.fromByteBuffer(ByteBuffer.wrap(bytes)))
+
+    onHeapAcc.foreach { a =>
+      val readerH = HistogramVector(a, 0)
+      (0 until rawHistBuckets.length).foreach { i =>
+        val h = readerH(i)
+        h.compare(otelExpHistograms(i)) shouldEqual 0
+      }
+    }
+  }
+
+  val lastIncrHist = LongHistogram(bucketScheme, incrHistBuckets.last.map(_.toLong))
+
+
+  it("should work for the downsampling round trip of a histogram vector") {
+
+    val myBucketScheme = CustomBuckets(Array(3d, 10d, Double.PositiveInfinity))
+    // time, sum, count, histogram
+    val bucketData = Seq(
+      Array(0d, 0d, 1d),
+      Array(0d, 2d, 3d),
+      Array(2d, 5d, 6d),
+      Array(2d, 5d, 9d),
+      Array(2d, 5d, 10d),
+      Array(2d, 8d, 14d),
+      Array(0d, 0d, 2d),
+      Array(1d, 7d, 9d),
+      Array(1d, 15d, 19d),
+      Array(2d, 16d, 21d),
+      Array(0d, 1d, 1d),
+      Array(0d, 15d, 15d),
+      Array(1d, 16d, 19d),
+      Array(4d, 20d, 25d)
+    )
+
+    val appender = HistogramVector.appendingExp(memFactory, 1024)
+    bucketData.foreach { rawBuckets =>
+      BinaryHistogram.writeDelta(myBucketScheme, rawBuckets.map(_.toLong), buffer)
+      appender.addData(buffer) shouldEqual Ack
+    }
+
+    appender.length shouldEqual bucketData.length
+
+    val reader = appender.reader.asInstanceOf[SectDeltaHistogramReader]
+    reader.length shouldEqual bucketData.length
+
+    reader.dropPositions(MemoryAccessor.nativePtrAccessor, appender.addr) shouldEqual debox.Buffer(6, 10)
+
+    (0 until bucketData.length).foreach { i =>
+      verifyHistogram(reader(i), i, bucketData, myBucketScheme)
+    }
+
+    val optimized = appender.optimize(memFactory)
+
+    val optReader = HistogramVector(BinaryVector.asBuffer(optimized))
+
+    val bytes = optReader.toBytes(acc, optimized)
+
+    val onHeapAcc = Seq(MemoryReader.fromArray(bytes),
+      MemoryReader.fromByteBuffer(BinaryVector.asBuffer(optimized)),
+      MemoryReader.fromByteBuffer(ByteBuffer.wrap(bytes)))
+
+    onHeapAcc.foreach { a =>
+      val readerH = HistogramVector(a, 0).asInstanceOf[SectDeltaHistogramReader]
+      readerH.dropPositions(a, 0) shouldEqual debox.Buffer(6, 10)
+      (0 until bucketData.length).foreach { i =>
+        val h = readerH(i)
+        verifyHistogram(h, i, bucketData, myBucketScheme)
+      }
+    }
+  }
+
+
+
+   it("histogram should have right formatCode after sum operation is applied") {
+     val appender = HistogramVector.appendingExp(memFactory, 1024)
+     otelExpHistograms.foreach { h =>
+       BinaryHistogram.writeDelta(h.buckets, h.values, buffer)
+       appender.addData(buffer) shouldEqual Ack
+     }
+     appender.length shouldEqual otelExpHistograms.length
+
+    val mutableHisto = appender.reader.asHistReader.sum(0, 2)
+    BinHistogram(mutableHisto.serialize()).formatCode shouldEqual HistFormat_OtelExp_XOR
+  }
+
+  it("should reject initially invalid BinaryHistogram") {
+    val appender = HistogramVector.appendingExp(memFactory, 1024)
+
+    // Create some garbage
+    buffer.putStringWithoutLengthAscii(0, "monkeying")
+
+    appender.addData(buffer) shouldEqual InvalidHistogram
+    appender.length shouldEqual 0
+
+    // Reject null histograms also
+    buffer.putShort(0, 1)
+    buffer.putByte(2, 0)
+    appender.addData(buffer) shouldEqual InvalidHistogram
+    appender.length shouldEqual 0
+  }
+
+
+  // Test for Section reader code in RowHistogramReader, that we can jump back and forth
+  it("should be able to randomly look up any element in long HistogramVector") {
+    val numElements = 150
+    val appender = HistogramVector.appendingExp(memFactory, numElements * 20)
+    (0 until numElements).foreach { i =>
+      BinaryHistogram.writeDelta(bucketScheme, rawLongBuckets(i % rawLongBuckets.length), buffer)
+      appender.addData(buffer) shouldEqual Ack
+    }
+
+    val optimized = appender.optimize(memFactory)
+    val optReader = HistogramVector(BinaryVector.asBuffer(optimized))
+
+    for { _ <- 0 to 50 } {
+      val elemNo = scala.util.Random.nextInt(numElements)
+      verifyHistogram(optReader(elemNo), elemNo % (rawLongBuckets.length))
+    }
+  }
+
+
+}

--- a/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -428,26 +428,27 @@ class HistogramTest extends NativeVectorTest {
       b1.bucketIndexToArrayIndex(5) shouldEqual 11
       b1.bucketTop(b1.bucketIndexToArrayIndex(-1)) shouldEqual 1.0
 
-      val b2 = Base2ExpHistogramBuckets(2, -2, 7) // 0.8408 to 2.378
-      val b3 = Base2ExpHistogramBuckets(2, -4, 9) // 0.594 to 2.378
+      val b2 = Base2ExpHistogramBuckets(2, -2, 6) // 0.8408 to 2.000
+      b2.endBucketTop shouldEqual 1.9999999999999998 +- 0.0001
+      val b3 = Base2ExpHistogramBuckets(2, -4, 8) // 0.594 to 2.000
       b1.canAccommodate(b2) shouldEqual false
       b2.canAccommodate(b1) shouldEqual false
       b3.canAccommodate(b1) shouldEqual true
       b3.canAccommodate(b2) shouldEqual true
 
       val bAdd = b1.add(b2)
-      bAdd.numBuckets shouldEqual 10
+      bAdd.numBuckets shouldEqual 9
       bAdd.scale shouldEqual 2
       bAdd.startBucketTop shouldBe 0.5946035575013606 +- 0.0001
-      bAdd.endBucketTop shouldBe 2.378414245732675 +- 0.0001
+      bAdd.endBucketTop shouldBe 1.9999999999999998 +- 0.0001
       bAdd.canAccommodate(b1) shouldEqual true
       bAdd.canAccommodate(b2) shouldEqual true
 
       val bAddValues = new Array[Double](bAdd.numBuckets)
       bAdd.addValues(bAddValues, b1, MutableHistogram(b1, Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)))
-      bAddValues.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 3.0, 5.0, 7.0, 9.0, 11.0, 11.0, 11.0)
-      bAdd.addValues(bAddValues, b2, MutableHistogram(b2, Array(0, 1, 2, 3, 4, 5, 6, 7)))
-      bAddValues.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 13.0, 16.0, 17.0, 18.0)
+      bAddValues.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 3.0, 5.0, 7.0, 9.0, 11.0, 11.0)
+      bAdd.addValues(bAddValues, b2, MutableHistogram(b2, Array(0, 1, 2, 3, 4, 5, 6)))
+      bAddValues.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 13.0, 16.0, 17.0)
 
       val b4 = Base2ExpHistogramBuckets(5, 15, 36) // 1.414 to 3.018
       b4.numBuckets shouldEqual 37
@@ -462,13 +463,13 @@ class HistogramTest extends NativeVectorTest {
       val bAdd2 = bAdd.add(b4).add(b5)
       val bAdd2Values = new Array[Double](bAdd2.numBuckets)
       bAdd2.addValues(bAdd2Values, bAdd, MutableHistogram(bAdd, bAddValues))
-      bAdd2Values.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 13.0, 16.0, 17.0, 18.0, 18.0, 18.0, 18.0, 18.0)
+      bAdd2Values.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 13.0, 16.0, 17.0, 17.0, 17.0, 17.0, 17.0, 17.0)
 
       bAdd2.addValues(bAdd2Values, b4, MutableHistogram(b4, (0 until 37 map (i => i.toDouble)).toArray))
-      bAdd2Values.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 14.0, 25.0, 34.0, 43.0, 51.0, 54.0, 54.0, 54.0)
+      bAdd2Values.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 14.0, 25.0, 34.0, 42.0, 50.0, 53.0, 53.0, 53.0)
 
       bAdd2.addValues(bAdd2Values, b5, MutableHistogram(b5, Array(0.0, 10.0, 11, 12, 13, 14, 15)))
-      bAdd2Values.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 14.0, 25.0, 34.0, 43.0, 62.0, 67.0, 69.0, 69.0)
+      bAdd2Values.toSeq shouldEqual Seq(0.0, 0.0, 1.0, 4.0, 7.0, 10.0, 14.0, 25.0, 34.0, 42.0, 61.0, 66.0, 68.0, 68.0)
 
     }
 

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -6,6 +6,7 @@ sbt -Drust.optimize=true "jmh/jmh:run -rf json -i 2 -wi 2 -f 1 \
  -jvmArgsAppend -Xmx4g \
  -jvmArgsAppend -XX:MaxInlineSize=99 \
  -jvmArgsAppend -Dkamon.enabled=false \
+ filodb.jmh.HistVectorBenchmark \
  filodb.jmh.Base2ExponentialHistogramQueryBenchmark \
  filodb.jmh.QueryHiCardInMemoryBenchmark \
  filodb.jmh.QueryInMemoryBenchmark \


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?


From tests, we are finding that OTel Exponential histogram scale, bucketOffset and bucketCount can be volatile from sample to sample from same source. Frequently changing bucket scheme results in new chunk being created, and this can bleed at high scale.

This PR creates a new vector ExpHistogramVector which stores the bucket definition along with each sample in the vector. During reads, we reuse the values array that stores bucket counts to avoid object allocation.

E2E local test works.
Optimizations done after benchmark. There was a performance hits were because of `Math.pow` due to reset of bucket scheme for each same. They have been optimized with pre computation and usage of `Math.exp`.

```
[info] Benchmark                                Mode  Cnt        Score   Error  Units
[info] HistVectorBenchmark.ingestion           thrpt    2  4100004.872          ops/s
[info] HistVectorBenchmark.ingestionExpVector  thrpt    2  4133372.497          ops/s
[info] HistVectorBenchmark.queries             thrpt    2   111176.203          ops/s
[info] HistVectorBenchmark.queriesExpVector    thrpt    2   108522.270          ops/s
[info] Base2ExponentialHistogramQueryBenchmark.histQuantileRangeQueries        thrpt    2  134.069          ops/s
```

Flame graph for hist-quantile benchmark
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/98fe8d2c-243a-4319-8313-1dfd5f8be270" />

Prior to the PR, with regular histogram vectors: 

```
[info] Benchmark                                                                Mode  Cnt    Score   Error  Units
[info] Base2ExponentialHistogramQueryBenchmark.histQuantileRangeQueries        thrpt    2  135.804          ops/s
```



