### PR TITLE
feat(core): even-distribution histogram quantile via order-statistic interpolation (#2275)

### DIFF
--- a/core/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/core/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -60,8 +60,14 @@ trait Histogram extends Ordered[Histogram] {
     if (numBuckets <= 0) Double.NaN else bucketValue(numBuckets - 1)
 
   /**
-   * Calculates histogram quantile based on bucket values using Prometheus scheme (increasing/LE)
+   * Calculates histogram quantile based on bucket values using Prometheus scheme (increasing/LE).
+   *
+   * When `evenDistribution` is true, the calculation uses the order-statistic convention instead:
+   * the rank is `(N-1)*q + 1`, samples are assumed evenly spaced within a bucket at
+   * `k*width/(count+1)`, and the top fractional sample interpolates toward `max`.
    */
+  //scalastyle:off method.length
+  //scalastyle:off cyclomatic.complexity
   def quantile(q: Double,
                min: Double = 0, // negative observations not supported yet
                max: Double = Double.PositiveInfinity,
@@ -70,8 +76,9 @@ trait Histogram extends Ordered[Histogram] {
     else if (q > 1) Double.PositiveInfinity
     else if (numBuckets < 2 || topBucketValue <= 0) Double.NaN
     else {
-      // find rank for the quantile using total number of occurrences (which is the last bucket value)
-      var rank = q * topBucketValue
+      // find rank for the quantile using total number of occurrences (which is the last bucket value).
+      // evenDistribution uses the order-statistic convention (N-1)*q + 1; default uses Prometheus' q*N.
+      val rank = if (evenDistribution) (topBucketValue - 1) * q + 1 else q * topBucketValue
       // using rank, find the le bucket which would have the identified rank
       val bucket = firstBucketGTE(rank)
 
@@ -89,23 +96,78 @@ trait Histogram extends Ordered[Histogram] {
       } else if (bucket == 0 && bucketTop(0) <= 0) {
         return bucketTop(0) // zero or negative bucket
       } else {
-
-        // interpolate quantile within boundaries of "bucket"
-        val count = if (bucket == 0) bucketValue(bucket) else bucketValue(bucket) - bucketValue(bucket-1)
-        rank -= (if (bucket == 0) 0 else bucketValue(bucket-1))
-        val fraction = if (evenDistribution) rank / (count + 1) else rank / count
-        if (!hasExponentialBuckets || bucketStart == 0) {
-          bucketStart + (bucketEnd-bucketStart) * fraction
+        if (evenDistribution) {
+          // Order-statistic / even-distribution quantile. rank = (N-1)*q + 1; the quantile interpolates between the two
+          // samples straddling rank: the k-th (k = floor(rank)) and the (k+1)-th, where the j-th of
+          // `s` samples in a bucket [lo, hi] is assumed at lo + j*(hi-lo)/(s+1).  The two neighbours
+          // may live in different buckets, so the interpolation can cross a bucket boundary.
+          //
+          // Scheme-aware lower/upper edges (used only here, in evenDistribution mode):
+          // encodes integer-valued samples whose smallest possible value in bucket `no`
+          // is bucketTop(no-1)+1; the exclusive upper before max-capping is bucketTop(no)+1.
+          // For the GeometricBuckets minusOne (integer power-of-2) scheme, bucket `no` covers
+          // [base^no, base^(no+1)-1], so even bucket 0's lower edge is base^0 = bucketTop(-1)+1
+          // (= 1 for the standard 2/2 scheme), NOT 0 -- matching getValueForIndex(0) = 2^0.
+          // Other schemes keep a genuine zero-bucket lower edge of 0.
+          val minusOneGeom = this match {
+            case h: HistogramWithBuckets => h.buckets match {
+              case g: GeometricBuckets => g.minusOne
+              case _                    => false
+            }
+            case _ => false
+          }
+          def schemeEdges(no: Int): (Double, Double) = {
+            val lo = if (no == 0 && !minusOneGeom) 0d else bucketTop(no - 1) + 1
+            (lo, bucketTop(no) + 1)
+          }
+          // Reconstruct the g-th global sample within its own bucket (no max-snap).
+          def reconstructInBucket(g: Double): Double = {
+            val b = firstBucketGTE(g)                          // bucket containing the g-th sample
+            val prevBucketVal = if (b == 0) 0d else bucketValue(b - 1)
+            val s = bucketValue(b) - prevBucketVal
+            val (schemeLo, schemeHi) = schemeEdges(b)
+            // Clip the upper edge to `max`; collapses the bucket to a degenerate span when max <= lo.
+            var lo = schemeLo
+            val hi = Math.min(schemeHi, max)
+            if (min > lo && min <= hi) lo = min
+            val width = Math.max(0d, hi - lo)
+            lo + (g - prevBucketVal) * width / (s + 1)
+          }
+          val n = topBucketValue
+          val k = Math.floor(rank)                             // lower neighbour ordinal
+          val frac = rank - k
+          // Lower neighbour (k-th sample): snaps to max only past the last observation (q == 1).
+          val xi = if (k >= n) max else reconstructInBucket(k)
+          if (frac <= 0.001) xi
+          else {
+            // Upper neighbour is the (k+1)-th sample.  it snaps the LAST sample to `max` only when
+            // it shares a bucket with the lower neighbour; across a bucket boundary (pendingSample path)
+            // the last sample is reconstructed within its own bucket, NOT snapped.
+            val sameBucket = firstBucketGTE(k) == firstBucketGTE(k + 1)
+            val xi1 = if (k >= n || (sameBucket && k + 1 >= n)) max else reconstructInBucket(k + 1)
+            xi + (xi1 - xi) * frac
+          }
         } else {
-          val logBucketEnd = log2(bucketEnd)
-          val logBucketStart = log2(bucketStart)
-          val logRank = logBucketStart + (logBucketEnd - logBucketStart) * fraction
-          Math.pow(2, logRank)
+          // interpolate quantile within boundaries of "bucket"
+          val prevBucketVal = if (bucket == 0) 0d else bucketValue(bucket-1)
+          val count = bucketValue(bucket) - prevBucketVal
+          val localRank = rank - prevBucketVal
+          val fraction = localRank / count
+          if (!hasExponentialBuckets || bucketStart == 0) {
+            bucketStart + (bucketEnd-bucketStart) * fraction
+          } else {
+            val logBucketEnd = log2(bucketEnd)
+            val logBucketStart = log2(bucketStart)
+            val logRank = logBucketStart + (logBucketEnd - logBucketStart) * fraction
+            Math.pow(2, logRank)
+          }
         }
       }
     }
     result
   }
+  //scalastyle:on method.length
+  //scalastyle:on cyclomatic.complexity
 
   private def log2(v: Double) = Math.log(v) / Math.log(2)
 

--- a/core/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/core/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -117,6 +117,35 @@ class HistogramTest extends NativeVectorTest {
       customHistograms(0).quantile(0.95) shouldEqual 10
     }
 
+    it("should calculate even-distribution quantile (order-statistic convention) with max") {
+      // A fixed 64-bucket Base2 exponential histogram (scale=0 => base=2, startIndex=1, 63 pos buckets).
+      // Per-bucket (non-cumulative) counts sum to 120; max observed = 998821.
+      // Pinned values are the order-statistic / even-distribution quantiles: rank = (N-1)*q + 1,
+      // even sample spacing within a bucket, and the top fractional sample snapped toward `max`.
+      // p25 specifically exercises cross-bucket interpolation: rank=30.75, floor(rank)=30 falls exactly
+      // on a cumulative bucket boundary, so the two straddling samples live in different buckets.
+      val scheme = GeometricBuckets(2, 2, 64, minusOne = true)
+      val perBucket = Array[Long](
+        0,0,0,0,0,0,0,0,1,0,0,0,0,0,3,5,8,13,36,54,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0)
+      val hist = LongHistogram(scheme, perBucket.scanLeft(0L)(_ + _).tail)
+      val max = 998821.0
+
+      hist.quantile(0.25,  0, max, evenDistribution = true) shouldEqual 265117.1583 +- 0.1
+      hist.quantile(0.5,   0, max, evenDistribution = true) shouldEqual 478235.6757 +- 0.1
+      hist.quantile(0.9,   0, max, evenDistribution = true) shouldEqual 887521.4418 +- 0.1
+      hist.quantile(0.95,  0, max, evenDistribution = true) shouldEqual 938857.2845 +- 0.1
+      hist.quantile(0.99,  0, max, evenDistribution = true) shouldEqual 979925.9587 +- 0.1
+      hist.quantile(0.999, 0, max, evenDistribution = true) shouldEqual 996767.5663 +- 0.1
+
+      // The default (Prometheus q*N, linear) path must remain distinct from the even path: at the
+      // tail the even path snaps toward max while the default interpolates linearly within the bucket.
+      hist.quantile(0.999, 0, max, evenDistribution = false) should not equal
+        hist.quantile(0.999, 0, max, evenDistribution = true)
+    }
+
     it("should calculate quantile correctly for exponential bucket histograms") {
       val bucketScheme = Base2ExpHistogramBuckets(3, -5, 11) // 0.707 to 1.68
       val hist = MutableHistogram(bucketScheme, Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))


### PR DESCRIPTION
* feat(core): even-distribution histogram quantile via order-statistic interpolation

Extend Histogram.quantile's evenDistribution mode to use the order-statistic percentile convention instead of the Prometheus q*N rank:

- rank = (N-1)*q + 1
- reconstruct evenly-spaced samples within each bucket at j*width/(s+1) and interpolate between the two samples straddling rank; the two neighbours may live in different buckets, so interpolation can cross a bucket boundary
- the top fractional sample snaps toward `max` once its index reaches the total observation count

The default (Prometheus, linear/exponential) path is unchanged. Adds a value-pinned HistogramTest covering interior, tail max-snap, and cross-bucket-boundary quantiles.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* fix edge cases for quantile logic

* modify histogram logic

* fix comments

---------

(cherry picked from commit ac7547abd2e213d77008f13b9f0540e98adcf673)

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: