### PR TITLE
(query) fix negative rate value by leading NaN.

### DIFF
--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -177,6 +177,7 @@ trait DoubleVectorDataReader extends CounterVectorReader {
   def detectDropAndCorrection(acc: MemoryReader,
                               vector: BinaryVectorPtr,
                               meta: CorrectionMeta): CorrectionMeta = meta match {
+
     case NoCorrection =>   meta    // No last value, cannot compare.  Just pass it on.
     case DoubleCorrection(lastValue, correction) =>
       val firstValue = apply(acc, vector, 0)
@@ -367,7 +368,15 @@ extends DoubleVectorDataReader {
 
   override def updateCorrection(acc2: MemoryReader, vector: BinaryVectorPtr, meta: CorrectionMeta): CorrectionMeta = {
     assert(vector == vect && acc == acc2)
-    val lastValue = apply(acc2, vector, length(acc2, vector) - 1)
+    var index = length(acc2, vector) - 1
+    var lastValue = 0.0
+    do {
+      lastValue = apply(acc2, vector, index)
+      index -= 1
+    } while (lastValue.isNaN && index >= 0)
+    if (lastValue.isNaN) {
+      lastValue = 0.0
+    }
     // Return the last (original) value and all corrections onward
     meta match {
       case DoubleCorrection(_, corr) => DoubleCorrection(lastValue, corr + _correction)

--- a/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
+++ b/memory/src/main/scala/filodb.memory/format/vectors/DoubleVector.scala
@@ -181,7 +181,7 @@ trait DoubleVectorDataReader extends CounterVectorReader {
     case DoubleCorrection(lastValue, correction) =>
       val firstValue = apply(acc, vector, 0)
       // Last value is the new delta correction
-      if (firstValue < lastValue) DoubleCorrection(lastValue, correction + lastValue)
+      if (firstValue.isNaN || firstValue < lastValue) DoubleCorrection(lastValue, correction + lastValue)
       else                        meta
   }
 

--- a/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
@@ -105,6 +105,15 @@ class DoubleVectorTest extends NativeVectorTest {
       val appender = DoubleVector.appendingVectorNoNA(memFactory, 100, true)
       orig.foreach(appender.addData)
       appender.reader.asDoubleReader.detectDropAndCorrection(acc, appender.addr, DoubleCorrection(300, 0.0)) shouldEqual DoubleCorrection(300.0,300.0)
+      appender.reader.asDoubleReader.updateCorrection(acc, appender.addr, DoubleCorrection(300, 0.0)) shouldEqual DoubleCorrection(3909,0)
+    }
+
+    it("should encode counter drops when first and last are NaN") {
+      val orig = Seq(Double.NaN, 3904.0, 3904.0, 3905.0, Double.NaN, Double.NaN)
+      val appender = DoubleVector.appendingVectorNoNA(memFactory, 100, true)
+      orig.foreach(appender.addData)
+      appender.reader.asDoubleReader.detectDropAndCorrection(acc, appender.addr, DoubleCorrection(300, 0.0)) shouldEqual DoubleCorrection(300.0, 300.0)
+      appender.reader.asDoubleReader.updateCorrection(acc, appender.addr, DoubleCorrection(300, 0.0)) shouldEqual DoubleCorrection(3905, 0)
     }
 
     it("should encode counter drops when NaN is ingested at the end") {

--- a/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
+++ b/memory/src/test/scala/filodb.memory/format/vectors/DoubleVectorTest.scala
@@ -100,7 +100,12 @@ class DoubleVectorTest extends NativeVectorTest {
         DoubleVector(a, 0).toBuffer(a, 0).toList shouldEqual orig
       }
     }
-
+    it("should encode counter drops when NaN is ingested at the beginning") {
+      val orig = Seq(Double.NaN, 3904.0, 3904.0, 3905.0, 3908.0, 3909.0)
+      val appender = DoubleVector.appendingVectorNoNA(memFactory, 100, true)
+      orig.foreach(appender.addData)
+      appender.reader.asDoubleReader.detectDropAndCorrection(acc, appender.addr, DoubleCorrection(300, 0.0)) shouldEqual DoubleCorrection(300.0,300.0)
+    }
 
     it("should encode counter drops when NaN is ingested at the end") {
       val orig = Seq(3904.0,3904.0,3905.0,3908.0,3909.0,3910.0,3912.0,3914.0,3914.0,3915.0,3916.0,3917.0,3918.0,3919.0,3920.0,3922.0,Double.NaN)


### PR DESCRIPTION
NaN is not comparable. Check if the value is NaN before comparison.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: