### PR TITLE
fix(query) Add support to disable remote stitch by tenants

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -475,6 +475,8 @@ filodb {
       # There is no deterministic way but 5 mins is a reasonably good time for the agents to detect the change in
       # partitions and start sending the metrics to the new partition.
       period-of-uncertainty-ms  = 5 minutes
+      disabled-remote-stitch-tenant-column-name = "_ws_"
+      disabled-remote-stitch-tenants = []
     }
 
     # Config values are used when partialResults query parameter is not provided

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -164,6 +164,8 @@ filodb {
       max-time-range-remote-raw-export = 30 minutes
       enable-approximate-equals-in-stitch = true
       period-of-uncertainty-ms = 0 minutes
+      disabled-remote-stitch-tenant-column-name = "_ws_"
+      disabled-remote-stitch-tenants = []
     }
     allow-partial-results-metadataquery = true
     allow-partial-results-rangequery = false


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 
Enabling and disabling stick is a global config with no way to disable at tenant level if the global config is enabled. 

**New behavior :**
Add capabilities to disable the feature per tenant
