### PR TITLE
bug(query): Optimize join only if both sides can be optimized

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/AggLpOptimizationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/AggLpOptimizationSpec.scala
@@ -67,6 +67,10 @@ class AggLpOptimizationSpec extends AnyFunSpec with Matchers {
     val testCases = Seq(
       """sum(rate(foo{_ws_="demo",_ns_="localNs"}[300s])) by (container) + sum(rate(foo{_ws_="demo",_ns_="localNs"}[300s]))"""
         -> """(sum(rate(foo:::agg1_1{_ws_="demo",_ns_="localNs"}[300s])) by (container) + sum(rate(foo:::agg1_2{_ws_="demo",_ns_="localNs"}[300s])))""",
+
+      // this one cannot be optimized since one side has window < 60s. Optimize join only if both sides can be optimized
+      """(sum(rate(foo{_ws_="demo",_ns_="localNs"}[10s])) by (container) + sum(rate(foo{_ws_="demo",_ns_="localNs"}[300s])))"""
+        -> """(sum(rate(foo{_ws_="demo",_ns_="localNs"}[10s])) by (container) + sum(rate(foo{_ws_="demo",_ns_="localNs"}[300s])))""",
     )
     testOptimization(excludeRules1, testCases)
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Optimize Binary Join Logical plan only if both sides of join can be optimized. Raw and aggregated data may have different retentions. This leads to consistent explainable experience. 