### PR TITLE
feat(coordinator,http): TsCardinalities via coordinator actor, bypassing QueryActor

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
@@ -196,7 +196,10 @@ class FiloDbClusterDiscovery(settings: FilodbSettings,
     logger.info(s"[ClusterV2] Starting cardinality scatter. dataset=$ref prefix=$shardKeyPrefix " +
       s"depth=$depth numNodes=${nodeCoordActorSelections.size} perNodeTimeout=$timeout")
     val asks = nodeCoordActorSelections.zip(hostNames).map { case (nca, host) =>
-      nca.resolveOne(settings.ResolveActorTimeout)
+      // NOTE: the resolve leg is capped by the same budget. tasks.timeouts.resolve-actor is 10s and
+      // is shared with the shard-map discovery pipeline, so it cannot be lowered globally - without
+      // this cap an unreachable node could burn the full resolve timeout BEFORE the ask even starts.
+      nca.resolveOne(timeout.min(settings.ResolveActorTimeout))
         .flatMap { ncaRef => (ncaRef ? GetCardinalityScatter(ref, shardKeyPrefix, depth))(t) }
         .map {
           case lc: LocalCardinalities => Some(lc)

--- a/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
@@ -210,36 +210,15 @@ class FiloDbClusterDiscovery(settings: FilodbSettings,
     }
 
     Future.sequence(asks).map { results =>
-      val acc = new mutable.HashMap[Seq[String], CardinalityValue]()
-      val covered = mutable.Set[Int]()
-      results.flatten.foreach { lc =>
-        covered ++= lc.shards
-        lc.records.foreach { rec =>
-          acc.update(rec.prefix, acc.get(rec.prefix).map(sum(_, rec.value)).getOrElse(rec.value))
-        }
-      }
-      val missing = (0 until numShards).filterNot(covered.contains)
-      if (missing.nonEmpty) {
+      val merged = ClusterCardinalities.merge(ref, numShards, results)
+      if (merged.missingShards.nonEmpty) {
         logger.error(s"[ClusterV2] Cardinality result for dataset=$ref is incomplete. " +
-          s"nodesAnswered=${results.count(_.isDefined)}/${results.size} missingShards=$missing")
+          s"nodesAnswered=${results.count(_.isDefined)}/${results.size} " +
+          s"missingShards=${merged.missingShards}")
       }
-      // `shard` is meaningless once summed across shards
-      ClusterCardinalities(ref, acc.toSeq.map { case (p, v) => CardinalityRecord(-1, p, v) }, missing)
+      merged
     }
   }
-
-  /**
-   * Sums cardinality counts across shards. childrenCount and childrenQuota are deliberately not
-   * summed - they describe the trie shape and the quota of a single shard, neither of which
-   * aggregates meaningfully across shards.
-   */
-  private def sum(a: CardinalityValue, b: CardinalityValue): CardinalityValue =
-    CardinalityValue(
-      tsCount = a.tsCount + b.tsCount,
-      activeTsCount = a.activeTsCount + b.activeTsCount,
-      billableTsCount = a.billableTsCount + b.billableTsCount,
-      childrenCount = math.max(a.childrenCount, b.childrenCount),
-      childrenQuota = math.max(a.childrenQuota, b.childrenQuota))
 
   def shutdown(): Unit = {
     discoveryJobs.values.foreach(_.cancel())

--- a/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
@@ -192,12 +192,17 @@ class FiloDbClusterDiscovery(settings: FilodbSettings,
                                       numShards: Int,
                                       timeout: FiniteDuration): Future[ClusterCardinalities] = {
     val t = Timeout(timeout)
+    val startMs = System.currentTimeMillis()
+    logger.info(s"[ClusterV2] Starting cardinality scatter. dataset=$ref prefix=$shardKeyPrefix " +
+      s"depth=$depth numNodes=${nodeCoordActorSelections.size} perNodeTimeout=$timeout")
     val asks = nodeCoordActorSelections.zip(hostNames).map { case (nca, host) =>
       nca.resolveOne(settings.ResolveActorTimeout)
         .flatMap { ncaRef => (ncaRef ? GetCardinalityScatter(ref, shardKeyPrefix, depth))(t) }
         .map {
           case lc: LocalCardinalities => Some(lc)
           case other =>
+            // includes InternalServiceError from a node that refused because its shards are not
+            // all active - its shards are then reported missing rather than silently dropped
             logger.error(s"[ClusterV2] Cardinality scatter to host=$host for dataset=$ref " +
               s"returned $other")
             None
@@ -211,10 +216,16 @@ class FiloDbClusterDiscovery(settings: FilodbSettings,
 
     Future.sequence(asks).map { results =>
       val merged = ClusterCardinalities.merge(ref, numShards, results)
+      val elapsedMs = System.currentTimeMillis() - startMs
       if (merged.missingShards.nonEmpty) {
-        logger.error(s"[ClusterV2] Cardinality result for dataset=$ref is incomplete. " +
-          s"nodesAnswered=${results.count(_.isDefined)}/${results.size} " +
-          s"missingShards=${merged.missingShards}")
+        logger.error(s"[ClusterV2] Cardinality result for dataset=$ref is INCOMPLETE - counts would " +
+          s"undercount. nodesAnswered=${results.count(_.isDefined)}/${results.size} " +
+          s"numGroups=${merged.cardinalities.size} numMissingShards=${merged.missingShards.size} " +
+          s"missingShards=${merged.missingShards} elapsedMs=$elapsedMs")
+      } else {
+        logger.info(s"[ClusterV2] Cardinality scatter complete. dataset=$ref " +
+          s"nodesAnswered=${results.size}/${results.size} numGroups=${merged.cardinalities.size} " +
+          s"elapsedMs=$elapsedMs")
       }
       merged
     }

--- a/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/FiloDbClusterDiscovery.scala
@@ -15,6 +15,7 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 import filodb.coordinator.{ActorName, CurrentShardSnapshot, FilodbSettings, ShardMapper}
 import filodb.core.DatasetRef
+import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityValue}
 import filodb.core.metrics.FilodbMetrics
 
 class FiloDbClusterDiscovery(settings: FilodbSettings,
@@ -31,6 +32,8 @@ class FiloDbClusterDiscovery(settings: FilodbSettings,
   val clusterDiscoveryCounter = FilodbMetrics.counter("filodb-cluster-discovery")
   // Metric to track if we have unassigned shards on a given pod
   val unassignedShardsGauge = FilodbMetrics.gauge("v2-unassigned-shards")
+  // Metric to track per-node failures while scattering a cardinality scan
+  val cardinalityScatterFailedCounter = FilodbMetrics.counter("cardinality-scatter-failed")
 
   lazy val ordinalOfLocalhost: Int = {
     if (settings.localhostOrdinal.isDefined) settings.localhostOrdinal.get
@@ -165,6 +168,78 @@ class FiloDbClusterDiscovery(settings: FilodbSettings,
     val mapper = datasetToMapper.get(ref)
     if (mapper == null) new ShardMapper(0) else mapper
   }
+
+  /**
+   * Scatters a cardinality scan to every node of the cluster and merges the per-shard records
+   * into cluster-wide totals, grouped by shard key prefix.
+   *
+   * Unlike askShardSnapshot, a node that fails or times out is NOT substituted with an empty
+   * result. Every answering node reports the shards it actually scanned, and any shard nobody
+   * reports is returned in `missingShards`. These counts are used for metering, so silently
+   * omitting a node would produce an undercount that looks like real data.
+   *
+   * NOTE: missing shards are derived from what nodes report, NOT from shardsForOrdinal - the
+   * hostNames list is sorted lexicographically, so its index is not the node ordinal
+   * ("host-10" sorts before "host-2"). A failed node reports nothing, so all of its shards
+   * already show up as uncovered.
+   *
+   * Nodes are queried in parallel - each does a RocksDB scan, so a sequential fan-out would make
+   * latency the sum over pods rather than the max.
+   */
+  def reduceCardinalitiesFromAllNodes(ref: DatasetRef,
+                                      shardKeyPrefix: Seq[String],
+                                      depth: Int,
+                                      numShards: Int,
+                                      timeout: FiniteDuration): Future[ClusterCardinalities] = {
+    val t = Timeout(timeout)
+    val asks = nodeCoordActorSelections.zip(hostNames).map { case (nca, host) =>
+      nca.resolveOne(settings.ResolveActorTimeout)
+        .flatMap { ncaRef => (ncaRef ? GetCardinalityScatter(ref, shardKeyPrefix, depth))(t) }
+        .map {
+          case lc: LocalCardinalities => Some(lc)
+          case other =>
+            logger.error(s"[ClusterV2] Cardinality scatter to host=$host for dataset=$ref " +
+              s"returned $other")
+            None
+        }
+        .recover { case e =>
+          logger.error(s"[ClusterV2] Cardinality scatter to host=$host failed for dataset=$ref", e)
+          cardinalityScatterFailedCounter.increment(1, Map("dataset" -> ref.dataset))
+          None
+        }
+    }
+
+    Future.sequence(asks).map { results =>
+      val acc = new mutable.HashMap[Seq[String], CardinalityValue]()
+      val covered = mutable.Set[Int]()
+      results.flatten.foreach { lc =>
+        covered ++= lc.shards
+        lc.records.foreach { rec =>
+          acc.update(rec.prefix, acc.get(rec.prefix).map(sum(_, rec.value)).getOrElse(rec.value))
+        }
+      }
+      val missing = (0 until numShards).filterNot(covered.contains)
+      if (missing.nonEmpty) {
+        logger.error(s"[ClusterV2] Cardinality result for dataset=$ref is incomplete. " +
+          s"nodesAnswered=${results.count(_.isDefined)}/${results.size} missingShards=$missing")
+      }
+      // `shard` is meaningless once summed across shards
+      ClusterCardinalities(ref, acc.toSeq.map { case (p, v) => CardinalityRecord(-1, p, v) }, missing)
+    }
+  }
+
+  /**
+   * Sums cardinality counts across shards. childrenCount and childrenQuota are deliberately not
+   * summed - they describe the trie shape and the quota of a single shard, neither of which
+   * aggregates meaningfully across shards.
+   */
+  private def sum(a: CardinalityValue, b: CardinalityValue): CardinalityValue =
+    CardinalityValue(
+      tsCount = a.tsCount + b.tsCount,
+      activeTsCount = a.activeTsCount + b.activeTsCount,
+      billableTsCount = a.billableTsCount + b.billableTsCount,
+      childrenCount = math.max(a.childrenCount, b.childrenCount),
+      childrenQuota = math.max(a.childrenQuota, b.childrenQuota))
 
   def shutdown(): Unit = {
     discoveryJobs.values.foreach(_.cancel())

--- a/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
@@ -1,7 +1,7 @@
 package filodb.coordinator.v2
 
 import scala.collection.mutable
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
 import akka.actor.{ActorRef, OneForOneStrategy, Props}
@@ -129,15 +129,11 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
   private val ingestionConfigs = new mutable.HashMap[DatasetRef, IngestionConfig]()
   private val shardStats = new mutable.HashMap[DatasetRef, ShardHealthStats]()
 
-  // Per-node timeout for the cardinality scatter. Deliberately SHORTER than the caller's timeout:
-  // the HTTP route asks this actor with the same query.ask-timeout value, and the inner asks start
-  // after the outer one. With equal timeouts the outer always fires first, so a slow node would
-  // surface to the caller as a generic ask-timeout (HTTP 500) instead of our 503 naming the
-  // missing shards. Mirrors askShardSnapshot's `failureDetectionInterval - 5.seconds`.
-  private val cardinalityAskTimeout = {
-    val callerTimeout = settings.config.as[FiniteDuration]("query.ask-timeout")
-    if (callerTimeout > 10.seconds) callerTimeout - 5.seconds else callerTimeout / 2
-  }
+  // Per-node budget for the cardinality scatter, covering actor resolution plus the scan ask.
+  // Kept well below the caller's query.ask-timeout so a slow or unreachable node surfaces as our
+  // 503 naming the missing shards, rather than the caller's ask timing out first (a generic 500).
+  private val cardinalityAskTimeout =
+    settings.config.as[FiniteDuration]("metering-scatter-timeout")
 
   logger.info(s"[ClusterV2] Initializing NodeCoordActor at ${self.path}")
 

--- a/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
@@ -18,7 +18,7 @@ import filodb.coordinator.v2.NewNodeCoordinatorActor.InitNewNodeCoordinatorActor
 import filodb.core._
 import filodb.core.downsample.{DownsampleConfig, DownsampledTimeSeriesStore}
 import filodb.core.memstore.{TimeSeriesMemStore, TimeSeriesStore}
-import filodb.core.memstore.ratelimit.CardinalityRecord
+import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityValue}
 import filodb.core.metadata._
 import filodb.core.query.QueryContext
 import filodb.core.store.{IngestionConfig, StoreConfig}
@@ -66,6 +66,46 @@ final case class GetClusterCardinalities(ref: DatasetRef, shardKeyPrefix: Seq[St
 final case class ClusterCardinalities(ref: DatasetRef,
                                       cardinalities: Seq[CardinalityRecord],
                                       missingShards: Seq[Int])
+
+object ClusterCardinalities {
+
+  /**
+   * Folds per-node, per-shard cardinality records into cluster-wide totals grouped by shard key
+   * prefix. `None` entries are nodes that failed or timed out.
+   *
+   * Any shard that no answering node reports as scanned lands in `missingShards`. A failed node
+   * reports nothing, so all of its shards fall out of the covered set automatically - which is
+   * why this needs no notion of which node owns which shard.
+   */
+  def merge(ref: DatasetRef,
+            numShards: Int,
+            results: Seq[Option[LocalCardinalities]]): ClusterCardinalities = {
+    val acc = new mutable.HashMap[Seq[String], CardinalityValue]()
+    val covered = mutable.Set[Long]()
+    results.flatten.foreach { lc =>
+      covered ++= lc.shards.map(_.toLong)
+      lc.records.foreach { rec =>
+        acc.update(rec.prefix, acc.get(rec.prefix).map(sum(_, rec.value)).getOrElse(rec.value))
+      }
+    }
+    val missing = (0 until numShards).filterNot(sh => covered.contains(sh.toLong))
+    // `shard` is meaningless once summed across shards
+    ClusterCardinalities(ref, acc.toSeq.map { case (p, v) => CardinalityRecord(-1, p, v) }, missing)
+  }
+
+  /**
+   * Sums cardinality counts across shards. childrenCount and childrenQuota are deliberately NOT
+   * summed - they describe the trie shape and the quota of a single shard, neither of which
+   * aggregates meaningfully across shards, so the max is carried instead.
+   */
+  private def sum(a: CardinalityValue, b: CardinalityValue): CardinalityValue =
+    CardinalityValue(
+      tsCount = a.tsCount + b.tsCount,
+      activeTsCount = a.activeTsCount + b.activeTsCount,
+      billableTsCount = a.billableTsCount + b.billableTsCount,
+      childrenCount = math.max(a.childrenCount, b.childrenCount),
+      childrenQuota = math.max(a.childrenQuota, b.childrenQuota))
+}
 
 object NewNodeCoordinatorActor {
 

--- a/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
@@ -1,25 +1,71 @@
 package filodb.coordinator.v2
 
 import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
 import akka.actor.{ActorRef, OneForOneStrategy, Props}
 import akka.actor.SupervisorStrategy.Resume
 import akka.event.LoggingReceive
+import akka.pattern.pipe
 import kamon.Kamon
+import monix.execution.Scheduler
+import net.ceedubs.ficus.Ficus._
 
 import filodb.coordinator._
 import filodb.coordinator.v2.NewNodeCoordinatorActor.InitNewNodeCoordinatorActor
 import filodb.core._
 import filodb.core.downsample.{DownsampleConfig, DownsampledTimeSeriesStore}
 import filodb.core.memstore.{TimeSeriesMemStore, TimeSeriesStore}
+import filodb.core.memstore.ratelimit.CardinalityRecord
 import filodb.core.metadata._
+import filodb.core.query.QueryContext
 import filodb.core.store.{IngestionConfig, StoreConfig}
 import filodb.query.QueryCommand
 
 final case class GetShardMapScatter(ref: DatasetRef)
 case object LocalShardsHealthRequest
 case class DatasetShardHealth(dataset: DatasetRef, shard: Int, status: ShardStatus)
+
+/**
+ * Asks a single node for the cardinality records of the shards it owns. Sent by peer
+ * NewNodeCoordActors while serving a GetClusterCardinalities call, and answered without
+ * involving the QueryActor or the query scheduler.
+ *
+ * NOTE: intentionally NOT a QueryCommand - queryHandlers matches on QueryCommand and would
+ * forward this to the QueryActor, which is exactly the path this bypasses.
+ *
+ * @param shardKeyPrefix shard key prefix to scan under, e.g. Seq(ws) or Seq(ws, ns)
+ * @param depth hierarchical depth to group at: 1 = ws, 2 = ns, 3 = metric
+ */
+final case class GetCardinalityScatter(ref: DatasetRef, shardKeyPrefix: Seq[String], depth: Int)
+
+/**
+ * Cardinality records for the shards owned by one node. Records are per-shard; summing
+ * across shards is the caller's job.
+ *
+ * @param shards the shards actually scanned, all of which were ShardStatusActive
+ */
+final case class LocalCardinalities(ref: DatasetRef, shards: Seq[Int], records: Seq[CardinalityRecord])
+
+/**
+ * Asks the local NewNodeCoordActor for cluster-wide cardinalities. It scatters
+ * GetCardinalityScatter to every node and merges the per-shard records by prefix.
+ */
+final case class GetClusterCardinalities(ref: DatasetRef, shardKeyPrefix: Seq[String], depth: Int)
+
+/**
+ * Cluster-wide cardinalities, merged across all shards of all nodes.
+ *
+ * @param cardinalities merged records; the `shard` field is meaningless post-merge and is set to -1
+ * @param missingShards shards NOT covered by this result. Non-empty means the counts are an
+ *                      undercount - callers metering on these numbers should fail rather than
+ *                      publish them.
+ */
+final case class ClusterCardinalities(ref: DatasetRef,
+                                      cardinalities: Seq[CardinalityRecord],
+                                      missingShards: Seq[Int])
 
 object NewNodeCoordinatorActor {
 
@@ -43,6 +89,18 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
   private val localShardMaps = new mutable.HashMap[DatasetRef, ShardMapper]
   private val ingestionConfigs = new mutable.HashMap[DatasetRef, IngestionConfig]()
   private val shardStats = new mutable.HashMap[DatasetRef, ShardHealthStats]()
+
+  // Bounded pool for cardinality (RocksDB) scans, kept off this actor's thread and off the
+  // query scheduler. The bound is also the concurrency limit for cardinality requests.
+  private val cardScheduler: Scheduler = Scheduler.io(
+    name = "cardinality-scan",
+    reporter = monix.execution.UncaughtExceptionReporter(
+      logger.error("[ClusterV2] Uncaught exception in cardinality scan", _)))
+
+  // Only used for the cardinality futures above; the callbacks are trivial.
+  private implicit val cardExecutionContext: ExecutionContext = cardScheduler
+
+  private val cardinalityAskTimeout = settings.config.as[FiniteDuration]("query.ask-timeout")
 
   logger.info(s"[ClusterV2] Initializing NodeCoordActor at ${self.path}")
 
@@ -265,6 +323,75 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
     case InitNewNodeCoordinatorActor => initialize()
   }
 
-  def receive: Receive = queryHandlers orElse shardManagementHandlers orElse initHandler
+  /**
+   * Cardinality scans are RocksDB reads, so they are never run on this actor's thread: this
+   * mailbox also serves the k8s liveness/health probes (LocalShardsHealthRequest) and the
+   * peer shard-map gossip (GetShardMapScatter), and stalling either has blast radius well
+   * beyond the cardinality request itself. Actor state is read on the actor thread and the
+   * scan is handed to cardScheduler, with the reply piped back.
+   */
+  def cardinalityHandlers: Receive = LoggingReceive {
+    case g: GetCardinalityScatter =>
+      val replyTo = sender()
+      scanLocalCardinalities(g).recover { case e: Exception =>
+        logger.error(s"[ClusterV2] Error occurred when processing message $g", e)
+        InternalServiceError(s"Exception while executing GetCardinalityScatter for " +
+          s"dataset: ${g.ref.dataset} - ${e.getMessage}")
+      }.pipeTo(replyTo)
+
+    case g: GetClusterCardinalities =>
+      val replyTo = sender()
+      try {
+        val numShards = ingestionConfigs(g.ref).numShards
+        clusterDiscovery
+          .reduceCardinalitiesFromAllNodes(g.ref, g.shardKeyPrefix, g.depth, numShards, cardinalityAskTimeout)
+          .recover { case e: Exception =>
+            logger.error(s"[ClusterV2] Error occurred when processing message $g", e)
+            InternalServiceError(s"Exception while executing GetClusterCardinalities for " +
+              s"dataset: ${g.ref.dataset} - ${e.getMessage}")
+          }.pipeTo(replyTo)
+      } catch { case e: Exception =>
+        logger.error(s"[ClusterV2] Error occurred when processing message $g", e)
+        // send a response to avoid blocking of akka caller for long time
+        replyTo ! InternalServiceError(s"Exception while executing GetClusterCardinalities " +
+          s"for dataset: ${g.ref.dataset}")
+      }
+  }
+
+  /**
+   * Reads the shards this node owns on the actor thread, then scans them off-thread.
+   *
+   * Every owned shard must be ShardStatusActive. A shard that is assigned but recovering has a
+   * partially built cardinality tracker, so including it would silently undercount - we fail the
+   * whole node's scan instead. NOTE: this is deliberately stricter than HealthRoute's
+   * healthyShardStatuses, which admits ShardStatusRecovery and ShardStatusAssigned.
+   */
+  private def scanLocalCardinalities(g: GetCardinalityScatter): Future[Any] = {
+    val mapper = localShardMaps.get(g.ref)
+    if (mapper.isEmpty) {
+      Future.successful(InternalServiceError(s"Dataset ${g.ref.dataset} is not registered on this node"))
+    } else {
+      val assigned = mapper.get.assignedShards
+      val inactive = assigned.filterNot(mapper.get.isActiveShard)
+      if (inactive.nonEmpty) {
+        val statuses = inactive.map(sh => s"$sh=${mapper.get.statusForShard(sh)}").mkString(", ")
+        logger.warn(s"[ClusterV2] Refusing cardinality scan for dataset=${g.ref.dataset}: " +
+          s"shards not active [$statuses]")
+        Future.successful(
+          InternalServiceError(s"Cardinality count would be incorrect for dataset ${g.ref.dataset}: " +
+            s"shards not active [$statuses]"))
+      } else {
+        // intersect with the memstore's view so we never ask it for a shard it has not instantiated
+        val shards = assigned.intersect(memStore.activeShards(g.ref))
+        Future {
+          LocalCardinalities(g.ref, shards,
+            memStore.scanTsCardinalities(QueryContext(), g.ref, shards, g.shardKeyPrefix, g.depth))
+        }(cardScheduler)
+      }
+    }
+  }
+
+  def receive: Receive =
+    queryHandlers orElse shardManagementHandlers orElse cardinalityHandlers orElse initHandler
 
 }

--- a/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/v2/NewNodeCoordinatorActor.scala
@@ -1,8 +1,7 @@
 package filodb.coordinator.v2
 
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.{Failure, Success}
 
 import akka.actor.{ActorRef, OneForOneStrategy, Props}
@@ -10,12 +9,12 @@ import akka.actor.SupervisorStrategy.Resume
 import akka.event.LoggingReceive
 import akka.pattern.pipe
 import kamon.Kamon
-import monix.execution.Scheduler
 import net.ceedubs.ficus.Ficus._
 
 import filodb.coordinator._
 import filodb.coordinator.v2.NewNodeCoordinatorActor.InitNewNodeCoordinatorActor
 import filodb.core._
+import filodb.core.GlobalScheduler.globalImplicitScheduler
 import filodb.core.downsample.{DownsampleConfig, DownsampledTimeSeriesStore}
 import filodb.core.memstore.{TimeSeriesMemStore, TimeSeriesStore}
 import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityValue}
@@ -130,17 +129,15 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
   private val ingestionConfigs = new mutable.HashMap[DatasetRef, IngestionConfig]()
   private val shardStats = new mutable.HashMap[DatasetRef, ShardHealthStats]()
 
-  // Bounded pool for cardinality (RocksDB) scans, kept off this actor's thread and off the
-  // query scheduler. The bound is also the concurrency limit for cardinality requests.
-  private val cardScheduler: Scheduler = Scheduler.io(
-    name = "cardinality-scan",
-    reporter = monix.execution.UncaughtExceptionReporter(
-      logger.error("[ClusterV2] Uncaught exception in cardinality scan", _)))
-
-  // Only used for the cardinality futures above; the callbacks are trivial.
-  private implicit val cardExecutionContext: ExecutionContext = cardScheduler
-
-  private val cardinalityAskTimeout = settings.config.as[FiniteDuration]("query.ask-timeout")
+  // Per-node timeout for the cardinality scatter. Deliberately SHORTER than the caller's timeout:
+  // the HTTP route asks this actor with the same query.ask-timeout value, and the inner asks start
+  // after the outer one. With equal timeouts the outer always fires first, so a slow node would
+  // surface to the caller as a generic ask-timeout (HTTP 500) instead of our 503 naming the
+  // missing shards. Mirrors askShardSnapshot's `failureDetectionInterval - 5.seconds`.
+  private val cardinalityAskTimeout = {
+    val callerTimeout = settings.config.as[FiniteDuration]("query.ask-timeout")
+    if (callerTimeout > 10.seconds) callerTimeout - 5.seconds else callerTimeout / 2
+  }
 
   logger.info(s"[ClusterV2] Initializing NodeCoordActor at ${self.path}")
 
@@ -364,70 +361,95 @@ private[filodb] final class NewNodeCoordinatorActor(memStore: TimeSeriesStore,
   }
 
   /**
-   * Cardinality scans are RocksDB reads, so they are never run on this actor's thread: this
-   * mailbox also serves the k8s liveness/health probes (LocalShardsHealthRequest) and the
-   * peer shard-map gossip (GetShardMapScatter), and stalling either has blast radius well
-   * beyond the cardinality request itself. Actor state is read on the actor thread and the
-   * scan is handed to cardScheduler, with the reply piped back.
+   * GetCardinalityScatter is answered inline, exactly like the sibling handlers above and like
+   * QueryActor.execTopkCardinalityQuery, which already runs this same scan on an actor thread.
+   *
+   * GetClusterCardinalities cannot be: it scatters to every node INCLUDING this one, so blocking
+   * this mailbox while waiting would prevent us from ever processing our own
+   * GetCardinalityScatter, guaranteeing a self-timeout. Hence the Future + pipe. Its callbacks are
+   * trivial and run on the shared globalImplicitScheduler (imported above), which is why the
+   * synchronous handlers here need no ExecutionContext at all.
    */
   def cardinalityHandlers: Receive = LoggingReceive {
     case g: GetCardinalityScatter =>
-      val replyTo = sender()
-      scanLocalCardinalities(g).recover { case e: Exception =>
+      try {
+        sender() ! scanLocalCardinalities(g)
+      } catch { case e: Exception =>
         logger.error(s"[ClusterV2] Error occurred when processing message $g", e)
-        InternalServiceError(s"Exception while executing GetCardinalityScatter for " +
-          s"dataset: ${g.ref.dataset} - ${e.getMessage}")
-      }.pipeTo(replyTo)
+        // send a response to avoid blocking of akka caller for long time
+        sender() ! InternalServiceError(s"Exception while executing GetCardinalityScatter for " +
+          s"dataset: ${g.ref.dataset}")
+      }
 
     case g: GetClusterCardinalities =>
       val replyTo = sender()
       try {
         val numShards = ingestionConfigs(g.ref).numShards
-        clusterDiscovery
+        val resp = clusterDiscovery
           .reduceCardinalitiesFromAllNodes(g.ref, g.shardKeyPrefix, g.depth, numShards, cardinalityAskTimeout)
           .recover { case e: Exception =>
             logger.error(s"[ClusterV2] Error occurred when processing message $g", e)
             InternalServiceError(s"Exception while executing GetClusterCardinalities for " +
-              s"dataset: ${g.ref.dataset} - ${e.getMessage}")
-          }.pipeTo(replyTo)
+              s"dataset: ${g.ref.dataset}")
+          }
+        pipe(resp).pipeTo(replyTo)
       } catch { case e: Exception =>
         logger.error(s"[ClusterV2] Error occurred when processing message $g", e)
-        // send a response to avoid blocking of akka caller for long time
         replyTo ! InternalServiceError(s"Exception while executing GetClusterCardinalities " +
           s"for dataset: ${g.ref.dataset}")
       }
   }
 
   /**
-   * Reads the shards this node owns on the actor thread, then scans them off-thread.
+   * Scans this node's shards for cardinality records.
+   *
+   * The owned shard set comes from clusterDiscovery.shardsForLocalhost - the same source initShards
+   * uses - rather than from localShardMaps. It is cheap (pure arithmetic over the ordinal) and, more
+   * importantly, independent of whether the shard assignment events actually applied:
+   * updateFromShardEvent only logs on failure, so a dropped event would make a shard look "not mine"
+   * and be silently omitted from the count. Deriving the expected set independently means such a
+   * shard instead shows up as not-active below, and we refuse rather than undercount.
    *
    * Every owned shard must be ShardStatusActive. A shard that is assigned but recovering has a
    * partially built cardinality tracker, so including it would silently undercount - we fail the
    * whole node's scan instead. NOTE: this is deliberately stricter than HealthRoute's
    * healthyShardStatuses, which admits ShardStatusRecovery and ShardStatusAssigned.
    */
-  private def scanLocalCardinalities(g: GetCardinalityScatter): Future[Any] = {
-    val mapper = localShardMaps.get(g.ref)
-    if (mapper.isEmpty) {
-      Future.successful(InternalServiceError(s"Dataset ${g.ref.dataset} is not registered on this node"))
-    } else {
-      val assigned = mapper.get.assignedShards
-      val inactive = assigned.filterNot(mapper.get.isActiveShard)
-      if (inactive.nonEmpty) {
-        val statuses = inactive.map(sh => s"$sh=${mapper.get.statusForShard(sh)}").mkString(", ")
-        logger.warn(s"[ClusterV2] Refusing cardinality scan for dataset=${g.ref.dataset}: " +
-          s"shards not active [$statuses]")
-        Future.successful(
-          InternalServiceError(s"Cardinality count would be incorrect for dataset ${g.ref.dataset}: " +
-            s"shards not active [$statuses]"))
-      } else {
-        // intersect with the memstore's view so we never ask it for a shard it has not instantiated
-        val shards = assigned.intersect(memStore.activeShards(g.ref))
-        Future {
-          LocalCardinalities(g.ref, shards,
-            memStore.scanTsCardinalities(QueryContext(), g.ref, shards, g.shardKeyPrefix, g.depth))
-        }(cardScheduler)
-      }
+  private def scanLocalCardinalities(g: GetCardinalityScatter): Any = {
+    (localShardMaps.get(g.ref), ingestionConfigs.get(g.ref)) match {
+      case (Some(mapper), Some(ingestConfig)) =>
+        val owned = clusterDiscovery.shardsForLocalhost(ingestConfig.numShards)
+        val inactive = owned.filterNot(mapper.isActiveShard)
+        if (inactive.nonEmpty) {
+          val statuses = inactive.map(sh => s"$sh=${mapper.statusForShard(sh)}").mkString(", ")
+          logger.warn(s"[ClusterV2] Refusing cardinality scan for dataset=${g.ref.dataset}: " +
+            s"shards not active [$statuses]")
+          InternalServiceError(s"Cardinality count would be incorrect for dataset " +
+            s"${g.ref.dataset}: shards not active [$statuses]")
+        } else {
+          // intersect with the memstore's view so we never ask it for a shard it has not instantiated
+          val shards = owned.intersect(memStore.activeShards(g.ref))
+          if (shards.isEmpty) {
+            // IMPORTANT: scanTsCardinalities treats an empty shard list as "ALL local shards", so
+            // it must never be called with the empty result of this intersection.
+            logger.warn(s"[ClusterV2] No shards to scan for cardinality on this node. " +
+              s"dataset=${g.ref.dataset} ownedShards=$owned memStoreShards=${memStore.activeShards(g.ref)}")
+            LocalCardinalities(g.ref, Nil, Nil)
+          } else {
+            val startMs = System.currentTimeMillis()
+            val records = memStore.scanTsCardinalities(
+              QueryContext(), g.ref, shards, g.shardKeyPrefix, g.depth)
+            val elapsedMs = System.currentTimeMillis() - startMs
+            // This scan runs on the actor thread, so its duration is mailbox occupancy for this
+            // node - log it so slow scans are attributable without a profiler.
+            logger.info(s"[ClusterV2] Cardinality scan complete. dataset=${g.ref.dataset} " +
+              s"prefix=${g.shardKeyPrefix} depth=${g.depth} numShards=${shards.size} " +
+              s"numRecords=${records.size} elapsedMs=$elapsedMs")
+            LocalCardinalities(g.ref, shards, records)
+          }
+        }
+      case _ =>
+        InternalServiceError(s"Dataset ${g.ref.dataset} is not registered on this node")
     }
   }
 

--- a/coordinator/src/test/scala/filodb/coordinator/v2/ClusterCardinalitiesSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/v2/ClusterCardinalitiesSpec.scala
@@ -1,0 +1,242 @@
+package filodb.coordinator.v2
+
+import com.typesafe.config.ConfigFactory
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import filodb.core.{DatasetRef, TestData}
+import filodb.core.MetricsTestData._
+import filodb.core.memstore.{FixedMaxPartitionsEvictionPolicy, SomeData, TimeSeriesMemStore}
+import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityValue}
+import filodb.core.metadata.Schemas
+import filodb.core.query.{QueryConfig, QueryContext, QuerySession}
+import filodb.core.store.{ChunkSource, InMemoryMetaStore, NullColumnStore}
+import filodb.memory.format.SeqRowReader
+import filodb.memory.format.ZeroCopyUTF8String._
+import filodb.query.{QueryResult, StreamQueryResponse}
+import filodb.query.exec._
+import filodb.query.exec.TsCardExec.{CardCounts, RowData}
+
+/**
+ * Covers the direct (non-QueryActor) cardinality path:
+ *   - ClusterCardinalities.merge, the cross-node/cross-shard fold
+ *   - equivalence with the existing TsCardExec/TsCardReduceExec ExecPlan path
+ *
+ * The two paths read the same per-shard cardinality stores, so for the same prefix/depth they
+ * must produce identical counts. That equivalence is the point of this spec: the HTTP endpoints
+ * /timeseries and /timeseries/execplan are expected to be interchangeable.
+ */
+class ClusterCardinalitiesSpec extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val defaultPatience: PatienceConfig =
+    PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
+
+  private val config = ConfigFactory.load("application_test.conf").getConfig("filodb")
+  private val queryConfig = QueryConfig(config.getConfig("query"))
+  private val querySession = QuerySession(QueryContext(), queryConfig)
+
+  private val policy = new FixedMaxPartitionsEvictionPolicy(20)
+  private val memStore = new TimeSeriesMemStore(
+    config, new NullColumnStore, new NullColumnStore, new InMemoryMetaStore(), Some(policy))
+
+  private val dsRef = timeseriesDatasetMultipleShardKeys.ref
+  private val now = System.currentTimeMillis()
+  private val tuples = (100 until 0).by(-1).map { n => (now - n * 10000, n.toDouble) }
+
+  // 2 shards, with demo/App-0 series deliberately split across both so the merge has to sum
+  private val shardPartKeyLabelValues = Seq(
+    Seq(  // shard 0
+      ("http_req_total", Map("instance" -> "h1", "_ws_" -> "demo", "_ns_" -> "App-0")),
+      ("http_foo_total", Map("instance" -> "h1", "_ws_" -> "demo", "_ns_" -> "App-0"))
+    ),
+    Seq(  // shard 1
+      ("http_req_total", Map("instance" -> "h2", "_ws_" -> "demo", "_ns_" -> "App-0")),
+      ("http_bar_total", Map("instance" -> "h1", "_ws_" -> "demo", "_ns_" -> "App-0")),
+      ("http_req_total-A", Map("instance" -> "h2", "_ws_" -> "demo-A", "_ns_" -> "App-A"))
+    )
+  )
+  private val numShards = shardPartKeyLabelValues.size
+
+  private def initShard(partKeyLabelValues: Seq[(String, Map[String, String])], ishard: Int): Unit = {
+    val partTagsUTF8s = partKeyLabelValues.map { case (m, t) => (m, t.map { case (k, v) => (k.utf8, v.utf8) }) }
+    builder.reset()
+    partTagsUTF8s.foreach { case (metric, partTagsUTF8) =>
+      tuples.map { t => SeqRowReader(Seq(t._1, t._2, metric, partTagsUTF8)) }
+        .foreach(builder.addFromReader(_, Schemas.promCounter))
+    }
+    memStore.setup(dsRef, Schemas(Schemas.promCounter), ishard, TestData.storeConf, 1)
+    memStore.ingest(dsRef, ishard, SomeData(builder.allContainers.head, 0))
+  }
+
+  override def beforeAll(): Unit = {
+    for (ishard <- 0 until numShards) initShard(shardPartKeyLabelValues(ishard), ishard)
+    memStore.refreshIndexForTesting(dsRef)
+  }
+
+  override def afterAll(): Unit = memStore.shutdown()
+
+  private val executeDispatcher = new PlanDispatcher {
+    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+                         (implicit sched: Scheduler): Task[filodb.query.QueryResponse] =
+      plan.execPlan.execute(memStore, querySession)(sched)
+    override def clusterName: String = "raw"
+    override def isLocalCall: Boolean = true
+    override def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+                                  (implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
+  }
+
+  private def cv(ts: Long, active: Long, billable: Long, children: Long = 0, quota: Long = 0) =
+    CardinalityValue(ts, active, billable, children, quota)
+
+  // ---------- ClusterCardinalities.merge ----------
+
+  it("should sum counts for the same prefix across shards and across nodes") {
+    val nodeA = LocalCardinalities(dsRef, Seq(0, 1), Seq(
+      CardinalityRecord(0, Seq("demo", "App-0"), cv(2, 2, 2)),
+      CardinalityRecord(1, Seq("demo", "App-0"), cv(3, 3, 3))))
+    val nodeB = LocalCardinalities(dsRef, Seq(2, 3), Seq(
+      CardinalityRecord(2, Seq("demo", "App-0"), cv(5, 4, 4)),
+      CardinalityRecord(3, Seq("demo-A", "App-A"), cv(1, 1, 1))))
+
+    val merged = ClusterCardinalities.merge(dsRef, 4, Seq(Some(nodeA), Some(nodeB)))
+
+    merged.missingShards shouldEqual Nil
+    val byPrefix = merged.cardinalities.map(r => r.prefix -> r.value).toMap
+    byPrefix(Seq("demo", "App-0")) shouldEqual cv(10, 9, 9)
+    byPrefix(Seq("demo-A", "App-A")) shouldEqual cv(1, 1, 1)
+    // shard is meaningless post-merge
+    merged.cardinalities.map(_.shard).distinct shouldEqual Seq(-1)
+  }
+
+  it("should carry the max of childrenCount/childrenQuota rather than summing them") {
+    // these describe one shard's trie shape and quota; summing across shards would be nonsense
+    val node = LocalCardinalities(dsRef, Seq(0, 1), Seq(
+      CardinalityRecord(0, Seq("demo"), cv(2, 2, 2, children = 3, quota = 100)),
+      CardinalityRecord(1, Seq("demo"), cv(2, 2, 2, children = 5, quota = 100))))
+
+    val merged = ClusterCardinalities.merge(dsRef, 2, Seq(Some(node)))
+
+    merged.cardinalities.head.value shouldEqual cv(4, 4, 4, children = 5, quota = 100)
+  }
+
+  it("should report shards no node scanned as missing") {
+    val node = LocalCardinalities(dsRef, Seq(0, 1), Seq(
+      CardinalityRecord(0, Seq("demo"), cv(1, 1, 1))))
+
+    ClusterCardinalities.merge(dsRef, 4, Seq(Some(node))).missingShards shouldEqual Seq(2, 3)
+  }
+
+  it("should report a failed node's shards as missing without knowing which shards it owned") {
+    val nodeA = LocalCardinalities(dsRef, Seq(0, 1), Seq(
+      CardinalityRecord(0, Seq("demo"), cv(1, 1, 1))))
+    // nodeB failed/timed out - it reports nothing, so its shards fall out of the covered set
+    val merged = ClusterCardinalities.merge(dsRef, 4, Seq(Some(nodeA), None))
+
+    merged.missingShards shouldEqual Seq(2, 3)
+    // partial data is still returned; refusing it is the caller's (route's) decision
+    merged.cardinalities should have size 1
+  }
+
+  it("should report every shard missing when all nodes fail") {
+    val merged = ClusterCardinalities.merge(dsRef, 3, Seq(None, None))
+    merged.cardinalities shouldEqual Nil
+    merged.missingShards shouldEqual Seq(0, 1, 2)
+  }
+
+  it("should pass the overflow prefix through as an ordinary group") {
+    import filodb.core.memstore.ratelimit.CardinalityStore.OVERFLOW_PREFIX
+    val nodeA = LocalCardinalities(dsRef, Seq(0), Seq(CardinalityRecord(0, OVERFLOW_PREFIX, cv(7, 7, 7))))
+    val nodeB = LocalCardinalities(dsRef, Seq(1), Seq(CardinalityRecord(1, OVERFLOW_PREFIX, cv(3, 3, 3))))
+
+    val merged = ClusterCardinalities.merge(dsRef, 2, Seq(Some(nodeA), Some(nodeB)))
+
+    merged.cardinalities.map(r => r.prefix -> r.value).toMap shouldEqual
+      Map(OVERFLOW_PREFIX -> cv(10, 10, 10))
+  }
+
+  // ---------- equivalence with the existing ExecPlan path ----------
+
+  /** Runs the existing path: one TsCardExec per shard, reduced by TsCardReduceExec. */
+  private def viaExecPlan(prefix: Seq[String], depth: Int): Map[Seq[String], CardCounts] = {
+    val leaves = (0 until numShards).map { ishard =>
+      TsCardExec(QueryContext(), executeDispatcher, dsRef, ishard, prefix, depth, "raw")
+    }
+    val resp = TsCardReduceExec(QueryContext(), executeDispatcher, leaves)
+      .execute(memStore, querySession).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, rvs, _, _, _, _) =>
+        rvs.flatMap(_.rows().map(RowData.fromRowReader).toSeq).map { d =>
+          // group is "ws,ns,...,dataset" - drop the trailing dataset to get the prefix
+          d.group.toString.split(TsCardExec.PREFIX_DELIM).dropRight(1).toSeq -> d.counts
+        }.toMap
+    }
+  }
+
+  /** Runs the direct path: scan each node's shards, then merge. */
+  private def viaDirectPath(prefix: Seq[String],
+                            depth: Int,
+                            shardsPerNode: Seq[Seq[Int]]): Map[Seq[String], CardCounts] = {
+    val perNode = shardsPerNode.map { shards =>
+      Some(LocalCardinalities(dsRef, shards,
+        memStore.scanTsCardinalities(QueryContext(), dsRef, shards, prefix, depth)))
+    }
+    val merged = ClusterCardinalities.merge(dsRef, numShards, perNode)
+    merged.missingShards shouldEqual Nil
+    merged.cardinalities.map { r =>
+      r.prefix -> CardCounts(r.value.activeTsCount, r.value.billableTsCount, r.value.tsCount)
+    }.toMap
+  }
+
+  private val equivalenceCases = Seq(
+    (Nil, 1),
+    (Nil, 2),
+    (Seq("demo"), 1),
+    (Seq("demo"), 2),
+    (Seq("demo"), 3),
+    (Seq("demo", "App-0"), 2),
+    (Seq("demo", "App-0"), 3),
+    (Seq("demo", "App-0", "http_req_total"), 3)
+  )
+
+  it("should produce the same counts as the ExecPlan path, for one shard per node") {
+    equivalenceCases.foreach { case (prefix, depth) =>
+      withClue(s"prefix=$prefix depth=$depth: ") {
+        viaDirectPath(prefix, depth, Seq(Seq(0), Seq(1))) shouldEqual viaExecPlan(prefix, depth)
+      }
+    }
+  }
+
+  it("should produce the same counts as the ExecPlan path when one node owns several shards") {
+    // the direct path collapses a node's shards into a single scan, so this is the case where a
+    // per-node multi-shard scan must still equal the per-shard fan-out
+    equivalenceCases.foreach { case (prefix, depth) =>
+      withClue(s"prefix=$prefix depth=$depth: ") {
+        viaDirectPath(prefix, depth, Seq(Seq(0, 1))) shouldEqual viaExecPlan(prefix, depth)
+      }
+    }
+  }
+
+  it("should produce non-trivial counts, so the equivalence checks are not comparing empty maps") {
+    // guards against both paths silently returning nothing and the comparison passing anyway
+    val direct = viaDirectPath(Nil, 2, Seq(Seq(0), Seq(1)))
+    direct.keySet shouldEqual Set(Seq("demo", "App-0"), Seq("demo-A", "App-A"))
+    // 4 series under demo/App-0: req(shard0), foo(shard0), req(shard1), bar(shard1)
+    direct(Seq("demo", "App-0")).shortTerm shouldEqual 4
+    direct(Seq("demo-A", "App-A")).shortTerm shouldEqual 1
+  }
+
+  it("should scan all shards when the requested shard list is empty") {
+    // TimeSeriesMemStore treats an empty shard list as `all local shards`, which is what the
+    // scatter relies on
+    val all = memStore.scanTsCardinalities(QueryContext(), dsRef, Nil, Nil, 2)
+    val explicit = memStore.scanTsCardinalities(QueryContext(), dsRef, Seq(0, 1), Nil, 2)
+    all.toSet shouldEqual explicit.toSet
+  }
+}

--- a/coordinator/src/test/scala/filodb/coordinator/v2/ClusterCardinalitiesSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/v2/ClusterCardinalitiesSpec.scala
@@ -239,4 +239,26 @@ class ClusterCardinalitiesSpec extends AnyFunSpec with Matchers with ScalaFuture
     val explicit = memStore.scanTsCardinalities(QueryContext(), dsRef, Seq(0, 1), Nil, 2)
     all.toSet shouldEqual explicit.toSet
   }
+
+  it("should NOT be able to express 'scan nothing' via an empty shard list") {
+    // Pins the hazard the handler guards against: an empty shard list means ALL shards, not none,
+    // so a node whose owned-shard intersection comes out empty must short circuit instead of
+    // calling scanTsCardinalities. If this ever starts returning empty, that guard can be dropped.
+    memStore.scanTsCardinalities(QueryContext(), dsRef, Nil, Nil, 2) should not be empty
+  }
+
+  it("should report a node that scanned nothing as covering no shards") {
+    // shape returned by the handler's empty-intersection short circuit
+    val merged = ClusterCardinalities.merge(dsRef, numShards,
+      Seq(Some(LocalCardinalities(dsRef, Nil, Nil))))
+    merged.cardinalities shouldEqual Nil
+    merged.missingShards shouldEqual Seq(0, 1)
+  }
+
+  it("should treat a node that scanned fewer shards than it owns as partial") {
+    // if the memstore has not instantiated an owned shard, the node reports only what it scanned,
+    // so the gap must surface rather than being inferred as complete
+    val partial = LocalCardinalities(dsRef, Seq(0), Seq(CardinalityRecord(0, Seq("demo"), cv(1, 1, 1))))
+    ClusterCardinalities.merge(dsRef, numShards, Seq(Some(partial))).missingShards shouldEqual Seq(1)
+  }
 }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -517,7 +517,7 @@ filodb {
   # Maximum number of cardinality records returned by a single shard scan. Children beyond this
   # cap are summed into one overflow record under the `_overflow_` prefix. Also used as the
   # default overflow threshold when reducing cardinality results across shards.
-  metering-max-result-size = 10000
+  metering-max-result-size = 5000
   # Per-node budget for a cardinality scatter, covering BOTH actor resolution and the scan ask.
   # Deliberately small: an unreachable node should surface as a fast 503 naming its shards rather
   # than stalling the caller. Must stay below the caller's filodb.query.ask-timeout, and above the

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -518,6 +518,11 @@ filodb {
   # cap are summed into one overflow record under the `_overflow_` prefix. Also used as the
   # default overflow threshold when reducing cardinality results across shards.
   metering-max-result-size = 10000
+  # Per-node budget for a cardinality scatter, covering BOTH actor resolution and the scan ask.
+  # Deliberately small: an unreachable node should surface as a fast 503 naming its shards rather
+  # than stalling the caller. Must stay below the caller's filodb.query.ask-timeout, and above the
+  # time a healthy multi-shard cardinality scan takes.
+  metering-scatter-timeout = 10s
   # info config used for metric breakdown
   cluster-type = "raw" // possible values: downsample, raw, recRule, aggregates etc.
   # Name of the deployment partition that this FiloDB cluster belongs to

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -514,6 +514,10 @@ filodb {
   shard-key-level-ingestion-metrics-enabled = true
   # Time between each TenantIngestionMetering query/publish job
   metering-query-interval = 15 minutes
+  # Maximum number of cardinality records returned by a single shard scan. Children beyond this
+  # cap are summed into one overflow record under the `_overflow_` prefix. Also used as the
+  # default overflow threshold when reducing cardinality results across shards.
+  metering-max-result-size = 10000
   # info config used for metric breakdown
   cluster-type = "raw" // possible values: downsample, raw, recRule, aggregates etc.
   # Name of the deployment partition that this FiloDB cluster belongs to
@@ -1301,6 +1305,7 @@ akka {
       "filodb.query.exec.ExecPlan" = kryo
       "filodb.query.LogicalPlan" = kryo
       "filodb.query.TopkCardinalityResult" = kryo
+      "filodb.coordinator.v2.LocalCardinalities" = kryo
     }
 
     # Reduce the number of threads used by default by the fork-join pool, as it's not really doing much work.

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -95,6 +95,6 @@ object CardinalityStore {
   val MAX_RESULT_SIZE: Int =
     if (GlobalConfig.systemConfig.hasPath("filodb.metering-max-result-size")) {
       GlobalConfig.systemConfig.getInt("filodb.metering-max-result-size")
-    } else 10000
+    } else 5000
   val OVERFLOW_PREFIX = Seq("_overflow_")
 }

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityStore.scala
@@ -1,5 +1,7 @@
 package filodb.core.memstore.ratelimit
 
+import filodb.core.GlobalConfig
+
 /**
  * The data stored in each node of the Cardinality Store trie
  *
@@ -87,7 +89,12 @@ trait CardinalityStore {
 }
 
 object CardinalityStore {
-  // See scanChildren doc for details.
-  val MAX_RESULT_SIZE = 5000
+  // See scanChildren doc for details. Configurable via `filodb.metering-max-result-size`.
+  // NOTE: this cap applies per shard per scan, and also serves as the default overflow
+  // threshold for TsCardReduceExec, so raising it affects both cardinality query paths.
+  val MAX_RESULT_SIZE: Int =
+    if (GlobalConfig.systemConfig.hasPath("filodb.metering-max-result-size")) {
+      GlobalConfig.systemConfig.getInt("filodb.metering-max-result-size")
+    } else 10000
   val OVERFLOW_PREFIX = Seq("_overflow_")
 }

--- a/http/src/main/scala/filodb/http/CardinalityRoute.scala
+++ b/http/src/main/scala/filodb/http/CardinalityRoute.scala
@@ -1,0 +1,145 @@
+package filodb.http
+
+import akka.actor.ActorRef
+import akka.http.scaladsl.model.{StatusCodes => Codes}
+import akka.http.scaladsl.server.Directives._
+import com.typesafe.scalalogging.StrictLogging
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+
+import filodb.coordinator.NodeClusterActor.InternalServiceError
+import filodb.coordinator.v2.{ClusterCardinalities, GetClusterCardinalities}
+import filodb.core.DatasetRef
+import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityStore}
+import filodb.http.apiv1.HttpSchema
+import filodb.query.TsCardinalities
+
+/**
+ * One (ws, ns, metric) group and its cluster-wide cardinality counts.
+ *
+ * Count names match the TsCardinalitiesSamplV2 shape used by the existing
+ * /api/v2/metering/cardinality/timeseries API, so callers can share a decoder.
+ */
+final case class HttpCardinality(group: Map[String, String], cardinality: Map[String, Long])
+
+/**
+ * Serves cluster-wide time series cardinality without going through the QueryActor, the query
+ * planner, or the query scheduler. Reads the per-shard cardinality stores directly via a
+ * scatter to every node's NewNodeCoordinatorActor, and merges the result here.
+ *
+ * Only available with ClusteringV2 - the scatter relies on the deterministic ordinal-to-shard
+ * assignment in FiloDbClusterDiscovery.
+ */
+class CardinalityRoute(coordinatorActor: ActorRef,
+                       v2ClusterEnabled: Boolean,
+                       settings: HttpSettings) extends FiloRoute with StrictLogging {
+  import FailFastCirceSupport._
+  import io.circe.generic.auto._
+
+  import HttpSchema._
+  import filodb.coordinator.client.Client._
+
+  private val clusterType = settings.filoSettings.config.getString("cluster-type")
+  // Cardinality on a downsample cluster is a long term count. The raw cluster tracks
+  // active/billable/shortTerm instead. Same fork as TsCardExec.
+  private val isDownsample = clusterType.toLowerCase.contains("downsample")
+
+  val route = pathPrefix("api" / "v1" / "cardinality") {
+    // GET /api/v1/cardinality/<dataset>/timeseries?numGroupByFields=2&_ws_=..&_ns_=..
+    //   &limit=..&sortBy=active|total&allowPartial=false
+    //
+    // Returns ws/ns (or metric) level cardinality for the whole cluster in a single call.
+    // Fails with 503 when any shard is not active, since the counts would be an undercount.
+    path(Segment / "timeseries") { dataset =>
+      get {
+        parameter(("numGroupByFields".as[Int], "_ws_".as[String].?, "_ns_".as[String].?,
+                   "limit".as[Int].?, "sortBy".as[String].?, "allowPartial".as[Boolean].?))
+        { (numGroupByFields, ws, ns, limit, sortBy, allowPartial) =>
+          if (!v2ClusterEnabled) {
+            complete(Codes.NotImplemented ->
+              httpErr("NotSupported", "Cardinality API requires the ClusteringV2 shard assignment strategy"))
+          } else {
+            // prefix is positional: ws, then ns. An ns without a ws is not a valid prefix.
+            val prefix = (ws, ns) match {
+              case (Some(w), Some(n)) => Seq(w, n)
+              case (Some(w), None)    => Seq(w)
+              case _                  => Nil
+            }
+            badRequest(numGroupByFields, ws, ns, prefix) match {
+              case Some(err) => complete(Codes.BadRequest -> httpErr("BadArgument", err))
+              case None =>
+                val cmd = GetClusterCardinalities(DatasetRef.fromDotString(dataset), prefix, numGroupByFields)
+                val partialOk = allowPartial.contains(true)
+                onSuccess(asyncAsk(coordinatorActor, cmd, settings.queryAskTimeout)) {
+                  case cc: ClusterCardinalities if cc.missingShards.nonEmpty && !partialOk =>
+                    complete(Codes.ServiceUnavailable -> httpErr("IncorrectCount",
+                      s"Cardinality count for dataset $dataset would be incorrect: " +
+                      s"${cc.missingShards.size} shard(s) not active or unreachable " +
+                      s"[${cc.missingShards.mkString(",")}]. " +
+                      s"Retry, or pass allowPartial=true to accept an undercount."))
+                  case cc: ClusterCardinalities =>
+                    complete(httpList(present(cc, dataset, limit, sortBy)))
+                  case InternalServiceError(msg) =>
+                    complete(Codes.ServiceUnavailable -> httpErr("InternalServerError", msg))
+                  case other =>
+                    logger.error(s"Unexpected response to $cmd: $other")
+                    complete(Codes.InternalServerError ->
+                      httpErr("InternalServerError", s"Unexpected response for dataset $dataset"))
+                }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Mirrors the require()s on the TsCardinalities logical plan, so this API rejects the same
+   * prefix/depth combinations the PromQL path does.
+   */
+  private def badRequest(numGroupByFields: Int,
+                         ws: Option[String],
+                         ns: Option[String],
+                         prefix: Seq[String]): Option[String] = {
+    if (ws.isEmpty && ns.isDefined) {
+      Some("_ns_ cannot be specified without _ws_")
+    } else if (numGroupByFields < 1 || numGroupByFields > 3) {
+      Some("numGroupByFields must lie on [1, 3]")
+    } else if (numGroupByFields < prefix.size) {
+      Some("numGroupByFields must indicate a depth at least as deep as the given prefix")
+    } else if (numGroupByFields == 3 && prefix.size < 2) {
+      Some("cannot group at the metric level without both _ws_ and _ns_")
+    } else None
+  }
+
+  /**
+   * Turns merged records into the response shape: names the prefix fields, applies the
+   * downsample count remap, then sorts and truncates.
+   */
+  private def present(cc: ClusterCardinalities,
+                      dataset: String,
+                      limit: Option[Int],
+                      sortBy: Option[String]): Seq[HttpCardinality] = {
+    val byTotal = sortBy.forall(_ != "active")
+    val sorted = cc.cardinalities.sortBy { r =>
+      -(if (byTotal) r.value.tsCount else r.value.activeTsCount)
+    }
+    sorted.take(limit.getOrElse(CardinalityStore.MAX_RESULT_SIZE)).map(toHttpCardinality(_, dataset))
+  }
+
+  private def toHttpCardinality(rec: CardinalityRecord, dataset: String): HttpCardinality = {
+    val group = TsCardinalities.SHARD_KEY_LABELS.take(rec.prefix.size)
+      .zip(rec.prefix).toMap + ("_type_" -> dataset)
+    // NOTE: the downsample cluster stores its count in tsCount, but from a user's point of view
+    // that is the longterm count. Keep this consistent with TsCardExec.
+    val counts =
+      if (isDownsample) {
+        Map("active" -> 0L, "billable" -> 0L, "shortTerm" -> 0L, "longTerm" -> rec.value.tsCount)
+      } else {
+        Map("active" -> rec.value.activeTsCount,
+            "billable" -> rec.value.billableTsCount,
+            "shortTerm" -> rec.value.tsCount,
+            "longTerm" -> 0L)
+      }
+    HttpCardinality(group, counts)
+  }
+}

--- a/http/src/main/scala/filodb/http/CardinalityRoute.scala
+++ b/http/src/main/scala/filodb/http/CardinalityRoute.scala
@@ -5,29 +5,43 @@ import akka.http.scaladsl.model.{StatusCodes => Codes}
 import akka.http.scaladsl.server.Directives._
 import com.typesafe.scalalogging.StrictLogging
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.Printer
 
 import filodb.coordinator.NodeClusterActor.InternalServiceError
+import filodb.coordinator.client.IngestionCommands.UnknownDataset
+import filodb.coordinator.client.QueryCommands.LogicalPlan2Query
 import filodb.coordinator.v2.{ClusterCardinalities, GetClusterCardinalities}
 import filodb.core.DatasetRef
-import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityStore}
+import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityValue}
+import filodb.core.query.QueryContext
 import filodb.http.apiv1.HttpSchema
-import filodb.query.TsCardinalities
+import filodb.memory.format.RowReader
+import filodb.prometheus.parse.Parser
+import filodb.query.{MetadataSuccessResponse, QueryError, QueryResult, TsCardinalities, TsCardinalitiesSamplV2}
+import filodb.query.exec.TsCardExec
+import filodb.query.exec.TsCardExec.RowData
 
 /**
- * One (ws, ns, metric) group and its cluster-wide cardinality counts.
+ * Serves time series cardinality with the same request/response semantics as the user facing
+ * /api/v2/metering/cardinality/timeseries API in filodb-query-service, so that callers (and the
+ * MetadataRemoteExec decoder) need no special casing.
  *
- * Count names match the TsCardinalitiesSamplV2 shape used by the existing
- * /api/v2/metering/cardinality/timeseries API, so callers can share a decoder.
- */
-final case class HttpCardinality(group: Map[String, String], cardinality: Map[String, Long])
-
-/**
- * Serves cluster-wide time series cardinality without going through the QueryActor, the query
- * planner, or the query scheduler. Reads the per-shard cardinality stores directly via a
- * scatter to every node's NewNodeCoordinatorActor, and merges the result here.
+ * Two paths are exposed, and they are expected to return identical results:
  *
- * Only available with ClusteringV2 - the scatter relies on the deterministic ordinal-to-shard
- * assignment in FiloDbClusterDiscovery.
+ *  /promql/<dataset>/api/v2/metering/cardinality/timeseries
+ *      DIRECT - scatters to every node's cardinality store, bypassing the QueryActor, the query
+ *      planner and the query scheduler. Requires ClusteringV2.
+ *
+ *  /promql/<dataset>/api/v2/metering/query/cardinality/timeseries
+ *      QUERY - builds a TsCardinalities logical plan and hands it to the QueryActor, which
+ *      materializes one TsCardExec per shard and reduces them. The original path.
+ *
+ * NOTE on `datasets`: the user facing API accepts a CSV of raw/aggregated/recording-rules to fan
+ * out across clusters. That is a query-service concern - here the dataset comes from the path, so
+ * the parameter is not accepted.
+ *
+ * NOTE on downsample: neither path reaches the downsample cluster. Both answer from this cluster's
+ * own shards only, so `longTerm` is always 0 in the response.
  */
 class CardinalityRoute(coordinatorActor: ActorRef,
                        v2ClusterEnabled: Boolean,
@@ -39,34 +53,54 @@ class CardinalityRoute(coordinatorActor: ActorRef,
   import filodb.coordinator.client.Client._
 
   private val clusterType = settings.filoSettings.config.getString("cluster-type")
-  // Cardinality on a downsample cluster is a long term count. The raw cluster tracks
-  // active/billable/shortTerm instead. Same fork as TsCardExec.
-  private val isDownsample = clusterType.toLowerCase.contains("downsample")
 
-  val route = pathPrefix("api" / "v1" / "cardinality") {
-    // GET /api/v1/cardinality/<dataset>/timeseries?numGroupByFields=2&_ws_=..&_ns_=..
-    //   &limit=..&sortBy=active|total&allowPartial=false
-    //
-    // Returns ws/ns (or metric) level cardinality for the whole cluster in a single call.
-    // Fails with 503 when any shard is not active, since the counts would be an undercount.
-    path(Segment / "timeseries") { dataset =>
+  implicit val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
+
+  val route = pathPrefix("promql" / Segment) { dataset =>
+    // NOTE: the /query/ path is declared first - akka-http path matching is order sensitive and
+    // "cardinality" / "timeseries" would otherwise not reach it.
+    path("api" / "v2" / "metering" / "query" / "cardinality" / "timeseries") {
       get {
-        parameter(("numGroupByFields".as[Int], "_ws_".as[String].?, "_ns_".as[String].?,
-                   "limit".as[Int].?, "sortBy".as[String].?, "allowPartial".as[Boolean].?))
-        { (numGroupByFields, ws, ns, limit, sortBy, allowPartial) =>
-          if (!v2ClusterEnabled) {
-            complete(Codes.NotImplemented ->
-              httpErr("NotSupported", "Cardinality API requires the ClusteringV2 shard assignment strategy"))
-          } else {
-            // prefix is positional: ws, then ns. An ns without a ws is not a valid prefix.
-            val prefix = (ws, ns) match {
-              case (Some(w), Some(n)) => Seq(w, n)
-              case (Some(w), None)    => Seq(w)
-              case _                  => Nil
+        parameter(("match[]".as[String], "numGroupByFields".as[Int], "verbose".as[Boolean].?)) {
+          (matcher, numGroupByFields, _) =>
+            withPrefix(matcher, numGroupByFields) { prefix =>
+              val ref = DatasetRef.fromDotString(dataset)
+              // NOTE: no overrideClusterName, so this stays on the QueryActor's own
+              // SingleClusterPlanner ("raw"). It deliberately does NOT go through
+              // LongTimeRangePlanner, which would also materialize a downsample plan.
+              val lp = TsCardinalities(prefix, numGroupByFields)
+              val cmd = LogicalPlan2Query(ref, lp, queryContextForCardinality())
+              onSuccess(asyncAsk(coordinatorActor, cmd, settings.queryAskTimeout)) {
+                case qr: QueryResult =>
+                  val recs = qr.result.flatMap(_.rows().map(rowDataToRecord).toSeq)
+                  complete(MetadataSuccessResponse(present(recs, dataset)))
+                case qe: QueryError =>
+                  logger.error(s"QueryError for $cmd", qe.t)
+                  complete(Codes.InternalServerError -> httpErr(qe.t.getClass.getName, qe.t.getMessage))
+                case UnknownDataset =>
+                  complete(Codes.NotFound -> httpErr("DatasetUnknown", s"Dataset $dataset is not registered"))
+                case other =>
+                  logger.error(s"Unexpected response to $cmd: $other")
+                  complete(Codes.InternalServerError ->
+                    httpErr("InternalServerError", s"Unexpected response for dataset $dataset"))
+              }
             }
-            badRequest(numGroupByFields, ws, ns, prefix) match {
-              case Some(err) => complete(Codes.BadRequest -> httpErr("BadArgument", err))
-              case None =>
+        }
+      }
+    } ~
+    path("api" / "v2" / "metering" / "cardinality" / "timeseries") {
+      get {
+        // allowPartial is an addition over the user facing API: without it, a cluster with any
+        // non-active shard is refused rather than answered with an undercount.
+        parameter(("match[]".as[String], "numGroupByFields".as[Int], "verbose".as[Boolean].?,
+                   "allowPartial".as[Boolean].?)) {
+          (matcher, numGroupByFields, _, allowPartial) =>
+            if (!v2ClusterEnabled) {
+              complete(Codes.NotImplemented -> httpErr("NotSupported",
+                "Direct cardinality path requires the ClusteringV2 shard assignment strategy. " +
+                "Use api/v2/metering/query/cardinality/timeseries instead."))
+            } else {
+              withPrefix(matcher, numGroupByFields) { prefix =>
                 val cmd = GetClusterCardinalities(DatasetRef.fromDotString(dataset), prefix, numGroupByFields)
                 val partialOk = allowPartial.contains(true)
                 onSuccess(asyncAsk(coordinatorActor, cmd, settings.queryAskTimeout)) {
@@ -77,7 +111,10 @@ class CardinalityRoute(coordinatorActor: ActorRef,
                       s"[${cc.missingShards.mkString(",")}]. " +
                       s"Retry, or pass allowPartial=true to accept an undercount."))
                   case cc: ClusterCardinalities =>
-                    complete(httpList(present(cc, dataset, limit, sortBy)))
+                    complete(MetadataSuccessResponse(present(cc.cardinalities, dataset),
+                      partial = if (cc.missingShards.isEmpty) None else Some(true),
+                      message = if (cc.missingShards.isEmpty) None
+                                else Some(s"shards not counted: ${cc.missingShards.mkString(",")}")))
                   case InternalServiceError(msg) =>
                     complete(Codes.ServiceUnavailable -> httpErr("InternalServerError", msg))
                   case other =>
@@ -85,61 +122,89 @@ class CardinalityRoute(coordinatorActor: ActorRef,
                     complete(Codes.InternalServerError ->
                       httpErr("InternalServerError", s"Unexpected response for dataset $dataset"))
                 }
+              }
             }
-          }
         }
       }
     }
   }
 
   /**
-   * Mirrors the require()s on the TsCardinalities logical plan, so this API rejects the same
-   * prefix/depth combinations the PromQL path does.
+   * Turns the match[] selector into a shard key prefix, using the same parser and the same
+   * ordering rules as filodb-query-service: the equal-label map is read in SHARD_KEY_LABELS order
+   * (_ws_, _ns_, __name__) and must not have gaps, so _ns_ cannot be given without _ws_.
    */
-  private def badRequest(numGroupByFields: Int,
-                         ws: Option[String],
-                         ns: Option[String],
-                         prefix: Seq[String]): Option[String] = {
-    if (ws.isEmpty && ns.isDefined) {
-      Some("_ns_ cannot be specified without _ws_")
-    } else if (numGroupByFields < 1 || numGroupByFields > 3) {
-      Some("numGroupByFields must lie on [1, 3]")
-    } else if (numGroupByFields < prefix.size) {
-      Some("numGroupByFields must indicate a depth at least as deep as the given prefix")
-    } else if (numGroupByFields == 3 && prefix.size < 2) {
-      Some("cannot group at the metric level without both _ws_ and _ns_")
-    } else None
+  private def withPrefix(matcher: String, numGroupByFields: Int)
+                        (inner: Seq[String] => akka.http.scaladsl.server.Route)
+                        : akka.http.scaladsl.server.Route = {
+    val fieldMap =
+      try Parser.queryToEqualLabelMap(matcher)
+      catch { case e: Exception =>
+        logger.debug(s"could not parse match[]=$matcher", e)
+        Map.empty[String, String]
+      }
+    // take shard key labels while present, so {_ns_="x"} with no _ws_ yields an empty prefix
+    val prefix = TsCardinalities.SHARD_KEY_LABELS.map(fieldMap.get).takeWhile(_.isDefined).flatten
+
+    badRequest(numGroupByFields, fieldMap, prefix, matcher) match {
+      case Some(err) => complete(Codes.BadRequest -> httpErr("BadArgument", err))
+      case None      => inner(prefix)
+    }
   }
 
   /**
-   * Turns merged records into the response shape: names the prefix fields, applies the
-   * downsample count remap, then sorts and truncates.
+   * Mirrors the require()s on the TsCardinalities logical plan plus the query-service validation,
+   * so both paths reject the same inputs before any work is dispatched.
    */
-  private def present(cc: ClusterCardinalities,
-                      dataset: String,
-                      limit: Option[Int],
-                      sortBy: Option[String]): Seq[HttpCardinality] = {
-    val byTotal = sortBy.forall(_ != "active")
-    val sorted = cc.cardinalities.sortBy { r =>
-      -(if (byTotal) r.value.tsCount else r.value.activeTsCount)
-    }
-    sorted.take(limit.getOrElse(CardinalityStore.MAX_RESULT_SIZE)).map(toHttpCardinality(_, dataset))
+  private def badRequest(numGroupByFields: Int,
+                         fieldMap: Map[String, String],
+                         prefix: Seq[String],
+                         matcher: String): Option[String] = {
+    if (fieldMap.isEmpty && prefix.isEmpty && matcher.replaceAll("[{} ]", "").nonEmpty) {
+      Some(s"match[] is not a valid selector of equality matchers: $matcher")
+    } else if (prefix.size != fieldMap.size) {
+      Some("match[] shard key labels must be contiguous: _ns_ requires _ws_, " +
+           "and __name__ requires both _ws_ and _ns_")
+    } else if (numGroupByFields < 1 || numGroupByFields > 3) {
+      Some("numGroupByFields must lie on [1, 3]")
+    } else if (numGroupByFields < prefix.size) {
+      Some("numGroupByFields must indicate a depth at least as deep as the match[] prefix")
+    } else if (numGroupByFields == 3 && prefix.size < 2) {
+      Some("cannot group at the metric level without both _ws_ and _ns_ in match[]")
+    } else None
   }
 
-  private def toHttpCardinality(rec: CardinalityRecord, dataset: String): HttpCardinality = {
-    val group = TsCardinalities.SHARD_KEY_LABELS.take(rec.prefix.size)
-      .zip(rec.prefix).toMap + ("_type_" -> dataset)
-    // NOTE: the downsample cluster stores its count in tsCount, but from a user's point of view
-    // that is the longterm count. Keep this consistent with TsCardExec.
-    val counts =
-      if (isDownsample) {
-        Map("active" -> 0L, "billable" -> 0L, "shortTerm" -> 0L, "longTerm" -> rec.value.tsCount)
-      } else {
-        Map("active" -> rec.value.activeTsCount,
-            "billable" -> rec.value.billableTsCount,
-            "shortTerm" -> rec.value.tsCount,
-            "longTerm" -> 0L)
-      }
-    HttpCardinality(group, counts)
+  private def queryContextForCardinality(): QueryContext = {
+    val partition = settings.filoSettings.config.getString("partition")
+    if (partition.isEmpty) QueryContext()
+    else QueryContext(traceInfo = Map(TsCardExec.FILODB_PARTITION_KEY -> partition))
   }
+
+  /**
+   * Reverses TsCardExec's group encoding ("ws,ns,metric,dataset") back into a CardinalityRecord so
+   * the query path shares the presentation code with the direct path.
+   */
+  private def rowDataToRecord(rr: RowReader): CardinalityRecord = {
+    val data = RowData.fromRowReader(rr)
+    // the group is the prefix values plus a trailing dataset name
+    val prefix = data.group.toString.split(TsCardExec.PREFIX_DELIM).dropRight(1).toSeq
+    CardinalityRecord(-1, prefix,
+      CardinalityValue(tsCount = data.counts.shortTerm, activeTsCount = data.counts.active,
+        billableTsCount = data.counts.billable, childrenCount = 0, childrenQuota = 0))
+  }
+
+  private def present(records: Seq[CardinalityRecord], dataset: String): Seq[TsCardinalitiesSamplV2] =
+    records.map { rec =>
+      val group = TsCardinalities.SHARD_KEY_LABELS.take(rec.prefix.size).zip(rec.prefix).toMap
+      // NOTE: unlike the user facing API, neither of these endpoints reaches the downsample
+      // cluster, so there is no longterm count to report and no downsample -> longTerm remap
+      // (TsCardExec does that only when serving a downsample cluster). longTerm is always 0.
+      val counts = Map("active" -> rec.value.activeTsCount,
+                       "billable" -> rec.value.billableTsCount,
+                       "shortTerm" -> rec.value.tsCount,
+                       "longTerm" -> 0L)
+      // `dataset` is the user facing cluster flavour (raw/aggregated/recordingrules) and `_type` is
+      // the internal filodb dataset name - MetadataRemoteExec reads _type to rebuild the group key.
+      TsCardinalitiesSamplV2(group = group, cardinality = counts, dataset = clusterType, _type = dataset)
+    }
 }

--- a/http/src/main/scala/filodb/http/CardinalityRoute.scala
+++ b/http/src/main/scala/filodb/http/CardinalityRoute.scala
@@ -17,9 +17,24 @@ import filodb.core.query.QueryContext
 import filodb.http.apiv1.HttpSchema
 import filodb.memory.format.RowReader
 import filodb.prometheus.parse.Parser
-import filodb.query.{MetadataSuccessResponse, QueryError, QueryResult, TsCardinalities, TsCardinalitiesSamplV2}
+import filodb.query.{QueryError, QueryResult, TsCardinalities, TsCardinalitiesSamplV2}
 import filodb.query.exec.TsCardExec
 import filodb.query.exec.TsCardExec.RowData
+
+/**
+ * Response envelope for the cardinality APIs. Mirrors MetadataSuccessResponse field-for-field so
+ * the JSON is byte-identical to the user facing /api/v2/metering API.
+ *
+ * NOTE: `data` is typed as the concrete TsCardinalitiesSamplV2 rather than the sealed MetadataSampl
+ * trait ON PURPOSE. With MetadataSampl, circe's generic auto derivation wins the implicit lookup
+ * over PromCirceSupport.encodeMetadataSampl and emits a discriminator wrapper -
+ * {"TsCardinalitiesSamplV2": {...}} - which PromCirceSupport.decodeMetadataSampl cannot read; it
+ * expects a flat object with group/cardinality/dataset/_type.
+ */
+final case class TsCardinalitiesResponse(data: Seq[TsCardinalitiesSamplV2],
+                                         status: String = "success",
+                                         partial: Option[Boolean] = None,
+                                         message: Option[String] = None)
 
 /**
  * Serves time series cardinality with the same request/response semantics as the user facing
@@ -73,7 +88,7 @@ class CardinalityRoute(coordinatorActor: ActorRef,
               onSuccess(asyncAsk(coordinatorActor, cmd, settings.queryAskTimeout)) {
                 case qr: QueryResult =>
                   val recs = qr.result.flatMap(_.rows().map(rowDataToRecord).toSeq)
-                  complete(MetadataSuccessResponse(present(recs, dataset)))
+                  complete(TsCardinalitiesResponse(present(recs, dataset)))
                 case qe: QueryError =>
                   logger.error(s"QueryError for $cmd", qe.t)
                   complete(Codes.InternalServerError -> httpErr(qe.t.getClass.getName, qe.t.getMessage))
@@ -111,7 +126,7 @@ class CardinalityRoute(coordinatorActor: ActorRef,
                       s"[${cc.missingShards.mkString(",")}]. " +
                       s"Retry, or pass allowPartial=true to accept an undercount."))
                   case cc: ClusterCardinalities =>
-                    complete(MetadataSuccessResponse(present(cc.cardinalities, dataset),
+                    complete(TsCardinalitiesResponse(present(cc.cardinalities, dataset),
                       partial = if (cc.missingShards.isEmpty) None else Some(true),
                       message = if (cc.missingShards.isEmpty) None
                                 else Some(s"shards not counted: ${cc.missingShards.mkString(",")}")))

--- a/http/src/main/scala/filodb/http/FiloHttpServer.scala
+++ b/http/src/main/scala/filodb/http/FiloHttpServer.scala
@@ -54,6 +54,7 @@ class FiloHttpServer(actorSystem: ActorSystem, filoSettings: FilodbSettings) ext
     val defaultRoutes: List[FiloRoute] = List(AdminRoutes,
                                            new ClusterApiRoute(clusterProxy),
                                            new HealthRoute(coordinatorRef, v2ClusterEnabled, settings),
+                                           new CardinalityRoute(coordinatorRef, v2ClusterEnabled, settings),
                                            new PrometheusApiRoute(coordinatorRef, settings))
 
     // Load runtime api routes from class names.

--- a/http/src/test/scala/filodb/http/CardinalityRouteJsonSpec.scala
+++ b/http/src/test/scala/filodb/http/CardinalityRouteJsonSpec.scala
@@ -1,0 +1,47 @@
+package filodb.http
+
+import io.circe.Printer
+import io.circe.generic.auto._
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.query.{MetadataSampl, TsCardinalitiesSamplV2}
+import filodb.query.PromCirceSupport.decodeMetadataSampl
+
+class CardinalityRouteJsonSpec extends AnyFunSpec with Matchers {
+
+  private val printer = Printer.spaces2.copy(dropNullValues = true)
+
+  private val sample = TsCardinalitiesSamplV2(
+    Map("_ws_" -> "demo", "_ns_" -> "App-0"),
+    Map("active" -> 4L, "billable" -> 4L, "shortTerm" -> 6L, "longTerm" -> 0L),
+    "raw", "prometheus")
+
+  it("should render the flat wire shape the query-service decoder expects") {
+    val json = printer.print(TsCardinalitiesResponse(Seq(sample)).asJson)
+    // scalastyle:off
+    println(json)
+    // scalastyle:on
+    // the discriminator wrapper that sealed-trait auto derivation would produce must NOT appear
+    json should not include "TsCardinalitiesSamplV2"
+    // and PromCirceSupport must be able to read each element back
+    val elem = io.circe.parser.parse(json).toOption.get
+      .hcursor.downField("data").downArray.focus.get
+    decode[MetadataSampl](elem.noSpaces) shouldEqual Right(sample)
+  }
+
+  it("should omit partial/message on a complete result and include them on a partial one") {
+    printer.print(TsCardinalitiesResponse(Seq(sample)).asJson) should not include "partial"
+
+    val partial = TsCardinalitiesResponse(Seq(sample),
+      partial = Some(true), message = Some("shards not counted: 2,3"))
+    val json = printer.print(partial.asJson)
+    // scalastyle:off
+    println(json)
+    // scalastyle:on
+    json should include ("\"partial\" : true")
+    json should include ("shards not counted: 2,3")
+  }
+}


### PR DESCRIPTION
## Problem

A ws/ns cardinality query is a set of blocking RocksDB prefix scans, but it's executed as a normal query: `SingleClusterPlanner:1089-1097` materializes one `TsCardExec` per shard across every shard in the cluster (no pruning even when `_ws_`/`_ns_` are given, since a namespace can be spread across all of them), and each leaf runs on the shared `QueryScheduler`.

**So cardinality scans compete directly with PromQL.** Every leaf occupies a scheduler slot for the duration of a disk-bound scan, and user queries queue behind them.

## Change

Serve cardinality from the coordinator actor instead, reading the per-shard stores directly — no planner, no QueryActor, no query scheduler. PromQL and cardinality no longer contend for the same execution resources.

The scan itself costs the same; what changes is *where* it runs. As a secondary benefit the fan-out collapses from one ExecPlan per shard to one message per node — `TimeSeriesMemStore.scanTsCardinalities` already accepted `shards: Seq[Int]` — which removes the per-shard plan serialization and remote hops.

It reuses the existing ClusterV2 scatter-gather shape: `GetCardinalityScatter` /`reduceCardinalitiesFromAllNodes` mirror `GetShardMapScatter` / `reduceMappersFromAllNodes`.

Both endpoints ship so callers can choose and so the two can be diffed:

```
GET /promql/<ds>/api/v2/metering/cardinality/timeseries          # direct
GET /promql/<ds>/api/v2/metering/query/cardinality/timeseries    # existing QueryActor path
```

Request/response semantics match query-service's `/api/v2/metering/cardinality/timeseries` — same `match[]` parser and `SHARD_KEY_LABELS` ordering, same flat `TsCardinalitiesSamplV2` shape, so `MetadataRemoteExec` decodes it unchanged.

```bash
curl -sG 'localhost:8080/promql/prometheus/api/v2/metering/cardinality/timeseries' \
  --data-urlencode 'match[]={_ws_="my-ws"}' -d 'numGroupByFields=2'
```

```json
{
"data":[
      {
          "group": {"_ws_":"my-ws","_ns_":"my-ns"},
          "cardinality": {"active":430,"billable":430,"shortTerm":430,"longTerm":0},
          "dataset":"raw",
          "_type":"prometheus"
      }
    ],"status":"success"}
```

## Correctness: fail loud, never undercount

These are billing numbers, so a node refuses its whole scan unless **every** owned shard is `ShardStatusActive` — deliberately stricter than `HealthRoute.healthyShardStatuses`, which admits `Recovery`/`Assigned` (a recovering shard has a partially built tracker). Missing shards are derived from what nodes *positively report scanning*, so a dead node needs no special case:

```json
HTTP 503
{ "errorType":"ServiceUnavailable", "error":"...2 shard(s) not active or unreachable [2,3]. Retry, or pass allowPartial=true..."}
```

`allowPartial=true` returns 200 with `partial:true` and the uncounted shards named.

## Notes for reviewers

- **Inline on the actor thread.** The leaf scan runs inline, like `QueryActor.execTopkCardinalityQuery` already does. `GetClusterCardinalities` must stay async — it scatters to every node *including itself*, so blocking would guarantee a self-timeout. No new schedulers or implicits.

- **The scan now occupies the coordinator mailbox**, which also forwards `QueryCommand`s. That's a much shorter hold than a scheduler slot and it's off the query execution path, but it isn't zero — hence `elapsedMs` logging on every scan so it stays observable.

- **Per-node ask timeout is `query.ask-timeout - 5s`** (mirroring `askShardSnapshot`). With equal timeouts the caller's ask fires first and a slow node surfaces as a generic 500 instead of the 503.

- **No downsample fan-out** from either path, so `longTerm` is always 0.

- **`MAX_RESULT_SIZE` is now configurable** (`filodb.metering-max-result-size`, default 10000, was hardcoded 5000). This also moves the `OVERFLOW_GROUP` threshold on the *existing* API, since `TsCardReduceExec` shares the value.

## Testing

- `ClusterCardinalitiesSpec` (13) covers the merge — cross-shard/cross-node summing, `childrenCount`/`childrenQuota` taking max rather than summing, failed-node and partial-coverage detection — plus equivalence with `TsCardReduceExec` for one-shard-per-node and multi-shard-per-node. `CardinalityRouteJsonSpec` (2) pins the wire shape.

- Verified against a local cluster: **32/32 prefix × depth combinations byte-identical across both
endpoints**, including empty-prefix at ns level and metric-level depth 3.

- Verified against partial local cluster ( 1 node up and 1 node down ) - Expected query failure with correct error message.