### PR TITLE
fix(queryplanner): unwrap shard key filter values when building the metadata routing key

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -1402,6 +1402,25 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
     PlanResult(execPlan::Nil)
   }
 
+  /**
+   * Builds the routing key identifying the partition assignment for one group of shard key filters.
+   *
+   * Matches Equals explicitly to read the filter's value. Filter declares no `value` member, so a bare
+   * `filter.value` resolves instead through the implicit akka.util.Helpers.Requiring conversion
+   * imported above, whose `value` returns the wrapped object itself. The routing key then carries the
+   * filter's toString ("Equals(myWs)") rather than its value ("myWs"), matches no assignment, and
+   * metadata queries fall back to the local partition instead of fanning out.
+   *
+   * Only called when every shard key filter is an Equals, so a non-Equals cannot reach here.
+   */
+  private def buildRoutingMap(group: Seq[ColumnFilter],
+                              nonMetricCols: Seq[String]): Map[String, String] =
+    nonMetricCols.flatMap(shardKeyCol =>
+      group.collectFirst {
+        case ColumnFilter(c, Equals(value)) if c == shardKeyCol => c -> value.toString
+      }
+    ).toMap
+
   private def resolveMetadataPartitions(lp: MetadataQueryPlan, queryParams: PromQlQueryParams) = {
     val timeRange = TimeRange(queryParams.startSecs * 1000L, queryParams.endSecs * 1000L)
     // SeriesKeysByFilters stores its filters directly; getNonMetricShardKeyFilters doesn't extract them
@@ -1424,13 +1443,6 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
             }
         ))
 
-    def buildRoutingMap(group: Seq[ColumnFilter]): Map[String, String] =
-      nonMetricCols.flatMap(shardKeyCol =>
-        group.collectFirst {
-          case ColumnFilter(c, filter) if c == shardKeyCol => c -> filter.value.toString
-        }
-      ).toMap
-
     val shouldFallback = queryConfig.routingConfig.useLegacyMetadataRouting || !areEqualFilters ||
       shardKeyFilterGroups.isEmpty ||
       !shardKeyFilterGroups.forall(group => nonMetricCols.forall(col => group.exists(_.column == col)))
@@ -1446,7 +1458,7 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
           getMetadataPartitions(lp.filters, timeRange)
         } else {
           shardKeyFilterGroups
-            .map(buildRoutingMap)
+            .map(buildRoutingMap(_, nonMetricCols))
             .flatMap(routingMap => partitionLocationProvider.getPartitions(routingMap, timeRange))
             .distinct
         }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -2797,6 +2797,35 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       execPlan.asInstanceOf[MetadataRemoteExec].queryEndpoint shouldEqual "direct-remote-url"
     }
 
+    it("should pass unwrapped shard key values in the routing key to getPartitions") {
+      // The other tests in this describe block only assert which provider method was called, so they
+      // pass even when the routing key values are wrong. Capture the key itself: the values have to be
+      // the filter values ("demo"/"ns1"), not the filters' toString ("Equals(demo)"), or the lookup
+      // matches no partition assignment and metadata queries silently stop fanning out.
+      var capturedRoutingKey: Map[String, String] = null
+      val provider = new PartitionLocationProvider {
+        override def getPartitions(routingKey: Map[String, String],
+                                   timeRange: TimeRange): List[PartitionAssignment] = {
+          capturedRoutingKey = routingKey
+          List(PartitionAssignment("direct-partition", "direct-remote-url",
+            TimeRange(timeRange.startMs, timeRange.endMs), workUnit = "testWorkUnit"))
+        }
+
+        override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter],
+                                           timeRange: TimeRange): List[PartitionAssignment] =
+          List(PartitionAssignment("legacy-partition", "legacy-remote-url",
+            TimeRange(timeRange.startMs, timeRange.endMs), workUnit = "testWorkUnit"))
+      }
+      val engine = makeMultiShardPlanner(provider)
+      val lp = Parser.labelValuesQueryToLogicalPlan(
+        Seq("__metric__"), Some("""_ws_="demo",_ns_="ns1""""),
+        TimeStepParams(startSeconds, step, endSeconds))
+      engine.materialize(lp, QueryContext(origQueryParams = labelValuesQueryParams,
+        plannerParams = PlannerParams(processMultiPartition = true)))
+
+      capturedRoutingKey shouldEqual Map("_ws_" -> "demo", "_ns_" -> "ns1")
+    }
+
     it("should fall back to getMetadataPartitions when useLegacyMetadataRouting is true") {
       val provider = makeFallbackProvider("legacy-remote-url", "direct-remote-url")
       val legacyConfig = queryConfig.copy(


### PR DESCRIPTION


resolveMetadataPartitions built the routing key passed to PartitionLocationProvider.getPartitions with

  case ColumnFilter(c, filter) if c == shardKeyCol => c -> filter.value.toString

Filter declares no `value` member - only filterFunc, operatorString and valuesStrings - so `filter.value` did not resolve to the filter's value. It resolved through the implicit akka.util.Helpers.Requiring conversion imported at the top of this file, whose `value` returns the wrapped object itself. The expression was therefore an identity followed by toString, and every routing key value became the filter's toString: workspace "Equals(myWs)" instead of "myWs".

No partition assignment matches such a key, so getPartitions returned an empty list and materializeMetadataQueryPlan fell back to the local partition. Metadata queries - label values, label names, series - silently stopped fanning out to remote partitions on every multipartition planner. Range queries were unaffected: they route via getRoutingKeys, which unwraps with `eq.value.toString` on a value typed as Equals.

Match Equals explicitly so the value comes from the case class field and the implicit cannot apply. buildRoutingMap only runs when areEqualFilters holds, so every filter reaching it is an Equals.

The existing resolveMetadataPartitions tests assert only which provider method was called and pass regardless of the key's contents, which is how this went unnoticed. The new test captures the routing key the provider receives and asserts the unwrapped values.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: