### PR TITLE
support for last-over-time gauge aggregations to match promql

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -245,6 +245,25 @@ filodb {
       downsamplers = ["tTime(0)", "dSum(1)", "dMin(2)", "dSum(3)", "dMax(4)"]
       downsample-schema = "preagg-gauge"
     }
+
+    # new preagg schema to support last-over-time aggregations
+    preagg-gauge-lot {
+      columns = [
+        "timestamp:ts",
+        "count:double:detectDrops=false",
+        "min:double:detectDrops=false",
+        "sum:double:detectDrops=false",
+        "max:double:detectDrops=false",
+        "countl:double:detectDrops=false",
+        "minl:double:detectDrops=false",
+        "suml:double:detectDrops=false",
+        "maxl:double:detectDrops=false",
+      ]
+      value-column = "sum"
+      downsample-period-marker = "time(0)"
+      downsamplers = ["tTime(0)", "dSum(1)", "dMin(2)", "dSum(3)", "dMax(4)","dSum(5)", "dMin(6)", "dSum(7)", "dMax(8)"]
+      downsample-schema = "preagg-gauge-lot"
+    }
     preagg-delta-counter {
       columns = [
         "timestamp:ts",

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -247,7 +247,11 @@ filodb {
     }
 
     # new preagg schema to support last-over-time aggregations
-    preagg-gauge-lot {
+    # countl = count(last-over-time(http_requests{job="web-server"}[2m]))
+    # minl = min(last-over-time(http_requests{job="web-server"}[2m]))
+    # suml = sum(last-over-time(http_requests{job="web-server"}[2m]))
+    # maxl = max(last-over-time(http_requests{job="web-server"}[2m]))
+    preagg-gauge-v2 {
       columns = [
         "timestamp:ts",
         "count:double:detectDrops=false",
@@ -261,8 +265,8 @@ filodb {
       ]
       value-column = "sum"
       downsample-period-marker = "time(0)"
-      downsamplers = ["tTime(0)", "dSum(1)", "dMin(2)", "dSum(3)", "dMax(4)","dSum(5)", "dMin(6)", "dSum(7)", "dMax(8)"]
-      downsample-schema = "preagg-gauge-lot"
+      downsamplers = ["tTime(0)", "dSum(1)", "dMin(2)", "dSum(3)", "dMax(4)","dLast(5)", "dLast(6)", "dLast(7)", "dLast(8)"]
+      downsample-schema = "preagg-gauge-v2"
     }
     preagg-delta-counter {
       columns = [

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -473,7 +473,7 @@ object Schemas extends StrictLogging {
   val otelExpDeltaHistogram = global.schemas("otel-exp-delta-histogram")
   val dsGauge = global.schemas("ds-gauge")
   val preaggGauge = global.schemas("preagg-gauge")
-  val preaggGaugeLot = global.schemas("preagg-gauge-lot")
+  val preaggGaugeV2 = global.schemas("preagg-gauge-v2")
   val preaggDeltaCounter = global.schemas("preagg-delta-counter")
   val preaggDeltaHistogram = global.schemas("preagg-delta-histogram")
   val preaggOtelDeltaHistogram = global.schemas("preagg-otel-delta-histogram")

--- a/core/src/main/scala/filodb.core/metadata/Schemas.scala
+++ b/core/src/main/scala/filodb.core/metadata/Schemas.scala
@@ -473,6 +473,7 @@ object Schemas extends StrictLogging {
   val otelExpDeltaHistogram = global.schemas("otel-exp-delta-histogram")
   val dsGauge = global.schemas("ds-gauge")
   val preaggGauge = global.schemas("preagg-gauge")
+  val preaggGaugeLot = global.schemas("preagg-gauge-lot")
   val preaggDeltaCounter = global.schemas("preagg-delta-counter")
   val preaggDeltaHistogram = global.schemas("preagg-delta-histogram")
   val preaggOtelDeltaHistogram = global.schemas("preagg-otel-delta-histogram")


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?


New preagg-gauge schema with additional columns to support gauge last-over-time aggregations. This is to match promql aggregation query behavior.
- countl = `count(last-over-time(http_requests{job="web-server"}[2m]))`
- minl = `min(last-over-time(http_requests{job="web-server"}[2m]))`
- suml = `sum(last-over-time(http_requests{job="web-server"}[2m]))`
- maxl = `max(last-over-time(http_requests{job="web-server"}[2m]))`