### PR TITLE
feat(core): add scrape endpoint for otel metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ ThisBuild / dependencyOverrides ++= Seq(
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
   "com.typesafe.akka" %% "akka-actor" % "2.5.32",
-  "com.typesafe.akka" %% "akka-stream" % "2.5.32"
+  "com.typesafe.akka" %% "akka-stream" % "2.5.32",
+  "com.google.protobuf" % "protobuf-java" % "3.21.7"
 )
 
 enablePlugins(ProtobufPlugin)

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -95,6 +95,10 @@ filodb {
 
       # Client PKCS#12 keystore for mTLS (only used when exporter-type = "otlp")
       # otlp-client-p12-keystore-path = ""
+
+      # Enables scrape endpoint at http://<host>:<prometheus-port>/metrics
+      prometheus-enabled = false
+      prometheus-port = 9464
     }
   }
 

--- a/core/src/main/scala/filodb.core/metrics/FilodbMetrics.scala
+++ b/core/src/main/scala/filodb.core/metrics/FilodbMetrics.scala
@@ -15,6 +15,7 @@ import io.opentelemetry.api.common.{AttributeKey, Attributes}
 import io.opentelemetry.api.metrics._
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
+import io.opentelemetry.exporter.prometheus.PrometheusHttpServer
 import io.opentelemetry.instrumentation.oshi.SystemMetrics
 import io.opentelemetry.instrumentation.runtimemetrics.java8.{Classes, Cpu, GarbageCollector, MemoryPools, Threads}
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -48,7 +49,9 @@ case class OTelMetricsConfig(exportIntervalSeconds: Int = 60,
                              // one of client cert/key or p12 keystore must be provided for mTLS
                              otlpClientCertPath: Option[String],
                              otlpClientKeyPath: Option[String],
-                             otlpClientP12KeystorePath: Option[String])
+                             otlpClientP12KeystorePath: Option[String],
+                             prometheusEnabled: Boolean = false,
+                             prometheusPort: Int = 9464)
 
 /**
  * Factory interface for creating MetricExporter instances
@@ -133,8 +136,10 @@ object OTelMetricsConfig {
       otlpTrustedCertsPath = metricsConfig.as[Option[String]]("otlp-trusted-certs-path"),
       otlpClientCertPath = metricsConfig.as[Option[String]]("otlp-client-cert-path"),
       otlpClientKeyPath = metricsConfig.as[Option[String]]("otlp-client-key-path"),
-      otlpClientP12KeystorePath = metricsConfig.as[Option[String]]("otlp-client-p12-keystore-path")
+      otlpClientP12KeystorePath = metricsConfig.as[Option[String]]("otlp-client-p12-keystore-path"),
       // TODO add support for passwords if needed later
+      prometheusEnabled = metricsConfig.as[Boolean]("prometheus-enabled"),
+      prometheusPort = metricsConfig.as[Int]("prometheus-port")
     )
   }
 }
@@ -284,6 +289,14 @@ private class FilodbMetrics(filodbMetricsConfig: Config) extends StrictLogging {
     val sdkMeterProviderBuilder = SdkMeterProvider.builder()
       .setResource(resource)
       .registerMetricReader(metricReader)
+
+    if (otelConfig.prometheusEnabled) {
+      val prometheusReader = PrometheusHttpServer.builder()
+        .setPort(otelConfig.prometheusPort)
+        .build()
+      sdkMeterProviderBuilder.registerMetricReader(prometheusReader)
+      logger.info(s"OTel Prometheus scrape endpoint enabled on port ${otelConfig.prometheusPort}")
+    }
     if (otelConfig.exponentialHistogram) {
       sdkMeterProviderBuilder.registerView(InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(),
         View.builder().setAggregation(Aggregation.base2ExponentialBucketHistogram(64, 20)).build())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
   val ficusVersion      = "1.5.2" // Updated for Scala 2.13
   val kamonBundleVersion = "2.7.3"
   val otelVersion       = "1.54.1"
+  val otelVersionAlpha  = otelVersion + "-alpha"
   val otelInstVersion   = "2.20.1-alpha"
   val monixKafkaVersion = "1.0.0-RC7"
   val sparkVersion      = "3.4.0"
@@ -53,6 +54,7 @@ object Dependencies {
     "io.opentelemetry"             % "opentelemetry-sdk-metrics"            % otelVersion,
     "io.opentelemetry"             % "opentelemetry-exporter-otlp"          % otelVersion,
     "io.opentelemetry"             % "opentelemetry-exporter-logging-otlp"  % otelVersion,
+    "io.opentelemetry"             % "opentelemetry-exporter-prometheus"    % otelVersionAlpha,
     "io.opentelemetry.instrumentation" % "opentelemetry-runtime-telemetry-java8" % otelInstVersion,
     "io.opentelemetry.instrumentation" % "opentelemetry-oshi"                    % otelInstVersion,
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Currently, OTel metrics are only available via OTLP push.
This PR additionally adds the option to expose OTel metrics via a Prometheus-style scrape endpoint.

### Notes
- Forces protobuf-java library to 3.21.7 (version used before this PR). Required because new opentelemetry-exporter-prometheus library transitively imports 4.31.1. Compilation fails without pinned version.