### PR TITLE
fix(core): Fix flaky histogram test due to incomplete precision check

### DIFF
--- a/core/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
+++ b/core/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala
@@ -545,7 +545,11 @@ class HistogramTest extends NativeVectorTest {
         for (i <- 1 until b.numBuckets) {
           val bucketTop = b.bucketTop(i)
           val index = b.startIndexPositiveBuckets + i - 1
-          bucketTop shouldEqual Math.pow(b.base, index + 1) +- epsilon
+          val expected = Math.pow(b.base, index + 1)
+          // bucketTop is computed via exp(n * log(base)) for perf, which can diverge from pow(base, n)
+          // by a few ULPs at large magnitudes. Scale the tolerance with the expected value's magnitude
+          // instead of using a fixed absolute epsilon, which is too tight for large bucket tops.
+          bucketTop shouldEqual expected +- (epsilon * Math.max(1.0, Math.abs(expected)))
         }
       }
     }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This flaky test was observed
```
      [info]   TestFailedException was thrown during property evaluation.
      [info]     Message: 2.920077220094292E9 did not equal 2.920077220094296E9 plus or minus 1.0E-6
      [info]     Location: (HistogramTest.scala:548)
      [info]     Occurred when passed generated values (
      [info]       arg0 = Base2ExpHistogramBuckets(scale=11, startIndexPositiveBuckets=64395, numPositiveBuckets=104)
      [info]     )
      [info]   org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException:
      [info]   at org.scalatestplus.scalacheck.UnitCheckerAsserting$$anon$1.indicateFailure(CheckerAsserting.scala:190)
      [info]   at org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check(CheckerAsserting.scala:160)
      [info]   at org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll(ScalaCheckDrivenPropertyChecks.scala:1007)
      [info]   at filodb.memory.format.vectors.HistogramTest.$anonfun$new$44(HistogramTest.scala:539)
      [info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
```


**Root cause:** The production code (Base2ExpHistogramBuckets.bucketTop, Histogram.scala:778) computes Math.exp((index+1) * logBase(scale)) instead of  Math.pow(base, index+1) for performance. These two formulas are mathematically equivalent but take different floating-point paths, so at large magnitudes  (here, a bucket top of ~2.92e9) they can diverge by a few ULPs — well within double precision's inherent error, but larger than the fixed absolute  tolerance epsilon = 1.0E-6 the test used to compare them. That's a difference of ~4e-6 on a ~2.9e9 value, i.e. a few parts in 10^15 — normal FP noise, not  a computation error.

  **Fix** in core/src/test/scala/filodb.memory/format/vectors/HistogramTest.scala: scale the comparison tolerance with the magnitude of the expected value  (epsilon * max(1.0, |expected|)) instead of using a fixed absolute epsilon, so the test still catches real bugs but tolerates the expected FP noise at  large bucket-top values.