### PR TITLE
fix(queryplanner): resolve metadata partitions via the V2 read API, not the legacy getPartitions

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -1459,7 +1459,10 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
         } else {
           shardKeyFilterGroups
             .map(buildRoutingMap(_, nonMetricCols))
-            .flatMap(routingMap => partitionLocationProvider.getPartitions(routingMap, timeRange))
+            // getPartitionsTrait, not the getPartitions kept for backward compatibility: the traffic
+            // router rejects a V1 read for a namespace converted to the V2 schema with "please use the
+            // V2 read API", which leaves this branch with no assignments and falls back to local.
+            .flatMap(routingMap => partitionLocationProvider.getPartitionsTrait(routingMap, timeRange))
             .distinct
         }
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -7,7 +7,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
-import akka.util.Helpers.Requiring
 import com.typesafe.scalalogging.StrictLogging
 import io.grpc.ManagedChannel
 
@@ -1405,11 +1404,12 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
   /**
    * Builds the routing key identifying the partition assignment for one group of shard key filters.
    *
-   * Matches Equals explicitly to read the filter's value. Filter declares no `value` member, so a bare
-   * `filter.value` resolves instead through the implicit akka.util.Helpers.Requiring conversion
-   * imported above, whose `value` returns the wrapped object itself. The routing key then carries the
-   * filter's toString ("Equals(myWs)") rather than its value ("myWs"), matches no assignment, and
-   * metadata queries fall back to the local partition instead of fanning out.
+   * Matches Equals explicitly so the value comes from the case class field. Filter itself declares no
+   * `value` member, so a bare `filter.value` compiles only through an implicit identity conversion -
+   * this file used to import akka.util.Helpers.Requiring, whose `value` returns the wrapped object
+   * itself. That put the filter's toString ("Equals(myWs)") in the routing key rather than its value
+   * ("myWs"), matched no assignment, and sent metadata queries to the local partition instead of
+   * fanning them out.
    *
    * Only called when every shard key filter is an Equals, so a non-Equals cannot reach here.
    */

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -2797,6 +2797,38 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       execPlan.asInstanceOf[MetadataRemoteExec].queryEndpoint shouldEqual "direct-remote-url"
     }
 
+    it("should resolve metadata partitions through getPartitionsTrait, not the V1 getPartitions") {
+      // getPartitions is kept only for backward compatibility and maps to the traffic router's V1 read
+      // API, which rejects namespaces converted to the V2 schema ("please use the V2 read API"). The
+      // provider below fails the V1 method so a regression cannot pass silently.
+      var traitCalls = 0
+      val provider = new PartitionLocationProvider {
+        override def getPartitions(routingKey: Map[String, String],
+                                   timeRange: TimeRange): List[PartitionAssignment] =
+          fail("resolveMetadataPartitions must not call the V1 getPartitions")
+
+        override def getPartitionsTrait(routingKey: Map[String, String],
+                                        timeRange: TimeRange): List[PartitionAssignmentTrait] = {
+          traitCalls += 1
+          List(PartitionAssignment("direct-partition", "direct-remote-url",
+            TimeRange(timeRange.startMs, timeRange.endMs), workUnit = "testWorkUnit"))
+        }
+
+        override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter],
+                                           timeRange: TimeRange): List[PartitionAssignment] =
+          fail("all-Equals shard keys should not take the fallback path")
+      }
+      val engine = makeMultiShardPlanner(provider)
+      val lp = Parser.labelValuesQueryToLogicalPlan(
+        Seq("__metric__"), Some("""_ws_="demo",_ns_="ns1""""),
+        TimeStepParams(startSeconds, step, endSeconds))
+      val execPlan = engine.materialize(lp, QueryContext(origQueryParams = labelValuesQueryParams,
+        plannerParams = PlannerParams(processMultiPartition = true)))
+
+      traitCalls shouldEqual 1
+      execPlan.asInstanceOf[MetadataRemoteExec].queryEndpoint shouldEqual "direct-remote-url"
+    }
+
     it("should pass unwrapped shard key values in the routing key to getPartitions") {
       // The other tests in this describe block only assert which provider method was called, so they
       // pass even when the routing key values are wrong. Capture the key itself: the values have to be


### PR DESCRIPTION
## Problem

Metadata queries (label values, label names, series) still do not fan out to remote partitions
after #2337, because `resolveMetadataPartitions` has a second, independent defect: it calls
`PartitionLocationProvider.getPartitions`, which the trait itself documents as kept only for
backward compatibility:

```scala
  // keep this function for backward compatibility.
  def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment]
```

Implementations map that method to the partition-assignment V1 read API, which is rejected outright
for any namespace migrated to the V2 schema:

```
  getPartitionAssignments failed: "The namespace mp-namespace-central-1 has been converted to the
  V2 schema; please use the V2 read API"  statusCode: 400
```

Because it throws rather than returning empty, the query surfaces as an HTTP 500
`query_materialization_failed` — a different symptom from the routing key defect fixed in #2337,
with the same root call.

`getPartitionsTrait` has existed since #1917 ("Support Partition Assignment V2", 2025-04-14) — 16
months before the metadata path was added in #2130. Every other caller already uses the V2-capable
methods: the range query path calls `getPartitionsTrait`
(`PartitionLocationPlanner.scala:74`), and the metadata fallback path calls
`getMetadataPartitionsTrait` (`MultiPartitionPlanner.scala:1509`). This branch was the only one left
on the legacy method.

## Changes

1. **`getPartitionsTrait` instead of the V1 `getPartitions`.** Type-compatible: `getPartitionsTrait`
   returns `List[PartitionAssignmentTrait]`, which is what the sibling branches of the same `match`
   already return and what `materializeMetadataQueryPlan` consumes via `proportionMap`. That consumer
   expands `proportionMap.values` into one exec plan per partition, so a V2 assignment spanning two
   partitions (e.g. tsdb1 @0.5 + tsdb2 @0.5) now fans out to both — correct for metadata, which is a
   union where proportions are irrelevant.

2. **Remove the unused `import akka.util.Helpers.Requiring`.** That import is what let the routing
   key bug in #2337 compile in the first place: `Requiring[A]` is an implicit value class over *any*
   `A` whose `value()` returns the wrapped object itself, so `filter.value` type-checked as an
   identity on a `Filter` that declares no `value` member, and the routing key carried
   `"Equals(myWs)"` instead of `"myWs"`. Nothing in the file uses `requiring`/`value` from that
   conversion, so it only keeps the trap armed for the next caller. With it removed, the old
   expression no longer compiles:

   ```
   MultiPartitionPlanner.scala:1420: value value is not a member of filodb.core.query.Filter
   ```

   The #2337 fix is now enforced by the compiler rather than by review.

## Testing

`sbt "coordinator/testOnly *MultiPartitionPlannerSpec"` — 78 tests, all pass. Also ran
`*ShardKeyRegexPlannerSpec *SingleClusterPlannerSpec *PlannerHierarchySpec` alongside it: 252 tests,
all pass. scalastyle clean for both Compile and Test.

The new test uses a provider whose `getPartitions` calls `fail(...)`, because the pre-existing test
doubles override both methods and so pass with either one — that blindness is why #2130 landed with
this defect and green CI. `resolveMetadataPartitions` stays under the 50-line scalastyle cap (46
lines); the routing-key helper is a class-level private method for that reason.

## Notes

Not a regression — this code path has never worked since it was introduced in #2130. Range queries
are unaffected.
