### PR TITLE
feat(spark-jobs): Label churn finder job can customize startTime for calculating churn

### DIFF
--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -1,10 +1,16 @@
 package filodb.labelchurnfinder
 
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+
 import scala.collection.mutable
+import scala.concurrent.duration.FiniteDuration
 
 import com.typesafe.scalalogging.{Logger, StrictLogging}
 import kamon.Kamon
 import monix.execution.Scheduler
+import net.ceedubs.ficus.Ficus._
 import org.apache.datasketches.cpc.{CpcSketch, CpcUnion}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
@@ -45,14 +51,18 @@ case class ChurnSketches(active: CpcSketch, total: CpcSketch) {
 /**
  * Requires following typesafe config properties:
  *
- *
+ * {{{
  * filodb.labelchurnfinder.pk-filters = [
  *  {
  *     _ns_ = "bulk_ns"
  *     _ws_ = "tag_value_as_regex"
  *  }
  * ]
- *
+ * filodb.labelchurnfinder.dataset = "dataset_name"
+ * # one of the two config below is needed
+ * filodb.labelchurnfinder.for-time-period  = 2 days
+ * filodb.labelchurnfinder.since-time  = <timestamp string in iso format>
+ * }}}
  */
 class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable with StrictLogging {
 
@@ -66,20 +76,26 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
       .config(conf)
       .getOrCreate()
 
+    val totalFromTs =
+         dsSettings.filodbConfig.as[Option[FiniteDuration]]("labelchurnfinder.for-time-period")
+           .map(dur => System.currentTimeMillis() - dur.toMillis)
+           .orElse(dsSettings.filodbConfig.as[Option[String]]("labelchurnfinder.since-time")
+                             .map( str => Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str)).toEpochMilli))
+           .getOrElse(System.currentTimeMillis() - FiniteDuration(7, TimeUnit.DAYS).toMillis)
 
     LCFContext.log.info(s"This is the Label Churn Finder. Starting job.")
     val lcfTask = new LcfTask(dsSettings)
 
     val splits = if (lcfTask.colStore.partKeysV2TableEnabled) {
       spark.sparkContext
-        .makeRDD(lcfTask.colStore.getScanSplits(lcfTask.rawDatasetRef))
+        .makeRDD(lcfTask.colStore.getScanSplits(lcfTask.datasetRef))
         .mapPartitions { split =>
           Kamon.init() // kamon init should be first thing in worker jvm
           split.flatMap(_.asInstanceOf[CassandraTokenRangeSplit].tokens)
         }.map( sp => (sp, -1))
     } else {
       spark.sparkContext
-        .makeRDD(lcfTask.colStore.getScanSplits(lcfTask.rawDatasetRef))
+        .makeRDD(lcfTask.colStore.getScanSplits(lcfTask.datasetRef))
         .mapPartitions { split =>
           Kamon.init() // kamon init should be first thing in worker jvm
           split.flatMap(_.asInstanceOf[CassandraTokenRangeSplit].tokens)
@@ -90,7 +106,7 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
     }
 
     val result = splits.map { case (split, shard) =>
-      lcfTask.computeLabelChurn(split, shard)
+      lcfTask.computeLabelChurn(split, shard, totalFromTs)
     }.fold(mutable.HashMap.empty[Seq[String], ChurnSketches]) { (acc, m) =>
       m.foreach { case (key, sketch) =>
         if (acc.contains(key)) {

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LcfTask.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LcfTask.scala
@@ -20,22 +20,24 @@ class LcfTask(dsSettings: DownsamplerSettings) extends Serializable with StrictL
 
   @transient lazy private[labelchurnfinder] val logK = 10
   @transient lazy private val schemas = Schemas.fromConfig(dsSettings.filodbConfig).get
-  @transient lazy private[labelchurnfinder] val rawDatasetRef = DatasetRef(dsSettings.rawDatasetName)
+  @transient lazy val datasetName = dsSettings.filodbConfig.as[String]("labelchurnfinder.dataset")
+  @transient lazy val datasetRef = DatasetRef(datasetName)
 
   @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(dsSettings.cassandraConfig)
   @transient lazy private[labelchurnfinder] val colStore =
     new CassandraColumnStore(dsSettings.filodbConfig, sched, session, false)(sched)
-  @transient lazy val filters = dsSettings.filodbConfig
+  @transient lazy private[labelchurnfinder] val filters = dsSettings.filodbConfig
     .as[Seq[Map[String, String]]]("labelchurnfinder.pk-filters").map(_.mapValues(_.r.pattern).toSeq)
 
-  @transient lazy val numShards = dsSettings.filodbSettings.streamConfigs
-    .find(_.getString("dataset") == rawDatasetRef.dataset)
+  @transient lazy private[labelchurnfinder] val numShards = dsSettings.filodbSettings.streamConfigs
+    .find(_.getString("dataset") == datasetName)
     .getOrElse(ConfigFactory.empty())
     .as[Option[Int]]("num-shards").get
 
   def computeLabelChurn(split: (String, String),
-                        shard: Int): mutable.HashMap[Seq[String], ChurnSketches] = {
-    colStore.scanPartKeysByStartEndTimeRangeNoAsync(rawDatasetRef, shard, split, 0, Long.MaxValue, 0, Long.MaxValue)
+                        shard: Int,
+                        totalFromTs: Long): mutable.HashMap[Seq[String], ChurnSketches] = {
+    colStore.scanPartKeysByStartEndTimeRangeNoAsync(datasetRef, shard, split, 0, Long.MaxValue, 0, Long.MaxValue)
     .foldLeft(mutable.HashMap.empty[Seq[String], ChurnSketches]) { case (acc, pk) =>
       val rawSchemaId = RecordSchema.schemaID(pk.partKey, UnsafeUtils.arayOffset)
       val schema = schemas(rawSchemaId)
@@ -57,7 +59,7 @@ class LcfTask(dsSettings: DownsamplerSettings) extends Serializable with StrictL
           val key = Seq(ws, ns, pkKey)
           val sketch = acc.getOrElseUpdate(key, ChurnSketches(new CpcSketch(logK), new CpcSketch(logK)))
           val valBytes = pkVal.getBytes
-          sketch.total.update(valBytes)
+          if (pk.endTime > totalFromTs) sketch.total.update(valBytes)
           if (pk.endTime == Long.MaxValue) sketch.active.update(valBytes)
         }
       }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Instead of taking total time series, we can customize the cut off time during which churn will be calculated.
Time series not ingesting during the time will not be involved in calculation of churn.