### PR TITLE
fix(gateway) fix the parsing of timeseries-dev-source.conf to address the new substitutions

### DIFF
--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress
 import java.nio.charset.Charset
 import java.util.concurrent.Executors
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
@@ -105,7 +106,7 @@ object GatewayServer extends StrictLogging {
     val numSamples = userOpts.samplesPerSeries() * userOpts.numSeriesPerMetric() * userOpts.numMetrics()
     val numSeries = userOpts.numSeriesPerMetric()
 
-    val sourceConfig = ConfigFactory.parseFile(new java.io.File(userOpts.sourceConfigPath()))
+    val sourceConfig = ConfigFactory.parseFile(new java.io.File(userOpts.sourceConfigPath())).resolve()
     val numShards = sourceConfig.getInt("num-shards")
 
     val dataset = settings.datasetFromStream(sourceConfig)
@@ -349,7 +350,7 @@ object GatewayServer extends StrictLogging {
     // Now create Kafka config, sink
     // TODO: use the official KafkaIngestionStream stuff to parse the file.  This is just faster for now.
     val producerCfg = KafkaProducerConfig.default.copy(
-      bootstrapServers = sourceConf.getString("sourceconfig.bootstrap.servers").split(',').toList
+      bootstrapServers = sourceConf.getStringList("sourceconfig.bootstrap.servers").asScala.toList
     )
     val topicName = sourceConf.getString("sourceconfig.filo-topic-name")
 

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesConsumer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesConsumer.scala
@@ -2,6 +2,8 @@ package filodb.timeseries
 
 import java.lang.{Long => JLong}
 
+import scala.collection.JavaConverters._
+
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 import monix.execution.Scheduler
@@ -15,11 +17,11 @@ object TestTimeseriesConsumer extends StrictLogging {
   implicit val io = Scheduler.io("kafka-consumer")
 
   def main(args: Array[String]): Unit = {
-    val sourceConfig = ConfigFactory.parseFile(new java.io.File(args(0)))
+    val sourceConfig = ConfigFactory.parseFile(new java.io.File(args(0))).resolve()
     val topicName = sourceConfig.getString("sourceconfig.filo-topic-name")
 
     val consumerCfg = KafkaConsumerConfig.default.copy(
-      bootstrapServers = sourceConfig.getString("sourceconfig.bootstrap.servers").split(',').toList,
+      bootstrapServers = sourceConfig.getStringList("sourceconfig.bootstrap.servers").asScala.toList,
       groupId = "timeseries-source-consumer",
       autoOffsetReset = AutoOffsetReset.Latest
     )

--- a/gateway/src/main/scala/filodb/timeseries/TestTimeseriesPrometheusConsumer.scala
+++ b/gateway/src/main/scala/filodb/timeseries/TestTimeseriesPrometheusConsumer.scala
@@ -2,6 +2,7 @@ package filodb.timeseries
 
 import java.lang.{Long => JLong}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
@@ -47,11 +48,11 @@ object TestTimeseriesPrometheusConsumer extends StrictLogging {
     logger.info(s"Using source config file: $sourceConfigPath")
 
 
-    val sourceConfig = ConfigFactory.parseFile(new java.io.File(sourceConfigPath))
+    val sourceConfig = ConfigFactory.parseFile(new java.io.File(sourceConfigPath)).resolve()
     val topicName = sourceConfig.getString("sourceconfig.filo-topic-name")
 
     val consumerCfg = KafkaConsumerConfig.default.copy(
-      bootstrapServers = sourceConfig.getString("sourceconfig.bootstrap.servers").split(',').toList,
+      bootstrapServers = sourceConfig.getStringList("sourceconfig.bootstrap.servers").asScala.toList,
       groupId = "timeseries-prometheus-consumer",
       autoOffsetReset = AutoOffsetReset.Latest,
       properties = Map(


### PR DESCRIPTION
**Pull Request checklist**

This PR fixes the way the timeseries-dev-source.conf is parsed to resolve the new substitutions introduced by the following PR https://github.com/filodb/FiloDB/pull/2053