### PR TITLE
fix(core):  Max length of label value should be 32KB instead of 64KB as it is encoded as short

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -338,7 +338,7 @@ class RecordBuilder(memFactory: MemFactory,
     require(mapOffset > curRecordOffset, "illegal state, did you call startMap() first?")
     // check key size, must be < 60KB
     require(keyLen < 192, s"key is too large: ${keyLen} bytes")
-    require(valueLen < 64*1024, s"value is too large: $valueLen bytes")
+    require(valueLen < 32 * 1024, s"value is too large: $valueLen bytes")
 
     // Check if key is a predefined key
     val predefKeyNum =  // but if there are no predefined keys, skip the cost of hashing the key


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** label value supported length is 64 KB. This length is encoded as `short` which can support max length of `32, 767`. Hence we would silently drop the data.   

**New behavior :** Fixing the assert to check to allow label value length of <= 32,767.