### PR TITLE
maint(index) Upgrade tantivy 0.22 -> 0.24

### DIFF
--- a/core/src/rust/Cargo.lock
+++ b/core/src/rust/Cargo.lock
@@ -105,10 +105,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.16.0"
+name = "bon"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "ced38439e7a86a4761f7f7d5ded5ff009135939ecb464a24452eaa4c1696af7d"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce61d2d3844c6b8d31b2353d9f66cf5e632b3e9549583fe3cac2f4f6136725e"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -211,6 +230,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +284,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thousands",
@@ -238,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "either"
@@ -292,7 +346,7 @@ dependencies = [
  "bytes",
  "dhat",
  "filesize",
- "hashbrown",
+ "hashbrown 0.14.5",
  "jni",
  "nohash-hasher",
  "nom",
@@ -304,7 +358,7 @@ dependencies = [
  "tantivy-common",
  "tantivy-fst",
  "tantivy_utils",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -314,6 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "fs4"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +381,43 @@ checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
 dependencies = [
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -351,10 +448,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
+name = "hashbrown"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "htmlescape"
@@ -363,22 +465,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
-name = "instant"
-version = "0.1.13"
+name = "hyperloglogplus"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
 dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+ "serde",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -400,7 +505,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.63",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -418,15 +523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
-dependencies = [
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -481,7 +577,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -492,11 +588,10 @@ checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 
 [[package]]
 name = "measure_time"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbefd235b0aadd181626f281e1d684e116972988c14c264e42069d5e8a5775cc"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
 dependencies = [
- "instant",
  "log",
 ]
 
@@ -586,16 +681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,9 +703,9 @@ checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
 
 [[package]]
 name = "ownedbytes"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a059efb063b8f425b948e042e6b9bd85edfe60e913630ed727b23e2dfcc558"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -649,6 +734,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,10 +767,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.86"
+name = "prettyplease"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -686,7 +793,7 @@ checksum = "ec932c60e6faf77dc6601ea149a23d821598b019b450bb1d98fe89c0301c0b61"
 dependencies = [
  "ahash",
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
  "parking_lot",
 ]
 
@@ -820,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +944,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -855,18 +974,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -875,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -893,11 +1012,20 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -913,10 +1041,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "syn"
-version = "2.0.74"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -925,14 +1059,15 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d0582f186c0a6d55655d24543f15e43607299425c5ad8352c242b914b31856"
+checksum = "ca2374a21157427c5faff2d90930f035b6c22a5d7b0e5b0b7f522e988ef33c06"
 dependencies = [
  "aho-corasick",
  "arc-swap",
  "base64",
  "bitpacking",
+ "bon",
  "byteorder",
  "census",
  "crc32fast",
@@ -942,6 +1077,7 @@ dependencies = [
  "fnv",
  "fs4",
  "htmlescape",
+ "hyperloglogplus",
  "itertools",
  "levenshtein_automata",
  "log",
@@ -949,13 +1085,12 @@ dependencies = [
  "lz4_flex",
  "measure_time",
  "memmap2",
- "num_cpus",
  "once_cell",
  "oneshot",
  "rayon",
  "regex",
  "rust-stemmers",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sketches-ddsketch",
@@ -968,7 +1103,7 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.12",
  "time",
  "uuid",
  "winapi",
@@ -976,18 +1111,18 @@ dependencies = [
 
 [[package]]
 name = "tantivy-bitpacker"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284899c2325d6832203ac6ff5891b297fc5239c3dc754c5bc1977855b23c10df"
+checksum = "1adc286a39e089ae9938935cd488d7d34f14502544a36607effd2239ff0e2494"
 dependencies = [
  "bitpacking",
 ]
 
 [[package]]
 name = "tantivy-columnar"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12722224ffbe346c7fec3275c699e508fd0d4710e629e933d5736ec524a1f44e"
+checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -1001,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-common"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8019e3cabcfd20a1380b491e13ff42f57bb38bf97c3d5fa5c07e50816e0621f4"
+checksum = "e91b6ea6090ce03dc72c27d0619e77185d26cc3b20775966c346c6d4f7e99d7f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1025,19 +1160,23 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847434d4af57b32e309f4ab1b4f1707a6c566656264caa427ff4285c4d9d0b82"
+checksum = "e810cdeeebca57fc3f7bfec5f85fdbea9031b2ac9b990eb5ff49b371d52bbe6a"
 dependencies = [
  "nom",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "tantivy-sstable"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69578242e8e9fc989119f522ba5b49a38ac20f576fc778035b96cc94f41f98e"
+checksum = "709f22c08a4c90e1b36711c1c6cad5ae21b20b093e535b69b18783dd2cb99416"
 dependencies = [
+ "futures-util",
+ "itertools",
  "tantivy-bitpacker",
  "tantivy-common",
  "tantivy-fst",
@@ -1046,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-stacker"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56d6ff5591fc332739b3ce7035b57995a3ce29a93ffd6012660e0949c956ea8"
+checksum = "2bcdebb267671311d1e8891fd9d1301803fdb8ad21ba22e0a30d0cab49ba59c1"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -1057,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-tokenizer-api"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0dcade25819a89cfe6f17d932c9cedff11989936bf6dd4f336d50392053b04"
+checksum = "dfa942fcee81e213e09715bbce8734ae2180070b97b33839a795ba1de201547d"
 dependencies = [
  "serde",
 ]
@@ -1068,7 +1207,7 @@ dependencies = [
 name = "tantivy_utils"
 version = "0.1.0"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.3",
  "nohash-hasher",
  "quick_cache",
  "tantivy",
@@ -1095,7 +1234,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1103,6 +1251,17 @@ name = "thiserror-impl"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1189,71 +1348,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
-dependencies = [
- "cfg-if",
- "once_cell",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
-
-[[package]]
-name = "web-sys"
-version = "0.3.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "winapi"

--- a/core/src/rust/filodb_core/Cargo.toml
+++ b/core/src/rust/filodb_core/Cargo.toml
@@ -18,8 +18,8 @@ num-derive = "0.4.2"
 num-traits = "0.2.19"
 quick_cache = { version = "0.6.2", features = ["stats"] }
 regex = "1.10.5"
-tantivy = "0.22.0"
-tantivy-common = "0.7.0"
+tantivy = "0.24.1"
+tantivy-common = "0.9.0"
 tantivy-fst = "0.5.0"
 tantivy_utils = { path = "../tantivy_utils" }
 thiserror = "1.0.62"

--- a/core/src/rust/filodb_core/src/ingestion/fields.rs
+++ b/core/src/rust/filodb_core/src/ingestion/fields.rs
@@ -130,17 +130,14 @@ mod tests {
         let _ = parse_indexed_field(&buf, &mut doc, &index.schema).expect("Should succeed");
 
         assert!(doc.field_names.contains(&COL1_NAME.to_string()));
-        if let Some(OwnedValue::Str(actual)) = doc
+        let actual: OwnedValue = doc
             .doc
             .get_sorted_field_values()
             .into_iter()
             .map(|(_, value)| (*value.first().unwrap()).into())
             .next()
-        {
-            assert_eq!(actual, expected.to_string());
-        } else {
-            assert!(false, "Expected OwnedValue::Str");
-        };
+            .unwrap();
+        assert_eq!(actual, OwnedValue::Str(expected.to_string()));
     }
 
     #[test]
@@ -188,16 +185,13 @@ mod tests {
         let _ = parse_multicolumn_field(&buf, &mut doc, &index.schema).expect("Should succeed");
 
         assert!(doc.field_names.contains(&COL1_NAME.to_string()));
-        if let Some(OwnedValue::Str(actual)) = doc
+        let actual: OwnedValue = doc
             .doc
             .get_sorted_field_values()
             .into_iter()
             .map(|(_, value)| (*value.first().unwrap()).into())
             .next()
-        {
-            assert_eq!(actual, expected.to_string());
-        } else {
-            assert!(false, "Expected OwnedValue::Str");
-        };
+            .unwrap();
+        assert_eq!(actual, OwnedValue::Str(expected.to_string()));
     }
 }

--- a/core/src/rust/filodb_core/src/ingestion/fields.rs
+++ b/core/src/rust/filodb_core/src/ingestion/fields.rs
@@ -107,7 +107,6 @@ fn parse_multicolumn_field<'a>(
 mod tests {
     use bytes::BufMut;
     use tantivy::{schema::OwnedValue, Document};
-
     use tantivy_utils::test_utils::{
         build_test_schema, COL1_NAME, JSON_ATTRIBUTE1_NAME, JSON_COL_NAME,
     };
@@ -131,17 +130,29 @@ mod tests {
         let _ = parse_indexed_field(&buf, &mut doc, &index.schema).expect("Should succeed");
 
         assert!(doc.field_names.contains(&COL1_NAME.to_string()));
-        assert_eq!(
-            **doc
-                .doc
-                .get_sorted_field_values()
-                .first()
-                .unwrap()
-                .1
-                .first()
-                .unwrap(),
-            OwnedValue::Str(expected.into())
-        );
+        if let Some(OwnedValue::Str(actual)) = doc
+            .doc
+            .get_sorted_field_values()
+            .into_iter()
+            .map(|(_, value)| (*value.first().unwrap()).into())
+            .next()
+        {
+            assert_eq!(actual, expected.to_string());
+        } else {
+            panic!("Expected OwnedValue::Str");
+        };
+        // assert_eq!(
+        //     **doc
+        //         .doc
+        //         .get_sorted_field_values()
+        //         .first()
+        //         .unwrap()
+        //         .1
+        //         .first()
+        //         .map(|c| c)
+        //         .unwrap().into(),
+        //     OwnedValue::Str(expected.into())
+        // );
     }
 
     #[test]
@@ -189,16 +200,16 @@ mod tests {
         let _ = parse_multicolumn_field(&buf, &mut doc, &index.schema).expect("Should succeed");
 
         assert!(doc.field_names.contains(&COL1_NAME.to_string()));
-        assert_eq!(
-            **doc
-                .doc
-                .get_sorted_field_values()
-                .first()
-                .unwrap()
-                .1
-                .first()
-                .unwrap(),
-            OwnedValue::Str(expected.into())
-        );
+        if let Some(OwnedValue::Str(actual)) = doc
+            .doc
+            .get_sorted_field_values()
+            .into_iter()
+            .map(|(_, value)| (*value.first().unwrap()).into())
+            .next()
+        {
+            assert_eq!(actual, expected.to_string());
+        } else {
+            panic!("Expected OwnedValue::Str");
+        };
     }
 }

--- a/core/src/rust/filodb_core/src/ingestion/fields.rs
+++ b/core/src/rust/filodb_core/src/ingestion/fields.rs
@@ -139,20 +139,8 @@ mod tests {
         {
             assert_eq!(actual, expected.to_string());
         } else {
-            panic!("Expected OwnedValue::Str");
+            assert!(false, "Expected OwnedValue::Str");
         };
-        // assert_eq!(
-        //     **doc
-        //         .doc
-        //         .get_sorted_field_values()
-        //         .first()
-        //         .unwrap()
-        //         .1
-        //         .first()
-        //         .map(|c| c)
-        //         .unwrap().into(),
-        //     OwnedValue::Str(expected.into())
-        // );
     }
 
     #[test]
@@ -209,7 +197,7 @@ mod tests {
         {
             assert_eq!(actual, expected.to_string());
         } else {
-            panic!("Expected OwnedValue::Str");
+            assert!(false, "Expected OwnedValue::Str");
         };
     }
 }

--- a/core/src/rust/filodb_core/src/query_parser.rs
+++ b/core/src/rust/filodb_core/src/query_parser.rs
@@ -298,10 +298,11 @@ fn parse_long_range_query<'a>(
     // 8 byte end
     let (input, end) = le_i64(input)?;
 
-    let query = RangeQuery::new_i64_bounds(
-        field_name.to_string(),
-        Bound::Included(start),
-        Bound::Included(end),
+    let field = schema.get_field(field_name).to_nom_err()?;
+
+    let query = RangeQuery::new(
+        Bound::Included(Term::from_field_i64(field, start)),
+        Bound::Included(Term::from_field_i64(field, end)),
     );
 
     Ok((input, Box::new(query)))

--- a/core/src/rust/filodb_core/src/query_parser.rs
+++ b/core/src/rust/filodb_core/src/query_parser.rs
@@ -298,11 +298,11 @@ fn parse_long_range_query<'a>(
     // 8 byte end
     let (input, end) = le_i64(input)?;
 
-    let field = schema.get_field(field_name).to_nom_err()?;
+    let resolved_field = schema.get_field(field_name).to_nom_err()?;
 
     let query = RangeQuery::new(
-        Bound::Included(Term::from_field_i64(field, start)),
-        Bound::Included(Term::from_field_i64(field, end)),
+        Bound::Included(Term::from_field_i64(resolved_field, start)),
+        Bound::Included(Term::from_field_i64(resolved_field, end)),
     );
 
     Ok((input, Box::new(query)))

--- a/core/src/rust/filodb_core/src/query_parser/filodb_query.rs
+++ b/core/src/rust/filodb_core/src/query_parser/filodb_query.rs
@@ -3,10 +3,11 @@
 use std::{ops::Bound, sync::Arc};
 
 use quick_cache::Weighter;
+use tantivy::index::SegmentId;
 use tantivy::{
     query::{AllQuery, Query, RangeQuery, TermQuery, TermSetQuery},
     schema::{Field, IndexRecordOption, Schema},
-    SegmentId, TantivyError, Term,
+    TantivyError, Term,
 };
 use tantivy_common::BitSet;
 use tantivy_utils::field_constants;
@@ -90,10 +91,10 @@ impl tantivy_utils::query::cache::CachableQuery for FiloDBQuery {
                 Ok(Box::new(query))
             }
             FiloDBQuery::ByEndTime(ended_at) => {
-                let query = RangeQuery::new_i64_bounds(
-                    field_constants::END_TIME.to_string(),
-                    Bound::Included(0),
-                    Bound::Included(*ended_at),
+                let field = schema.get_field(field_constants::END_TIME)?;
+                let query = RangeQuery::new(
+                    Bound::Included(Term::from_field_i64(field, 0)),
+                    Bound::Included(Term::from_field_i64(field, *ended_at)),
                 );
 
                 Ok(Box::new(query))

--- a/core/src/rust/tantivy_utils/Cargo.toml
+++ b/core/src/rust/tantivy_utils/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 rust-version = "1.78"
 
 [dependencies]
-hashbrown = "0.14.5"
+hashbrown = "0.15.2"
 nohash-hasher = "0.2.0"
 quick_cache = { version = "0.6.2", features = ["stats"] }
-tantivy = "0.22.0"
-tantivy-common = "0.7.0"
+tantivy = "0.24.1"
+tantivy-common = "0.9.0"
 tantivy-fst = "0.5.0"

--- a/core/src/rust/tantivy_utils/src/collectors/column_cache.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/column_cache.rs
@@ -3,9 +3,10 @@
 use std::sync::Arc;
 
 use quick_cache::{sync::Cache, Equivalent};
+use tantivy::index::SegmentId;
 use tantivy::{
     columnar::{BytesColumn, Column, DynamicColumn, HasAssociatedColumnType, StrColumn},
-    SegmentId, SegmentReader,
+    SegmentReader,
 };
 
 // Max column items to cache.  These are relatively cheap (< 1KB)

--- a/core/src/rust/tantivy_utils/src/collectors/part_key_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/part_key_collector.rs
@@ -21,9 +21,10 @@ impl UnresolvedPartKey {
         let part_key_field = searcher.schema().get_field(PART_KEY)?;
 
         let Some(OwnedValue::Bytes(part_key)) = doc_data
+            .field_values()
             .into_iter()
-            .filter(|x| x.field == part_key_field)
-            .map(|x| x.value)
+            .filter(|(field, _)| *field == part_key_field)
+            .map(|(_, value)| value.into())
             .next()
         else {
             return Err(TantivyError::FieldNotFound(PART_KEY.to_string()));

--- a/core/src/rust/tantivy_utils/src/collectors/part_key_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/part_key_collector.rs
@@ -22,7 +22,6 @@ impl UnresolvedPartKey {
 
         let Some(OwnedValue::Bytes(part_key)) = doc_data
             .field_values()
-            .into_iter()
             .filter(|(field, _)| *field == part_key_field)
             .map(|(_, value)| value.into())
             .next()

--- a/core/src/rust/tantivy_utils/src/collectors/part_key_record_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/part_key_record_collector.rs
@@ -32,7 +32,6 @@ impl UnresolvedPartKeyRecord {
 
         let Some(OwnedValue::Bytes(part_key)) = doc_data
             .field_values()
-            .into_iter()
             .filter(|(field, _)| *field == part_key_field)
             .map(|(_, value)| value.into())
             .next()

--- a/core/src/rust/tantivy_utils/src/collectors/part_key_record_collector.rs
+++ b/core/src/rust/tantivy_utils/src/collectors/part_key_record_collector.rs
@@ -31,9 +31,10 @@ impl UnresolvedPartKeyRecord {
         let part_key_field = searcher.schema().get_field(PART_KEY)?;
 
         let Some(OwnedValue::Bytes(part_key)) = doc_data
+            .field_values()
             .into_iter()
-            .filter(|x| x.field == part_key_field)
-            .map(|x| x.value)
+            .filter(|(field, _)| *field == part_key_field)
+            .map(|(_, value)| value.into())
             .next()
         else {
             return Err(TantivyError::FieldNotFound(PART_KEY.to_string()));

--- a/core/src/rust/tantivy_utils/src/query/cache.rs
+++ b/core/src/rust/tantivy_utils/src/query/cache.rs
@@ -3,11 +3,12 @@
 use std::{hash::Hash, sync::Arc};
 
 use quick_cache::{sync::Cache, Equivalent, Weighter};
+use tantivy::index::SegmentId;
 use tantivy::{
     collector::SegmentCollector,
     query::{EnableScoring, Query, Weight},
     schema::{Field, Schema},
-    Searcher, SegmentId, TantivyError,
+    Searcher, TantivyError,
 };
 use tantivy_common::BitSet;
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
No change in behavior expected, tantity upgraded

**New behavior :**
NA


Following are the results for the JMH tests

Lucene 
```
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                         Mode  Cnt        Score       Error  Units
[info] PartKeyLuceneIndexBenchmark.emptyPartIdsLookupWithEqualsFilters  thrpt    5    59244.289 ±  3745.757  ops/s
[info] PartKeyLuceneIndexBenchmark.getLabelNames                        thrpt    5      496.276 ±    10.932  ops/s
[info] PartKeyLuceneIndexBenchmark.getMetricNames                       thrpt    5      417.537 ±     5.399  ops/s
[info] PartKeyLuceneIndexBenchmark.getMetricNamesSearchAndIterate       thrpt    5        0.595 ±     0.029  ops/s
[info] PartKeyLuceneIndexBenchmark.indexNames                           thrpt    5  2669633.267 ± 63241.077  ops/s
[info] PartKeyLuceneIndexBenchmark.indexValues                          thrpt    5     2364.378 ±    80.261  ops/s
[info] PartKeyLuceneIndexBenchmark.partIdsLookupOverTime                thrpt    5     1108.198 ±    28.733  ops/s
[info] PartKeyLuceneIndexBenchmark.partIdsLookupWithEnumRegexFilter     thrpt    5     9157.707 ±   159.633  ops/s
[info] PartKeyLuceneIndexBenchmark.partIdsLookupWithEqualsFilters       thrpt    5      119.867 ±     3.743  ops/s
[info] PartKeyLuceneIndexBenchmark.partIdsLookupWithPrefixRegexFilters  thrpt    5     2024.598 ±   100.499  ops/s
[info] PartKeyLuceneIndexBenchmark.partIdsLookupWithSuffixRegexFilters  thrpt    5     1285.420 ±    62.553  ops/s
[info] PartKeyLuceneIndexBenchmark.startTimeLookupWithPartId            thrpt    5     8730.719 ±   212.746  ops/s
[info] Benchmark result is saved to jmh-result.json
```

Tantivy 0.24 
```
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                          Mode  Cnt       Score      Error  Units
[info] PartKeyTantivyIndexBenchmark.emptyPartIdsLookupWithEqualsFilters  thrpt    5  127239.818 ± 4062.705  ops/s
[info] PartKeyTantivyIndexBenchmark.getLabelNames                        thrpt    5     155.028 ±    1.264  ops/s
[info] PartKeyTantivyIndexBenchmark.getMetricNames                       thrpt    5     660.219 ±   18.836  ops/s
[info] PartKeyTantivyIndexBenchmark.getMetricNamesSearchAndIterate       thrpt    5       0.534 ±    0.071  ops/s
[info] PartKeyTantivyIndexBenchmark.indexNames                           thrpt    5   91897.068 ± 4066.508  ops/s
[info] PartKeyTantivyIndexBenchmark.indexValues                          thrpt    5     964.292 ±   36.884  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupOverTime                thrpt    5   15044.028 ±  678.688  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithEnumRegexFilter     thrpt    5   35119.814 ±  936.187  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithEqualsFilters       thrpt    5     293.185 ±   18.222  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithPrefixRegexFilters  thrpt    5    5553.633 ±  389.551  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithSuffixRegexFilters  thrpt    5    5674.180 ±  591.361  ops/s
[info] PartKeyTantivyIndexBenchmark.startTimeLookupWithPartId            thrpt    5   26556.422 ±  219.451  ops/s
```

Tantivy 0.22
```
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                          Mode  Cnt       Score      Error  Units
[info] PartKeyTantivyIndexBenchmark.emptyPartIdsLookupWithEqualsFilters  thrpt    5  124273.956 ± 8756.878  ops/s
[info] PartKeyTantivyIndexBenchmark.getLabelNames                        thrpt    5     177.894 ±   11.655  ops/s
[info] PartKeyTantivyIndexBenchmark.getMetricNames                       thrpt    5     602.656 ±   20.541  ops/s
[info] PartKeyTantivyIndexBenchmark.getMetricNamesSearchAndIterate       thrpt    5       0.545 ±    0.054  ops/s
[info] PartKeyTantivyIndexBenchmark.indexNames                           thrpt    5   97679.311 ± 2820.490  ops/s
[info] PartKeyTantivyIndexBenchmark.indexValues                          thrpt    5     863.077 ±  145.458  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupOverTime                thrpt    5   15367.359 ±  318.019  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithEnumRegexFilter     thrpt    5   37945.732 ± 2855.462  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithEqualsFilters       thrpt    5     263.394 ±   18.259  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithPrefixRegexFilters  thrpt    5    5006.791 ±  208.549  ops/s
[info] PartKeyTantivyIndexBenchmark.partIdsLookupWithSuffixRegexFilters  thrpt    5    5058.430 ±  276.161  ops/s
[info] PartKeyTantivyIndexBenchmark.startTimeLookupWithPartId            thrpt    5   26160.238 ±  668.057  ops/s
[info] Benchmark result is saved to jmh-result.json
```
