### PR TITLE
feat(downsample): Allowing to persist downsampled data using arbitrary implementation of ChunkPersistor and DSPartitionReader

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
@@ -12,7 +12,6 @@ trait BaseDatasetTable extends StrictLogging {
   def dataset: DatasetRef
   def suffix: String
   lazy val keyspace = connector.keyspace
-  //lazy val tableString = s"${keyspace}.${dataset.dataset + s"_$suffix"}"
   lazy val tableName = s"${dataset.dataset + s"_$suffix"}"
   lazy val tableString = s"${keyspace}.${tableName}"
   lazy val session = connector.session

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/BaseDatasetTable.scala
@@ -12,7 +12,9 @@ trait BaseDatasetTable extends StrictLogging {
   def dataset: DatasetRef
   def suffix: String
   lazy val keyspace = connector.keyspace
-  lazy val tableString = s"${keyspace}.${dataset.dataset + s"_$suffix"}"
+  //lazy val tableString = s"${keyspace}.${dataset.dataset + s"_$suffix"}"
+  lazy val tableName = s"${dataset.dataset + s"_$suffix"}"
+  lazy val tableString = s"${keyspace}.${tableName}"
   lazy val session = connector.session
 
   // A Cassandra CQL string to create the table.  Should have IF NOT EXISTS.

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/IngestionTimeIndexTable.scala
@@ -38,7 +38,7 @@ sealed class IngestionTimeIndexTable(val dataset: DatasetRef,
                      |) WITH compression = {
                     'sstable_compression': '$sstableCompression'}""".stripMargin
 
-  private lazy val writeIndexCql = session.prepare(
+  lazy val writeIndexCql = session.prepare(
     s"INSERT INTO $tableString (partition, ingestion_time, start_time, info) " +
     s"VALUES (?, ?, ?, ?) USING TTL ?")
     .setConsistencyLevel(writeConsistencyLevel)

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysV2Table.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/PartitionKeysV2Table.scala
@@ -106,7 +106,8 @@ sealed class PartitionKeysV2Table(val dataset: DatasetRef,
 
     val res: Observable[Iterator[PartKeyRecord]] = Observable.fromIterable(0 until numBuckets)
       .mapParallelUnordered(scanParallelism) { bucket =>
-        val fut = session.executeAsync(scanCql.bind(shard: JInt, bucket: JInt))
+        val cql = scanCql.bind(shard: JInt, bucket: JInt)
+        val fut = session.executeAsync(cql)
                          .toIterator.handleErrors
                          .map { rowIt => rowIt.map(PartitionKeysV2Table.rowToPartKeyRecord) }
         Task.fromFuture(fut)

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/TimeSeriesChunksTable.scala
@@ -41,7 +41,7 @@ sealed class TimeSeriesChunksTable(val dataset: DatasetRef,
                     |) WITH compression = {
                     'sstable_compression': '$sstableCompression'}""".stripMargin
 
-  private lazy val writeChunksCql = session.prepare(
+  lazy val writeChunksCql = session.prepare(
     s"INSERT INTO $tableString (partition, chunkid, info, chunks) " +
     s"VALUES (?, ?, ?, ?) USING TTL ?")
     .setConsistencyLevel(writeConsistencyLevel)

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -594,6 +594,12 @@ filodb {
     # See filodb.downsampler.chunk.SparkSessionFactory for details.
     spark-session-factory = "filodb.downsampler.chunk.DefaultSparkSessionFactory"
 
+    use-chunks-persistor = true
+    chunks-persistor = "filodb.downsampler.chunk.DefaultChunkPersistor"
+    chunks-persistor-splits = "-1"
+
+    ds-index-reader = "filodb.downsampler.chunk.DefaultDSPartitionReader"
+
     # Name of the dataset from which to downsample
     # raw-dataset-name = "prometheus"
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -594,9 +594,8 @@ filodb {
     # See filodb.downsampler.chunk.SparkSessionFactory for details.
     spark-session-factory = "filodb.downsampler.chunk.DefaultSparkSessionFactory"
 
-    use-chunks-persistor = true
+    use-chunks-persistor = false
     chunks-persistor = "filodb.downsampler.chunk.DefaultChunkPersistor"
-    chunks-persistor-splits = "-1"
 
     ds-index-reader = "filodb.downsampler.chunk.DefaultDSPartitionReader"
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -363,7 +363,6 @@ class BatchDownsampler(val settings: DownsamplerSettings,
   ): ListBuffer[Row] = {
     val start = System.currentTimeMillis()
     @volatile var numChunks = 0
-    // write all chunks to cassandra
     val allRows = new ListBuffer[Row]
     downsampledChunksToPersist.foreach { case (res, chunks) =>
       // FIXME if listener in chunkset below is not copied + overridden to no-op, we get a SEGV because
@@ -384,18 +383,16 @@ class BatchDownsampler(val settings: DownsamplerSettings,
           arr
         }
         allRows += Row(
-          res.toString(),
-          toBuffer(partBytes).array(),
-          c.info.id,
-          toBuffer(ChunkSetInfo.toBytes(c.info)).array(),
-          chunkList.toArray,
-          c.info.ingestionTime,
-          c.info.startTime,
-          ChunkSetInfo.toBytes(c.info)
+          res.toString(), //Resolution
+          toBuffer(partBytes).array(), //PK
+          c.info.id, // chunk Id
+          toBuffer(ChunkSetInfo.toBytes(c.info)).array(), //info
+          chunkList.toArray, // chunks
+          c.info.ingestionTime, // ingestion_time
+          c.info.startTime, // start_time
+          ChunkSetInfo.toBytes(c.info) //index_info
         )
       }
-      //      downsampleCassandraColStore.write(downsampleRefsByRes(res),
-      //      Observable.fromIteratorUnsafe(chunksToPersist), settings.ttlByResolution(res))
     }
     allRows
   }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -168,7 +168,6 @@ class BatchDownsampler(val settings: DownsamplerSettings,
           DownsamplerContext.dsLogger.warn(s"Skipping series with unknown schema ID $rawSchemaId")
         }
       }
-      //numDsChunks = persistDownsampledChunks(downsampledChunksToPersist)
       if (settings.shouldUseChunksPersistor) {
         chunksToPersist = getDownsampledChunksAsList(downsampledChunksToPersist)
       } else {
@@ -186,7 +185,7 @@ class BatchDownsampler(val settings: DownsamplerSettings,
     val endedAt = System.currentTimeMillis()
     DownsamplerContext.dsLogger.info(
       s"Finished iterating through and downsampling batchSize=${readablePartsBatch.size} " +
-      s"partitions in current executor timeTakenMs=${endedAt-startedAt} numDsChunks=$numDsChunks")
+      s"partitions in current executor timeTakenMs=${endedAt-startedAt}, persisted downsampled chunks=$numDsChunks")
     chunksToPersist
   }
 
@@ -433,7 +432,6 @@ class BatchDownsampler(val settings: DownsamplerSettings,
     numDownsampledChunksWritten.increment(numChunks)
     downsampleBatchPersistLatency.record(System.currentTimeMillis() - start)
     numChunks
-    //ListBuffer.empty[Row]
   }
 
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -226,7 +226,7 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
       s"partitions. Tune num-token-range-splits-for-scans if parallelism is low or latency is high")
 
     KamonShutdownHook.registerShutdownHook()
-
+    DownsamplerContext.dsLogger.info(s"Downsample Index Reader: ${settings.dsIndexReader}")
     val dsIndexReader = Class.forName(settings.dsIndexReader)
       .getDeclaredConstructor()
       .newInstance()
@@ -303,6 +303,7 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
       DownsamplerContext.dsLogger.info(s"Downsampled $downsampledBatches batches")
 
       if (settings.shouldUseChunksPersistor) {
+        DownsamplerContext.dsLogger.info(s"Using Chunk Persistor ${settings.chunksPersistor}")
         val persistor = chunkPersistor.get
 //        val persistor: ChunkPersistor = Class.forName(settings.chunksPersistor)
 //            .getDeclaredConstructor()

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -70,7 +70,7 @@ class DefaultDSPartitionReader extends DSPartitionReader {
       .makeRDD(splits)
       .mapPartitions { splitIter: Iterator[ScanSplit] =>
         Kamon.init()
-        KamonShutdownHook.registerShutdownHook() // ???
+        KamonShutdownHook.registerShutdownHook()
         val rawDataSource = batchDownsampler.rawCassandraColStore
         rawDataSource.initialize(
           batchDownsampler.rawDatasetRef, -1, settings.rawDatasetIngestionConfig.resources
@@ -314,6 +314,8 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
         DownsamplerContext.dsLogger.info(s"Downsampled rows/time series: $rows")
 
         persistor.persist(cachedDownsampledDf, batchDownsampler)
+      } else {
+        downsampledRowsRdd.foreach(_ => {})
       }
     }
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -86,7 +86,6 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val shouldUseChunksPersistor = downsamplerConfig.getBoolean("use-chunks-persistor")
   @transient lazy val chunksPersistor = downsamplerConfig.getString("chunks-persistor")
-  @transient lazy val chunkPersistorSplits = downsamplerConfig.getString("chunks-persistor-splits")
 
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")
 

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -82,6 +82,12 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val sparkSessionFactoryClass = downsamplerConfig.getString("spark-session-factory")
 
+  @transient lazy val dsIndexReader = downsamplerConfig.getString("ds-index-reader")
+
+  @transient lazy val shouldUseChunksPersistor = downsamplerConfig.getBoolean("use-chunks-persistor")
+  @transient lazy val chunksPersistor = downsamplerConfig.getString("chunks-persistor")
+  @transient lazy val chunkPersistorSplits = downsamplerConfig.getString("chunks-persistor-splits")
+
   @transient lazy val exportRuleKey = downsamplerConfig.as[Seq[String]]("data-export.key-labels")
 
   @transient lazy val exportDropLabels = downsamplerConfig.as[Seq[String]]("data-export.drop-labels")

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -1508,8 +1508,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val downsampledPartData1 = downsampleColStore.readRawPartitions(
       batchDownsampler.downsampleRefsByRes(FiniteDuration(1, "min")),
       0,
-      SinglePartitionScan(dsGaugePartKeyBytes))
-      .toListL.runToFuture.futureValue.head
+      SinglePartitionScan(dsGaugePartKeyBytes)
+    ).toListL.runToFuture.futureValue.head
 
     val downsampledPart1 = new PagedReadablePartition(Schemas.gauge.downsample.get, 0, 0,
       downsampledPartData1, 1.minute.toMillis.toInt)


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
BatchDownsampler currently performs two functions: (1) downsampling the data (2) persisting the data

**New behavior :**
ChunkPersitor trait is added allowing to use ChunkPersistor to save the downsampled data. DSPartitionReader is added allowing to read the data that needs to be downsampled.


**Other information**: