### PR TITLE
perf(index) Use FILTER instead of MUST and publish lucene caching stats

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -907,6 +907,20 @@ filodb {
         deleted-doc-merge-threshold = 0.1
     }
 
+    lucene {
+        # RAM buffer size in MB for IndexWriter. Controls how much memory is used for indexing
+        # before flushing to disk. Lucene default is 16MB.
+        ram-buffer-size-mb = 16.0
+
+        # Maximum number of documents to buffer before flushing. When set to -1, only 
+        # ram-buffer-size-mb controls flushing. Lucene default is disabled (-1).
+        max-buffered-docs = -1
+
+        # Whether to use compound file format. When false, provides better search performance
+        # but uses more file handles. Lucene default is true.
+        use-compound-file = true
+    }
+
     # At the cost of some extra heap memory, we can track queries holding shared lock for a long time
     # and starving the exclusive access of lock for eviction
     track-queries-holding-eviction-lock = true

--- a/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyIndex.scala
@@ -272,6 +272,11 @@ abstract class PartKeyIndexRaw(ref: DatasetRef,
   def startFlushThread(flushDelayMinSeconds: Int, flushDelayMaxSeconds: Int): Unit
 
   /**
+   * Start background thread for collecting and publishing index statistics
+   */
+  def startStatsThread(): Unit
+
+  /**
    * Find partitions that ended ingesting before a given timestamp. Used to identify partitions that can be purged.
    * @return matching partIds
    */

--- a/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyTantivyIndex.scala
@@ -111,6 +111,11 @@ class PartKeyTantivyIndex(ref: DatasetRef,
       flushDelayMinSeconds, TimeUnit.SECONDS)
   }
 
+  override def startStatsThread(): Unit = {
+    // Tantivy already publishes stats in the flush thread, no separate stats thread needed
+    logger.debug(s"Tantivy index stats are published via flush thread for dataset=${ref.dataset} shard=$shardNum")
+  }
+
   override def partIdsEndedBefore(endedBefore: Long): Buffer[Int] = {
     val result: debox.Buffer[Int] = debox.Buffer.empty[Int]
     val partIds = TantivyNativeMethods.partIdsEndedBefore(indexHandle, endedBefore)

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -107,6 +107,12 @@ filodb {
       deleted-doc-merge-threshold = 0.1
     }
 
+    lucene {
+      ram-buffer-size-mb = 16.0
+      max-buffered-docs = -1
+      use-compound-file = true
+    }
+
     flush-task-parallelism = 1
     ensure-block-memory-headroom-percent = 5
     ensure-tsp-count-headroom-percent = 5


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

All queries use MUST even though we don't use scoring. Additionally no query stats are published for Lucene index

**New behavior :**

FiloDB indexing does not use scoring and thus replacing ``MUST`` with ``FILTER``.  Additionally`` LRUQueryCache`` stats are added similar to tantivy based implementation

